### PR TITLE
fix(character): add name/tint input validation to character creation

### DIFF
--- a/crates/services/src/base/character_create.rs
+++ b/crates/services/src/base/character_create.rs
@@ -48,9 +48,9 @@ pub(crate) async fn handle_create_character(
     };
     off += consumed;
 
-    // Name length validation (matches C++ Account.py: rejects names < 3 chars).
-    if name.len() < 3 {
-        tracing::info!(%addr, name_len = name.len(), "createCharacter: name too short");
+    // Name validation (matches Python Account.py:isCharacterNameAllowed).
+    if let Err(reason) = validate_character_name(&name) {
+        tracing::info!(%addr, %name, %reason, "createCharacter: name rejected");
         send_char_create_failed(socket, addr, key, connected, 2).await?;
         return Ok(());
     }
@@ -64,6 +64,15 @@ pub(crate) async fn handle_create_character(
         }
     };
     off += consumed;
+
+    // Extra name validation — same format rules, but allowed to be empty.
+    if !extra_name.is_empty() {
+        if let Err(reason) = validate_character_name(&extra_name) {
+            tracing::info!(%addr, %extra_name, %reason, "createCharacter: extra_name rejected");
+            send_char_create_failed(socket, addr, key, connected, 2).await?;
+            return Ok(());
+        }
+    }
 
     if off + 4 > payload.len() {
         tracing::warn!(%addr, "createCharacter: payload too short for CharDefId");
@@ -112,6 +121,13 @@ pub(crate) async fn handle_create_character(
     let skin_tint_color_id = i32::from_le_bytes([
         payload[off], payload[off + 1], payload[off + 2], payload[off + 3],
     ]);
+
+    // Skin tint validation (matches Python Account.py: ERROR_CharacterCreationInvalidSkinColor).
+    if !(0..=15).contains(&skin_tint_color_id) {
+        tracing::info!(%addr, skin_tint_color_id, "createCharacter: invalid skin tint");
+        send_char_create_failed(socket, addr, key, connected, 2).await?;
+        return Ok(());
+    }
 
     // Derive alignment, archetype, gender, bodyset, starting position from CharDefId.
     let (alignment, archetype, gender, bodyset, world_location, start_x, start_y, start_z) =
@@ -403,4 +419,93 @@ pub(crate) async fn handle_create_character(
     }
 
     Ok(())
+}
+
+/// Validate a character name for length, format, and whitespace rules.
+///
+/// Allowed characters: ASCII letters, digits, spaces, hyphens, apostrophes.
+/// Rejects: leading/trailing whitespace, consecutive spaces, control chars,
+/// HTML/script injection, zero-width characters, and names outside 3-20 chars.
+///
+/// Returns `Ok(())` if valid, or `Err(reason)` with a human-readable rejection reason.
+fn validate_character_name(name: &str) -> Result<(), &'static str> {
+    if name.len() < 3 {
+        return Err("too short (min 3)");
+    }
+    if name.len() > 20 {
+        return Err("too long (max 20)");
+    }
+    if name != name.trim() {
+        return Err("leading or trailing whitespace");
+    }
+    if name.contains("  ") {
+        return Err("consecutive spaces");
+    }
+    if !name.chars().all(|c| c.is_ascii_alphanumeric() || c == ' ' || c == '-' || c == '\'') {
+        return Err("invalid characters (only letters, digits, spaces, hyphens, apostrophes)");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn name_valid() {
+        assert!(validate_character_name("John").is_ok());
+        assert!(validate_character_name("Sam Carter").is_ok());
+        assert!(validate_character_name("O'Neill").is_ok());
+        assert!(validate_character_name("Teal-c").is_ok());
+        assert!(validate_character_name("abc").is_ok()); // min length
+        assert!(validate_character_name("12345678901234567890").is_ok()); // max length (20)
+    }
+
+    #[test]
+    fn name_too_short() {
+        assert!(validate_character_name("AB").is_err());
+        assert!(validate_character_name("A").is_err());
+        assert!(validate_character_name("").is_err());
+    }
+
+    #[test]
+    fn name_too_long() {
+        assert!(validate_character_name("123456789012345678901").is_err()); // 21 chars
+        assert!(validate_character_name("AAAAAAAAAAAAAAAAAAAAA").is_err());
+    }
+
+    #[test]
+    fn name_rejects_html() {
+        assert!(validate_character_name("<script>").is_err());
+        assert!(validate_character_name("a]>b").is_err());
+    }
+
+    #[test]
+    fn name_rejects_control_chars() {
+        assert!(validate_character_name("abc\0def").is_err());
+        assert!(validate_character_name("abc\ndef").is_err());
+        assert!(validate_character_name("abc\tdef").is_err());
+    }
+
+    #[test]
+    fn name_rejects_bad_whitespace() {
+        assert!(validate_character_name(" Leading").is_err());
+        assert!(validate_character_name("Trailing ").is_err());
+        assert!(validate_character_name("Two  Spaces").is_err());
+    }
+
+    #[test]
+    fn name_rejects_non_ascii() {
+        assert!(validate_character_name("Ünïcödé").is_err());
+        assert!(validate_character_name("名前").is_err());
+    }
+
+    #[test]
+    fn skin_tint_valid_range() {
+        for i in 0..=15i32 {
+            assert!((0..=15).contains(&i));
+        }
+        assert!(!(0..=15).contains(&-1i32));
+        assert!(!(0..=15).contains(&16i32));
+    }
 }


### PR DESCRIPTION
## Summary

- Add defense-in-depth input validation for character creation: name length (3-20), format (ASCII alphanumeric + spaces/hyphens/apostrophes), whitespace rules (no leading/trailing/consecutive), extra_name validation, skin tint range check (0-15)
- All SQL queries already use parameterized bindings — this hardens the application layer against stored XSS, control character injection, and invalid data reaching the DB

## Context

Audit of issue #56 revealed that **7 of 8 acceptance criteria were already implemented** — starting equipment, abilities, world/position, visual tints, and skin tint mapping were all done. The only gap was input validation on the name and skin tint fields.

The stale agent memory from March 4th claimed "Rust version is missing most of this (only basic fields, pos=0,0,0, no items/abilities/world_id)" which is no longer true.

## Changes

- `crates/services/src/base/character_create.rs`: Add `validate_character_name()` function, wire it into name and extra_name parsing, add skin tint range check, add 8 unit tests

## Test plan

- [x] `cargo check -p cimmeria-services` — compiles clean (4 pre-existing warnings)
- [x] `cargo test -p cimmeria-services -- character_create` — 8/8 tests pass
- [ ] In-game: Create character with valid name → succeeds
- [ ] In-game: Create character with 2-char name → rejected
- [ ] In-game: Create character with duplicate name → "name taken" error
- [ ] In-game: Create character with each archetype → correct starting gear/abilities/zone

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)