### PR TITLE
fix(admin): derive server health from core services only

### DIFF
--- a/frontend/src/components/ServerControls.tsx
+++ b/frontend/src/components/ServerControls.tsx
@@ -32,7 +32,7 @@ function deriveHealth(sv: SupervisorStatusResponse | null): ServerHealth {
   if (!sv.process_running) return 'offline';
   if (sv.services) {
     const s = sv.services;
-    if (s.auth && s.base && s.cell && s.database) return 'healthy';
+    if (s.auth && s.base && s.cell) return 'healthy';
     return 'degraded';
   }
   return 'degraded';


### PR DESCRIPTION
## Summary
- Server status LED was stuck on "Degraded" when running without a database, even though auth/base/cell were all healthy
- `deriveHealth()` now requires only the three core game services (auth, base, cell) for "Online" — a missing DB pool no longer blocks it

## Test plan
- [ ] Start supervisor, then start server without a database configured
- [ ] Verify status LED changes from "Offline" → "Online" (not "Degraded")
- [ ] Verify status shows "Degraded" when a core service (auth/base/cell) is actually down

🤖 Generated with [Claude Code](https://claude.com/claude-code)