### PR TITLE
Wire bandolier ammo through stats system and persist per-slot

### DIFF
--- a/.claude/agent-memory/rust-gameserver-dev/MEMORY.md
+++ b/.claude/agent-memory/rust-gameserver-dev/MEMORY.md
@@ -6,6 +6,9 @@
 - Key files: `crates/services/src/base.rs`, `crates/services/src/mercury_ext.rs`, `crates/services/src/auth.rs`
 - C++ reference: `src/baseapp/mercury/sgw/` (client_handler.cpp, connect_handler.cpp, messages.cpp)
 
+## Build Environment
+- See [build-environment.md](build-environment.md) — repo `.cargo/config.toml` hardcodes another user's rust-lld path; need `CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_RUSTFLAGS` override.
+
 ## Audit Findings (2026-03-04)
 See [audit-findings.md](audit-findings.md) for full details.
 

--- a/.claude/agent-memory/rust-gameserver-dev/build-environment.md
+++ b/.claude/agent-memory/rust-gameserver-dev/build-environment.md
@@ -1,0 +1,17 @@
+---
+name: Build environment quirks
+description: Cimmeria repo's .cargo/config.toml hardcodes another user's rust-lld path; need an env override to build.
+type: project
+---
+
+The repo `.cargo/config.toml` hardcodes a `rust-lld` linker path under another user's home directory. To build on this host, prepend:
+
+```
+CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_RUSTFLAGS='-C linker=C:\Users\steven.cady\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib\rustlib\x86_64-pc-windows-msvc\bin\rust-lld.exe'
+```
+
+to every `cargo check`/`cargo test`/`cargo build` invocation.
+
+**Why:** this avoids editing tracked config (which would conflict for the original author).
+
+**How to apply:** wrap every cargo command. Tests that don't need a linker (`cargo check`) sometimes work without it but `cargo test` always needs it.

--- a/crates/entity/src/cell_entity.rs
+++ b/crates/entity/src/cell_entity.rs
@@ -165,16 +165,16 @@ pub struct CellEntity {
     pub state_field: u32,
 
     // ── Ammo state ────────────────────────────────────────────────────────────
-    /// Current ammo count for active bandolier weapon.
-    pub current_ammo: i32,
-    /// Maximum ammo for the active weapon (clip size).
-    pub max_ammo: i32,
-    /// Ammo type enum value for `onEntityProperty(AmmoTypeId)`.
-    pub ammo_type: i32,
+    //
+    // Per-slot ammo lives on `BandolierItem` (`current_ammo`, `cur_ammo_type`)
+    // and on the `Stat[AMMO_SLOT_1+slot]` map. Use `active_ammo()`,
+    // `active_clip_size()`, `active_ammo_type()`, and `set_slot_ammo()` to
+    // read and write — never re-introduce a shadow scalar.
+
     /// When `Some(t)`, a reload is in progress and the magazine is not yet
-    /// available; fire paths must reject until `Instant::now() >= t` and on
-    /// elapse refill `current_ammo` to `max_ammo`. Set by RequestReload, cleared
-    /// on first fire attempt past the deadline.
+    /// available; fire paths must reject until `Instant::now() >= t`. The
+    /// reload-completion tick (cell::service::reload_completion_tick) refills
+    /// the active slot via `refill_active_slot()` and clears this field.
     pub reload_complete_at: Option<std::time::Instant>,
 
     // ── NPC AI state ──────────────────────────────────────────────────────────
@@ -216,6 +216,12 @@ pub struct CellEntity {
 
     /// Player's bandolier items (quick-access equipment slots).
     pub bandolier_items: HashMap<i32, BandolierItem>,
+
+    /// Slot ids whose `current_ammo`/`cur_ammo_type` have changed since the
+    /// last persistence flush. Stage A wires this in but doesn't drain it —
+    /// stages B/C/D read/clear this on reload completion, slot swap, ammo
+    /// change, and logout.
+    pub bandolier_ammo_dirty: HashSet<i32>,
 }
 
 /// An item in a dead NPC's loot list, ready for display to players.
@@ -240,6 +246,12 @@ pub struct BandolierItem {
     pub clip_size: i32,
     /// Default ammo type for weapons.
     pub default_ammo_type: i32,
+    /// Remaining ammo in this slot's magazine. Per-slot, persisted as
+    /// `sgw_inventory.ammo`.
+    pub current_ammo: i32,
+    /// Currently selected ammo subtype (defaults to `default_ammo_type`).
+    /// Persisted per-slot — players can pick a non-default subtype per weapon.
+    pub cur_ammo_type: i32,
 }
 
 /// NPC AI state machine.
@@ -292,9 +304,6 @@ impl CellEntity {
             body_set: None,
             components: Vec::new(),
             state_field: 0,
-            current_ammo: 0,
-            max_ammo: 0,
-            ammo_type: 0,
             reload_complete_at: None,
             ai_state: AiState::Idle,
             threat_list: HashMap::new(),
@@ -310,6 +319,7 @@ impl CellEntity {
             vendor_entity: None,
             active_bandolier_slot: 0,
             bandolier_items: HashMap::new(),
+            bandolier_ammo_dirty: HashSet::new(),
         }
     }
 
@@ -343,6 +353,58 @@ impl CellEntity {
     /// Uses squared distance comparison to avoid a square root.
     pub fn is_in_aoi(&self, other_pos: &Vector3) -> bool {
         self.position.distance_squared_to(other_pos) <= self.aoi_radius * self.aoi_radius
+    }
+
+    // ── Bandolier ammo helpers ───────────────────────────────────────────────
+    //
+    // Per-slot ammo lives on `BandolierItem.current_ammo` and is mirrored to
+    // the `Stat[AMMO_SLOT_1+slot]` map. These helpers are the read/write path
+    // for fire, reload, slot swap, and ammo-change; the shadow scalars that
+    // used to live on `CellEntity` were removed in Stage C.
+
+    /// Read the active slot's current ammo, or 0 if no item equipped.
+    pub fn active_ammo(&self) -> i32 {
+        self.bandolier_items
+            .get(&self.active_bandolier_slot)
+            .map_or(0, |i| i.current_ammo)
+    }
+
+    /// Read the active slot's clip size, or 0 if no item equipped.
+    pub fn active_clip_size(&self) -> i32 {
+        self.bandolier_items
+            .get(&self.active_bandolier_slot)
+            .map_or(0, |i| i.clip_size)
+    }
+
+    /// Read the active slot's selected ammo type, or 0 if no item equipped.
+    pub fn active_ammo_type(&self) -> i32 {
+        self.bandolier_items
+            .get(&self.active_bandolier_slot)
+            .map_or(0, |i| i.cur_ammo_type)
+    }
+
+    /// Set ammo for a slot, mirroring to the AmmoSlot{N} stat. Returns the
+    /// clamped value, or `None` if the slot is unequipped.
+    ///
+    /// Marks the slot dirty in `bandolier_ammo_dirty` for batched persistence.
+    pub fn set_slot_ammo(&mut self, slot_id: i32, current: i32) -> Option<i32> {
+        let item = self.bandolier_items.get_mut(&slot_id)?;
+        item.current_ammo = current.clamp(0, item.clip_size);
+        let clamped = item.current_ammo;
+        let stat_id = crate::stats::AMMO_SLOT_1 + slot_id;
+        if let Some(stat) = self.stats.get_mut(stat_id) {
+            stat.set_current(clamped);
+        }
+        self.bandolier_ammo_dirty.insert(slot_id);
+        Some(clamped)
+    }
+
+    /// Refill the active slot's magazine to its `clip_size`. Returns the new
+    /// ammo value, or `None` if no slot is equipped.
+    pub fn refill_active_slot(&mut self) -> Option<i32> {
+        let slot = self.active_bandolier_slot;
+        let max = self.bandolier_items.get(&slot).map(|i| i.clip_size)?;
+        self.set_slot_ammo(slot, max)
     }
 }
 
@@ -446,11 +508,15 @@ mod tests {
     // ── New field defaults ─────────────────────────────────────────────────
 
     #[test]
-    fn new_entity_ammo_defaults_zero() {
+    fn new_entity_ammo_defaults_empty() {
         let entity = make_entity();
-        assert_eq!(entity.current_ammo, 0);
-        assert_eq!(entity.max_ammo, 0);
-        assert_eq!(entity.ammo_type, 0);
+        // Stage C: shadow scalars are gone — assert the helper-derived view
+        // (no items in bandolier => zero everything) and that no slot is dirty.
+        assert_eq!(entity.active_ammo(), 0);
+        assert_eq!(entity.active_clip_size(), 0);
+        assert_eq!(entity.active_ammo_type(), 0);
+        assert!(entity.bandolier_items.is_empty());
+        assert!(entity.bandolier_ammo_dirty.is_empty());
     }
 
     #[test]
@@ -508,5 +574,102 @@ mod tests {
         let spawn = Vector3::new(100.0, 5.0, 200.0);
         entity.spawn_position = Some(spawn);
         assert_eq!(entity.spawn_position.unwrap(), spawn);
+    }
+
+    // ── Bandolier ammo helpers ──────────────────────────────────────────────
+
+    fn make_bandolier_item(item_id: i32, clip: i32) -> BandolierItem {
+        BandolierItem {
+            item_id,
+            clip_size: clip,
+            default_ammo_type: 1,
+            current_ammo: clip,
+            cur_ammo_type: 1,
+        }
+    }
+
+    #[test]
+    fn active_ammo_helpers_with_no_item_return_zero() {
+        let entity = make_entity();
+        assert_eq!(entity.active_ammo(), 0);
+        assert_eq!(entity.active_clip_size(), 0);
+        assert_eq!(entity.active_ammo_type(), 0);
+    }
+
+    #[test]
+    fn active_ammo_helpers_read_from_active_slot() {
+        let mut entity = make_entity();
+        entity.active_bandolier_slot = 1;
+        entity.bandolier_items.insert(0, make_bandolier_item(100, 30));
+        entity.bandolier_items.insert(1, BandolierItem {
+            item_id: 200, clip_size: 12, default_ammo_type: 2,
+            current_ammo: 8, cur_ammo_type: 2,
+        });
+
+        assert_eq!(entity.active_ammo(), 8);
+        assert_eq!(entity.active_clip_size(), 12);
+        assert_eq!(entity.active_ammo_type(), 2);
+    }
+
+    /// Seed an AmmoSlot stat so the `set_current()` clamp doesn't pin to 0.
+    /// Stage B's world-entry init does this for real; tests have to mirror it
+    /// because Stage A leaves the helper callable but unseeded by default.
+    fn seed_ammo_stat(entity: &mut CellEntity, slot_id: i32, clip: i32) {
+        let stat_id = crate::stats::AMMO_SLOT_1 + slot_id;
+        if let Some(stat) = entity.stats.get_mut(stat_id) {
+            stat.update(0, clip, clip);
+            stat.clear_dirty();
+        }
+    }
+
+    #[test]
+    fn set_slot_ammo_clamps_and_marks_dirty() {
+        let mut entity = make_entity();
+        entity.bandolier_items.insert(0, make_bandolier_item(100, 30));
+        seed_ammo_stat(&mut entity, 0, 30);
+
+        // Clamp above clip_size.
+        let result = entity.set_slot_ammo(0, 999);
+        assert_eq!(result, Some(30));
+        assert!(entity.bandolier_ammo_dirty.contains(&0));
+        assert_eq!(entity.stats.get(crate::stats::AMMO_SLOT_1).unwrap().cur, 30);
+
+        // Clamp below zero.
+        entity.bandolier_ammo_dirty.clear();
+        let result = entity.set_slot_ammo(0, -5);
+        assert_eq!(result, Some(0));
+        assert!(entity.bandolier_ammo_dirty.contains(&0));
+        assert_eq!(entity.stats.get(crate::stats::AMMO_SLOT_1).unwrap().cur, 0);
+    }
+
+    #[test]
+    fn set_slot_ammo_unequipped_returns_none() {
+        let mut entity = make_entity();
+        let result = entity.set_slot_ammo(2, 5);
+        assert_eq!(result, None);
+        assert!(entity.bandolier_ammo_dirty.is_empty());
+    }
+
+    #[test]
+    fn refill_active_slot_fills_to_clip_size() {
+        let mut entity = make_entity();
+        entity.bandolier_items.insert(0, BandolierItem {
+            item_id: 100, clip_size: 30, default_ammo_type: 1,
+            current_ammo: 5, cur_ammo_type: 1,
+        });
+        seed_ammo_stat(&mut entity, 0, 30);
+
+        let result = entity.refill_active_slot();
+        assert_eq!(result, Some(30));
+        assert_eq!(entity.bandolier_items[&0].current_ammo, 30);
+        let stat = entity.stats.get(crate::stats::AMMO_SLOT_1).unwrap();
+        assert_eq!(stat.cur, 30);
+    }
+
+    #[test]
+    fn refill_active_slot_unequipped_returns_none() {
+        let mut entity = make_entity();
+        let result = entity.refill_active_slot();
+        assert_eq!(result, None);
     }
 }

--- a/crates/entity/src/cell_entity.rs
+++ b/crates/entity/src/cell_entity.rs
@@ -174,8 +174,13 @@ pub struct CellEntity {
     /// When `Some(t)`, a reload is in progress and the magazine is not yet
     /// available; fire paths must reject until `Instant::now() >= t`. The
     /// reload-completion tick (cell::service::reload_completion_tick) refills
-    /// the active slot via `refill_active_slot()` and clears this field.
+    /// the slot pinned by `reload_slot_id` and clears both fields.
     pub reload_complete_at: Option<std::time::Instant>,
+    /// The bandolier slot that initiated the in-flight reload. Pinning to
+    /// this slot (rather than `active_bandolier_slot` at completion time)
+    /// prevents a mid-reload weapon swap from refilling the wrong magazine.
+    /// `None` whenever `reload_complete_at` is `None`.
+    pub reload_slot_id: Option<i32>,
 
     // ── NPC AI state ──────────────────────────────────────────────────────────
     /// AI state for NPC entities (Idle, Fighting, Dead, Leashing).
@@ -305,6 +310,7 @@ impl CellEntity {
             components: Vec::new(),
             state_field: 0,
             reload_complete_at: None,
+            reload_slot_id: None,
             ai_state: AiState::Idle,
             threat_list: HashMap::new(),
             spawn_position: None,

--- a/crates/services/src/base/world_entry.rs
+++ b/crates/services/src/base/world_entry.rs
@@ -42,6 +42,7 @@ use super::world_entry_methods::{
     handle_repair_inventory_item, handle_repair_inventory_items, handle_paid_repair_inventory_items,
     handle_recharge_inventory_items, handle_paid_recharge_inventory_items,
 };
+use super::world_entry_methods::inventory::update_bandolier_ammo;
 use super::world_entry_methods::{
     default_player_load_data, query_player_load_data,
     query_player_load_data_by_account, query_world_entry, query_world_stargates,
@@ -1008,6 +1009,23 @@ pub(crate) async fn handle_cell_message(
                     Err(e) => {
                         tracing::warn!(player_id, slot_id, error = %e, "ActiveSlotUpdate: DB write failed");
                     }
+                }
+            }
+        }
+        CellToBaseMsg::BandolierAmmoUpdate { player_id, slot_id, current_ammo, cur_ammo_type } => {
+            // `player_id` from the cell is the DB character_id (matches the
+            // `ActiveSlotUpdate` convention right above). Stage A wires the
+            // handler in but the cell does not yet emit this message —
+            // Stages B/C/D drive it from reload completion / slot swap /
+            // ammo change / logout.
+            if let Some(pool) = db_pool {
+                if let Err(e) = update_bandolier_ammo(
+                    pool.as_ref(), player_id, slot_id, current_ammo, cur_ammo_type,
+                ).await {
+                    tracing::warn!(
+                        player_id, slot_id, current_ammo, cur_ammo_type, error = %e,
+                        "BandolierAmmoUpdate: DB write failed"
+                    );
                 }
             }
         }

--- a/crates/services/src/base/world_entry.rs
+++ b/crates/services/src/base/world_entry.rs
@@ -1012,18 +1012,31 @@ pub(crate) async fn handle_cell_message(
                 }
             }
         }
-        CellToBaseMsg::BandolierAmmoUpdate { player_id, slot_id, current_ammo, cur_ammo_type } => {
+        CellToBaseMsg::BandolierAmmoUpdate { player_id, slot_id, expected_item_id, current_ammo, cur_ammo_type } => {
             // `player_id` from the cell is the DB character_id (matches the
-            // `ActiveSlotUpdate` convention right above). Stage A wires the
-            // handler in but the cell does not yet emit this message —
-            // Stages B/C/D drive it from reload completion / slot swap /
-            // ammo change / logout.
+            // `ActiveSlotUpdate` convention right above).
+            //
+            // Validate bounds before persisting — these payloads cross a
+            // service boundary, and any out-of-range value would become
+            // durable corruption. Bandolier holds 5 slots (0-4); ammo and
+            // ammo_type IDs are non-negative.
+            if !(0..5).contains(&slot_id)
+                || current_ammo < 0
+                || cur_ammo_type < 0
+                || expected_item_id <= 0
+            {
+                tracing::warn!(
+                    player_id, slot_id, expected_item_id, current_ammo, cur_ammo_type,
+                    "BandolierAmmoUpdate: dropping out-of-range payload"
+                );
+                return;
+            }
             if let Some(pool) = db_pool {
                 if let Err(e) = update_bandolier_ammo(
-                    pool.as_ref(), player_id, slot_id, current_ammo, cur_ammo_type,
+                    pool.as_ref(), player_id, slot_id, expected_item_id, current_ammo, cur_ammo_type,
                 ).await {
                     tracing::warn!(
-                        player_id, slot_id, current_ammo, cur_ammo_type, error = %e,
+                        player_id, slot_id, expected_item_id, current_ammo, cur_ammo_type, error = %e,
                         "BandolierAmmoUpdate: DB write failed"
                     );
                 }

--- a/crates/services/src/base/world_entry_methods/inventory/ammo.rs
+++ b/crates/services/src/base/world_entry_methods/inventory/ammo.rs
@@ -1,0 +1,47 @@
+//! SQL helpers for persisting per-bandolier-slot ammo state.
+//!
+//! Stage A wires the message + handler + writer end-to-end so subsequent
+//! stages can call this without touching the channel/handler plumbing. The
+//! cell does not yet emit `BandolierAmmoUpdate` (Stages B/C/D).
+
+use sqlx::PgPool;
+
+/// Persist the current ammo and selected ammo subtype for a bandolier slot.
+///
+/// The bandolier is `container_id = 3` (`INV_Bandolier`); the (character_id,
+/// container_id, slot_id) triple is unique under
+/// `sgw_inventory_unique_slot`, so this UPDATE touches at most one row.
+///
+/// A zero-row result means the slot was unequipped between the cell sending
+/// `BandolierAmmoUpdate` and this UPDATE running — log and move on, the next
+/// equip will re-seed from `default_ammo_type` and full clip.
+pub async fn update_bandolier_ammo(
+    pool: &PgPool,
+    character_id: i32,
+    slot_id: i32,
+    current_ammo: i32,
+    cur_ammo_type: i32,
+) -> Result<(), sqlx::Error> {
+    let res = sqlx::query(
+        "UPDATE sgw_inventory \
+         SET ammo = $1, cur_ammo_type = $2 \
+         WHERE character_id = $3 AND container_id = 3 AND slot_id = $4",
+    )
+    .bind(current_ammo)
+    .bind(cur_ammo_type)
+    .bind(character_id)
+    .bind(slot_id)
+    .execute(pool)
+    .await?;
+
+    if res.rows_affected() == 0 {
+        tracing::warn!(
+            character_id,
+            slot_id,
+            current_ammo,
+            cur_ammo_type,
+            "update_bandolier_ammo: no rows updated (slot empty?)"
+        );
+    }
+    Ok(())
+}

--- a/crates/services/src/base/world_entry_methods/inventory/ammo.rs
+++ b/crates/services/src/base/world_entry_methods/inventory/ammo.rs
@@ -1,8 +1,4 @@
 //! SQL helpers for persisting per-bandolier-slot ammo state.
-//!
-//! Stage A wires the message + handler + writer end-to-end so subsequent
-//! stages can call this without touching the channel/handler plumbing. The
-//! cell does not yet emit `BandolierAmmoUpdate` (Stages B/C/D).
 
 use sqlx::PgPool;
 
@@ -12,35 +8,41 @@ use sqlx::PgPool;
 /// container_id, slot_id) triple is unique under
 /// `sgw_inventory_unique_slot`, so this UPDATE touches at most one row.
 ///
-/// A zero-row result means the slot was unequipped between the cell sending
-/// `BandolierAmmoUpdate` and this UPDATE running — log and move on, the next
-/// equip will re-seed from `default_ammo_type` and full clip.
+/// `expected_item_id` is added to the WHERE clause as a TOCTOU guard. Between
+/// the cell sending `BandolierAmmoUpdate` and this UPDATE running, the player
+/// could have swapped the slot's weapon. Without the `type_id` predicate the
+/// UPDATE would silently scribble the old weapon's ammo onto the new one.
+/// A zero-row result here means either the slot is unequipped *or* the item
+/// changed — in both cases dropping the write is correct.
 pub async fn update_bandolier_ammo(
     pool: &PgPool,
     character_id: i32,
     slot_id: i32,
+    expected_item_id: i32,
     current_ammo: i32,
     cur_ammo_type: i32,
 ) -> Result<(), sqlx::Error> {
     let res = sqlx::query(
         "UPDATE sgw_inventory \
          SET ammo = $1, cur_ammo_type = $2 \
-         WHERE character_id = $3 AND container_id = 3 AND slot_id = $4",
+         WHERE character_id = $3 AND container_id = 3 AND slot_id = $4 AND type_id = $5",
     )
     .bind(current_ammo)
     .bind(cur_ammo_type)
     .bind(character_id)
     .bind(slot_id)
+    .bind(expected_item_id)
     .execute(pool)
     .await?;
 
     if res.rows_affected() == 0 {
-        tracing::warn!(
+        tracing::debug!(
             character_id,
             slot_id,
+            expected_item_id,
             current_ammo,
             cur_ammo_type,
-            "update_bandolier_ammo: no rows updated (slot empty?)"
+            "update_bandolier_ammo: no rows updated (slot empty or item swapped)"
         );
     }
     Ok(())

--- a/crates/services/src/base/world_entry_methods/inventory/grant.rs
+++ b/crates/services/src/base/world_entry_methods/inventory/grant.rs
@@ -330,6 +330,12 @@ pub async fn handle_grant_item(
                         item_id: row.item_id,
                         clip_size: row.clip_size,
                         default_ammo_type: row.default_ammo_type_id,
+                        // Stage A: a freshly-granted bandolier item starts
+                        // with an empty mag and the default ammo subtype.
+                        // Stages B/C will pick up these defaults; today the
+                        // shadow scalars on CellEntity still drive fire/reload.
+                        current_ammo: 0,
+                        cur_ammo_type: row.default_ammo_type_id,
                     };
                     if let Err(e) = tx
                         .send(BaseToCellMsg::UpdateBandolierItem {

--- a/crates/services/src/base/world_entry_methods/inventory/mod.rs
+++ b/crates/services/src/base/world_entry_methods/inventory/mod.rs
@@ -1,7 +1,9 @@
+pub mod ammo;
 pub mod core;
 pub mod grant;
 pub mod move_;
 
+pub use ammo::update_bandolier_ammo;
 pub use core::{send_full_inventory_update, handle_remove_inventory_item};
 pub use grant::{normalize_item_ids, item_allows_container, handle_grant_item};
 pub use move_::handle_move_inventory_item;

--- a/crates/services/src/base/world_entry_methods/mod.rs
+++ b/crates/services/src/base/world_entry_methods/mod.rs
@@ -12,7 +12,7 @@ pub mod vendor;
 
 // Re-export all public functions for backward compatibility
 pub use world_entry::{query_world_entry, query_world_stargates};
-pub use player_load::{query_player_load_data, query_player_load_data_by_account, query_inventory_items, default_player_load_data, query_bandolier_items, query_archetype_ability_tree, query_active_weapon_stats};
+pub use player_load::{query_player_load_data, query_player_load_data_by_account, query_inventory_items, default_player_load_data, query_bandolier_items, query_archetype_ability_tree};
 pub use progression::{handle_grant_xp, handle_grant_cash};
 pub use missions::{query_saved_missions, handle_mission_update};
 pub use mail::handle_mail_request;

--- a/crates/services/src/base/world_entry_methods/player_load/core.rs
+++ b/crates/services/src/base/world_entry_methods/player_load/core.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use sqlx::PgPool;
 
 use crate::mercury::PlayerLoadData;
-use super::meta::{default_player_load_data, query_archetype_ability_tree, query_active_weapon_stats};
+use super::meta::{default_player_load_data, query_archetype_ability_tree, query_bandolier_items};
 
 /// Container IDs used in equipment-visual queries. Mirrors the DB schema:
 /// 3 = bandolier, 4..=14 = the eleven equipment slots (head, torso, etc.).
@@ -145,8 +145,11 @@ pub async fn query_player_load_data(
                     );
                     crate::mercury::archetype_ability_tree(row.archetype)
                 });
-            let (active_weapon_clip_size, active_ammo_type) =
-                query_active_weapon_stats(pool.as_ref(), player_id, row.bandolier_slot).await;
+            // Stage C: bandolier_items now carries clip_size + cur_ammo_type
+            // for every populated slot, so the old `query_active_weapon_stats`
+            // (which only fetched the active slot's clip + default ammo) is
+            // redundant. `map_loaded.rs` reads the active item directly.
+            let bandolier_items = query_bandolier_items(db_pool, player_id).await;
 
             PlayerLoadData {
                 player_id,
@@ -169,8 +172,7 @@ pub async fn query_player_load_data(
                 access_level: row.access_level,
                 skin_color_id: row.skin_color_id,
                 active_bandolier_slot: row.bandolier_slot,
-                active_weapon_clip_size,
-                active_ammo_type,
+                bandolier_items,
                 ability_tree,
                 items,
             }

--- a/crates/services/src/base/world_entry_methods/player_load/meta.rs
+++ b/crates/services/src/base/world_entry_methods/player_load/meta.rs
@@ -48,8 +48,7 @@ pub fn default_player_load_data() -> PlayerLoadData {
         access_level: 0,
         skin_color_id: 0,
         active_bandolier_slot: 0,
-        active_weapon_clip_size: 0,
-        active_ammo_type: 0,
+        bandolier_items: vec![],
         ability_tree: archetype_ability_tree(1),
         items: vec![],
     }
@@ -61,13 +60,22 @@ struct BandolierItemRow {
     item_id: i32,
     clip_size: i32,
     default_ammo_type_id: i32,
+    /// Per-slot remaining ammo from `sgw_inventory.ammo`. Populated by Stage A
+    /// but not yet read by fire/reload — Stage C wires the consumers.
+    current_ammo: i32,
+    /// Per-slot selected ammo subtype from `sgw_inventory.cur_ammo_type`. Zero
+    /// means "no explicit choice" — Rust-side defaulting falls back to the
+    /// item's default_ammo_type below.
+    cur_ammo_type: i32,
 }
 
 const BANDOLIER_ITEMS_QUERY: &str = r#"
 SELECT inv.slot_id, inv.type_id AS item_id, COALESCE(ri.clip_size, 0) AS clip_size,
        CASE WHEN ri.default_ammo_type IS NULL THEN 0
             ELSE array_position(enum_range(NULL::resources."EAmmoType"), ri.default_ammo_type) - 1
-       END AS default_ammo_type_id
+       END AS default_ammo_type_id,
+       inv.ammo AS current_ammo,
+       inv.cur_ammo_type
 FROM sgw_inventory inv
 JOIN resources.items ri ON ri.item_id = inv.type_id
 WHERE inv.character_id = $1 AND inv.container_id = 3
@@ -79,12 +87,22 @@ fn map_bandolier_rows(
 ) -> Vec<(i32, cimmeria_entity::cell_entity::BandolierItem)> {
     rows.into_iter()
         .map(|row| {
+            // Treat 0 as "no explicit choice" and fall back to the item's
+            // default ammo type — matches the legacy Account.py behavior where
+            // a slot with no override picks default_ammo_type at load time.
+            let cur_ammo_type = if row.cur_ammo_type == 0 {
+                row.default_ammo_type_id
+            } else {
+                row.cur_ammo_type
+            };
             (
                 row.slot_id,
                 cimmeria_entity::cell_entity::BandolierItem {
                     item_id: row.item_id,
                     clip_size: row.clip_size,
                     default_ammo_type: row.default_ammo_type_id,
+                    current_ammo: row.current_ammo,
+                    cur_ammo_type,
                 },
             )
         })
@@ -185,42 +203,3 @@ pub async fn query_archetype_ability_tree(pool: &PgPool, archetype_id: i32) -> O
     Some(ability_tree)
 }
 
-/// Query active weapon stats from the player's equipped bandolier slot.
-pub async fn query_active_weapon_stats(
-    pool: &PgPool,
-    player_id: i32,
-    bandolier_slot: i32,
-) -> (i32, i32) {
-    #[derive(sqlx::FromRow)]
-    struct ActiveWeaponRow {
-        clip_size: i32,
-        default_ammo_type_id: i32,
-    }
-
-    match sqlx::query_as::<_, ActiveWeaponRow>(
-        r#"
-        SELECT COALESCE(ri.clip_size, 0) AS clip_size,
-               CASE WHEN ri.default_ammo_type IS NULL THEN 0
-                    ELSE array_position(enum_range(NULL::resources."EAmmoType"), ri.default_ammo_type) - 1
-               END AS default_ammo_type_id
-        FROM sgw_inventory inv
-        JOIN resources.items ri ON ri.item_id = inv.type_id
-        WHERE inv.character_id = $1
-          AND inv.container_id = 3
-          AND inv.slot_id = $2
-        LIMIT 1
-        "#,
-    )
-    .bind(player_id)
-    .bind(bandolier_slot)
-    .fetch_optional(pool)
-    .await
-    {
-        Ok(Some(row)) => (row.clip_size, row.default_ammo_type_id),
-        Ok(None) => (0, 0),
-        Err(e) => {
-            tracing::error!(player_id, bandolier_slot, "query_active_weapon_stats failed: {e}");
-            (0, 0)
-        }
-    }
-}

--- a/crates/services/src/base/world_entry_methods/player_load/mod.rs
+++ b/crates/services/src/base/world_entry_methods/player_load/mod.rs
@@ -2,4 +2,4 @@ pub mod core;
 pub mod meta;
 
 pub use core::{query_player_load_data, query_player_load_data_by_account, query_inventory_items};
-pub use meta::{default_player_load_data, query_bandolier_items, query_archetype_ability_tree, query_active_weapon_stats};
+pub use meta::{default_player_load_data, query_bandolier_items, query_archetype_ability_tree};

--- a/crates/services/src/cell/abilities.rs
+++ b/crates/services/src/cell/abilities.rs
@@ -389,17 +389,7 @@ pub async fn handle_use_ability(
         // dirty ammo stat (e.g. ground-targeted ability that consumed ammo
         // without picking up a target via auto-aim).
         if needs_ammo_stat_send {
-            let attacker_payload = match space_mgr.get_entity_mut(entity_id) {
-                Some(e) => {
-                    let p = e.stats.serialize_dirty();
-                    e.stats.clear_dirty();
-                    p
-                }
-                None => Vec::new(),
-            };
-            if !attacker_payload.is_empty() {
-                send_entity_method(entity_id, 20, attacker_payload, tx, space_mgr).await;
-            }
+            flush_attacker_ammo_stat(entity_id, tx, space_mgr).await;
         }
         return;
     }
@@ -410,7 +400,14 @@ pub async fn handle_use_ability(
     // entities mutably at once, we snapshot the attacker stats first.
     let attacker_stats = match space_mgr.get_entity(entity_id) {
         Some(e) => e.stats.clone(),
-        None => return,
+        None => {
+            // Defensive: entity vanished after the consume mutation. Flush
+            // before exiting so the client still sees the ammo decrement.
+            if needs_ammo_stat_send {
+                flush_attacker_ammo_stat(entity_id, tx, space_mgr).await;
+            }
+            return;
+        }
     };
 
     // Calculate QR
@@ -418,6 +415,11 @@ pub async fn handle_use_ability(
         Some(e) => e,
         None => {
             tracing::debug!(target_id, "useAbility: target not found");
+            // Flush ammo decrement even when target lookup fails — the shot
+            // still left the chamber from the player's perspective.
+            if needs_ammo_stat_send {
+                flush_attacker_ammo_stat(entity_id, tx, space_mgr).await;
+            }
             return;
         }
     };
@@ -452,7 +454,15 @@ pub async fn handle_use_ability(
     // Apply health damage to target
     let target = match space_mgr.get_entity_mut(target_eid) {
         Some(e) => e,
-        None => return,
+        None => {
+            // Flush ammo decrement before exiting — the shot was fired even
+            // if the target was removed between the immutable lookup above
+            // and the mutable lookup here.
+            if needs_ammo_stat_send {
+                flush_attacker_ammo_stat(entity_id, tx, space_mgr).await;
+            }
+            return;
+        }
     };
 
     let (effect_results, _total_health_damage) = combat::calculate_damage(
@@ -529,19 +539,9 @@ pub async fn handle_use_ability(
     // onStatUpdate to attacker — drains AmmoSlot{N} dirty bits set by
     // `set_slot_ammo` on the consume path so the bandolier UI updates on every
     // shot. Skipped if the consume path didn't run (no ammo cost or NPC
-    // attacker), and we re-acquire `entity` because `target` borrowed `space_mgr`.
+    // attacker).
     if needs_ammo_stat_send {
-        let attacker_payload = match space_mgr.get_entity_mut(entity_id) {
-            Some(e) => {
-                let p = e.stats.serialize_dirty();
-                e.stats.clear_dirty();
-                p
-            }
-            None => Vec::new(),
-        };
-        if !attacker_payload.is_empty() {
-            send_entity_method(entity_id, 20, attacker_payload, tx, space_mgr).await;
-        }
+        flush_attacker_ammo_stat(entity_id, tx, space_mgr).await;
     }
 
     // ── Send state field update if target died ──
@@ -753,6 +753,28 @@ fn generate_loot_on_death(
 /// Formula: 10 * mob_level.
 fn kill_xp(mob_level: u32) -> u64 {
     10 * mob_level as u64
+}
+
+/// Drain the attacker's dirty stats and push `onStatUpdate` (method 20) to its
+/// client. Used by `handle_use_ability` after a successful ammo consume — and
+/// crucially before any early-return that follows the consume — so the client
+/// always sees the AmmoSlot{N} decrement, even when downstream lookups fail.
+async fn flush_attacker_ammo_stat(
+    entity_id: u32,
+    tx: &mpsc::Sender<CellToBaseMsg>,
+    space_mgr: &mut SpaceManager,
+) {
+    let payload = match space_mgr.get_entity_mut(entity_id) {
+        Some(e) => {
+            let p = e.stats.serialize_dirty();
+            e.stats.clear_dirty();
+            p
+        }
+        None => Vec::new(),
+    };
+    if !payload.is_empty() {
+        send_entity_method(entity_id, 20, payload, tx, space_mgr).await;
+    }
 }
 
 /// Generate a pseudo-random value in [0.0, 1.0) from entity/ability/sequence.

--- a/crates/services/src/cell/abilities.rs
+++ b/crates/services/src/cell/abilities.rs
@@ -258,6 +258,18 @@ pub async fn handle_use_ability(
     // sole refill path, so the eager promotion that used to live here is gone.
     let required_ammo = ability_def.as_ref().map_or(0, |d| d.required_ammo);
 
+    // Block firing while a reload warmup is still pending. Without this, the
+    // player could fire during the reload animation — those shots would
+    // decrement against the pre-refill ammo and then be silently overwritten
+    // by the tick's refill, effectively granting free ammo.
+    if required_ammo > 0
+        && entity.is_player
+        && entity.reload_complete_at.is_some_and(|t| std::time::Instant::now() < t)
+    {
+        tracing::debug!(entity_id, ability_id, "useAbility: reload in progress, blocking fire");
+        return;
+    }
+
     let current_ammo = entity.active_ammo();
     if required_ammo > 0 && entity.is_player && current_ammo < required_ammo {
         tracing::debug!(entity_id, ability_id, current = current_ammo, required = required_ammo, "useAbility: not enough ammo");

--- a/crates/services/src/cell/abilities.rs
+++ b/crates/services/src/cell/abilities.rs
@@ -253,22 +253,14 @@ pub async fn handle_use_ability(
         None => return,
     };
 
-    // Check ammo for ranged abilities (players only — NPCs have infinite ammo)
+    // Check ammo for ranged abilities (players only — NPCs have infinite ammo).
+    // Stage C: read through the bandolier helpers; Stage B's reload tick is the
+    // sole refill path, so the eager promotion that used to live here is gone.
     let required_ammo = ability_def.as_ref().map_or(0, |d| d.required_ammo);
 
-    // If a pending reload's warmup has elapsed, promote the refill now so the
-    // ammo check below sees the full magazine. If it hasn't elapsed, the fire
-    // is gated by the ammo check (current_ammo is still pre-reload).
-    if let Some(deadline) = entity.reload_complete_at {
-        if std::time::Instant::now() >= deadline {
-            entity.current_ammo = entity.max_ammo;
-            entity.reload_complete_at = None;
-            tracing::debug!(entity_id, "useAbility: reload warmup elapsed, magazine refilled");
-        }
-    }
-
-    if required_ammo > 0 && entity.is_player && entity.current_ammo < required_ammo {
-        tracing::debug!(entity_id, ability_id, current = entity.current_ammo, required = required_ammo, "useAbility: not enough ammo");
+    let current_ammo = entity.active_ammo();
+    if required_ammo > 0 && entity.is_player && current_ammo < required_ammo {
+        tracing::debug!(entity_id, ability_id, current = current_ammo, required = required_ammo, "useAbility: not enough ammo");
         return;
     }
 
@@ -276,10 +268,17 @@ pub async fn handle_use_ability(
     let cooldown_duration = std::time::Duration::from_secs_f32(cooldown_secs);
     entity.abilities.start_ability_cooldown(ability_id, cooldown_duration);
 
-    // Consume ammo (players only)
+    // Consume ammo (players only). Routes through `set_slot_ammo` so the
+    // AmmoSlot{N} stat updates and the slot is marked dirty for batched
+    // persistence (drained on reload completion / slot swap / ammo change /
+    // logout — Stage D wires the swap and logout flushes).
+    let mut needs_ammo_stat_send = false;
     if required_ammo > 0 && entity.is_player {
-        entity.current_ammo -= required_ammo;
-        tracing::debug!(entity_id, ability_id, ammo_remaining = entity.current_ammo, "useAbility: consumed ammo");
+        let new_ammo = entity.active_ammo() - required_ammo;
+        let slot = entity.active_bandolier_slot;
+        entity.set_slot_ammo(slot, new_ammo);
+        needs_ammo_stat_send = true;
+        tracing::debug!(entity_id, ability_id, ammo_remaining = entity.active_ammo(), "useAbility: consumed ammo");
     }
 
     // Get effect sequence ID for this ability invocation
@@ -371,7 +370,23 @@ pub async fn handle_use_ability(
     // ── Combat resolution (if target specified) ──
 
     if target_id <= 0 {
-        return; // Self-buff or no-target ability — skip damage
+        // Self-buff or no-target ability — skip damage but still flush any
+        // dirty ammo stat (e.g. ground-targeted ability that consumed ammo
+        // without picking up a target via auto-aim).
+        if needs_ammo_stat_send {
+            let attacker_payload = match space_mgr.get_entity_mut(entity_id) {
+                Some(e) => {
+                    let p = e.stats.serialize_dirty();
+                    e.stats.clear_dirty();
+                    p
+                }
+                None => Vec::new(),
+            };
+            if !attacker_payload.is_empty() {
+                send_entity_method(entity_id, 20, attacker_payload, tx, space_mgr).await;
+            }
+        }
+        return;
     }
 
     let target_eid = target_id as u32;
@@ -495,6 +510,24 @@ pub async fn handle_use_ability(
 
     // onStatUpdate to target (their health bar changes)
     send_entity_method(target_eid, 20, target_stat_update, tx, space_mgr).await;
+
+    // onStatUpdate to attacker — drains AmmoSlot{N} dirty bits set by
+    // `set_slot_ammo` on the consume path so the bandolier UI updates on every
+    // shot. Skipped if the consume path didn't run (no ammo cost or NPC
+    // attacker), and we re-acquire `entity` because `target` borrowed `space_mgr`.
+    if needs_ammo_stat_send {
+        let attacker_payload = match space_mgr.get_entity_mut(entity_id) {
+            Some(e) => {
+                let p = e.stats.serialize_dirty();
+                e.stats.clear_dirty();
+                p
+            }
+            None => Vec::new(),
+        };
+        if !attacker_payload.is_empty() {
+            send_entity_method(entity_id, 20, attacker_payload, tx, space_mgr).await;
+        }
+    }
 
     // ── Send state field update if target died ──
 
@@ -759,5 +792,103 @@ mod tests {
             let v = pseudo_random(i, i as i32 * 7, i * 13);
             assert!(v >= 0.0 && v < 1.0, "value out of range: {v}");
         }
+    }
+
+    /// Stage E: firing an ability with `required_ammo > 0` must decrement the
+    /// active slot's `current_ammo`, mirror that into the AmmoSlot{N} stat,
+    /// mark the slot dirty for batched persistence, and emit `onStatUpdate`
+    /// (method 20) carrying the new AmmoSlot value.
+    #[tokio::test]
+    async fn consume_ammo_writes_ammoslot_stat_and_marks_dirty() {
+        use cimmeria_entity::abilities::AbilityDef;
+        use cimmeria_entity::cell_entity::BandolierItem;
+        use cimmeria_entity::stats::AMMO_SLOT_1;
+
+        let mut mgr = SpaceManager::new(1);
+        let xml = r#"<?xml version="1.0"?><Spaces><Space WorldName="Castle_CellBlock" Instanced="true" MinX="-800" MaxX="800" MinY="-800" MaxY="800" /></Spaces>"#;
+        mgr.parse_spaces_xml(xml).unwrap();
+        mgr.create_startup_spaces(r#"<?xml version="1.0"?><Spaces></Spaces>"#).unwrap();
+        mgr.create_entity(1, "Castle_CellBlock", [0.0; 3], [0.0; 3]).unwrap();
+
+        // A ranged ability with required_ammo = 1, no warmup, short cooldown.
+        // event_set_id = None → no onSequence sends, keeping rx noise down.
+        let ability_id = 4242;
+        mgr.ability_defs.insert(ability_id, AbilityDef {
+            ability_id,
+            name: "test_fire".to_string(),
+            cooldown: 0.5,
+            warmup: 0.0,
+            flags: 0,
+            is_ranged: true,
+            min_range: 0,
+            max_range: 30,
+            target_type_id: 0,
+            effect_ids: vec![],
+            moniker_ids: vec![],
+            required_ammo: 1,
+            event_set_id: None,
+            velocity: 0.0,
+        });
+
+        // Player setup: bandolier slot 0 holds a 30-round magazine, full.
+        // is_player must be true so `send_entity_method` routes the
+        // onStatUpdate via the player path (EntityMethodCall).
+        if let Some(e) = mgr.get_entity_mut(1) {
+            e.is_player = true;
+            e.player_id = Some(100);
+            e.abilities.add_ability(ability_id);
+            e.bandolier_items.insert(0, BandolierItem {
+                item_id: 1,
+                clip_size: 30,
+                default_ammo_type: 2,
+                current_ammo: 30,
+                cur_ammo_type: 2,
+            });
+            if let Some(stat) = e.stats.get_mut(AMMO_SLOT_1) {
+                stat.update(0, 30, 30);
+                stat.clear_dirty();
+            }
+        }
+
+        let (tx, mut rx) = mpsc::channel(32);
+        // target_id = 0 → no target path (skips combat resolution and
+        // damage-side stat sends). The consume + ammo-stat-flush block at
+        // the no-target branch (abilities.rs:376-388) still runs.
+        handle_use_ability(1, ability_id, 0, &tx, &mut mgr).await;
+
+        // ── Entity-state assertions ─────────────────────────────────────
+        let entity = mgr.get_entity(1).unwrap();
+        assert_eq!(entity.bandolier_items[&0].current_ammo, 29, "current_ammo should decrement by required_ammo");
+        assert_eq!(entity.stats.get(AMMO_SLOT_1).unwrap().cur, 29, "AmmoSlot1 stat should mirror current_ammo");
+        assert!(entity.bandolier_ammo_dirty.contains(&0), "active slot should be marked dirty for batched persist");
+
+        // ── Wire-message assertions ─────────────────────────────────────
+        // Drain rx and find the onStatUpdate (method 20). Other messages
+        // (onTimerUpdate=12, onStateFieldUpdate=19) may also arrive.
+        let mut found_stat_update = false;
+        while let Ok(msg) = rx.try_recv() {
+            if let CellToBaseMsg::EntityMethodCall { entity_id, method_index, args } = msg {
+                if method_index == 20 && entity_id == 1 {
+                    // Stat list payload: count:u32, then per-stat (id:i32, min:i32, cur:i32, max:i32).
+                    assert!(args.len() >= 4, "stat update payload too short");
+                    let count = u32::from_le_bytes([args[0], args[1], args[2], args[3]]);
+                    assert!(count >= 1, "stat update should contain at least one entry");
+                    // Walk the entries to find AmmoSlot1.
+                    let mut found_ammo = false;
+                    for i in 0..count as usize {
+                        let off = 4 + i * 16;
+                        let stat_id = i32::from_le_bytes([args[off], args[off+1], args[off+2], args[off+3]]);
+                        let cur = i32::from_le_bytes([args[off+8], args[off+9], args[off+10], args[off+11]]);
+                        if stat_id == AMMO_SLOT_1 {
+                            assert_eq!(cur, 29, "onStatUpdate should report AmmoSlot1.cur = 29");
+                            found_ammo = true;
+                        }
+                    }
+                    assert!(found_ammo, "onStatUpdate did not contain AmmoSlot1 entry");
+                    found_stat_update = true;
+                }
+            }
+        }
+        assert!(found_stat_update, "expected an EntityMethodCall(method=20, onStatUpdate) carrying AmmoSlot1");
     }
 }

--- a/crates/services/src/cell/abilities.rs
+++ b/crates/services/src/cell/abilities.rs
@@ -258,13 +258,16 @@ pub async fn handle_use_ability(
     // sole refill path, so the eager promotion that used to live here is gone.
     let required_ammo = ability_def.as_ref().map_or(0, |d| d.required_ammo);
 
-    // Block firing while a reload warmup is still pending. Without this, the
-    // player could fire during the reload animation — those shots would
-    // decrement against the pre-refill ammo and then be silently overwritten
-    // by the tick's refill, effectively granting free ammo.
+    // Block firing while a reload is in flight — checked as `is_some()`, not
+    // `now < deadline`. Between the deadline elapsing and the next 100 ms
+    // `reload_completion_tick`, the warmup is "over" by clock but the magazine
+    // hasn't been refilled yet; allowing fire in that window would decrement
+    // against pre-refill ammo and then be silently overwritten by the tick,
+    // effectively granting free ammo. The tick is the sole authority that
+    // clears `reload_complete_at`, so we gate on its presence.
     if required_ammo > 0
         && entity.is_player
-        && entity.reload_complete_at.is_some_and(|t| std::time::Instant::now() < t)
+        && entity.reload_complete_at.is_some()
     {
         tracing::debug!(entity_id, ability_id, "useAbility: reload in progress, blocking fire");
         return;

--- a/crates/services/src/cell/cell_methods/inventory.rs
+++ b/crates/services/src/cell/cell_methods/inventory.rs
@@ -42,13 +42,14 @@ pub async fn flush_dirty_bandolier_ammo(
     // Drain into a Vec so we don't hold the borrow on `entity` across awaits.
     let dirty: Vec<i32> = entity.bandolier_ammo_dirty.drain().collect();
     for slot_id in dirty {
-        let (current_ammo, cur_ammo_type) = match entity.bandolier_items.get(&slot_id) {
-            Some(item) => (item.current_ammo, item.cur_ammo_type),
+        let (item_id, current_ammo, cur_ammo_type) = match entity.bandolier_items.get(&slot_id) {
+            Some(item) => (item.item_id, item.current_ammo, item.cur_ammo_type),
             None => continue,
         };
         let _ = tx.send(CellToBaseMsg::BandolierAmmoUpdate {
             player_id,
             slot_id,
+            expected_item_id: item_id,
             current_ammo,
             cur_ammo_type,
         }).await;
@@ -187,7 +188,7 @@ pub async fn dispatch(
                     // drains the active slot when reloads finish; this catches
                     // mid-magazine swaps where the player swaps weapons before
                     // reloading the empty one.
-                    let (prev_persist, new_ammo_type): (Option<(i32, i32, i32)>, Option<i32>) = {
+                    let (prev_persist, new_ammo_type): (Option<(i32, i32, i32, i32)>, Option<i32>) = {
                         let entity = match space_mgr.get_entity_mut(entity_id) {
                             Some(e) => e,
                             None => return true,
@@ -195,13 +196,29 @@ pub async fn dispatch(
                         let prev_slot = entity.active_bandolier_slot;
                         let prev_persist = if entity.bandolier_ammo_dirty.contains(&prev_slot) {
                             entity.bandolier_items.get(&prev_slot).map(|item| {
-                                (prev_slot, item.current_ammo, item.cur_ammo_type)
+                                (prev_slot, item.item_id, item.current_ammo, item.cur_ammo_type)
                             })
                         } else {
                             None
                         };
                         if prev_persist.is_some() {
                             entity.bandolier_ammo_dirty.remove(&prev_slot);
+                        }
+                        // Cancel any in-flight reload only if the swap actually
+                        // moves to a different slot. A same-slot "swap" (no-op
+                        // from the client, or replayed packet) must not cancel
+                        // an in-progress reload. Otherwise the fire-gate would
+                        // still block until the deadline, and the tick would
+                        // refill the original slot — but the player has moved
+                        // on; re-pressing R after swapping back restarts the
+                        // reload from scratch.
+                        if slot_id != prev_slot && entity.reload_complete_at.is_some() {
+                            entity.reload_complete_at = None;
+                            entity.reload_slot_id = None;
+                            tracing::debug!(
+                                entity_id, prev_slot, new_slot = slot_id,
+                                "active slot change cancelled in-flight reload"
+                            );
                         }
                         entity.active_bandolier_slot = slot_id;
                         let new_ammo_type = entity.bandolier_items
@@ -212,10 +229,11 @@ pub async fn dispatch(
 
                     // Phase 2: send messages now that the borrow is released.
                     if let Some(player_id) = player_id {
-                        if let Some((p_slot, current_ammo, cur_ammo_type)) = prev_persist {
+                        if let Some((p_slot, item_id, current_ammo, cur_ammo_type)) = prev_persist {
                             let _ = tx.send(CellToBaseMsg::BandolierAmmoUpdate {
                                 player_id,
                                 slot_id: p_slot,
+                                expected_item_id: item_id,
                                 current_ammo,
                                 cur_ammo_type,
                             }).await;
@@ -271,13 +289,26 @@ pub async fn dispatch(
                         Some(e) => e,
                         None => return true,
                     };
-                    let slot = entity.bandolier_items.iter()
-                        .find(|(_, item)| item.item_id == item_id)
-                        .map(|(s, _)| *s);
-                    let slot = match slot {
-                        Some(s) => s,
-                        None => {
+                    // Match all slots holding this item_id. The wire request
+                    // doesn't carry a slot/instance id, so duplicate weapons
+                    // are ambiguous — reject rather than guess. A future
+                    // protocol revision should add slot id to the message.
+                    let matches: Vec<i32> = entity.bandolier_items.iter()
+                        .filter(|(_, item)| item.item_id == item_id)
+                        .map(|(s, _)| *s)
+                        .collect();
+                    let slot = match matches.as_slice() {
+                        [s] => *s,
+                        [] => {
                             tracing::warn!(entity_id, item_id, "requestAmmoChange: item not in bandolier");
+                            return true;
+                        }
+                        ambiguous => {
+                            tracing::warn!(
+                                entity_id, item_id,
+                                slot_count = ambiguous.len(),
+                                "requestAmmoChange: ambiguous — multiple slots hold this item_id, rejecting"
+                            );
                             return true;
                         }
                     };
@@ -286,20 +317,22 @@ pub async fn dispatch(
                     // BandolierAmmoUpdate emitted below persists it now.
                     let item = entity.bandolier_items.get_mut(&slot).unwrap();
                     item.cur_ammo_type = ammo_type;
+                    let item_id_for_persist = item.item_id;
                     let current_ammo = item.current_ammo;
                     entity.bandolier_ammo_dirty.insert(slot);
                     entity.bandolier_ammo_dirty.remove(&slot);
                     let is_active = slot == entity.active_bandolier_slot;
                     let player_id = entity.player_id;
-                    (player_id, (slot, current_ammo, ammo_type), is_active)
+                    (player_id, (slot, item_id_for_persist, current_ammo, ammo_type), is_active)
                 };
 
                 // Phase 2: persist + (if active) refresh the client's ammo-type indicator.
                 if let Some(player_id) = player_id {
-                    let (slot_id, current_ammo, cur_ammo_type) = persist;
+                    let (slot_id, expected_item_id, current_ammo, cur_ammo_type) = persist;
                     let _ = tx.send(CellToBaseMsg::BandolierAmmoUpdate {
                         player_id,
                         slot_id,
+                        expected_item_id,
                         current_ammo,
                         cur_ammo_type,
                     }).await;
@@ -425,9 +458,10 @@ mod tests {
         // → ActiveSlotUpdate(1) → onEntityProperty(AmmoTypeId, slot1.cur_ammo_type=7).
         let m1 = rx.try_recv().expect("expected BandolierAmmoUpdate(prev slot)");
         match m1 {
-            CellToBaseMsg::BandolierAmmoUpdate { player_id, slot_id, current_ammo, cur_ammo_type } => {
+            CellToBaseMsg::BandolierAmmoUpdate { player_id, slot_id, expected_item_id, current_ammo, cur_ammo_type } => {
                 assert_eq!(player_id, 100);
                 assert_eq!(slot_id, 0, "first swap msg should flush prev slot 0");
+                assert_eq!(expected_item_id, 10, "should carry slot 0's item_id for TOCTOU guard");
                 assert_eq!(current_ammo, 28);
                 assert_eq!(cur_ammo_type, 1);
             }
@@ -477,6 +511,59 @@ mod tests {
         assert_eq!(entity.active_bandolier_slot, 0);
     }
 
+    /// CodeRabbit #4: starting a reload on slot 0, swapping to slot 1, then
+    /// letting the warmup elapse must NOT refill slot 1 with slot 0's clip
+    /// size. The fix cancels the in-flight reload on swap, so the tick has
+    /// nothing to promote and slot 1's ammo stays where it was.
+    #[tokio::test]
+    async fn slot_swap_cancels_in_flight_reload() {
+        use crate::cell::content::build_engine;
+        use cimmeria_entity::cell_entity::BandolierItem;
+
+        let mut mgr = make_test_space_mgr();
+        mgr.create_entity(1, "Castle_CellBlock", [0.0; 3], [0.0; 3]).unwrap();
+
+        if let Some(e) = mgr.get_entity_mut(1) {
+            e.is_player = true;
+            e.player_id = Some(100);
+            e.bandolier_items.insert(0, BandolierItem {
+                item_id: 10, clip_size: 30, default_ammo_type: 1,
+                current_ammo: 5, cur_ammo_type: 1,
+            });
+            e.bandolier_items.insert(1, BandolierItem {
+                item_id: 11, clip_size: 12, default_ammo_type: 7,
+                current_ammo: 8, cur_ammo_type: 7,
+            });
+            e.active_bandolier_slot = 0;
+            // Simulate a reload of slot 0 currently warming up.
+            e.reload_complete_at = Some(
+                std::time::Instant::now() + std::time::Duration::from_secs(10),
+            );
+            e.reload_slot_id = Some(0);
+        }
+        mgr.connect_entity(1);
+
+        let (tx, mut rx) = mpsc::channel(64);
+        let engine = build_engine(None).await;
+
+        // Swap to slot 1.
+        let mut swap = Vec::with_capacity(8);
+        swap.extend_from_slice(&3i32.to_le_bytes());
+        swap.extend_from_slice(&1i32.to_le_bytes());
+        dispatch(1, REQUEST_ACTIVE_SLOT_CHANGE, &swap, &tx, &mut mgr, &engine).await;
+
+        let entity = mgr.get_entity(1).unwrap();
+        assert!(entity.reload_complete_at.is_none(), "swap should cancel in-flight reload");
+        assert!(entity.reload_slot_id.is_none(), "swap should clear pinned slot");
+        assert_eq!(entity.bandolier_items[&0].current_ammo, 5, "cancelled reload must NOT refill slot 0");
+        assert_eq!(entity.bandolier_items[&1].current_ammo, 8, "slot 1 untouched");
+        assert_eq!(entity.active_bandolier_slot, 1);
+
+        // Drain the rx so the channel doesn't error if assertions above
+        // succeeded (slot-swap emits ActiveSlotUpdate and onEntityProperty).
+        while rx.try_recv().is_ok() {}
+    }
+
     /// Stage E: requestAmmoChange must update the slot's `cur_ammo_type`,
     /// emit exactly one BandolierAmmoUpdate (drained immediately, NOT pending
     /// for logout flush), and — when the slot is active — push an
@@ -514,9 +601,10 @@ mod tests {
         // First message: BandolierAmmoUpdate carrying the new type + existing ammo.
         let m1 = rx.try_recv().expect("expected BandolierAmmoUpdate");
         match m1 {
-            CellToBaseMsg::BandolierAmmoUpdate { player_id, slot_id, current_ammo, cur_ammo_type } => {
+            CellToBaseMsg::BandolierAmmoUpdate { player_id, slot_id, expected_item_id, current_ammo, cur_ammo_type } => {
                 assert_eq!(player_id, 100);
                 assert_eq!(slot_id, 0);
+                assert_eq!(expected_item_id, 42, "should carry the slot's item_id for TOCTOU guard");
                 assert_eq!(current_ammo, 20);
                 assert_eq!(cur_ammo_type, 3);
             }

--- a/crates/services/src/cell/cell_methods/inventory.rs
+++ b/crates/services/src/cell/cell_methods/inventory.rs
@@ -165,6 +165,14 @@ pub async fn dispatch(
                 let bag_id = i32::from_le_bytes([args[0], args[1], args[2], args[3]]);
                 let slot_id = i32::from_le_bytes([args[4], args[5], args[6], args[7]]);
                 tracing::debug!(entity_id, bag_id, slot_id, "requestActiveSlotChange");
+                // Reject out-of-range slots before any mutation. The bandolier
+                // has 5 slots (0-4); a forged value would otherwise leave the
+                // entity in an impossible local state, cancel any in-flight
+                // reload, and propagate via ActiveSlotUpdate to base.
+                if !(0..5).contains(&slot_id) {
+                    tracing::warn!(entity_id, bag_id, slot_id, "requestActiveSlotChange: slot_id out of range, rejecting");
+                    return true;
+                }
                 // Only bandolier (container 3) carries an active slot.
                 if bag_id == 3 {
                     // Resolve player_id BEFORE taking the mutable borrow on
@@ -285,6 +293,14 @@ pub async fn dispatch(
                     return true;
                 }
 
+                // Snapshot the weapon's allowed-ammo whitelist BEFORE taking
+                // the mutable entity borrow — both read from `space_mgr` and
+                // can't coexist. `None` means the cache had no entry (custom
+                // item the loader skipped), in which case we accept any
+                // positive ammo_type to match the legacy `pass` semantics
+                // for unknown weapons.
+                let weapon_def = space_mgr.item_defs.get(&item_id).cloned();
+
                 // Phase 1: locate the slot, mutate, capture the BandolierAmmoUpdate
                 // payload + active-slot flag, drop the mutable borrow.
                 let (player_id, persist, is_active) = {
@@ -315,6 +331,25 @@ pub async fn dispatch(
                             return true;
                         }
                     };
+                    // Validate ammo_type against the weapon's allowed
+                    // subtypes whitelist (snapshotted into `weapon_def`
+                    // above). Without this an attacker could persist an
+                    // arbitrary ammo subtype that the client UI can't
+                    // render. Falls through when the cache entry is
+                    // missing — see comment at the snapshot site.
+                    if let Some(def) = weapon_def.as_ref() {
+                        let allowed = ammo_type == def.default_ammo_type
+                            || def.allowed_ammo_types.iter().any(|&a| a == ammo_type);
+                        if !allowed {
+                            tracing::warn!(
+                                entity_id, item_id, ammo_type,
+                                allowed = ?def.allowed_ammo_types,
+                                default_ammo = def.default_ammo_type,
+                                "requestAmmoChange: ammo_type not in weapon's allowed list, rejecting"
+                            );
+                            return true;
+                        }
+                    }
                     // Mutate the slot. We mark dirty (so any in-flight flush
                     // path sees the change) and immediately drain — the
                     // BandolierAmmoUpdate emitted below persists it now.
@@ -672,6 +707,88 @@ mod tests {
                 "cur_ammo_type should be unchanged for bad_ammo_type={bad_ammo_type}");
             assert!(!entity.bandolier_ammo_dirty.contains(&0),
                 "no dirty flag for bad_ammo_type={bad_ammo_type}");
+        }
+    }
+
+    /// CodeRabbit #15: requestAmmoChange must reject ammo subtypes that aren't
+    /// in the weapon's `allowed_ammo_types` whitelist (mirrors
+    /// `resources.items.ammo_types`). Items with no cache entry fall through
+    /// (matching legacy `pass` for unknown weapons) — already covered by
+    /// the existing happy-path test.
+    #[tokio::test]
+    async fn request_ammo_change_rejects_unlisted_subtype() {
+        use crate::cell::spawner::WeaponDef;
+
+        let mut mgr = make_test_space_mgr();
+        mgr.create_entity(1, "Castle_CellBlock", [0.0; 3], [0.0; 3]).unwrap();
+        // Seed the item_defs cache so the validation runs (without an
+        // entry, the handler falls through and accepts any positive value).
+        mgr.item_defs.insert(42, WeaponDef {
+            clip_size: 30,
+            default_ammo_type: 1,
+            allowed_ammo_types: vec![1, 3, 5],  // 7 not allowed
+        });
+
+        if let Some(e) = mgr.get_entity_mut(1) {
+            e.is_player = true;
+            e.player_id = Some(100);
+            e.bandolier_items.insert(0, BandolierItem {
+                item_id: 42, clip_size: 30, default_ammo_type: 1,
+                current_ammo: 20, cur_ammo_type: 1,
+            });
+            e.active_bandolier_slot = 0;
+        }
+
+        let (tx, mut rx) = mpsc::channel(8);
+
+        // ammo_type = 7 — positive, but not in the weapon's whitelist.
+        let mut args = Vec::with_capacity(8);
+        args.extend_from_slice(&42i32.to_le_bytes());
+        args.extend_from_slice(&7i32.to_le_bytes());
+
+        let engine = cimmeria_content_engine::chain::ChainEngine::new();
+        let handled = dispatch(1, REQUEST_AMMO_CHANGE, &args, &tx, &mut mgr, &engine).await;
+
+        assert!(handled);
+        assert!(rx.try_recv().is_err(), "no rx messages for unlisted ammo_type");
+        let entity = mgr.get_entity(1).unwrap();
+        assert_eq!(entity.bandolier_items[&0].cur_ammo_type, 1, "cur_ammo_type unchanged");
+        assert!(!entity.bandolier_ammo_dirty.contains(&0));
+    }
+
+    /// CodeRabbit out-of-diff: REQUEST_ACTIVE_SLOT_CHANGE must reject slot_id
+    /// outside 0..5 before mutating active_bandolier_slot or sending
+    /// ActiveSlotUpdate. A forged value would otherwise leave the entity in
+    /// an impossible state.
+    #[tokio::test]
+    async fn request_active_slot_change_rejects_out_of_range_slot() {
+        use crate::cell::content::build_engine;
+
+        for bad_slot in [-1i32, 5, 99, i32::MAX] {
+            let mut mgr = make_test_space_mgr();
+            mgr.create_entity(1, "Castle_CellBlock", [0.0; 3], [0.0; 3]).unwrap();
+
+            if let Some(e) = mgr.get_entity_mut(1) {
+                e.is_player = true;
+                e.player_id = Some(100);
+                e.active_bandolier_slot = 0;
+            }
+            mgr.connect_entity(1);
+
+            let (tx, mut rx) = mpsc::channel(8);
+            let engine = build_engine(None).await;
+
+            let mut args = Vec::with_capacity(8);
+            args.extend_from_slice(&3i32.to_le_bytes());      // bag_id = 3
+            args.extend_from_slice(&bad_slot.to_le_bytes());  // out-of-range slot
+
+            let handled = dispatch(1, REQUEST_ACTIVE_SLOT_CHANGE, &args, &tx, &mut mgr, &engine).await;
+            assert!(handled, "handler claims the index even when slot is invalid (bad_slot={bad_slot})");
+            assert!(rx.try_recv().is_err(), "no messages emitted for bad_slot={bad_slot}");
+            assert_eq!(
+                mgr.get_entity(1).unwrap().active_bandolier_slot, 0,
+                "active_bandolier_slot must not change for bad_slot={bad_slot}"
+            );
         }
     }
 }

--- a/crates/services/src/cell/cell_methods/inventory.rs
+++ b/crates/services/src/cell/cell_methods/inventory.rs
@@ -271,14 +271,17 @@ pub async fn dispatch(
                 let ammo_type = i32::from_le_bytes([args[4], args[5], args[6], args[7]]);
                 tracing::debug!(entity_id, item_id, ammo_type, "requestAmmoChange");
 
-                // Loose validation — the legacy is literally `pass`. Reject the
-                // obvious-junk case (zero), then accept whatever the client
-                // sent. The proper whitelist lives on the item template's
-                // `ammo_types` (crates/entity/src/inventory.rs:81).
+                // Loose validation — the legacy is literally `pass`. Reject
+                // anything non-positive: 0 is the "no choice" sentinel, and
+                // the DB column has CHECK (cur_ammo_type >= 0), so a negative
+                // value would mutate cell + client state then fail the DB
+                // write later, leaving them ahead of persistence. The proper
+                // whitelist lives on the item template's `ammo_types`
+                // (crates/entity/src/inventory.rs:81).
                 // TODO: validate against item.ammo_types whitelist
                 //       (see crates/entity/src/inventory.rs:81 — `Item.ammo_types`).
-                if ammo_type == 0 {
-                    tracing::warn!(entity_id, item_id, "requestAmmoChange: rejecting zero ammo_type");
+                if ammo_type <= 0 {
+                    tracing::warn!(entity_id, item_id, ammo_type, "requestAmmoChange: rejecting non-positive ammo_type");
                     return true;
                 }
 
@@ -632,37 +635,43 @@ mod tests {
         assert!(rx.try_recv().is_err(), "no further rx messages expected");
     }
 
-    /// Stage E: ammo_type=0 is rejected with a warn, no rx messages emitted.
-    /// Matches the deviation Stage D introduced to filter obvious-junk requests.
+    /// CodeRabbit #12 (and earlier rejects-zero): non-positive ammo_type is
+    /// rejected before mutating local state. Without this, a negative value
+    /// would update `bandolier_items` + send `onEntityProperty`, then fail
+    /// the DB write (`cur_ammo_type >= 0` CHECK) — leaving cell + client
+    /// state ahead of persistence.
     #[tokio::test]
-    async fn request_ammo_change_rejects_zero() {
-        let mut mgr = make_test_space_mgr();
-        mgr.create_entity(1, "Castle_CellBlock", [0.0; 3], [0.0; 3]).unwrap();
+    async fn request_ammo_change_rejects_non_positive() {
+        for bad_ammo_type in [0i32, -1, -42] {
+            let mut mgr = make_test_space_mgr();
+            mgr.create_entity(1, "Castle_CellBlock", [0.0; 3], [0.0; 3]).unwrap();
 
-        if let Some(e) = mgr.get_entity_mut(1) {
-            e.is_player = true;
-            e.player_id = Some(100);
-            e.bandolier_items.insert(0, BandolierItem {
-                item_id: 42, clip_size: 30, default_ammo_type: 1,
-                current_ammo: 20, cur_ammo_type: 1,
-            });
-            e.active_bandolier_slot = 0;
+            if let Some(e) = mgr.get_entity_mut(1) {
+                e.is_player = true;
+                e.player_id = Some(100);
+                e.bandolier_items.insert(0, BandolierItem {
+                    item_id: 42, clip_size: 30, default_ammo_type: 1,
+                    current_ammo: 20, cur_ammo_type: 1,
+                });
+                e.active_bandolier_slot = 0;
+            }
+
+            let (tx, mut rx) = mpsc::channel(8);
+
+            let mut args = Vec::with_capacity(8);
+            args.extend_from_slice(&42i32.to_le_bytes());
+            args.extend_from_slice(&bad_ammo_type.to_le_bytes());
+
+            let engine = cimmeria_content_engine::chain::ChainEngine::new();
+            let handled = dispatch(1, REQUEST_AMMO_CHANGE, &args, &tx, &mut mgr, &engine).await;
+
+            assert!(handled, "REQUEST_AMMO_CHANGE should be claimed (bad_ammo_type={bad_ammo_type})");
+            assert!(rx.try_recv().is_err(), "no rx messages for bad_ammo_type={bad_ammo_type}");
+            let entity = mgr.get_entity(1).unwrap();
+            assert_eq!(entity.bandolier_items[&0].cur_ammo_type, 1,
+                "cur_ammo_type should be unchanged for bad_ammo_type={bad_ammo_type}");
+            assert!(!entity.bandolier_ammo_dirty.contains(&0),
+                "no dirty flag for bad_ammo_type={bad_ammo_type}");
         }
-
-        let (tx, mut rx) = mpsc::channel(8);
-
-        let mut args = Vec::with_capacity(8);
-        args.extend_from_slice(&42i32.to_le_bytes());
-        args.extend_from_slice(&0i32.to_le_bytes());
-
-        let engine = cimmeria_content_engine::chain::ChainEngine::new();
-        let handled = dispatch(1, REQUEST_AMMO_CHANGE, &args, &tx, &mut mgr, &engine).await;
-
-        // Handler still returns true (claims the index), but no side effects.
-        assert!(handled, "REQUEST_AMMO_CHANGE should be claimed by the inventory dispatch");
-        assert!(rx.try_recv().is_err(), "no rx messages should be emitted for ammo_type=0");
-        let entity = mgr.get_entity(1).unwrap();
-        assert_eq!(entity.bandolier_items[&0].cur_ammo_type, 1, "cur_ammo_type should be unchanged");
-        assert!(!entity.bandolier_ammo_dirty.contains(&0));
     }
 }

--- a/crates/services/src/cell/cell_methods/inventory.rs
+++ b/crates/services/src/cell/cell_methods/inventory.rs
@@ -2,6 +2,7 @@
 
 use tokio::sync::mpsc;
 use cimmeria_content_engine::chain::ChainEngine;
+use cimmeria_entity::cell_entity::CellEntity;
 use crate::cell::messages::CellToBaseMsg;
 use crate::cell::space_manager::SpaceManager;
 
@@ -12,6 +13,47 @@ pub const USE_ITEM: u16 = 39;
 pub const REPAIR_ITEM_REQUEST: u16 = 40;
 pub const REQUEST_ACTIVE_SLOT_CHANGE: u16 = 41;
 pub const REQUEST_AMMO_CHANGE: u16 = 42;
+
+/// `GENERICPROPERTY_AmmoTypeId` from `entities/defs/enumerations.xml`. Used as
+/// the property-id arg for `onEntityProperty` ammo-type indicator updates.
+const GENERICPROPERTY_AMMO_TYPE_ID: i32 = 3;
+
+/// Build the `onEntityProperty(propId, value)` arg payload (8 bytes LE).
+fn build_entity_property_args(prop_id: i32, value: i32) -> Vec<u8> {
+    let mut args = Vec::with_capacity(8);
+    args.extend_from_slice(&prop_id.to_le_bytes());
+    args.extend_from_slice(&value.to_le_bytes());
+    args
+}
+
+/// Drain `entity.bandolier_ammo_dirty` and emit one `BandolierAmmoUpdate` per
+/// slot. Used by the logout / world-transition flush paths.
+///
+/// Slots that are dirty but no longer have a `BandolierItem` (e.g. swapped out
+/// before logout) are silently dropped — there's nothing to persist for them.
+pub async fn flush_dirty_bandolier_ammo(
+    entity: &mut CellEntity,
+    player_id: i32,
+    tx: &mpsc::Sender<CellToBaseMsg>,
+) {
+    if entity.bandolier_ammo_dirty.is_empty() {
+        return;
+    }
+    // Drain into a Vec so we don't hold the borrow on `entity` across awaits.
+    let dirty: Vec<i32> = entity.bandolier_ammo_dirty.drain().collect();
+    for slot_id in dirty {
+        let (current_ammo, cur_ammo_type) = match entity.bandolier_items.get(&slot_id) {
+            Some(item) => (item.current_ammo, item.cur_ammo_type),
+            None => continue,
+        };
+        let _ = tx.send(CellToBaseMsg::BandolierAmmoUpdate {
+            player_id,
+            slot_id,
+            current_ammo,
+            cur_ammo_type,
+        }).await;
+    }
+}
 
 /// Fire a weapon attack event for an equipped item.
 /// Called after a ranged weapon attack is launched.
@@ -134,14 +176,69 @@ pub async fn dispatch(
                             None
                         }
                     };
-                    // Update the cell-side entity immediately so subsequent
-                    // ability/ammo checks see the new slot, then persist via base.
-                    if let Some(entity) = space_mgr.get_entity_mut(entity_id) {
+
+                    // Phase 1: capture the previous slot's pending-flush state
+                    // and the new slot's `cur_ammo_type` while we have a
+                    // mutable borrow. Drop the borrow before any awaits.
+                    //
+                    // Stage D: if the previously-active slot was dirty (fires
+                    // since the last flush), emit one BandolierAmmoUpdate for
+                    // it before swapping. The reload-completion tick already
+                    // drains the active slot when reloads finish; this catches
+                    // mid-magazine swaps where the player swaps weapons before
+                    // reloading the empty one.
+                    let (prev_persist, new_ammo_type): (Option<(i32, i32, i32)>, Option<i32>) = {
+                        let entity = match space_mgr.get_entity_mut(entity_id) {
+                            Some(e) => e,
+                            None => return true,
+                        };
+                        let prev_slot = entity.active_bandolier_slot;
+                        let prev_persist = if entity.bandolier_ammo_dirty.contains(&prev_slot) {
+                            entity.bandolier_items.get(&prev_slot).map(|item| {
+                                (prev_slot, item.current_ammo, item.cur_ammo_type)
+                            })
+                        } else {
+                            None
+                        };
+                        if prev_persist.is_some() {
+                            entity.bandolier_ammo_dirty.remove(&prev_slot);
+                        }
                         entity.active_bandolier_slot = slot_id;
-                    }
+                        let new_ammo_type = entity.bandolier_items
+                            .get(&slot_id)
+                            .map(|i| i.cur_ammo_type);
+                        (prev_persist, new_ammo_type)
+                    };
+
+                    // Phase 2: send messages now that the borrow is released.
                     if let Some(player_id) = player_id {
+                        if let Some((p_slot, current_ammo, cur_ammo_type)) = prev_persist {
+                            let _ = tx.send(CellToBaseMsg::BandolierAmmoUpdate {
+                                player_id,
+                                slot_id: p_slot,
+                                current_ammo,
+                                cur_ammo_type,
+                            }).await;
+                        }
                         let _ = tx.send(CellToBaseMsg::ActiveSlotUpdate { player_id, slot_id }).await;
                     }
+
+                    // Stage D: refresh the client's ammo-type indicator for the
+                    // newly-active slot. If the new slot is empty (no item),
+                    // send 0 to mirror legacy "no weapon equipped" behavior
+                    // (SGWPlayer.py:522 — `activeItem.ammoType if activeItem else 0`).
+                    let property_value = new_ammo_type.unwrap_or(0);
+                    let property_args = build_entity_property_args(
+                        GENERICPROPERTY_AMMO_TYPE_ID,
+                        property_value,
+                    );
+                    crate::cell::abilities::send_entity_method(
+                        entity_id,
+                        crate::cell::client_methods::spawnable_entity::ON_ENTITY_PROPERTY,
+                        property_args,
+                        tx,
+                        space_mgr,
+                    ).await;
                 } else {
                     tracing::warn!(entity_id, bag_id, slot_id, "requestActiveSlotChange: ignoring non-bandolier container");
                 }
@@ -154,10 +251,330 @@ pub async fn dispatch(
             if args.len() >= 8 {
                 let item_id = i32::from_le_bytes([args[0], args[1], args[2], args[3]]);
                 let ammo_type = i32::from_le_bytes([args[4], args[5], args[6], args[7]]);
-                tracing::info!(entity_id, item_id, ammo_type, "UNIMPLEMENTED: requestAmmoChange");
+                tracing::debug!(entity_id, item_id, ammo_type, "requestAmmoChange");
+
+                // Loose validation — the legacy is literally `pass`. Reject the
+                // obvious-junk case (zero), then accept whatever the client
+                // sent. The proper whitelist lives on the item template's
+                // `ammo_types` (crates/entity/src/inventory.rs:81).
+                // TODO: validate against item.ammo_types whitelist
+                //       (see crates/entity/src/inventory.rs:81 — `Item.ammo_types`).
+                if ammo_type == 0 {
+                    tracing::warn!(entity_id, item_id, "requestAmmoChange: rejecting zero ammo_type");
+                    return true;
+                }
+
+                // Phase 1: locate the slot, mutate, capture the BandolierAmmoUpdate
+                // payload + active-slot flag, drop the mutable borrow.
+                let (player_id, persist, is_active) = {
+                    let entity = match space_mgr.get_entity_mut(entity_id) {
+                        Some(e) => e,
+                        None => return true,
+                    };
+                    let slot = entity.bandolier_items.iter()
+                        .find(|(_, item)| item.item_id == item_id)
+                        .map(|(s, _)| *s);
+                    let slot = match slot {
+                        Some(s) => s,
+                        None => {
+                            tracing::warn!(entity_id, item_id, "requestAmmoChange: item not in bandolier");
+                            return true;
+                        }
+                    };
+                    // Mutate the slot. We mark dirty (so any in-flight flush
+                    // path sees the change) and immediately drain — the
+                    // BandolierAmmoUpdate emitted below persists it now.
+                    let item = entity.bandolier_items.get_mut(&slot).unwrap();
+                    item.cur_ammo_type = ammo_type;
+                    let current_ammo = item.current_ammo;
+                    entity.bandolier_ammo_dirty.insert(slot);
+                    entity.bandolier_ammo_dirty.remove(&slot);
+                    let is_active = slot == entity.active_bandolier_slot;
+                    let player_id = entity.player_id;
+                    (player_id, (slot, current_ammo, ammo_type), is_active)
+                };
+
+                // Phase 2: persist + (if active) refresh the client's ammo-type indicator.
+                if let Some(player_id) = player_id {
+                    let (slot_id, current_ammo, cur_ammo_type) = persist;
+                    let _ = tx.send(CellToBaseMsg::BandolierAmmoUpdate {
+                        player_id,
+                        slot_id,
+                        current_ammo,
+                        cur_ammo_type,
+                    }).await;
+                } else {
+                    tracing::warn!(entity_id, "requestAmmoChange: entity has no player_id — skipping persist");
+                }
+
+                if is_active {
+                    let property_args = build_entity_property_args(
+                        GENERICPROPERTY_AMMO_TYPE_ID,
+                        ammo_type,
+                    );
+                    crate::cell::abilities::send_entity_method(
+                        entity_id,
+                        crate::cell::client_methods::spawnable_entity::ON_ENTITY_PROPERTY,
+                        property_args,
+                        tx,
+                        space_mgr,
+                    ).await;
+                }
+            } else {
+                tracing::warn!(entity_id, args_len = args.len(), "requestAmmoChange: truncated args");
             }
             true
         }
         _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cimmeria_entity::abilities::AbilityDef;
+    use cimmeria_entity::cell_entity::BandolierItem;
+    use cimmeria_entity::stats::{AMMO_SLOT_1, AMMO_SLOT_2};
+
+    use crate::cell::abilities::handle_use_ability;
+
+    fn make_test_space_mgr() -> SpaceManager {
+        let mut mgr = SpaceManager::new(1);
+        let xml = r#"<?xml version="1.0"?><Spaces><Space WorldName="Castle_CellBlock" Instanced="true" MinX="-800" MaxX="800" MinY="-800" MaxY="800" /></Spaces>"#;
+        let cxml = r#"<?xml version="1.0"?><Spaces></Spaces>"#;
+        mgr.parse_spaces_xml(xml).unwrap();
+        mgr.create_startup_spaces(cxml).unwrap();
+        mgr
+    }
+
+    /// Register a no-warmup, ranged ability with `required_ammo = 1` and no
+    /// event-set (silences onSequence noise during tests).
+    fn register_test_fire_ability(mgr: &mut SpaceManager, ability_id: i32) {
+        mgr.ability_defs.insert(ability_id, AbilityDef {
+            ability_id,
+            name: format!("test_fire_{ability_id}"),
+            cooldown: 0.001, // very short so back-to-back fires aren't gated
+            warmup: 0.0,
+            flags: 0,
+            is_ranged: true,
+            min_range: 0,
+            max_range: 30,
+            target_type_id: 0,
+            effect_ids: vec![],
+            moniker_ids: vec![],
+            required_ammo: 1,
+            event_set_id: None,
+            velocity: 0.0,
+        });
+    }
+
+    /// Stage E: per-slot ammo must survive an active-slot swap.
+    ///
+    /// Simplified vs the prompt — instead of running the full handle_use_ability
+    /// twice on slot 0 then once on slot 1 (which would require waiting out
+    /// cooldowns), we exercise the swap path directly: fire once, swap, fire
+    /// once, swap back, and verify both slots' ammo is preserved across the
+    /// swap. The slot-swap message order assertion is the load-bearing piece.
+    #[tokio::test]
+    async fn slot_swap_preserves_per_slot_ammo() {
+        let mut mgr = make_test_space_mgr();
+        mgr.create_entity(1, "Castle_CellBlock", [0.0; 3], [0.0; 3]).unwrap();
+
+        let ability_id = 5001;
+        register_test_fire_ability(&mut mgr, ability_id);
+
+        // Two bandolier slots: slot 0 (clip 30, full), slot 1 (clip 12, full).
+        if let Some(e) = mgr.get_entity_mut(1) {
+            e.is_player = true;
+            e.player_id = Some(100);
+            e.abilities.add_ability(ability_id);
+            e.bandolier_items.insert(0, BandolierItem {
+                item_id: 10, clip_size: 30, default_ammo_type: 1,
+                current_ammo: 30, cur_ammo_type: 1,
+            });
+            e.bandolier_items.insert(1, BandolierItem {
+                item_id: 11, clip_size: 12, default_ammo_type: 7,
+                current_ammo: 12, cur_ammo_type: 7,
+            });
+            e.active_bandolier_slot = 0;
+            if let Some(s) = e.stats.get_mut(AMMO_SLOT_1) { s.update(0, 30, 30); s.clear_dirty(); }
+            if let Some(s) = e.stats.get_mut(AMMO_SLOT_2) { s.update(0, 12, 12); s.clear_dirty(); }
+        }
+
+        let (tx, mut rx) = mpsc::channel(64);
+
+        // Fire two shots on slot 0 → current_ammo == 28 (cooldown is 1ms,
+        // so the second fire happens past the deadline).
+        handle_use_ability(1, ability_id, 0, &tx, &mut mgr).await;
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        handle_use_ability(1, ability_id, 0, &tx, &mut mgr).await;
+        assert_eq!(mgr.get_entity(1).unwrap().bandolier_items[&0].current_ammo, 28);
+
+        // Drain rx so the swap-message assertions below can scan a clean buffer.
+        while rx.try_recv().is_ok() {}
+
+        // ── Swap to slot 1 ──────────────────────────────────────────────
+        // Args: bag_id=3 (bandolier), slot_id=1.
+        let mut swap_args = Vec::with_capacity(8);
+        swap_args.extend_from_slice(&3i32.to_le_bytes());
+        swap_args.extend_from_slice(&1i32.to_le_bytes());
+        let engine = cimmeria_content_engine::chain::ChainEngine::new();
+        dispatch(1, REQUEST_ACTIVE_SLOT_CHANGE, &swap_args, &tx, &mut mgr, &engine).await;
+
+        // Stage D message order on swap: BandolierAmmoUpdate(prev=0, ammo=28)
+        // → ActiveSlotUpdate(1) → onEntityProperty(AmmoTypeId, slot1.cur_ammo_type=7).
+        let m1 = rx.try_recv().expect("expected BandolierAmmoUpdate(prev slot)");
+        match m1 {
+            CellToBaseMsg::BandolierAmmoUpdate { player_id, slot_id, current_ammo, cur_ammo_type } => {
+                assert_eq!(player_id, 100);
+                assert_eq!(slot_id, 0, "first swap msg should flush prev slot 0");
+                assert_eq!(current_ammo, 28);
+                assert_eq!(cur_ammo_type, 1);
+            }
+            other => panic!("expected BandolierAmmoUpdate, got {other:?}"),
+        }
+        let m2 = rx.try_recv().expect("expected ActiveSlotUpdate");
+        match m2 {
+            CellToBaseMsg::ActiveSlotUpdate { player_id, slot_id } => {
+                assert_eq!(player_id, 100);
+                assert_eq!(slot_id, 1);
+            }
+            other => panic!("expected ActiveSlotUpdate, got {other:?}"),
+        }
+        let m3 = rx.try_recv().expect("expected onEntityProperty(AmmoTypeId)");
+        match m3 {
+            CellToBaseMsg::EntityMethodCall { entity_id, method_index, args } => {
+                assert_eq!(entity_id, 1);
+                assert_eq!(
+                    method_index,
+                    crate::cell::client_methods::spawnable_entity::ON_ENTITY_PROPERTY,
+                    "third swap msg should be onEntityProperty"
+                );
+                let prop_id = i32::from_le_bytes([args[0], args[1], args[2], args[3]]);
+                let value = i32::from_le_bytes([args[4], args[5], args[6], args[7]]);
+                assert_eq!(prop_id, GENERICPROPERTY_AMMO_TYPE_ID);
+                assert_eq!(value, 7, "ammo type should be slot 1's cur_ammo_type");
+            }
+            other => panic!("expected EntityMethodCall, got {other:?}"),
+        }
+
+        // Fire once on slot 1 → current_ammo == 11.
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        handle_use_ability(1, ability_id, 0, &tx, &mut mgr).await;
+        assert_eq!(mgr.get_entity(1).unwrap().bandolier_items[&1].current_ammo, 11);
+
+        // ── Swap back to slot 0 ─────────────────────────────────────────
+        let mut swap_back = Vec::with_capacity(8);
+        swap_back.extend_from_slice(&3i32.to_le_bytes());
+        swap_back.extend_from_slice(&0i32.to_le_bytes());
+        dispatch(1, REQUEST_ACTIVE_SLOT_CHANGE, &swap_back, &tx, &mut mgr, &engine).await;
+
+        // Slot 0's ammo is preserved across the swap.
+        let entity = mgr.get_entity(1).unwrap();
+        assert_eq!(entity.bandolier_items[&0].current_ammo, 28, "slot 0 ammo preserved across swap");
+        assert_eq!(entity.bandolier_items[&1].current_ammo, 11, "slot 1 ammo preserved across swap");
+        assert_eq!(entity.stats.get(AMMO_SLOT_1).unwrap().cur, 28, "AmmoSlot1 stat still reads 28");
+        assert_eq!(entity.active_bandolier_slot, 0);
+    }
+
+    /// Stage E: requestAmmoChange must update the slot's `cur_ammo_type`,
+    /// emit exactly one BandolierAmmoUpdate (drained immediately, NOT pending
+    /// for logout flush), and — when the slot is active — push an
+    /// `onEntityProperty(AmmoTypeId)` to the client.
+    #[tokio::test]
+    async fn request_ammo_change_updates_slot_and_sends_property() {
+        let mut mgr = make_test_space_mgr();
+        mgr.create_entity(1, "Castle_CellBlock", [0.0; 3], [0.0; 3]).unwrap();
+
+        if let Some(e) = mgr.get_entity_mut(1) {
+            e.is_player = true;
+            e.player_id = Some(100);
+            e.bandolier_items.insert(0, BandolierItem {
+                item_id: 42, clip_size: 30, default_ammo_type: 1,
+                current_ammo: 20, cur_ammo_type: 1,
+            });
+            e.active_bandolier_slot = 0;
+        }
+
+        let (tx, mut rx) = mpsc::channel(16);
+
+        // Args: item_id=42, ammo_type=3 (8 bytes LE).
+        let mut args = Vec::with_capacity(8);
+        args.extend_from_slice(&42i32.to_le_bytes());
+        args.extend_from_slice(&3i32.to_le_bytes());
+
+        let engine = cimmeria_content_engine::chain::ChainEngine::new();
+        dispatch(1, REQUEST_AMMO_CHANGE, &args, &tx, &mut mgr, &engine).await;
+
+        // Slot mutated, dirty NOT set (drained immediately by the handler).
+        let entity = mgr.get_entity(1).unwrap();
+        assert_eq!(entity.bandolier_items[&0].cur_ammo_type, 3);
+        assert!(!entity.bandolier_ammo_dirty.contains(&0), "dirty flag should be drained immediately");
+
+        // First message: BandolierAmmoUpdate carrying the new type + existing ammo.
+        let m1 = rx.try_recv().expect("expected BandolierAmmoUpdate");
+        match m1 {
+            CellToBaseMsg::BandolierAmmoUpdate { player_id, slot_id, current_ammo, cur_ammo_type } => {
+                assert_eq!(player_id, 100);
+                assert_eq!(slot_id, 0);
+                assert_eq!(current_ammo, 20);
+                assert_eq!(cur_ammo_type, 3);
+            }
+            other => panic!("expected BandolierAmmoUpdate, got {other:?}"),
+        }
+
+        // Second message: onEntityProperty(AmmoTypeId, 3) since slot is active.
+        let m2 = rx.try_recv().expect("expected onEntityProperty");
+        match m2 {
+            CellToBaseMsg::EntityMethodCall { entity_id, method_index, args } => {
+                assert_eq!(entity_id, 1);
+                assert_eq!(
+                    method_index,
+                    crate::cell::client_methods::spawnable_entity::ON_ENTITY_PROPERTY,
+                );
+                let prop_id = i32::from_le_bytes([args[0], args[1], args[2], args[3]]);
+                let value = i32::from_le_bytes([args[4], args[5], args[6], args[7]]);
+                assert_eq!(prop_id, GENERICPROPERTY_AMMO_TYPE_ID);
+                assert_eq!(value, 3);
+            }
+            other => panic!("expected EntityMethodCall, got {other:?}"),
+        }
+
+        // No additional messages.
+        assert!(rx.try_recv().is_err(), "no further rx messages expected");
+    }
+
+    /// Stage E: ammo_type=0 is rejected with a warn, no rx messages emitted.
+    /// Matches the deviation Stage D introduced to filter obvious-junk requests.
+    #[tokio::test]
+    async fn request_ammo_change_rejects_zero() {
+        let mut mgr = make_test_space_mgr();
+        mgr.create_entity(1, "Castle_CellBlock", [0.0; 3], [0.0; 3]).unwrap();
+
+        if let Some(e) = mgr.get_entity_mut(1) {
+            e.is_player = true;
+            e.player_id = Some(100);
+            e.bandolier_items.insert(0, BandolierItem {
+                item_id: 42, clip_size: 30, default_ammo_type: 1,
+                current_ammo: 20, cur_ammo_type: 1,
+            });
+            e.active_bandolier_slot = 0;
+        }
+
+        let (tx, mut rx) = mpsc::channel(8);
+
+        let mut args = Vec::with_capacity(8);
+        args.extend_from_slice(&42i32.to_le_bytes());
+        args.extend_from_slice(&0i32.to_le_bytes());
+
+        let engine = cimmeria_content_engine::chain::ChainEngine::new();
+        let handled = dispatch(1, REQUEST_AMMO_CHANGE, &args, &tx, &mut mgr, &engine).await;
+
+        // Handler still returns true (claims the index), but no side effects.
+        assert!(handled, "REQUEST_AMMO_CHANGE should be claimed by the inventory dispatch");
+        assert!(rx.try_recv().is_err(), "no rx messages should be emitted for ammo_type=0");
+        let entity = mgr.get_entity(1).unwrap();
+        assert_eq!(entity.bandolier_items[&0].cur_ammo_type, 1, "cur_ammo_type should be unchanged");
+        assert!(!entity.bandolier_ammo_dirty.contains(&0));
     }
 }

--- a/crates/services/src/cell/cell_methods/player/world.rs
+++ b/crates/services/src/cell/cell_methods/player/world.rs
@@ -150,12 +150,16 @@ async fn handle_reload(
         std::time::Duration::from_secs_f32(total_time),
     );
 
-    // Defer the actual ammo refill until after the warmup so the player can't
-    // fire the new magazine before the weapon animation completes. The fire
-    // path (cell::abilities::handle_use_ability) checks reload_complete_at and
-    // promotes the pending refill on first attempt past the deadline.
+    // Defer the actual ammo refill until after the warmup. The reload-completion
+    // tick promotes pending refills; the fire-path gates on `reload_complete_at`
+    // to prevent shooting during the warmup.
+    //
+    // Pin the reload to the slot that started it. If the player swaps weapons
+    // mid-reload, the tick must refill *this* slot — not whatever slot is
+    // active when the deadline elapses.
     let warmup_duration = std::time::Duration::from_secs_f32(warmup.max(0.0));
     entity.reload_complete_at = Some(std::time::Instant::now() + warmup_duration);
+    entity.reload_slot_id = Some(entity.active_bandolier_slot);
 
     tracing::info!(entity_id, old, target = target_ammo, warmup, cooldown, "Weapon reload started");
 

--- a/crates/services/src/cell/cell_methods/player/world.rs
+++ b/crates/services/src/cell/cell_methods/player/world.rs
@@ -136,12 +136,13 @@ async fn handle_reload(
         }
     };
 
-    if entity.current_ammo >= entity.max_ammo && entity.reload_complete_at.is_none() {
+    if entity.active_ammo() >= entity.active_clip_size() && entity.reload_complete_at.is_none() {
         tracing::debug!(entity_id, "requestReload: already at max ammo");
         return;
     }
 
-    let old = entity.current_ammo;
+    let old = entity.active_ammo();
+    let target_ammo = entity.active_clip_size();
 
     let total_time = warmup + cooldown;
     entity.abilities.start_ability_cooldown(
@@ -156,7 +157,7 @@ async fn handle_reload(
     let warmup_duration = std::time::Duration::from_secs_f32(warmup.max(0.0));
     entity.reload_complete_at = Some(std::time::Instant::now() + warmup_duration);
 
-    tracing::info!(entity_id, old, target = entity.max_ammo, warmup, cooldown, "Weapon reload started");
+    tracing::info!(entity_id, old, target = target_ammo, warmup, cooldown, "Weapon reload started");
 
     let timer_args = cimmeria_entity::abilities::serialize_timer_update(
         ABILITY_RELOAD_WEAPON,
@@ -215,7 +216,7 @@ async fn handle_reload(
     let mut args = Vec::with_capacity(8);
     args.extend_from_slice(&7i32.to_le_bytes());
     let ammo_type = space_mgr.get_entity(entity_id)
-        .map_or(0, |e| e.ammo_type);
+        .map_or(0, |e| e.active_ammo_type());
     args.extend_from_slice(&ammo_type.to_le_bytes());
     let _ = tx.send(CellToBaseMsg::EntityMethodCall {
         entity_id,

--- a/crates/services/src/cell/content/executor.rs
+++ b/crates/services/src/cell/content/executor.rs
@@ -73,12 +73,37 @@ pub(super) async fn execute_actions(
 
                 // If this is a weapon (bandolier), set ammo state on the entity.
                 // Weapons start unloaded — the player must press R to reload.
+                //
+                // Stage C: insert a `BandolierItem` for the granted slot and seed
+                // the AmmoSlot{N} stat to (0, 0, clip_size) so subsequent fire /
+                // reload paths (which now read through `active_ammo()` and
+                // `set_slot_ammo`) operate on a valid clamp range. We also send
+                // an `onStatUpdate` so the client renders the empty mag for the
+                // new weapon without waiting for the next fire.
+                let mut ammo_stat_payload: Option<Vec<u8>> = None;
                 if cid == 3 {
-                    if let Some(clip) = weapon_clip_size(item_id) {
+                    if let Some((clip, default_ammo_type)) = weapon_stats(item_id, &space_mgr.item_defs) {
                         if let Some(entity) = space_mgr.get_entity_mut(entity_id) {
-                            entity.max_ammo = clip;
-                            entity.current_ammo = 0;
-                            tracing::info!(entity_id, item_id, clip, "Weapon granted unloaded");
+                            // The weapon-grant chain doesn't tell us which slot
+                            // the base will assign — content engine grants
+                            // implicitly fill the active bandolier slot.
+                            let slot_id = entity.active_bandolier_slot;
+                            entity.bandolier_items.insert(slot_id, cimmeria_entity::cell_entity::BandolierItem {
+                                item_id,
+                                clip_size: clip,
+                                default_ammo_type,
+                                current_ammo: 0,
+                                cur_ammo_type: default_ammo_type,
+                            });
+                            entity.bandolier_ammo_dirty.insert(slot_id);
+                            let stat_id = cimmeria_entity::stats::AMMO_SLOT_1 + slot_id;
+                            if let Some(stat) = entity.stats.get_mut(stat_id) {
+                                stat.update(0, 0, clip);
+                                let payload = entity.stats.serialize_dirty();
+                                entity.stats.clear_dirty();
+                                ammo_stat_payload = Some(payload);
+                            }
+                            tracing::info!(entity_id, item_id, slot_id, clip, "Weapon granted unloaded");
                         }
                     }
                 }
@@ -90,6 +115,14 @@ pub(super) async fn execute_actions(
                     container_id: cid,
                     count,
                 }).await;
+
+                if let Some(payload) = ammo_stat_payload {
+                    if !payload.is_empty() {
+                        crate::cell::abilities::send_entity_method(
+                            entity_id, 20, payload, tx, space_mgr,
+                        ).await;
+                    }
+                }
             }
             Action::DisplayDialog { dialog_id } | Action::StartDialog { dialog_set_id: dialog_id } => {
                 tracing::info!(entity_id, dialog_id, chain_id, "Content: displaying dialog");
@@ -402,14 +435,18 @@ pub(super) fn item_container(item_id: i32, item_containers: &std::collections::H
     *item_containers.get(&item_id).unwrap_or(&1)
 }
 
-/// Return the clip size for known weapon items (from items.clip_size in DB).
-/// Weapons granted via content chains start unloaded (current_ammo = 0).
-fn weapon_clip_size(item_id: i32) -> Option<i32> {
-    match item_id {
-        55 => Some(15),  // SI 3 9mm Pistol
-        21 => Some(30),  // TODO: verify clip size from DB
-        _ => None,
-    }
+/// Return the clip size and default ammo type for a granted weapon item.
+///
+/// Reads from the `space_mgr.item_defs` cache loaded at startup from
+/// `resources.items` (see `spawner::load_item_defs`). Returns `None` for
+/// non-weapon items (clip_size IS NULL in DB) or when the cache wasn't
+/// populated (e.g. tests without a DB pool) — callers skip the bandolier
+/// seeding in that case, and the player can still receive the item normally.
+fn weapon_stats(
+    item_id: i32,
+    item_defs: &std::collections::HashMap<i32, crate::cell::spawner::WeaponDef>,
+) -> Option<(i32, i32)> {
+    item_defs.get(&item_id).map(|d| (d.clip_size, d.default_ammo_type))
 }
 
 /// Send per-player InteractionType update if the NPC is already in the player's AoI.

--- a/crates/services/src/cell/dispatch.rs
+++ b/crates/services/src/cell/dispatch.rs
@@ -604,14 +604,26 @@ mod tests {
 
     #[tokio::test]
     async fn dispatch_reload_sends_entity_property() {
+        use cimmeria_entity::cell_entity::BandolierItem;
+        use cimmeria_entity::stats::AMMO_SLOT_1;
+
         let mut mgr = make_test_space_mgr();
         mgr.create_entity(1, "Castle_CellBlock", [0.0; 3], [0.0; 3]).unwrap();
 
-        // Set up ammo state
+        // Stage C: shadow scalars are gone. Seed the bandolier item + AmmoSlot
+        // stat the same way `InitPlayerState` does for a real world entry.
         if let Some(e) = mgr.get_entity_mut(1) {
-            e.current_ammo = 5;
-            e.max_ammo = 30;
-            e.ammo_type = 2;
+            e.bandolier_items.insert(0, BandolierItem {
+                item_id: 1,
+                clip_size: 30,
+                default_ammo_type: 2,
+                current_ammo: 5,
+                cur_ammo_type: 2,
+            });
+            if let Some(stat) = e.stats.get_mut(AMMO_SLOT_1) {
+                stat.update(0, 5, 30);
+                stat.clear_dirty();
+            }
         }
 
         let engine = cimmeria_content_engine::chain::ChainEngine::new();
@@ -621,9 +633,9 @@ mod tests {
         dispatch_cell_method(1, CM_REQUEST_RELOAD, &args, &tx, &mut mgr, &engine).await;
 
         // Reload sets the deadline but does NOT immediately refill — the magazine
-        // stays at the pre-reload count until warmup elapses (see use_ability path).
+        // stays at the pre-reload count until the reload tick runs past warmup.
         let entity = mgr.get_entity(1).unwrap();
-        assert_eq!(entity.current_ammo, 5, "magazine should not refill until warmup elapses");
+        assert_eq!(entity.active_ammo(), 5, "magazine should not refill until warmup elapses");
         assert!(entity.reload_complete_at.is_some(), "reload deadline should be set");
 
         // Reload sends a TimerUpdate (method 12) for the cooldown bar; the
@@ -641,13 +653,25 @@ mod tests {
 
     #[tokio::test]
     async fn dispatch_reload_already_full_no_message() {
+        use cimmeria_entity::cell_entity::BandolierItem;
+        use cimmeria_entity::stats::AMMO_SLOT_1;
+
         let mut mgr = make_test_space_mgr();
         mgr.create_entity(1, "Castle_CellBlock", [0.0; 3], [0.0; 3]).unwrap();
 
-        // Already at max
+        // Already at max — bandolier item with clip_size == current_ammo.
         if let Some(e) = mgr.get_entity_mut(1) {
-            e.current_ammo = 30;
-            e.max_ammo = 30;
+            e.bandolier_items.insert(0, BandolierItem {
+                item_id: 1,
+                clip_size: 30,
+                default_ammo_type: 0,
+                current_ammo: 30,
+                cur_ammo_type: 0,
+            });
+            if let Some(stat) = e.stats.get_mut(AMMO_SLOT_1) {
+                stat.update(0, 30, 30);
+                stat.clear_dirty();
+            }
         }
 
         let engine = cimmeria_content_engine::chain::ChainEngine::new();

--- a/crates/services/src/cell/gate_travel.rs
+++ b/crates/services/src/cell/gate_travel.rs
@@ -72,6 +72,18 @@ pub async fn handle_dial_gate(
         "Gate travel: initiating world transition"
     );
 
+    // Stage D: world transition destroys the cell entity and re-creates it on
+    // the destination world. Flush any pending bandolier ammo writes before
+    // teardown — anything still in `bandolier_ammo_dirty` after this is lost
+    // to the cross-world re-spawn.
+    if let Some(entity) = space_mgr.get_entity_mut(entity_id) {
+        if let Some(player_id) = entity.player_id {
+            super::cell_methods::inventory::flush_dirty_bandolier_ammo(
+                entity, player_id, tx,
+            ).await;
+        }
+    }
+
     // Remove entity from current space (CellService side)
     space_mgr.destroy_entity(entity_id);
 

--- a/crates/services/src/cell/messages.rs
+++ b/crates/services/src/cell/messages.rs
@@ -389,6 +389,19 @@ pub enum CellToBaseMsg {
     /// Persist the player's active bandolier slot.
     ActiveSlotUpdate { player_id: i32, slot_id: i32 },
 
+    /// Persist a single bandolier slot's per-slot ammo state.
+    ///
+    /// Sent by the cell on the batched cadence (reload completion, slot swap,
+    /// `requestAmmoChange`, logout) — see Stage B/C/D in
+    /// docs/gameplay/weapon-ammo-reload.md (TBD). `player_id` here matches the
+    /// DB `character_id`, mirroring the field naming used by `ActiveSlotUpdate`.
+    BandolierAmmoUpdate {
+        player_id: i32,
+        slot_id: i32,
+        current_ammo: i32,
+        cur_ammo_type: i32,
+    },
+
     /// Grant cash (naquadah) to a player and persist to the database.
     GrantCash {
         entity_id: u32,

--- a/crates/services/src/cell/messages.rs
+++ b/crates/services/src/cell/messages.rs
@@ -395,9 +395,15 @@ pub enum CellToBaseMsg {
     /// `requestAmmoChange`, logout) — see Stage B/C/D in
     /// docs/gameplay/weapon-ammo-reload.md (TBD). `player_id` here matches the
     /// DB `character_id`, mirroring the field naming used by `ActiveSlotUpdate`.
+    ///
+    /// `expected_item_id` guards against TOCTOU: if the slot's item changes
+    /// between the cell sending this message and the base writing the row,
+    /// the SQL `WHERE type_id = $expected_item_id` clause skips the write
+    /// rather than scribbling stale ammo onto the new weapon.
     BandolierAmmoUpdate {
         player_id: i32,
         slot_id: i32,
+        expected_item_id: i32,
         current_ammo: i32,
         cur_ammo_type: i32,
     },

--- a/crates/services/src/cell/service.rs
+++ b/crates/services/src/cell/service.rs
@@ -226,6 +226,10 @@ impl CellService {
                 Ok(map) => { space_mgr.item_containers = map; }
                 Err(e) => { tracing::warn!("Failed to load item containers: {e}"); }
             }
+            match spawner::load_item_defs(pool).await {
+                Ok(map) => { space_mgr.item_defs = map; }
+                Err(e) => { tracing::warn!("Failed to load item defs: {e}"); }
+            }
             match spawner::load_loot_tables(pool).await {
                 Ok(tables) => { space_mgr.loot_tables = tables; }
                 Err(e) => { tracing::warn!("Failed to load loot tables: {e}"); }
@@ -311,6 +315,11 @@ async fn run_cell_loop(
 
                 aoi_tick_counter = aoi_tick_counter.wrapping_add(1);
 
+                // Promote pending reloads whose warmup deadline has elapsed.
+                // Runs before NPC movement so any onStatUpdate from the refill
+                // is delivered in the same tick as other AoI-driven updates.
+                reload_completion_tick(tx, &mut space_mgr).await;
+
                 // NPC movement runs every AoI tick (100ms) for smooth pathing
                 npc_movement_tick(&mut space_mgr);
 
@@ -373,6 +382,16 @@ async fn handle_base_message(
 
         BaseToCellMsg::DestroyEntity { entity_id } => {
             tracing::debug!(entity_id, "DestroyEntity");
+            // Stage D: flush any pending bandolier ammo writes before tearing
+            // down the entity. Logout is a hard boundary — anything still in
+            // `bandolier_ammo_dirty` after this is lost.
+            if let Some(entity) = space_mgr.get_entity_mut(entity_id) {
+                if let Some(player_id) = entity.player_id {
+                    super::cell_methods::inventory::flush_dirty_bandolier_ammo(
+                        entity, player_id, tx,
+                    ).await;
+                }
+            }
             space_mgr.destroy_entity(entity_id);
         }
 
@@ -383,6 +402,18 @@ async fn handle_base_message(
 
         BaseToCellMsg::DisconnectEntity { entity_id } => {
             tracing::debug!(entity_id, "DisconnectEntity");
+            // Flush dirty bandolier ammo BEFORE space_mgr.disconnect_entity,
+            // which internally calls destroy_entity. Without this, the entity
+            // is gone by the time DestroyEntity arrives next and its flush
+            // is a silent no-op — that's why per-slot ammo and the loaded
+            // state never persisted across a logoff.
+            if let Some(entity) = space_mgr.get_entity_mut(entity_id) {
+                if let Some(player_id) = entity.player_id {
+                    super::cell_methods::inventory::flush_dirty_bandolier_ammo(
+                        entity, player_id, tx,
+                    ).await;
+                }
+            }
             space_mgr.disconnect_entity(entity_id, tx).await;
         }
 
@@ -419,6 +450,24 @@ async fn handle_base_message(
                     bandolier_item_count = entity.bandolier_items.len(),
                     "Applied bandolier state to cell entity"
                 );
+
+                // Stage B: Seed each populated bandolier slot's AmmoSlot{N} stat
+                // from its persisted current_ammo / clip_size. The default stat
+                // tuple is (0,0,0), and `set_slot_ammo` clamps via the stat
+                // bounds — without this seed, every later refill/decrement
+                // would silently pin to 0. Clearing dirty avoids a duplicate
+                // stat send (the initial mapLoaded uses serialize_all()).
+                let slot_seed: Vec<(i32, i32, i32)> = entity.bandolier_items
+                    .iter()
+                    .map(|(&slot, item)| (slot, item.current_ammo, item.clip_size))
+                    .collect();
+                for (slot_id, current, clip) in slot_seed {
+                    let stat_id = cimmeria_entity::stats::AMMO_SLOT_1 + slot_id;
+                    if let Some(stat) = entity.stats.get_mut(stat_id) {
+                        stat.update(0, current, clip);
+                        stat.clear_dirty();
+                    }
+                }
 
                 // Restore saved missions BEFORE content engine fires, so that
                 // chain conditions correctly see existing mission state and
@@ -533,6 +582,36 @@ async fn handle_base_message(
             if let Some(entity) = space_mgr.get_entity_mut(entity_id) {
                 entity.active_bandolier_slot = active_bandolier_slot;
                 entity.bandolier_items = bandolier_items.into_iter().collect();
+
+                // Re-seed AmmoSlot{N} stats from the new bandolier set so the
+                // client's bandolier UI reflects the actual ammo of any newly-
+                // equipped weapon. Without this, post-vendor-buy or post-grant
+                // bars show stale stats from the previous weapon.
+                //
+                // Slots that disappeared from `bandolier_items` get reset to
+                // (0, 0, 0) so an empty slot's bar clears.
+                let new_states: Vec<(i32, i32, i32)> = (0..5)
+                    .map(|slot_id| {
+                        let (cur, max) = entity.bandolier_items.get(&slot_id)
+                            .map_or((0, 0), |item| (item.current_ammo, item.clip_size));
+                        (slot_id, cur, max)
+                    })
+                    .collect();
+                for (slot_id, cur, max) in new_states {
+                    let stat_id = cimmeria_entity::stats::AMMO_SLOT_1 + slot_id;
+                    if let Some(stat) = entity.stats.get_mut(stat_id) {
+                        stat.update(0, cur, max);
+                    }
+                }
+                // Push the dirty stats to the client immediately so the UI
+                // updates without waiting for the next stat broadcast.
+                let payload = entity.stats.serialize_dirty();
+                entity.stats.clear_dirty();
+                if !payload.is_empty() {
+                    super::abilities::send_entity_method(
+                        entity_id, 20, payload, tx, space_mgr,
+                    ).await;
+                }
             }
         }
 
@@ -562,6 +641,87 @@ async fn run_aoi_tick(
         if tx.send(event).await.is_err() {
             tracing::warn!("Failed to send AoI event to BaseApp (channel closed)");
             return;
+        }
+    }
+}
+
+/// Promote any reload whose warmup deadline has elapsed: refill the active
+/// bandolier slot's magazine, clear `reload_complete_at`, send `onStatUpdate`
+/// for the AmmoSlot{N} stat to the player, and queue a `BandolierAmmoUpdate`
+/// to base for persistence.
+///
+/// Stage C: this is the sole refill path. The fire-path eager-promotion has
+/// been removed; `handle_use_ability` reads ammo through `entity.active_ammo()`
+/// and the bandolier UI updates on every fire via the AmmoSlot{N} stat.
+async fn reload_completion_tick(
+    tx: &mpsc::Sender<CellToBaseMsg>,
+    space_mgr: &mut SpaceManager,
+) {
+    let now = std::time::Instant::now();
+
+    // Snapshot ready-to-promote player IDs first to avoid holding a borrow on
+    // `space_mgr` across the `send_entity_method` await below.
+    let ready: Vec<u32> = space_mgr.all_player_entity_ids()
+        .into_iter()
+        .filter(|&eid| {
+            space_mgr.get_entity(eid)
+                .and_then(|e| e.reload_complete_at)
+                .map_or(false, |t| now >= t)
+        })
+        .collect();
+
+    for entity_id in ready {
+        // Phase 1: mutate entity state, capture stat-update payload + the
+        // BandolierAmmoUpdate fields we need to send afterwards. Drop the
+        // mutable borrow before any `.await`.
+        let (stat_payload, persist) = {
+            let entity = match space_mgr.get_entity_mut(entity_id) {
+                Some(e) => e,
+                None => continue,
+            };
+
+            if entity.refill_active_slot().is_none() {
+                // No bandolier item in the active slot — clear the deadline
+                // anyway so we don't loop forever, but skip the wire send.
+                entity.reload_complete_at = None;
+                tracing::debug!(entity_id, "reload tick: active slot empty, no refill");
+                continue;
+            }
+            entity.reload_complete_at = None;
+
+            // The slot was marked dirty by `set_slot_ammo`; persistence drains
+            // it via the BandolierAmmoUpdate below.
+            entity.bandolier_ammo_dirty.remove(&entity.active_bandolier_slot);
+
+            let payload = entity.stats.serialize_dirty();
+            entity.stats.clear_dirty();
+
+            let persist = entity.player_id.map(|pid| (
+                pid,
+                entity.active_bandolier_slot,
+                entity.active_ammo(),
+                entity.active_ammo_type(),
+            ));
+
+            (payload, persist)
+        };
+
+        // Phase 2: send onStatUpdate (method 20) — payload may be empty if
+        // refill was a no-op (e.g. magazine was already at clip_size when the
+        // deadline elapsed because of a concurrent path).
+        if !stat_payload.is_empty() {
+            super::abilities::send_entity_method(entity_id, 20, stat_payload, tx, space_mgr).await;
+        }
+
+        // Phase 3: persistence. CellToBaseMsg::BandolierAmmoUpdate is consumed
+        // by base's existing handler that writes `sgw_inventory.ammo`.
+        if let Some((player_id, slot_id, current_ammo, cur_ammo_type)) = persist {
+            let _ = tx.send(CellToBaseMsg::BandolierAmmoUpdate {
+                player_id,
+                slot_id,
+                current_ammo,
+                cur_ammo_type,
+            }).await;
         }
     }
 }
@@ -910,4 +1070,273 @@ async fn npc_ai_leash(
     let mut state_args = Vec::with_capacity(4);
     state_args.extend_from_slice(&state_field.to_le_bytes());
     super::abilities::send_entity_method(npc_id, 19, state_args, tx, space_mgr).await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cimmeria_entity::cell_entity::BandolierItem;
+    use cimmeria_entity::stats::{AMMO_SLOT_1, AMMO_SLOT_2, AMMO_SLOT_3};
+
+    fn make_test_space_mgr() -> SpaceManager {
+        let mut mgr = SpaceManager::new(1);
+        let xml = r#"<?xml version="1.0"?><Spaces><Space WorldName="Castle_CellBlock" Instanced="true" MinX="-800" MaxX="800" MinY="-800" MaxY="800" /></Spaces>"#;
+        mgr.parse_spaces_xml(xml).unwrap();
+        mgr.create_startup_spaces(r#"<?xml version="1.0"?><Spaces></Spaces>"#).unwrap();
+        mgr
+    }
+
+    /// Stage E: when reload_complete_at has elapsed, the tick must
+    /// (a) refill the active slot's magazine to clip_size, (b) sync the
+    /// AmmoSlot{N} stat, (c) clear reload_complete_at, (d) drain the slot's
+    /// dirty flag (the BandolierAmmoUpdate emitted next persists it), and
+    /// (e) emit onStatUpdate (method 20) plus the BandolierAmmoUpdate.
+    #[tokio::test]
+    async fn reload_completion_tick_refills_and_sends_stat() {
+        let mut mgr = make_test_space_mgr();
+        mgr.create_entity(1, "Castle_CellBlock", [0.0; 3], [0.0; 3]).unwrap();
+
+        if let Some(e) = mgr.get_entity_mut(1) {
+            e.is_player = true;
+            e.player_id = Some(100);
+            e.bandolier_items.insert(0, BandolierItem {
+                item_id: 1, clip_size: 30, default_ammo_type: 2,
+                current_ammo: 5, cur_ammo_type: 2,
+            });
+            e.active_bandolier_slot = 0;
+            // Already-elapsed deadline so the tick promotes immediately.
+            e.reload_complete_at = Some(
+                std::time::Instant::now() - std::time::Duration::from_millis(1),
+            );
+            if let Some(s) = e.stats.get_mut(AMMO_SLOT_1) { s.update(0, 5, 30); s.clear_dirty(); }
+        }
+        // connect_entity inserts the entity into space.players, which
+        // `all_player_entity_ids()` reads. Without it the tick skips the entity.
+        mgr.connect_entity(1);
+
+        let (tx, mut rx) = mpsc::channel(16);
+        reload_completion_tick(&tx, &mut mgr).await;
+
+        // ── Entity-state assertions ─────────────────────────────────────
+        let entity = mgr.get_entity(1).unwrap();
+        assert_eq!(entity.bandolier_items[&0].current_ammo, 30, "magazine refilled to clip_size");
+        assert_eq!(entity.stats.get(AMMO_SLOT_1).unwrap().cur, 30, "AmmoSlot1 stat refilled");
+        assert!(entity.reload_complete_at.is_none(), "reload_complete_at cleared");
+        assert!(!entity.bandolier_ammo_dirty.contains(&0), "active slot's dirty flag drained");
+
+        // ── Wire-message assertions ─────────────────────────────────────
+        // First: onStatUpdate (method 20) carrying AmmoSlot1=30.
+        let m1 = rx.try_recv().expect("expected onStatUpdate");
+        match m1 {
+            CellToBaseMsg::EntityMethodCall { entity_id, method_index, args } => {
+                assert_eq!(entity_id, 1);
+                assert_eq!(method_index, 20);
+                let count = u32::from_le_bytes([args[0], args[1], args[2], args[3]]);
+                assert!(count >= 1);
+                let mut found_ammo = false;
+                for i in 0..count as usize {
+                    let off = 4 + i * 16;
+                    let stat_id = i32::from_le_bytes([args[off], args[off+1], args[off+2], args[off+3]]);
+                    let cur = i32::from_le_bytes([args[off+8], args[off+9], args[off+10], args[off+11]]);
+                    if stat_id == AMMO_SLOT_1 {
+                        assert_eq!(cur, 30);
+                        found_ammo = true;
+                    }
+                }
+                assert!(found_ammo, "onStatUpdate missing AmmoSlot1=30");
+            }
+            other => panic!("expected EntityMethodCall, got {other:?}"),
+        }
+
+        // Second: BandolierAmmoUpdate for persistence.
+        let m2 = rx.try_recv().expect("expected BandolierAmmoUpdate");
+        match m2 {
+            CellToBaseMsg::BandolierAmmoUpdate { player_id, slot_id, current_ammo, cur_ammo_type } => {
+                assert_eq!(player_id, 100);
+                assert_eq!(slot_id, 0);
+                assert_eq!(current_ammo, 30);
+                assert_eq!(cur_ammo_type, 2);
+            }
+            other => panic!("expected BandolierAmmoUpdate, got {other:?}"),
+        }
+
+        assert!(rx.try_recv().is_err(), "no further rx messages expected");
+    }
+
+    /// Stage E: InitPlayerState's bandolier-seed loop must populate AmmoSlot{N}
+    /// stats from each persisted item's `current_ammo`/`clip_size`, leave empty
+    /// slots at the default (0,0,0), and clear dirty flags so the initial
+    /// mapLoaded `serialize_all()` is the sole carrier.
+    ///
+    /// Calling the full handle_base_message branch would require a ChainEngine
+    /// with content tables loaded; the seeding logic is purely synchronous
+    /// mutation of the entity, so we exercise it in isolation here.
+    #[tokio::test]
+    async fn init_player_state_seeds_ammo_stats() {
+        let mut mgr = make_test_space_mgr();
+        mgr.create_entity(1, "Castle_CellBlock", [0.0; 3], [0.0; 3]).unwrap();
+
+        let bandolier_items = vec![
+            (0, BandolierItem {
+                item_id: 100, clip_size: 30, default_ammo_type: 2,
+                current_ammo: 25, cur_ammo_type: 2,
+            }),
+            (1, BandolierItem {
+                item_id: 101, clip_size: 12, default_ammo_type: 5,
+                current_ammo: 12, cur_ammo_type: 5,
+            }),
+        ];
+
+        // Mirror the InitPlayerState branch's bandolier seeding (service.rs:444-454).
+        // This is the load-bearing chunk under test; the rest of the handler
+        // (mission restoration, region registration, content engine fire) is
+        // exercised by other test paths.
+        if let Some(entity) = mgr.get_entity_mut(1) {
+            entity.player_id = Some(100);
+            entity.active_bandolier_slot = 0;
+            entity.bandolier_items = bandolier_items.into_iter().collect();
+
+            let slot_seed: Vec<(i32, i32, i32)> = entity.bandolier_items
+                .iter()
+                .map(|(&slot, item)| (slot, item.current_ammo, item.clip_size))
+                .collect();
+            for (slot_id, current, clip) in slot_seed {
+                let stat_id = cimmeria_entity::stats::AMMO_SLOT_1 + slot_id;
+                if let Some(stat) = entity.stats.get_mut(stat_id) {
+                    stat.update(0, current, clip);
+                    stat.clear_dirty();
+                }
+            }
+        }
+
+        let entity = mgr.get_entity(1).unwrap();
+
+        // Populated slots seeded from their bandolier items.
+        let slot1 = entity.stats.get(AMMO_SLOT_1).unwrap();
+        assert_eq!((slot1.min, slot1.cur, slot1.max), (0, 25, 30));
+        assert!(!slot1.dirty, "AmmoSlot1 dirty cleared so mapLoaded serialize_all owns the initial send");
+
+        let slot2 = entity.stats.get(AMMO_SLOT_2).unwrap();
+        assert_eq!((slot2.min, slot2.cur, slot2.max), (0, 12, 12));
+        assert!(!slot2.dirty);
+
+        // Empty slots remain at their default (0, 0, 0) tuple.
+        let slot3 = entity.stats.get(AMMO_SLOT_3).unwrap();
+        assert_eq!((slot3.min, slot3.cur, slot3.max), (0, 0, 0), "unequipped slot stays at default");
+    }
+
+    /// Stage E: on logout (BaseToCellMsg::DestroyEntity), all dirty bandolier
+    /// slots must be flushed via BandolierAmmoUpdate before the entity is torn
+    /// down. The flush path is exercised by handle_base_message; here we
+    /// invoke the matching helper + destroy directly to keep the test focused
+    /// (avoids spinning up a ChainEngine).
+    #[tokio::test]
+    async fn logout_flushes_all_dirty_bandolier_slots() {
+        let mut mgr = make_test_space_mgr();
+        mgr.create_entity(1, "Castle_CellBlock", [0.0; 3], [0.0; 3]).unwrap();
+
+        if let Some(e) = mgr.get_entity_mut(1) {
+            e.is_player = true;
+            e.player_id = Some(100);
+            e.bandolier_items.insert(0, BandolierItem {
+                item_id: 10, clip_size: 30, default_ammo_type: 1,
+                current_ammo: 17, cur_ammo_type: 1,
+            });
+            e.bandolier_items.insert(1, BandolierItem {
+                item_id: 11, clip_size: 12, default_ammo_type: 7,
+                current_ammo: 4, cur_ammo_type: 7,
+            });
+            // Pre-mark both slots dirty as if shots were fired but no swap /
+            // reload-completion / ammo-change had drained them.
+            e.bandolier_ammo_dirty.insert(0);
+            e.bandolier_ammo_dirty.insert(1);
+        }
+
+        let (tx, mut rx) = mpsc::channel(16);
+
+        // Mirror handle_base_message's DestroyEntity branch: flush, then destroy.
+        if let Some(entity) = mgr.get_entity_mut(1) {
+            if let Some(player_id) = entity.player_id {
+                super::super::cell_methods::inventory::flush_dirty_bandolier_ammo(
+                    entity, player_id, &tx,
+                ).await;
+            }
+        }
+        mgr.destroy_entity(1);
+
+        // Collect the two BandolierAmmoUpdate messages (HashSet drain order is
+        // unspecified, so build a slot_id → (current_ammo, type) map).
+        let mut updates = std::collections::HashMap::new();
+        while let Ok(msg) = rx.try_recv() {
+            if let CellToBaseMsg::BandolierAmmoUpdate {
+                player_id, slot_id, current_ammo, cur_ammo_type
+            } = msg {
+                assert_eq!(player_id, 100);
+                updates.insert(slot_id, (current_ammo, cur_ammo_type));
+            }
+        }
+        assert_eq!(updates.len(), 2, "expected one BandolierAmmoUpdate per dirty slot");
+        assert_eq!(updates.get(&0), Some(&(17, 1)));
+        assert_eq!(updates.get(&1), Some(&(4, 7)));
+
+        // Entity removed from the space manager.
+        assert!(mgr.get_entity(1).is_none(), "entity should be destroyed after teardown");
+    }
+
+    /// Regression: the LOG_OFF flow sends `DisconnectEntity` before
+    /// `DestroyEntity`. `space_manager::disconnect_entity` internally calls
+    /// `destroy_entity`, so by the time the cell loop processes the subsequent
+    /// `DestroyEntity` message, the entity is already gone — its flush hook
+    /// becomes a silent no-op and per-slot ammo never persists.
+    ///
+    /// The fix flushes inside the `DisconnectEntity` handler (BEFORE
+    /// `space_mgr.disconnect_entity`). This test mirrors that order and
+    /// verifies the persistence message goes out.
+    #[tokio::test]
+    async fn disconnect_entity_flushes_dirty_ammo_before_destroy() {
+        let mut mgr = make_test_space_mgr();
+        mgr.create_entity(1, "Castle_CellBlock", [0.0; 3], [0.0; 3]).unwrap();
+
+        if let Some(e) = mgr.get_entity_mut(1) {
+            e.is_player = true;
+            e.player_id = Some(100);
+            e.bandolier_items.insert(0, BandolierItem {
+                item_id: 10, clip_size: 30, default_ammo_type: 1,
+                current_ammo: 17, cur_ammo_type: 1,
+            });
+            e.bandolier_ammo_dirty.insert(0);
+        }
+
+        let (tx, mut rx) = mpsc::channel(16);
+
+        // Mirror handle_base_message's DisconnectEntity branch verbatim:
+        // flush bandolier ammo BEFORE space_mgr.disconnect_entity (which
+        // internally destroys the entity).
+        if let Some(entity) = mgr.get_entity_mut(1) {
+            if let Some(player_id) = entity.player_id {
+                super::super::cell_methods::inventory::flush_dirty_bandolier_ammo(
+                    entity, player_id, &tx,
+                ).await;
+            }
+        }
+        mgr.disconnect_entity(1, &tx).await;
+
+        // The first message must be the BandolierAmmoUpdate (the regression
+        // was that flushing AFTER disconnect_entity silently dropped it).
+        let mut got_ammo_update = false;
+        while let Ok(msg) = rx.try_recv() {
+            if let CellToBaseMsg::BandolierAmmoUpdate {
+                player_id, slot_id, current_ammo, cur_ammo_type
+            } = msg {
+                assert_eq!(player_id, 100);
+                assert_eq!(slot_id, 0);
+                assert_eq!(current_ammo, 17);
+                assert_eq!(cur_ammo_type, 1);
+                got_ammo_update = true;
+                break;
+            }
+        }
+        assert!(got_ammo_update, "DisconnectEntity must flush bandolier ammo before destroy");
+        assert!(mgr.get_entity(1).is_none(), "entity should be destroyed after disconnect");
+    }
 }

--- a/crates/services/src/cell/service.rs
+++ b/crates/services/src/cell/service.rs
@@ -680,28 +680,46 @@ async fn reload_completion_tick(
                 None => continue,
             };
 
-            if entity.refill_active_slot().is_none() {
-                // No bandolier item in the active slot — clear the deadline
-                // anyway so we don't loop forever, but skip the wire send.
-                entity.reload_complete_at = None;
-                tracing::debug!(entity_id, "reload tick: active slot empty, no refill");
+            // Refill the slot that *started* the reload, not whatever slot is
+            // currently active. Without pinning, a mid-reload weapon swap
+            // would mis-attribute the refill to the new weapon.
+            let slot_id = match entity.reload_slot_id {
+                Some(s) => s,
+                None => {
+                    // Defensive: shouldn't happen — reload_complete_at is only
+                    // set together with reload_slot_id. Clear and move on.
+                    entity.reload_complete_at = None;
+                    tracing::warn!(entity_id, "reload tick: deadline set without slot_id, clearing");
+                    continue;
+                }
+            };
+
+            // Look up the clip size for the pinned slot. If the slot is
+            // empty (item removed mid-reload), clear the deadline and skip
+            // the wire send rather than refilling nothing.
+            let clip_size = entity.bandolier_items.get(&slot_id).map(|i| i.clip_size);
+            let new_ammo = match clip_size {
+                Some(cs) => entity.set_slot_ammo(slot_id, cs),
+                None => None,
+            };
+            entity.reload_complete_at = None;
+            entity.reload_slot_id = None;
+
+            if new_ammo.is_none() {
+                tracing::debug!(entity_id, slot_id, "reload tick: pinned slot empty, no refill");
                 continue;
             }
-            entity.reload_complete_at = None;
 
             // The slot was marked dirty by `set_slot_ammo`; persistence drains
             // it via the BandolierAmmoUpdate below.
-            entity.bandolier_ammo_dirty.remove(&entity.active_bandolier_slot);
+            entity.bandolier_ammo_dirty.remove(&slot_id);
 
             let payload = entity.stats.serialize_dirty();
             entity.stats.clear_dirty();
 
-            let persist = entity.player_id.map(|pid| (
-                pid,
-                entity.active_bandolier_slot,
-                entity.active_ammo(),
-                entity.active_ammo_type(),
-            ));
+            let (item_id, cur_ammo, cur_ammo_type) = entity.bandolier_items.get(&slot_id)
+                .map_or((0, 0, 0), |i| (i.item_id, i.current_ammo, i.cur_ammo_type));
+            let persist = entity.player_id.map(|pid| (pid, slot_id, item_id, cur_ammo, cur_ammo_type));
 
             (payload, persist)
         };
@@ -715,10 +733,11 @@ async fn reload_completion_tick(
 
         // Phase 3: persistence. CellToBaseMsg::BandolierAmmoUpdate is consumed
         // by base's existing handler that writes `sgw_inventory.ammo`.
-        if let Some((player_id, slot_id, current_ammo, cur_ammo_type)) = persist {
+        if let Some((player_id, slot_id, expected_item_id, current_ammo, cur_ammo_type)) = persist {
             let _ = tx.send(CellToBaseMsg::BandolierAmmoUpdate {
                 player_id,
                 slot_id,
+                expected_item_id,
                 current_ammo,
                 cur_ammo_type,
             }).await;
@@ -1108,6 +1127,7 @@ mod tests {
             e.reload_complete_at = Some(
                 std::time::Instant::now() - std::time::Duration::from_millis(1),
             );
+            e.reload_slot_id = Some(0);
             if let Some(s) = e.stats.get_mut(AMMO_SLOT_1) { s.update(0, 5, 30); s.clear_dirty(); }
         }
         // connect_entity inserts the entity into space.players, which
@@ -1122,6 +1142,7 @@ mod tests {
         assert_eq!(entity.bandolier_items[&0].current_ammo, 30, "magazine refilled to clip_size");
         assert_eq!(entity.stats.get(AMMO_SLOT_1).unwrap().cur, 30, "AmmoSlot1 stat refilled");
         assert!(entity.reload_complete_at.is_none(), "reload_complete_at cleared");
+        assert!(entity.reload_slot_id.is_none(), "reload_slot_id cleared");
         assert!(!entity.bandolier_ammo_dirty.contains(&0), "active slot's dirty flag drained");
 
         // ── Wire-message assertions ─────────────────────────────────────
@@ -1151,9 +1172,10 @@ mod tests {
         // Second: BandolierAmmoUpdate for persistence.
         let m2 = rx.try_recv().expect("expected BandolierAmmoUpdate");
         match m2 {
-            CellToBaseMsg::BandolierAmmoUpdate { player_id, slot_id, current_ammo, cur_ammo_type } => {
+            CellToBaseMsg::BandolierAmmoUpdate { player_id, slot_id, expected_item_id, current_ammo, cur_ammo_type } => {
                 assert_eq!(player_id, 100);
                 assert_eq!(slot_id, 0);
+                assert_eq!(expected_item_id, 1, "should carry the slot's item_id for TOCTOU guard");
                 assert_eq!(current_ammo, 30);
                 assert_eq!(cur_ammo_type, 2);
             }
@@ -1265,19 +1287,19 @@ mod tests {
         mgr.destroy_entity(1);
 
         // Collect the two BandolierAmmoUpdate messages (HashSet drain order is
-        // unspecified, so build a slot_id → (current_ammo, type) map).
+        // unspecified, so build a slot_id → (item_id, current_ammo, type) map).
         let mut updates = std::collections::HashMap::new();
         while let Ok(msg) = rx.try_recv() {
             if let CellToBaseMsg::BandolierAmmoUpdate {
-                player_id, slot_id, current_ammo, cur_ammo_type
+                player_id, slot_id, expected_item_id, current_ammo, cur_ammo_type
             } = msg {
                 assert_eq!(player_id, 100);
-                updates.insert(slot_id, (current_ammo, cur_ammo_type));
+                updates.insert(slot_id, (expected_item_id, current_ammo, cur_ammo_type));
             }
         }
         assert_eq!(updates.len(), 2, "expected one BandolierAmmoUpdate per dirty slot");
-        assert_eq!(updates.get(&0), Some(&(17, 1)));
-        assert_eq!(updates.get(&1), Some(&(4, 7)));
+        assert_eq!(updates.get(&0), Some(&(10, 17, 1)));
+        assert_eq!(updates.get(&1), Some(&(11, 4, 7)));
 
         // Entity removed from the space manager.
         assert!(mgr.get_entity(1).is_none(), "entity should be destroyed after teardown");
@@ -1326,10 +1348,11 @@ mod tests {
         let mut got_ammo_update = false;
         while let Ok(msg) = rx.try_recv() {
             if let CellToBaseMsg::BandolierAmmoUpdate {
-                player_id, slot_id, current_ammo, cur_ammo_type
+                player_id, slot_id, expected_item_id, current_ammo, cur_ammo_type
             } = msg {
                 assert_eq!(player_id, 100);
                 assert_eq!(slot_id, 0);
+                assert_eq!(expected_item_id, 10, "should carry the slot's item_id");
                 assert_eq!(current_ammo, 17);
                 assert_eq!(cur_ammo_type, 1);
                 got_ammo_update = true;

--- a/crates/services/src/cell/space_manager.rs
+++ b/crates/services/src/cell/space_manager.rs
@@ -116,6 +116,11 @@ pub struct SpaceManager {
     /// Loaded at startup so runtime item grants go into the correct inventory bag
     /// (e.g. mission items into INV_Mission, weapons into bandolier).
     pub item_containers: HashMap<i32, i32>,
+    /// Weapon defs (clip_size + default_ammo_type) keyed by item_id.
+    /// Loaded from `resources.items` at startup. Used by the content engine's
+    /// GrantItem path to seed bandolier slots when a weapon is granted at
+    /// runtime, so the client renders the correct empty magazine.
+    pub item_defs: HashMap<i32, super::spawner::WeaponDef>,
     /// Loot tables: loot_table_id → entries.
     /// Loaded from `resources.loot` at startup for NPC death loot generation.
     pub loot_tables: HashMap<i32, Vec<super::spawner::LootTableEntry>>,
@@ -145,6 +150,7 @@ impl SpaceManager {
             effect_defs: HashMap::new(),
             sequence_map: HashMap::new(),
             item_containers: HashMap::new(),
+            item_defs: HashMap::new(),
             loot_tables: HashMap::new(),
             respawners: Vec::new(),
         }
@@ -775,6 +781,17 @@ impl SpaceManager {
                     ids.push(entity.entity_id.0 as u32);
                 }
             }
+        }
+        ids
+    }
+
+    /// Collect all player entity IDs (entries in each space's `players` set)
+    /// across all spaces. Returned as a `Vec` so callers can iterate without
+    /// holding a borrow on `SpaceManager`.
+    pub fn all_player_entity_ids(&self) -> Vec<u32> {
+        let mut ids = Vec::new();
+        for space in self.spaces.values() {
+            ids.extend(space.players.iter().copied());
         }
         ids
     }

--- a/crates/services/src/cell/spawner.rs
+++ b/crates/services/src/cell/spawner.rs
@@ -913,3 +913,50 @@ pub async fn load_item_containers(
     tracing::info!(count = map.len(), "Loaded item container mappings");
     Ok(map)
 }
+
+/// Cached weapon stats for runtime item grants.
+///
+/// The content engine's `GrantItem` action seeds bandolier slots and AmmoSlot
+/// stats from this cache so the client renders the correct empty magazine for
+/// the new weapon. Mirrors the per-row clip_size + default_ammo_type that
+/// `BANDOLIER_ITEMS_QUERY` reads for player_load.
+#[derive(Debug, Clone, Copy)]
+pub struct WeaponDef {
+    pub clip_size: i32,
+    /// 0-based EAmmoType index, matching the wire format used in
+    /// `bandolier_items` and `onEntityProperty(AmmoTypeId)`.
+    pub default_ammo_type: i32,
+}
+
+/// Load weapon stats (clip_size + default_ammo_type) from `resources.items`.
+///
+/// Skips items with `clip_size IS NULL` (non-weapons). The `default_ammo_type`
+/// conversion mirrors `BANDOLIER_ITEMS_QUERY` exactly so that values seeded
+/// here for runtime grants match the wire format the player_load path uses.
+pub async fn load_item_defs(
+    pool: &PgPool,
+) -> Result<std::collections::HashMap<i32, WeaponDef>, sqlx::Error> {
+    use sqlx::Row;
+
+    let rows = sqlx::query(
+        "SELECT item_id, clip_size, \
+                CASE WHEN default_ammo_type IS NULL THEN 0 \
+                     ELSE array_position(enum_range(NULL::resources.\"EAmmoType\"), default_ammo_type) - 1 \
+                END AS default_ammo_type_id \
+         FROM resources.items \
+         WHERE clip_size IS NOT NULL",
+    )
+    .fetch_all(pool)
+    .await?;
+
+    let mut map = std::collections::HashMap::with_capacity(rows.len());
+    for r in &rows {
+        let item_id: i32 = r.get("item_id");
+        let clip_size: i32 = r.get("clip_size");
+        let default_ammo_type: i32 = r.get("default_ammo_type_id");
+        map.insert(item_id, WeaponDef { clip_size, default_ammo_type });
+    }
+
+    tracing::info!(count = map.len(), "Loaded weapon defs");
+    Ok(map)
+}

--- a/crates/services/src/cell/spawner.rs
+++ b/crates/services/src/cell/spawner.rs
@@ -920,19 +920,29 @@ pub async fn load_item_containers(
 /// stats from this cache so the client renders the correct empty magazine for
 /// the new weapon. Mirrors the per-row clip_size + default_ammo_type that
 /// `BANDOLIER_ITEMS_QUERY` reads for player_load.
-#[derive(Debug, Clone, Copy)]
+///
+/// `allowed_ammo_types` is the whitelist of subtypes a player may pick via
+/// `requestAmmoChange` for this weapon — empty means "no choice; default
+/// only". Mirrors `resources.items.ammo_types` converted to 0-based indices.
+#[derive(Debug, Clone)]
 pub struct WeaponDef {
     pub clip_size: i32,
     /// 0-based EAmmoType index, matching the wire format used in
     /// `bandolier_items` and `onEntityProperty(AmmoTypeId)`.
     pub default_ammo_type: i32,
+    /// 0-based EAmmoType indices the player may pick via requestAmmoChange.
+    /// Empty Vec means "no allowed subtypes" (default ammo type only).
+    pub allowed_ammo_types: Vec<i32>,
 }
 
-/// Load weapon stats (clip_size + default_ammo_type) from `resources.items`.
+/// Load weapon stats (clip_size + default_ammo_type + allowed ammo subtypes)
+/// from `resources.items`.
 ///
 /// Skips items with `clip_size IS NULL` (non-weapons). The `default_ammo_type`
 /// conversion mirrors `BANDOLIER_ITEMS_QUERY` exactly so that values seeded
 /// here for runtime grants match the wire format the player_load path uses.
+/// `ammo_types` is unnested and each enum entry converted via the same
+/// `array_position` trick, then aggregated back to an `integer[]` array.
 pub async fn load_item_defs(
     pool: &PgPool,
 ) -> Result<std::collections::HashMap<i32, WeaponDef>, sqlx::Error> {
@@ -942,7 +952,12 @@ pub async fn load_item_defs(
         "SELECT item_id, clip_size, \
                 CASE WHEN default_ammo_type IS NULL THEN 0 \
                      ELSE array_position(enum_range(NULL::resources.\"EAmmoType\"), default_ammo_type) - 1 \
-                END AS default_ammo_type_id \
+                END AS default_ammo_type_id, \
+                COALESCE( \
+                    (SELECT array_agg((array_position(enum_range(NULL::resources.\"EAmmoType\"), e) - 1)::integer) \
+                     FROM unnest(ammo_types) AS e), \
+                    '{}'::integer[] \
+                ) AS allowed_ammo_type_ids \
          FROM resources.items \
          WHERE clip_size IS NOT NULL",
     )
@@ -954,7 +969,8 @@ pub async fn load_item_defs(
         let item_id: i32 = r.get("item_id");
         let clip_size: i32 = r.get("clip_size");
         let default_ammo_type: i32 = r.get("default_ammo_type_id");
-        map.insert(item_id, WeaponDef { clip_size, default_ammo_type });
+        let allowed_ammo_types: Vec<i32> = r.get("allowed_ammo_type_ids");
+        map.insert(item_id, WeaponDef { clip_size, default_ammo_type, allowed_ammo_types });
     }
 
     tracing::info!(count = map.len(), "Loaded weapon defs");

--- a/crates/services/src/mercury/types.rs
+++ b/crates/services/src/mercury/types.rs
@@ -77,10 +77,11 @@ pub struct PlayerLoadData {
     pub skin_color_id: i32,
     /// Active bandolier slot (0-based) from `sgw_player.bandolier_slot`.
     pub active_bandolier_slot: i32,
-    /// Active weapon clip size from `sgw_player.active_weapon_clip_size`.
-    pub active_weapon_clip_size: i32,
-    /// Active ammo type enum from `sgw_player.active_ammo_type`.
-    pub active_ammo_type: i32,
+    /// Bandolier items keyed by slot id. Loaded from `sgw_inventory` (container 3)
+    /// joined to `resources.items`. Stage C: this is the single source of truth
+    /// for the active weapon's clip size and ammo subtype on the wire — the old
+    /// shadow `active_weapon_clip_size` / `active_ammo_type` fields are gone.
+    pub bandolier_items: Vec<(i32, cimmeria_entity::cell_entity::BandolierItem)>,
     /// Ability tree data (3 branches). Loaded from `resources.archetype_ability_tree`.
     pub ability_tree: cimmeria_entity::abilities::AbilityTreeData,
     /// Inventory items loaded from `sgw_inventory`.

--- a/crates/services/src/mercury/world_data/map_loaded.rs
+++ b/crates/services/src/mercury/world_data/map_loaded.rs
@@ -270,13 +270,23 @@ fn build_map_loaded_body_inner(
 
     // 20. onEntityProperty x6 (INT32 propId, INT32 value)
     //     GENERICPROPERTY IDs from Atrea.enums
+    //
+    // Stage C: AmmoTypeId is sourced directly from the active bandolier item.
+    // No shadow `active_ammo_type` field on PlayerLoadData anymore — if no
+    // item is in the active slot we fall back to 0 (matches legacy "no weapon
+    // equipped" behavior).
+    let active_ammo_type = data
+        .bandolier_items
+        .iter()
+        .find(|(slot, _)| *slot == data.active_bandolier_slot)
+        .map_or(0, |(_, item)| item.cur_ammo_type);
     for &(prop_id, value) in &[
         (2i32, data.applied_science_points), // AppliedSciencePoints
         (1,    data.training_points),        // TrainingPoints
         (7,    data.access_level),           // AccessLevel
         (8,    data.gender),                 // Gender
         (4,    0),                           // PvPFlag
-        (3,    0),                           // AmmoTypeId
+        (3,    active_ammo_type),            // AmmoTypeId
     ] {
         let mut args = Vec::with_capacity(8);
         args.extend_from_slice(&prop_id.to_le_bytes());

--- a/crates/services/src/mercury/world_data/map_loaded.rs
+++ b/crates/services/src/mercury/world_data/map_loaded.rs
@@ -165,7 +165,7 @@ fn build_map_loaded_body_inner(
     //    Uses StatList from entity crate — sends ALL stats, matching Python's
     //    `self.sendStats(self.client, False, False)` which sends everything.
     {
-        use cimmeria_entity::stats::{StatList, ArchetypeStatValues};
+        use cimmeria_entity::stats::{StatList, ArchetypeStatValues, AMMO_SLOT_1};
         let mut stat_list = StatList::new();
         stat_list.apply_archetype(&ArchetypeStatValues {
             coordination: stats.coordination,
@@ -179,6 +179,17 @@ fn build_map_loaded_body_inner(
             health_per_level: stats.health_per_level,
             focus_per_level: stats.focus_per_level,
         });
+        // Seed AmmoSlot{N} stats from persisted bandolier ammo so the UI
+        // shows the correct value at world entry. Without this seed every
+        // re-login sends the default (0, 0, 0) tuple — the cell-side
+        // InitPlayerState seeding (service.rs) sets the stats correctly on
+        // the entity but happens after this packet is already on the wire.
+        for (slot_id, item) in &data.bandolier_items {
+            let stat_id = AMMO_SLOT_1 + slot_id;
+            if let Some(stat) = stat_list.get_mut(stat_id) {
+                stat.update(0, item.current_ammo, item.clip_size);
+            }
+        }
         // onStatUpdate: dynamic values (min, current, max)
         let stat_args = stat_list.serialize_all();
         append_method!(method_idx::ON_STAT_UPDATE, &stat_args);

--- a/crates/services/src/mercury/world_data/mod.rs
+++ b/crates/services/src/mercury/world_data/mod.rs
@@ -178,8 +178,7 @@ mod tests {
             ability_tree: Default::default(),
             items: vec![],
             active_bandolier_slot: 0,
-            active_weapon_clip_size: 0,
-            active_ammo_type: 0,
+            bandolier_items: vec![],
         };
         let entry = WorldEntryInfo { player_entity_id: 42, space_id: 65552, pos: [0.0; 3], rot: [0.0; 3], world_name: "CombatSim".into(), class_id: 0x02, world_stargates: vec![] };
         let (packets, seqs) = build_map_loaded(&TEST_KEY, 5, &[], 42, &data, &entry);
@@ -215,8 +214,7 @@ mod tests {
             ability_tree: archetype_ability_tree(2),
             items: vec![],
             active_bandolier_slot: 0,
-            active_weapon_clip_size: 0,
-            active_ammo_type: 0,
+            bandolier_items: vec![],
         };
         let entry = WorldEntryInfo { player_entity_id: 100, space_id: 65552, pos: [0.0; 3], rot: [0.0; 3], world_name: "CombatSim".into(), class_id: 0x02, world_stargates: vec![] };
         let (packets, _seqs) = build_map_loaded(&TEST_KEY, 5, &[], 100, &data, &entry);
@@ -255,8 +253,7 @@ mod tests {
             ability_tree: archetype_ability_tree(2),
             items: vec![],
             active_bandolier_slot: 0,
-            active_weapon_clip_size: 0,
-            active_ammo_type: 0,
+            bandolier_items: vec![],
         };
         let entry = WorldEntryInfo { player_entity_id: 100, space_id: 65552, pos: [0.0; 3], rot: [0.0; 3], world_name: "CombatSim".into(), class_id: 0x02, world_stargates: vec![] };
         let (packets, _seqs) = build_map_loaded(&TEST_KEY, 5, &[], 100, &data, &entry);
@@ -305,8 +302,7 @@ mod tests {
             ability_tree: archetype_ability_tree(2),
             items: vec![],
             active_bandolier_slot: 0,
-            active_weapon_clip_size: 0,
-            active_ammo_type: 0,
+            bandolier_items: vec![],
         };
         let entry = WorldEntryInfo {
             player_entity_id: 100, space_id: 65552,

--- a/crates/services/src/mercury/world_data/mod.rs
+++ b/crates/services/src/mercury/world_data/mod.rs
@@ -548,18 +548,9 @@ mod tests {
             pos: [0.0; 3], rot: [0.0; 3], world_name: "CombatSim".into(), class_id: 0x02,
             world_stargates: vec![],
         };
-        let (packets, _seqs) = build_map_loaded(&TEST_KEY, 5, &[], 100, &data, &entry);
-        let enc = MercuryEncryption::from_session_key(TEST_KEY);
-
-        // Concatenate plaintext bodies across all fragments. Each fragment
-        // is `[flags:1][body...][footers:12]` so the body slice is `[1..len-12]`.
-        // For non-fragmented single packets the footers vary; this test only
-        // needs to find a stat tuple anywhere in the assembled bytes.
-        let mut all_bytes = Vec::new();
-        for pkt in &packets {
-            let pt = enc.decrypt(pkt).unwrap();
-            all_bytes.extend_from_slice(&pt);
-        }
+        // Assert against the raw, unfragmented mapLoaded body to avoid coupling
+        // the regression check to Mercury framing/footers.
+        let all_bytes = build_map_loaded_body(100, &data, &entry);
 
         // StatUpdate wire format (16 bytes per stat):
         //   stat_id:i32 LE | min:i32 LE | cur:i32 LE | max:i32 LE

--- a/crates/services/src/mercury/world_data/mod.rs
+++ b/crates/services/src/mercury/world_data/mod.rs
@@ -495,4 +495,114 @@ mod tests {
         let sk = u32::from_le_bytes([body[15], body[16], body[17], body[18]]);
         assert_eq!(sk, SKIN_TINTS[5], "skinTint should match SKIN_TINTS[5]");
     }
+
+    /// Regression: at world entry the `mapLoaded` packet's `onStatUpdate`
+    /// must seed AmmoSlot{N} stats from the persisted bandolier ammo.
+    /// Previously it built a fresh `StatList::new()` (defaults `(0, 0, 0)`)
+    /// so on re-login the bandolier UI showed an empty mag until the next
+    /// reload — even though the cell-side `bandolier_items.current_ammo`
+    /// loaded correctly from `sgw_inventory.ammo`.
+    #[test]
+    fn build_map_loaded_seeds_ammo_slot_stats_from_bandolier_items() {
+        use cimmeria_entity::cell_entity::BandolierItem;
+
+        let data = PlayerLoadData {
+            player_id: 1,
+            level: 5,
+            player_name: "Reloader".into(),
+            extra_name: String::new(),
+            alignment: 1,
+            archetype: 2,
+            gender: 1,
+            bodyset: "BS_HumanMale.BS_HumanMale".into(),
+            components: vec![],
+            exp: 0,
+            naquadah: 0,
+            known_stargates: vec![],
+            abilities: vec![],
+            training_points: 0,
+            applied_science_points: 0,
+            blueprint_ids: vec![],
+            first_login: 0,
+            access_level: 0,
+            skin_color_id: 0,
+            ability_tree: archetype_ability_tree(2),
+            items: vec![],
+            active_bandolier_slot: 0,
+            // Slot 0: 8 of 15 (mid-mag), slot 2: 12 of 12 (full).
+            // Slot 1, 3, 4 are empty — their AmmoSlot stats must stay
+            // at the default (0, 0, 0).
+            bandolier_items: vec![
+                (0, BandolierItem {
+                    item_id: 100, clip_size: 15, default_ammo_type: 1,
+                    current_ammo: 8, cur_ammo_type: 1,
+                }),
+                (2, BandolierItem {
+                    item_id: 101, clip_size: 12, default_ammo_type: 7,
+                    current_ammo: 12, cur_ammo_type: 7,
+                }),
+            ],
+        };
+        let entry = WorldEntryInfo {
+            player_entity_id: 100, space_id: 65552,
+            pos: [0.0; 3], rot: [0.0; 3], world_name: "CombatSim".into(), class_id: 0x02,
+            world_stargates: vec![],
+        };
+        let (packets, _seqs) = build_map_loaded(&TEST_KEY, 5, &[], 100, &data, &entry);
+        let enc = MercuryEncryption::from_session_key(TEST_KEY);
+
+        // Concatenate plaintext bodies across all fragments. Each fragment
+        // is `[flags:1][body...][footers:12]` so the body slice is `[1..len-12]`.
+        // For non-fragmented single packets the footers vary; this test only
+        // needs to find a stat tuple anywhere in the assembled bytes.
+        let mut all_bytes = Vec::new();
+        for pkt in &packets {
+            let pt = enc.decrypt(pkt).unwrap();
+            all_bytes.extend_from_slice(&pt);
+        }
+
+        // StatUpdate wire format (16 bytes per stat):
+        //   stat_id:i32 LE | min:i32 LE | cur:i32 LE | max:i32 LE
+        //
+        // Stat IDs: AMMO_SLOT_1=49, AMMO_SLOT_3=51 (skipping the empty slot 1).
+        let ammo_slot_1_tuple: [u8; 16] = [
+            49, 0, 0, 0,   // stat_id = 49 (AMMO_SLOT_1)
+             0, 0, 0, 0,   // min = 0
+             8, 0, 0, 0,   // cur = 8
+            15, 0, 0, 0,   // max = 15
+        ];
+        let ammo_slot_3_tuple: [u8; 16] = [
+            51, 0, 0, 0,   // stat_id = 51 (AMMO_SLOT_3 — slot index 2)
+             0, 0, 0, 0,   // min = 0
+            12, 0, 0, 0,   // cur = 12
+            12, 0, 0, 0,   // max = 12
+        ];
+
+        let contains = |needle: &[u8]| {
+            all_bytes.windows(needle.len()).any(|w| w == needle)
+        };
+
+        assert!(
+            contains(&ammo_slot_1_tuple),
+            "mapLoaded onStatUpdate must include AmmoSlot1 = (0, 8, 15) from persisted bandolier item",
+        );
+        assert!(
+            contains(&ammo_slot_3_tuple),
+            "mapLoaded onStatUpdate must include AmmoSlot3 = (0, 12, 12) from persisted bandolier item",
+        );
+
+        // Empty slot 1 (stat id 50) must NOT appear with a non-zero cur value.
+        // We look for a slot-1 tuple matching some plausible stale value (15)
+        // to make sure no leak from elsewhere overwrote it.
+        let stale_slot_2: [u8; 16] = [
+            50, 0, 0, 0,
+             0, 0, 0, 0,
+            15, 0, 0, 0,
+            15, 0, 0, 0,
+        ];
+        assert!(
+            !contains(&stale_slot_2),
+            "empty slot 1 should not have stale clip_size in its AmmoSlot stat",
+        );
+    }
 }

--- a/db/scripts/add_bandolier_cur_ammo_type.sql
+++ b/db/scripts/add_bandolier_cur_ammo_type.sql
@@ -1,0 +1,13 @@
+-- Migration: add cur_ammo_type column to sgw_inventory for per-slot ammo subtype.
+--
+-- Players can pick a non-default ammo subtype per bandolier weapon (e.g. AP
+-- rounds vs. tracer for the same rifle). Persisting this requires a column
+-- per inventory row — overloading the existing `flags` bitfield was rejected
+-- as too opaque.
+--
+-- A value of 0 means "no explicit choice" and the load path falls back to the
+-- item's `default_ammo_type` (resources.items.default_ammo_type). Safe to run
+-- on existing databases (uses IF NOT EXISTS).
+
+ALTER TABLE sgw_inventory
+    ADD COLUMN IF NOT EXISTS cur_ammo_type integer NOT NULL DEFAULT 0;

--- a/db/scripts/add_bandolier_cur_ammo_type.sql
+++ b/db/scripts/add_bandolier_cur_ammo_type.sql
@@ -11,3 +11,21 @@
 
 ALTER TABLE sgw_inventory
     ADD COLUMN IF NOT EXISTS cur_ammo_type integer NOT NULL DEFAULT 0;
+
+-- Guard against malformed payloads landing as durable corruption: ammo subtype
+-- IDs are always non-negative (0 sentinels "no explicit choice", positive
+-- values index into resources."EAmmoType"). PostgreSQL has no IF NOT EXISTS
+-- for CHECK constraints, so use a DO block for idempotency.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'sgw_inventory_cur_ammo_type_nonnegative_chk'
+          AND conrelid = 'sgw_inventory'::regclass
+    ) THEN
+        ALTER TABLE sgw_inventory
+            ADD CONSTRAINT sgw_inventory_cur_ammo_type_nonnegative_chk
+            CHECK (cur_ammo_type >= 0);
+    END IF;
+END $$;

--- a/db/sgw/Inventory/Tables/sgw_inventory.sql
+++ b/db/sgw/Inventory/Tables/sgw_inventory.sql
@@ -15,6 +15,7 @@ CREATE TABLE sgw_inventory (
     character_id integer NOT NULL,
     bound boolean DEFAULT false NOT NULL,
     ammo integer DEFAULT 0 NOT NULL,
+    cur_ammo_type integer DEFAULT 0 NOT NULL,
     CONSTRAINT local_id_check CHECK ((item_id >= 10000))
 )
 INHERITS (sgw_inventory_base);

--- a/db/sgw/Inventory/Tables/sgw_inventory.sql
+++ b/db/sgw/Inventory/Tables/sgw_inventory.sql
@@ -16,7 +16,8 @@ CREATE TABLE sgw_inventory (
     bound boolean DEFAULT false NOT NULL,
     ammo integer DEFAULT 0 NOT NULL,
     cur_ammo_type integer DEFAULT 0 NOT NULL,
-    CONSTRAINT local_id_check CHECK ((item_id >= 10000))
+    CONSTRAINT local_id_check CHECK ((item_id >= 10000)),
+    CONSTRAINT sgw_inventory_cur_ammo_type_nonnegative_chk CHECK ((cur_ammo_type >= 0))
 )
 INHERITS (sgw_inventory_base);
 

--- a/docs/gameplay/README.md
+++ b/docs/gameplay/README.md
@@ -12,6 +12,7 @@ Status key: **CW** = Confirmed Working, **NT** = Needs Test, **IM** = Implemente
 |--------|--------|---------------|------------------|----------|
 | [Combat](#combat) | IM | SGWCombatant | AbilityManager.py, EffectManager.py | HIGH |
 | [Abilities](#abilities) | IM | SGWAbilityManager | AbilityManager.py | HIGH |
+| [Weapon Ammo & Reload](#weapon-ammo--reload) | IM | SGWPlayer / SGWInventoryManager | SGWPlayer.py, AbilityManager.py, effects/Reload.py | HIGH |
 | [Effects](#effects) | IM | SGWCombatant | EffectManager.py | HIGH |
 | [Stats](#stats) | IM | SGWCombatant | Stat.py | HIGH |
 | [Inventory](#inventory) | NT | SGWInventoryManager | Inventory.py | HIGH |
@@ -72,6 +73,21 @@ Status key: **CW** = Confirmed Working, **NT** = Needs Test, **IM** = Implemente
 **Enums**: `TargetingMode`, `AbilityRange`, `AbilityType` in enumerations.xml
 
 **RE doc**: [ability-system.md](ability-system.md)
+
+---
+
+## Weapon Ammo & Reload
+
+**Status**: IM — Server-authoritative per-bandolier-slot ammo. Fire-gate validates `required_ammo` against `active_ammo()`, decrements via `set_slot_ammo`, mirrors to `Stat[AMMO_SLOT_1+slot]`. `requestReload(EReloadType)` (cell method 86 on SGWPlayer) sets a warmup deadline; a 100 ms tick refills the magazine. Persistence is batched (reload completion / slot swap / ammo change / logout / world transition).
+
+**Key cell methods (NetOut)**:
+- `requestReload(EReloadType)` — opcode 86 on SGWPlayer
+- `requestActiveSlotChange(BagId, SlotId)` — opcode 41 on SGWInventoryManager
+- `requestAmmoChange(ItemId, AmmoType)` — opcode 42 on SGWInventoryManager
+
+**Key client method (NetIn)**: `onStatUpdate` (method 20) carrying the AmmoSlot{N} stat — the bandolier UI's only refresh trigger.
+
+**RE doc**: [weapon-ammo-reload.md](weapon-ammo-reload.md)
 
 ---
 

--- a/docs/gameplay/ability-system.md
+++ b/docs/gameplay/ability-system.md
@@ -114,6 +114,16 @@ AbilityManager.useAbility()
 | EntityDoesNotHaveAbility | `CONDITION_FEEDBACK_EntityDoesNotHaveAbility` | Ability not in entity list |
 | PositionCheck* | `CONDITION_FEEDBACK_PositionCheck{Above,Below,Front,Flank,Rear}` | Invalid facing direction |
 
+## Reload Ability
+
+`ABILITY_RELOAD_WEAPON = 596` is the well-known reload ability. Its `warmup` and `cooldown` come from the standard `ability_defs` row — no special-cased timing. The `requestReload(EReloadType)` cell method on `SGWPlayer` ([`SGWPlayer.def:794-797`](../../entities/defs/SGWPlayer.def#L794), opcode 86) starts the reload by:
+
+1. Setting `reload_complete_at = now + warmup` on the cell entity.
+2. Calling `start_ability_cooldown(596, warmup + cooldown)` so subsequent fires are gated by the standard cooldown timer.
+3. Sending `onTimerUpdate` (method 12) so the client renders the cooldown bar.
+
+The warmup deadline gates **magazine refill timing**: a 100 ms `reload_completion_tick` checks `reload_complete_at` and calls `refill_active_slot()` (sets `current_ammo = clip_size`) when the deadline elapses. The fire-path does not promote pending refills — it only reads the current ammo. See [weapon-ammo-reload.md](weapon-ammo-reload.md) for the full sequence.
+
 ## Data References
 
 - **Ability definitions**: 1,887 in `db/resources.sql`

--- a/docs/gameplay/combat-system.md
+++ b/docs/gameplay/combat-system.md
@@ -118,6 +118,20 @@ Each entry: { StatId: INT32, Min: INT32, Current: INT32, Max: INT32 }
 Each entry: { StatID: INT32, Delta: INT32, DamageCode: INT32, StatResultCode: INT32 }
 ```
 
+## Ammo Gating
+
+Ranged abilities declare a `required_ammo` cost. On every `useAbility`, the cell fire-gate ([`crates/services/src/cell/abilities.rs:259-281`](../../crates/services/src/cell/abilities.rs#L259)) checks:
+
+```
+if required_ammo > 0 && entity.is_player && active_ammo() < required_ammo:
+    log "useAbility: not enough ammo"
+    return  (fire aborts; no effect dispatch, no cooldown)
+```
+
+If the check passes, the server decrements via `set_slot_ammo(active_slot, ammo - required_ammo)`, which mirrors the new value to `Stat[AMMO_SLOT_1+slot]` and emits `onStatUpdate` (method 20) so the bandolier UI refreshes the meter and count. NPCs (`is_player == false`) skip the gate entirely — they currently fire without consuming ammo.
+
+Full server-authoritative ammo model, reload flow, persistence cadence, and client UI subscription chain: [weapon-ammo-reload.md](weapon-ammo-reload.md).
+
 ## Damage Pipeline
 
 The damage calculation in `DamageCalc.calculateDamage()` follows this pipeline:

--- a/docs/gameplay/combat-system.md
+++ b/docs/gameplay/combat-system.md
@@ -122,7 +122,7 @@ Each entry: { StatID: INT32, Delta: INT32, DamageCode: INT32, StatResultCode: IN
 
 Ranged abilities declare a `required_ammo` cost. On every `useAbility`, the cell fire-gate ([`crates/services/src/cell/abilities.rs:259-281`](../../crates/services/src/cell/abilities.rs#L259)) checks:
 
-```
+```text
 if required_ammo > 0 && entity.is_player && active_ammo() < required_ammo:
     log "useAbility: not enough ammo"
     return  (fire aborts; no effect dispatch, no cooldown)

--- a/docs/gameplay/inventory-system.md
+++ b/docs/gameplay/inventory-system.md
@@ -86,6 +86,19 @@ The `Inventory` class in `python/cell/Inventory.py` handles all inventory logic.
 | `INV_Buyback` | Store buyback (session-only, not persisted) |
 | `INV_CommandBank` | Upper bound / org vault |
 
+## Bandolier and ammo
+
+`INV_Bandolier` (container id `3`) holds 5 equipment slots indexed `0..4` and is the only container that tracks an active slot. Each bandolier slot persists not only the equipped item but also its **per-slot magazine state**:
+
+| `sgw_inventory` column | Field | Purpose |
+|------------------------|-------|---------|
+| `ammo`                 | `BandolierItem.current_ammo` | Rounds remaining in this slot's magazine |
+| `cur_ammo_type`        | `BandolierItem.cur_ammo_type` | Selected ammo subtype (defaults to item's `default_ammo_type`) |
+
+Both columns are bandolier-slot-scoped — swapping weapons does not pool ammo across slots. The cell server mirrors `current_ammo` to `Stat[AMMO_SLOT_1+slot]` (stat IDs 49–53) so the client UI can subscribe to `Events.StatUpdated` for meter and count refresh.
+
+Persistence is **batched**: dirty slots are flushed at reload completion, slot swap, ammo change, logout, and world transition. Full message flow, sequence diagrams, and legacy reference points are in [weapon-ammo-reload.md](weapon-ammo-reload.md).
+
 ## Flush Update Order
 
 The `Inventory.flushUpdates()` method sends updates to the client in this order:

--- a/docs/gameplay/npc-ai.md
+++ b/docs/gameplay/npc-ai.md
@@ -211,7 +211,11 @@ Legacy accessors and their Rust equivalents:
 
 Legacy behavior: on spawn (`doAiSpawnAction`), the mob called `getClipSize()` on its equipped weapon and set its ammo stat to that value, representing a full reload at spawn. When `selectHostileAbility` found all abilities blocked by ammo, it called `triggerReload()`. The reload completed after a delay and refilled the clip, allowing the combat loop to resume.
 
-If/when NPC reload is needed, the same machinery applies: drop the `is_player` short-circuit in the fire-gate, set `reload_complete_at` from an AI-driven path, and let the existing `reload_completion_tick` ([`service.rs:610`](../../crates/services/src/cell/service.rs#L610)) refill the magazine.
+If/when NPC reload is needed, the same machinery applies — but **all three** of the following are required together; partial work will silently leave NPCs stuck mid-reload:
+
+1. Drop the `is_player` short-circuit in the fire-gate ([`abilities.rs`](../../crates/services/src/cell/abilities.rs)).
+2. Set `reload_complete_at` from an AI-driven path (an NPC equivalent of `requestReload`).
+3. **Widen `reload_completion_tick`** ([`service.rs:610`](../../crates/services/src/cell/service.rs#L610)) — it currently iterates `space_mgr.all_player_entity_ids()` only, so an NPC's deadline would never be promoted. Add an `all_reloadable_entity_ids()` accessor or extend the existing one to include fighting NPCs.
 
 See [weapon-ammo-reload.md](weapon-ammo-reload.md) for the full ammo and reload model.
 

--- a/docs/gameplay/npc-ai.md
+++ b/docs/gameplay/npc-ai.md
@@ -21,7 +21,7 @@ Defined in `python/Atrea/enums.py` lines 228-239.
 
 | State | Value | Implemented | Notes |
 |-------|-------|-------------|-------|
-| `AI_STATE_Spawning` | 0 | YES | Loads weapon ammo, transitions to Idle |
+| `AI_STATE_Spawning` | 0 | PARTIAL | Transitions to Idle. Legacy loaded weapon ammo here; the Rust port skips this since the fire-gate short-circuits on `!is_player`. See [Ammo Management](#ammo-management). |
 | `AI_STATE_Idle` | 1 | YES | Waits for threat |
 | `AI_STATE_Investigating` | 2 | NO | POI-based investigation loop |
 | `AI_STATE_Fighting` | 3 | YES | Target selection, ability selection, fire |
@@ -37,7 +37,7 @@ Defined in `python/Atrea/enums.py` lines 228-239.
 ### State Transitions (Implemented)
 
 ```
-Spawning  -->  Idle       (doAiSpawnAction complete, ammo loaded)
+Spawning  -->  Idle       (doAiSpawnAction complete; ammo seed skipped — fire-gate short-circuits on !is_player)
 Idle      -->  Fighting   (threatGenerated() called while alive)
 Fighting  -->  Idle       (threat list empty after target pruning)
 Any       -->  Dead       (isDead() returns true, loop exits)

--- a/docs/gameplay/npc-ai.md
+++ b/docs/gameplay/npc-ai.md
@@ -197,16 +197,23 @@ There is no priority weighting — the first usable ability in iteration order i
 
 ## Ammo Management
 
-Mobs use the same ammo model as players. Relevant accessors:
+Mobs use the same `bandolier_items` / `Stat[AMMO_SLOT_1+slot]` model as players in principle. In practice the **Rust port skips the ammo gate for non-players**: the fire-gate in [`crates/services/src/cell/abilities.rs:259-263`](../../crates/services/src/cell/abilities.rs#L259) short-circuits with `entity.is_player && current_ammo < required_ammo`, so NPCs currently fire without consuming rounds and never need to reload. `triggerReload()` is not yet ported.
 
-- `getAmmoStat()` — Returns the stat ID representing current ammo count
-- `getClipSize()` — Returns max ammo from the equipped weapon template
-- `getAmmoCount()` — Returns current ammo value
-- `consumeAmmo(amount)` — Decrements ammo by `amount`
+Legacy accessors and their Rust equivalents:
 
-On spawn (`doAiSpawnAction`), the mob calls `getClipSize()` on its equipped weapon and sets its ammo stat to that value. This represents a full reload at spawn.
+| Legacy (`SGWMob.py` / `SGWPlayer.py`) | Rust equivalent |
+|----------------------------------------|-----------------|
+| `getAmmoStat()` — stat ID for current slot | `crate::stats::AMMO_SLOT_1 + entity.active_bandolier_slot` |
+| `getClipSize()` — max ammo from equipped weapon | [`CellEntity::active_clip_size()`](../../crates/entity/src/cell_entity.rs#L373) |
+| `getAmmoCount()` — current ammo | [`CellEntity::active_ammo()`](../../crates/entity/src/cell_entity.rs#L366) |
+| `consumeAmmo(amount)` | [`CellEntity::set_slot_ammo(slot, current - amount)`](../../crates/entity/src/cell_entity.rs#L390) |
+| `triggerReload()` | Not ported for NPCs (player path: [`handle_reload`](../../crates/services/src/cell/cell_methods/player/world.rs#L121)) |
 
-When `selectHostileAbility` finds that all abilities are blocked by ammo, it calls `triggerReload()`. The reload completes after a delay and refills the clip, allowing the combat loop to resume.
+Legacy behavior: on spawn (`doAiSpawnAction`), the mob called `getClipSize()` on its equipped weapon and set its ammo stat to that value, representing a full reload at spawn. When `selectHostileAbility` found all abilities blocked by ammo, it called `triggerReload()`. The reload completed after a delay and refilled the clip, allowing the combat loop to resume.
+
+If/when NPC reload is needed, the same machinery applies: drop the `is_player` short-circuit in the fire-gate, set `reload_complete_at` from an AI-driven path, and let the existing `reload_completion_tick` ([`service.rs:610`](../../crates/services/src/cell/service.rs#L610)) refill the magazine.
+
+See [weapon-ammo-reload.md](weapon-ammo-reload.md) for the full ammo and reload model.
 
 ---
 

--- a/docs/gameplay/stat-system.md
+++ b/docs/gameplay/stat-system.md
@@ -130,7 +130,7 @@ Types: Physical, Energy, Hazmat, Psionic, Untyped (5 types x 3 sources = 15 stat
 
 | Stat | Purpose |
 |------|---------|
-| `ammoSlot1` .. `ammoSlot5` | Ammo counts per slot |
+| `ammoSlot1` .. `ammoSlot5` (IDs **49–53**) | Ammo counts per **bandolier slot** (slot-relative, not weapon-relative). Active slot's stat ID = `AMMO_SLOT_1 + active_bandolier_slot`. Mirrored from `BandolierItem.current_ammo`. See [weapon-ammo-reload.md](weapon-ammo-reload.md). |
 | `deploymentBarAmmo` | Deployment bar ammo |
 | `response` | Response ability cooldown reduction % |
 | `stealthRating` / `stealthMovement` | Stealth system |

--- a/docs/gameplay/weapon-ammo-reload.md
+++ b/docs/gameplay/weapon-ammo-reload.md
@@ -95,6 +95,7 @@ Client                       Cell                                       Base / D
   │                           │   warmup  = ability_defs[596].warmup   (e.g. 2.0s)
   │                           │   cooldown = ability_defs[596].cooldown
   │                           │   reload_complete_at = now + warmup
+  │                           │   reload_slot_id = Some(active_bandolier_slot)  ← pin
   │                           │   abilities.start_ability_cooldown(596, warmup+cooldown)
   │ ◀── onTimerUpdate (m12) ──│
   │ ◀── onStateFieldUpdate ───│  (BSF_IN_COMBAT | clear BSF_HOLSTER)
@@ -102,14 +103,18 @@ Client                       Cell                                       Base / D
   │  (warmup elapses, e.g. 2 s later)
   │                           │
   │                           │ reload_completion_tick (every 100 ms):
-  │                           │   for each entity where now >= reload_complete_at:
-  │                           │     refill_active_slot()           ← magazine = clip_size
+  │                           │   for each player where now >= reload_complete_at:
+  │                           │     slot = reload_slot_id              ← refills the
+  │                           │     set_slot_ammo(slot, clip_size)     ←  PINNED slot,
+  │                           │                                        ←  not active!
   │                           │     reload_complete_at = None
+  │                           │     reload_slot_id     = None
   │                           │     stats.serialize_dirty() → onStatUpdate
-  │ ◀── onStatUpdate (m20) ───│  AmmoSlot{N}: cur=clip_size
+  │ ◀── onStatUpdate (m20) ───│  AmmoSlot{N}: cur=clip_size  (N = pinned slot)
   │                           │ ──── BandolierAmmoUpdate ─────────▶│ UPDATE sgw_inventory
   │                           │      { player_id, slot_id,        │   SET ammo = …,
-  │                           │        current_ammo, cur_ammo_type}│       cur_ammo_type = …
+  │                           │        expected_item_id,          │       cur_ammo_type = …
+  │                           │        current_ammo, cur_ammo_type}│   WHERE … type_id = …
 ```
 
 The fire-path **only** reads `active_ammo()`; it does not promote pending refills itself. The 100 ms `reload_completion_tick` is the sole refill path (Stage C cleanup — see [`crates/services/src/cell/service.rs:602-681`](../../crates/services/src/cell/service.rs#L602)).

--- a/docs/gameplay/weapon-ammo-reload.md
+++ b/docs/gameplay/weapon-ammo-reload.md
@@ -1,0 +1,275 @@
+# Weapon Ammo & Reload
+
+> **Last updated**: 2026-04-29
+> **Status**: Implemented (player fire/reload + bandolier persistence)
+
+## Overview
+
+Ammo is **server-authoritative**. The cell server is the single source of truth for how many rounds each bandolier slot has, what subtype is loaded, and whether a reload is in progress. The client only renders — it does not predict ammo locally and never decrements its own counter.
+
+Concretely, the server:
+
+1. Validates fires against the active slot's current ammo on every `useAbility`.
+2. Decrements `BandolierItem.current_ammo` and mirrors it to `Stat[AMMO_SLOT_1+slot]`.
+3. Drives reloads on its own clock (warmup deadline) — the client's reload animation is purely cosmetic and is not trusted.
+4. Pushes `onStatUpdate` (method 20) to the attacker after every fire/reload so the bandolier UI re-reads the ammo stat and refreshes the meter and count text.
+
+Persistence is **batched**: dirty slots flush at natural drain points (reload completion, slot swap, ammo change, logout, world transition) rather than on every fire. The trade-off is documented under [Persistence cadence](#persistence-cadence).
+
+## Per-slot ammo storage
+
+Per-slot ammo lives in **two mirrored places** on the cell entity, both written through `set_slot_ammo()`:
+
+```
+                     CellEntity
+   ┌─────────────────────────────────────────────┐
+   │  bandolier_items: HashMap<i32, Bandolier… >│
+   │    [0] BandolierItem {                      │
+   │          item_id, clip_size,                │
+   │          current_ammo,    ◄── canonical     │
+   │          cur_ammo_type,   ◄── canonical     │
+   │          default_ammo_type                  │
+   │        }                                    │
+   │    [1] …                                    │
+   │                                             │
+   │  stats: StatList                            │
+   │    AMMO_SLOT_1 (49)  ◄── mirror of [0]     │
+   │    AMMO_SLOT_2 (50)  ◄── mirror of [1]     │
+   │    AMMO_SLOT_3 (51)                        │
+   │    AMMO_SLOT_4 (52)                        │
+   │    AMMO_SLOT_5 (53)                        │
+   │                                             │
+   │  active_bandolier_slot: i32                │
+   │  bandolier_ammo_dirty: HashSet<i32>        │
+   │  reload_complete_at: Option<Instant>       │
+   └─────────────────────────────────────────────┘
+```
+
+`BandolierItem` is the source of truth. `Stat[AMMO_SLOT_1+slot]` exists because the **client's UI subscribes to `Events.StatUpdated`** — it would not see a change to `BandolierItem` directly. Both are kept in sync through the single mutator [`set_slot_ammo()`](../../crates/entity/src/cell_entity.rs#L390); never write `current_ammo` directly. See [`CellEntity::active_ammo()`](../../crates/entity/src/cell_entity.rs#L366), [`active_clip_size()`](../../crates/entity/src/cell_entity.rs#L373), [`active_ammo_type()`](../../crates/entity/src/cell_entity.rs#L380), and [`refill_active_slot()`](../../crates/entity/src/cell_entity.rs#L404).
+
+Stat IDs `AMMO_SLOT_1..5` (49–53) are **bandolier-slot-relative**, not weapon-relative. The active slot's stat ID is computed as `AMMO_SLOT_1 + active_bandolier_slot`. This matches legacy [`SGWPlayer.py:1023`](../../python/cell/SGWPlayer.py#L1023) (`getAmmoStat() = ammoSlot1 + activeSlotId`).
+
+## Wire flow — fire
+
+```
+Client                                         Cell                        Base
+  │                                              │
+  │ useAbility(abilityId, targetId) ───────────▶ │
+  │                                              │ handle_use_ability:
+  │                                              │   required = ability_def.required_ammo
+  │                                              │   if required > 0 && is_player:
+  │                                              │     if active_ammo() < required:
+  │                                              │       log "useAbility: not enough ammo"
+  │                                              │       return  (fire aborts)
+  │                                              │   set_slot_ammo(active_slot, ammo - required)
+  │                                              │     ↳ marks bandolier_ammo_dirty
+  │                                              │     ↳ Stat[AMMO_SLOT_1+slot].set_current(...)
+  │                                              │   stats.serialize_dirty()
+  │                                              │   stats.clear_dirty()
+  │                                              │
+  │ ◀─── onStatUpdate (method 20) ────────────── │
+  │       AmmoSlot{N}: { min, cur, max }         │
+  │                                              │
+  │ Lua: Events.StatUpdated fires →              │
+  │   BandolierMod.onStatUpdated(unitId, statId, current, max) │
+  │   → refreshSlotAmmo(slotIndex):              │
+  │       setMaterialScalarProperty(             │
+  │         'CoreMaterial_AmmoMeter'..slotID,    │
+  │         'M_Percentage', current/max)         │
+  │       count text → string.format("%d", …)    │
+```
+
+The fire-gate skips the ammo check entirely for non-players (`entity.is_player == false`), so NPC mobs do not consume rounds — see [NPC ammo](#npc-ammo).
+
+Implementation: [`crates/services/src/cell/abilities.rs:259-281`](../../crates/services/src/cell/abilities.rs#L259) for the gate and consume; the `onStatUpdate` is dispatched from the post-resolve drain at [`abilities.rs:511-515`](../../crates/services/src/cell/abilities.rs#L511).
+
+## Wire flow — reload
+
+`requestReload(EReloadType)` is a Mercury **cell method** on `SGWPlayer` (def: [`entities/defs/SGWPlayer.def:794-797`](../../entities/defs/SGWPlayer.def#L794), opcode `0x14` = 86 — see [decompiled binding](../reverse-engineering/decompiled/14_standalone_named.c#L298900)).
+
+```
+Client                       Cell                                       Base / DB
+  │ requestReload(0) ────────▶│
+  │                           │ handle_reload (player/world.rs:121):
+  │                           │   if active_ammo() >= active_clip_size(): return
+  │                           │   warmup  = ability_defs[596].warmup   (e.g. 2.0s)
+  │                           │   cooldown = ability_defs[596].cooldown
+  │                           │   reload_complete_at = now + warmup
+  │                           │   abilities.start_ability_cooldown(596, warmup+cooldown)
+  │ ◀── onTimerUpdate (m12) ──│
+  │ ◀── onStateFieldUpdate ───│  (BSF_IN_COMBAT | clear BSF_HOLSTER)
+  │                           │
+  │  (warmup elapses, e.g. 2 s later)
+  │                           │
+  │                           │ reload_completion_tick (every 100 ms):
+  │                           │   for each entity where now >= reload_complete_at:
+  │                           │     refill_active_slot()           ← magazine = clip_size
+  │                           │     reload_complete_at = None
+  │                           │     stats.serialize_dirty() → onStatUpdate
+  │ ◀── onStatUpdate (m20) ───│  AmmoSlot{N}: cur=clip_size
+  │                           │ ──── BandolierAmmoUpdate ─────────▶│ UPDATE sgw_inventory
+  │                           │      { player_id, slot_id,        │   SET ammo = …,
+  │                           │        current_ammo, cur_ammo_type}│       cur_ammo_type = …
+```
+
+The fire-path **only** reads `active_ammo()`; it does not promote pending refills itself. The 100 ms `reload_completion_tick` is the sole refill path (Stage C cleanup — see [`crates/services/src/cell/service.rs:602-681`](../../crates/services/src/cell/service.rs#L602)).
+
+Matches legacy [`Reload.py`](../../python/cell/effects/Reload.py): the effect resolves at warmup completion and runs `setCurrent(max)` on the ammo stat. Legacy ammo consumption was at warmup completion ([`AbilityManager.py:669-670`](../../python/cell/AbilityManager.py#L669)); the Rust port consumes at fire-gate time instead, since there is no warmup state machine for typical fires.
+
+## `requestAmmoChange` flow
+
+```
+Client (player clicks an ammo subtype icon)
+  │
+  │ requestAmmoChange(item_id, ammo_type) ──▶ Cell
+  │                                              │ scan bandolier_items for matching item_id
+  │                                              │ item.cur_ammo_type = ammo_type
+  │                                              │ (mark + immediately drain dirty for this slot)
+  │                                              │
+  │                                              │ ──── BandolierAmmoUpdate ─▶ DB (immediate)
+  │                                              │
+  │                                              │ if slot == active_bandolier_slot:
+  │ ◀── onEntityProperty(AmmoTypeId, ammo_type) ─│   refreshes the ammo-type indicator
+```
+
+The persistence emit is **immediate**, not batched, because subtype is a deliberate user action and we want it durable before the next packet. The legacy validator was literally `pass`; we reject `ammo_type == 0` as obvious junk, with a TODO to whitelist against `Item.ammo_types` ([`crates/entity/src/inventory.rs:81`](../../crates/entity/src/inventory.rs#L81)).
+
+Def: [`entities/defs/interfaces/SGWInventoryManager.def:190-194`](../../entities/defs/interfaces/SGWInventoryManager.def#L190). Implementation: [`crates/services/src/cell/cell_methods/inventory.rs:250-329`](../../crates/services/src/cell/cell_methods/inventory.rs#L250).
+
+## Active slot swap
+
+```
+Client → Cell:  requestActiveSlotChange(bag_id=3, slot_id)
+                                        │
+                                        │ if bag_id != 3: ignore (only bandolier has active slot)
+                                        │
+                                        │ if prev_slot is dirty:
+                                        │   ──── BandolierAmmoUpdate(prev_slot, …) ─▶ DB
+                                        │   bandolier_ammo_dirty.remove(prev_slot)
+                                        │
+                                        │ active_bandolier_slot = slot_id
+                                        │
+                                        │ ──── ActiveSlotUpdate(player_id, slot_id) ─▶ Base
+                                        │
+                                        │ ── onEntityProperty(AmmoTypeId, value) ──▶ Client
+                                        │   value = new slot's cur_ammo_type, or 0 if empty
+```
+
+`onEntityProperty` is sent **even when the new slot is empty** (value=0), mirroring legacy [`SGWPlayer.py:522`](../../python/cell/SGWPlayer.py#L522) (`activeItem.ammoType if activeItem else 0`). The bandolier UI's `BandolierMod.refreshAll()` re-reads all 5 slot ammo stats independently on its own subscription path ([`Bandolier.lua:205`](../../game/sgw/Working/SGWGame/Content/UI/Core/Bandolier/Bandolier.lua#L205)), so we don't have to push per-slot stat updates here.
+
+The previous-slot flush catches the **mid-magazine swap** case: a player fires a few rounds, then swaps weapons before reloading the empty one. Without this, those fires would only persist on the next reload (which may never happen if the player swaps back to the original slot after the next world transition).
+
+Implementation: [`crates/services/src/cell/cell_methods/inventory.rs:162-249`](../../crates/services/src/cell/cell_methods/inventory.rs#L162).
+
+## Persistence cadence
+
+The `bandolier_ammo_dirty: HashSet<i32>` set is the persistence buffer. Every fire/reload/grant marks the affected slot dirty via `set_slot_ammo()`. Dirty slots drain at:
+
+| Drain point                              | What flushes                          | Code path |
+|------------------------------------------|---------------------------------------|-----------|
+| Reload completion tick (100 ms cadence)  | The active slot only                  | [`service.rs:610`](../../crates/services/src/cell/service.rs#L610) |
+| `requestActiveSlotChange`                | The previous slot, if dirty           | [`inventory.rs:184-205`](../../crates/services/src/cell/cell_methods/inventory.rs#L184) |
+| `requestAmmoChange`                      | The mutated slot, immediately         | [`inventory.rs:284-308`](../../crates/services/src/cell/cell_methods/inventory.rs#L284) |
+| Logout (`DestroyEntity`)                 | All dirty slots                       | [`service.rs:380-395`](../../crates/services/src/cell/service.rs#L380) |
+| World transition (`handle_dial_gate`)    | All dirty slots                       | [`gate_travel.rs:75-90`](../../crates/services/src/cell/gate_travel.rs#L75) |
+
+**Trade-off**: a server crash mid-magazine loses up to one magazine of ammo per active slot. We accepted this over write-per-fire because (a) ammo is cheap and easily refilled in-game, (b) write-per-fire would dominate the DB write rate during sustained combat, and (c) mid-magazine state is already non-deterministic from the player's view.
+
+Helper: [`flush_dirty_bandolier_ammo()`](../../crates/services/src/cell/cell_methods/inventory.rs#L34) drains the set into one `BandolierAmmoUpdate` per slot.
+
+## Client UI
+
+The bandolier UI lives in [`game/sgw/Working/SGWGame/Content/UI/Core/Bandolier/Bandolier.lua`](../../game/sgw/Working/SGWGame/Content/UI/Core/Bandolier/Bandolier.lua):
+
+- **Meter** — material `'CoreMaterial_AmmoMeter' .. slotID` driven via `setMaterialScalarProperty('M_Percentage', stat.current / stat.max)` ([line 246](../../game/sgw/Working/SGWGame/Content/UI/Core/Bandolier/Bandolier.lua#L246)).
+- **Empty state** — when no item: `M_Percentage = 0` ([line 249](../../game/sgw/Working/SGWGame/Content/UI/Core/Bandolier/Bandolier.lua#L249)).
+- **Count text** — `setProperty("Text", string.format("%d", stat.current))`.
+- **Subscription** — `Events.StatUpdated → BandolierMod.onStatUpdated → refreshSlotAmmo(slotIndex)` ([lines 180-186, 496](../../game/sgw/Working/SGWGame/Content/UI/Core/Bandolier/Bandolier.lua#L180)).
+
+Because the UI is stat-driven, **anything that changes `Stat[AMMO_SLOT_1+slot]` and emits `onStatUpdate` will refresh the bandolier**. This is why the server-side mirror in `set_slot_ammo()` is non-negotiable.
+
+## Reload timing
+
+The warmup window (e.g. 2 s for `ABILITY_RELOAD_WEAPON = 596`) ticks down on the client as a cosmetic animation. The server's `reload_completion_tick` runs every 100 ms and refills the magazine when the deadline is reached — typically mid-animation. Because `onStatUpdate` flushes the new ammo value immediately on refill, the meter visually fills before the animation completes. The next fire is gated by the cooldown timer (warmup + cooldown), not by the bar fill.
+
+This matches legacy [`Reload.py`](../../python/cell/effects/Reload.py) behavior: the effect script resolved at warmup completion via `setCurrent(max)` and `sendDirtyStats()`. The Rust port lifts the refill logic out of the effect script and into the cell tick — equivalent semantics, simpler ownership.
+
+## NPC ammo
+
+NPCs (`SGWMob`) use the **same `bandolier_items` / `AmmoSlot{N}` model conceptually**, but the fire-gate short-circuits the ammo requirement:
+
+```rust
+if required_ammo > 0 && entity.is_player && current_ammo < required_ammo { … abort … }
+```
+
+This means mobs do not currently consume rounds, do not need to reload, and do not have their `bandolier_ammo_dirty` populated by combat. The legacy [`SGWMob.py`](../../python/cell/SGWMob.py) implemented full mob ammo (`getAmmoStat`/`getClipSize`/`triggerReload`) but in practice mobs were rarely ammo-limited. We deferred the port; if/when mob reload is needed, the same `set_slot_ammo` + `reload_complete_at` machinery applies — just remove the `is_player` short-circuit and add an AI-driven `requestReload` equivalent.
+
+Cross-reference: [npc-ai.md § Ammo Management](npc-ai.md#ammo-management).
+
+## Sequence diagram (one shot + one reload)
+
+```
+Client                       Cell                              Base / DB
+  │
+  │ useAbility(596, 0) ───────▶│  active_ammo() = 5
+  │                            │  set_slot_ammo(0, 4)
+  │                            │  bandolier_ammo_dirty.insert(0)
+  │ ◀── onStatUpdate(m20) ─────│  AmmoSlot1: cur=4
+  │     refreshSlotAmmo(0): meter 5/5 → 4/5
+  │
+  │ … (4 more fires) …         │
+  │ useAbility(596, 0) ───────▶│  active_ammo() = 1
+  │                            │  set_slot_ammo(0, 0)
+  │ ◀── onStatUpdate(m20) ─────│  AmmoSlot1: cur=0
+  │     refreshSlotAmmo(0): meter 1/5 → 0/5
+  │
+  │ useAbility(596, 0) ───────▶│  active_ammo() = 0 < required=1
+  │                            │  log "not enough ammo", drop
+  │
+  │ requestReload(0) ─────────▶│  reload_complete_at = now + 2.0s
+  │                            │  start_ability_cooldown(596, 3.0s)
+  │ ◀── onTimerUpdate(m12) ────│  cooldown bar
+  │ ◀── onStateFieldUpdate ────│  +BSF_IN_COMBAT, -BSF_HOLSTER
+  │
+  │   (≈2 s later — next reload_completion_tick after deadline)
+  │                            │  refill_active_slot()  → cur=5
+  │                            │  reload_complete_at = None
+  │                            │  bandolier_ammo_dirty.remove(0)
+  │ ◀── onStatUpdate(m20) ─────│  AmmoSlot1: cur=5
+  │     refreshSlotAmmo(0): meter 0/5 → 5/5 (fills mid-animation)
+  │                            │ ── BandolierAmmoUpdate ───▶│ UPDATE sgw_inventory
+  │                            │   {pid, slot=0, cur=5,    │   ammo=5, cur_ammo_type=…
+  │                            │    cur_ammo_type=…}       │
+```
+
+## Legacy reference points
+
+| File | Purpose |
+|------|---------|
+| [`python/cell/effects/Reload.py`](../../python/cell/effects/Reload.py) | Reload effect script — `setCurrent(max)` + `sendDirtyStats()` on warmup completion |
+| [`python/cell/SGWPlayer.py:1023-1081`](../../python/cell/SGWPlayer.py#L1023) | `getAmmoStat()`, `getClipSize()`, `getAmmoCount()`, `consumeAmmo()` |
+| [`python/cell/AbilityManager.py:669-670`](../../python/cell/AbilityManager.py#L669) | Legacy ammo consumption point (warmup completion, not fire-gate) |
+| [`python/cell/AbilityManager.py:548-552`](../../python/cell/AbilityManager.py#L548) | Legacy `requiredAmmo` check + `CONDITION_FEEDBACK_AmmoCountLessThan` |
+| [`game/sgw/Working/SGWGame/Content/UI/Core/Bandolier/Bandolier.lua`](../../game/sgw/Working/SGWGame/Content/UI/Core/Bandolier/Bandolier.lua) | Client UI: meter, count text, `onStatUpdated` subscription |
+| [`entities/defs/SGWPlayer.def:794-797`](../../entities/defs/SGWPlayer.def#L794) | `requestReload` cell method def (UINT8 EReloadType) |
+| [`entities/defs/interfaces/SGWInventoryManager.def:190-194`](../../entities/defs/interfaces/SGWInventoryManager.def#L190) | `requestAmmoChange` cell method def (INT32 ItemId, INT32 AmmoType) |
+| [`entities/defs/interfaces/SGWInventoryManager.def:183-187`](../../entities/defs/interfaces/SGWInventoryManager.def#L183) | `requestActiveSlotChange` cell method def (INT32 BagId, INT32 SlotId) |
+
+## Data references (Rust)
+
+| File | Purpose |
+|------|---------|
+| [`crates/entity/src/cell_entity.rs`](../../crates/entity/src/cell_entity.rs) | `BandolierItem`, `active_ammo()`/`active_clip_size()`/`active_ammo_type()`/`set_slot_ammo()`/`refill_active_slot()`, `reload_complete_at`, `bandolier_ammo_dirty` |
+| [`crates/services/src/cell/abilities.rs`](../../crates/services/src/cell/abilities.rs) | `handle_use_ability` — fire-gate, consume, `onStatUpdate` drain |
+| [`crates/services/src/cell/cell_methods/player/world.rs`](../../crates/services/src/cell/cell_methods/player/world.rs) | `REQUEST_RELOAD` dispatch, `handle_reload` (warmup deadline + cooldown) |
+| [`crates/services/src/cell/service.rs`](../../crates/services/src/cell/service.rs) | `reload_completion_tick` (sole refill path), `InitPlayerState` bandolier seeding |
+| [`crates/services/src/cell/cell_methods/inventory.rs`](../../crates/services/src/cell/cell_methods/inventory.rs) | `REQUEST_ACTIVE_SLOT_CHANGE`, `REQUEST_AMMO_CHANGE`, `flush_dirty_bandolier_ammo` |
+| [`crates/services/src/cell/messages.rs`](../../crates/services/src/cell/messages.rs) | `CellToBaseMsg::BandolierAmmoUpdate`, `ActiveSlotUpdate`, `InitPlayerState` |
+
+## Related docs
+
+- [inventory-system.md § Bandolier and ammo](inventory-system.md#bandolier-and-ammo) — Bandolier container layout and DB schema
+- [combat-system.md](combat-system.md) — Ability fire pipeline, where the ammo gate sits
+- [ability-system.md](ability-system.md) — Ability warmup/cooldown semantics, `ABILITY_RELOAD_WEAPON = 596`
+- [stat-system.md](stat-system.md) — `AmmoSlot1..5` (49–53) stat IDs
+- [npc-ai.md § Ammo Management](npc-ai.md#ammo-management) — NPC fire-gate exemption

--- a/docs/gameplay/weapon-ammo-reload.md
+++ b/docs/gameplay/weapon-ammo-reload.md
@@ -205,7 +205,11 @@ NPCs (`SGWMob`) use the **same `bandolier_items` / `AmmoSlot{N}` model conceptua
 if required_ammo > 0 && entity.is_player && current_ammo < required_ammo { … abort … }
 ```
 
-This means mobs do not currently consume rounds, do not need to reload, and do not have their `bandolier_ammo_dirty` populated by combat. The legacy [`SGWMob.py`](../../python/cell/SGWMob.py) implemented full mob ammo (`getAmmoStat`/`getClipSize`/`triggerReload`) but in practice mobs were rarely ammo-limited. We deferred the port; if/when mob reload is needed, the same `set_slot_ammo` + `reload_complete_at` machinery applies — just remove the `is_player` short-circuit and add an AI-driven `requestReload` equivalent.
+This means mobs do not currently consume rounds, do not need to reload, and do not have their `bandolier_ammo_dirty` populated by combat. The legacy [`SGWMob.py`](../../python/cell/SGWMob.py) implemented full mob ammo (`getAmmoStat`/`getClipSize`/`triggerReload`) but in practice mobs were rarely ammo-limited. We deferred the port; if/when mob reload is needed, three changes are required together — partial work will silently break:
+
+1. Remove the `is_player` short-circuit in [`abilities.rs`](../../crates/services/src/cell/abilities.rs) so the ammo gate runs for NPCs.
+2. Add an AI-driven `requestReload` equivalent that calls `set_slot_ammo` + `reload_complete_at` on the mob entity.
+3. **Widen `reload_completion_tick` beyond players.** It currently iterates [`space_mgr.all_player_entity_ids()`](../../crates/services/src/cell/service.rs) only — an NPC that sets `reload_complete_at` will never be promoted by the existing tick, leaving the magazine empty forever. Either change the tick to scan all entities with `reload_complete_at = Some(_)`, add a `space_mgr.all_reloadable_entity_ids()` helper, or extend the iteration to include NPCs in fighting state.
 
 Cross-reference: [npc-ai.md § Ammo Management](npc-ai.md#ammo-management).
 

--- a/docs/gameplay/weapon-ammo-reload.md
+++ b/docs/gameplay/weapon-ammo-reload.md
@@ -20,7 +20,7 @@ Persistence is **batched**: dirty slots flush at natural drain points (reload co
 
 Per-slot ammo lives in **two mirrored places** on the cell entity, both written through `set_slot_ammo()`:
 
-```
+```text
                      CellEntity
    ┌─────────────────────────────────────────────┐
    │  bandolier_items: HashMap<i32, Bandolier… >│
@@ -51,7 +51,7 @@ Stat IDs `AMMO_SLOT_1..5` (49–53) are **bandolier-slot-relative**, not weapon-
 
 ## Wire flow — fire
 
-```
+```text
 Client                                         Cell                        Base
   │                                              │
   │ useAbility(abilityId, targetId) ───────────▶ │
@@ -85,9 +85,9 @@ Implementation: [`crates/services/src/cell/abilities.rs:259-281`](../../crates/s
 
 ## Wire flow — reload
 
-`requestReload(EReloadType)` is a Mercury **cell method** on `SGWPlayer` (def: [`entities/defs/SGWPlayer.def:794-797`](../../entities/defs/SGWPlayer.def#L794), opcode `0x14` = 86 — see [decompiled binding](../reverse-engineering/decompiled/14_standalone_named.c#L298900)).
+`requestReload(EReloadType)` is a Mercury **cell method** on `SGWPlayer` (def: [`entities/defs/SGWPlayer.def:794-797`](../../entities/defs/SGWPlayer.def#L794), wire opcode 86 / `0x56` — defined as `REQUEST_RELOAD` in [`crates/services/src/cell/cell_methods/player/constants.rs`](../../crates/services/src/cell/cell_methods/player/constants.rs); the `0x14` value in the [decompiled client binding](../reverse-engineering/decompiled/14_standalone_named.c#L298900) is a registration index, not the wire opcode).
 
-```
+```text
 Client                       Cell                                       Base / DB
   │ requestReload(0) ────────▶│
   │                           │ handle_reload (player/world.rs:121):
@@ -118,7 +118,7 @@ Matches legacy [`Reload.py`](../../python/cell/effects/Reload.py): the effect re
 
 ## `requestAmmoChange` flow
 
-```
+```text
 Client (player clicks an ammo subtype icon)
   │
   │ requestAmmoChange(item_id, ammo_type) ──▶ Cell
@@ -138,7 +138,7 @@ Def: [`entities/defs/interfaces/SGWInventoryManager.def:190-194`](../../entities
 
 ## Active slot swap
 
-```
+```text
 Client → Cell:  requestActiveSlotChange(bag_id=3, slot_id)
                                         │
                                         │ if bag_id != 3: ignore (only bandolier has active slot)
@@ -211,7 +211,7 @@ Cross-reference: [npc-ai.md § Ammo Management](npc-ai.md#ammo-management).
 
 ## Sequence diagram (one shot + one reload)
 
-```
+```text
 Client                       Cell                              Base / DB
   │
   │ useAbility(596, 0) ───────▶│  active_ammo() = 5

--- a/docs/gameplay/weapon-ammo-reload.md
+++ b/docs/gameplay/weapon-ammo-reload.md
@@ -170,10 +170,13 @@ The `bandolier_ammo_dirty: HashSet<i32>` set is the persistence buffer. Every fi
 | Reload completion tick (100 ms cadence)  | The active slot only                  | [`service.rs:610`](../../crates/services/src/cell/service.rs#L610) |
 | `requestActiveSlotChange`                | The previous slot, if dirty           | [`inventory.rs:184-205`](../../crates/services/src/cell/cell_methods/inventory.rs#L184) |
 | `requestAmmoChange`                      | The mutated slot, immediately         | [`inventory.rs:284-308`](../../crates/services/src/cell/cell_methods/inventory.rs#L284) |
-| Logout (`DestroyEntity`)                 | All dirty slots                       | [`service.rs:380-395`](../../crates/services/src/cell/service.rs#L380) |
+| Disconnect (`DisconnectEntity`)          | All dirty slots                       | [`service.rs:403-417`](../../crates/services/src/cell/service.rs#L403) |
+| Logout fallback (`DestroyEntity`)        | All dirty slots (idempotent)          | [`service.rs:383-396`](../../crates/services/src/cell/service.rs#L383) |
 | World transition (`handle_dial_gate`)    | All dirty slots                       | [`gate_travel.rs:75-90`](../../crates/services/src/cell/gate_travel.rs#L75) |
 
-**Trade-off**: a server crash mid-magazine loses up to one magazine of ammo per active slot. We accepted this over write-per-fire because (a) ammo is cheap and easily refilled in-game, (b) write-per-fire would dominate the DB write rate during sustained combat, and (c) mid-magazine state is already non-deterministic from the player's view.
+The flush hook lives on the `DisconnectEntity` cell handler — graceful logoff (`SGWPlayer.logOff`), Mercury `DISCONNECT (0x0C)`, and the tick-sync 60-second inactivity timeout ([`tick_sync.rs:32-56`](../../crates/services/src/base/tick_sync.rs#L32)) all route through `destroy_client_entities` ([`helpers.rs:67-111`](../../crates/services/src/base/helpers.rs#L67)) which sends `BaseToCellMsg::DisconnectEntity`. So a player who closes the game without logging out still has their ammo persisted, just with up to a 60-second delay after their last received packet. The `DestroyEntity` flush is a no-op fallback for any path that bypasses `DisconnectEntity`.
+
+**Trade-off**: a server crash mid-magazine — or any crash before the disconnect-detection window elapses — loses up to one magazine of ammo per active slot. We accepted this over write-per-fire because (a) ammo is cheap and easily refilled in-game, (b) write-per-fire would dominate the DB write rate during sustained combat, and (c) mid-magazine state is already non-deterministic from the player's view.
 
 Helper: [`flush_dirty_bandolier_ammo()`](../../crates/services/src/cell/cell_methods/inventory.rs#L34) drains the set into one `BandolierAmmoUpdate` per slot.
 

--- a/docs/technical/network-messages.md
+++ b/docs/technical/network-messages.md
@@ -616,6 +616,20 @@ Messages the client sends to the server.
 
 ---
 
+## Ammo & Reload Cell Methods
+
+The catalog above lists messages by client-side `Event_NetOut_*` / `Event_NetIn_*` name. Three of those map to known Mercury cell-method opcodes used by the weapon ammo and reload pipeline:
+
+| Wire opcode | Cell method | Interface | Args | Notes |
+|-------------|-------------|-----------|------|-------|
+| 41 (`0x29`) | `requestActiveSlotChange` | SGWInventoryManager | INT32 BagId, INT32 SlotId | Only `BagId == 3` (INV_Bandolier) carries an active slot |
+| 42 (`0x2A`) | `requestAmmoChange` | SGWInventoryManager | INT32 ItemId, INT32 AmmoType | Server validates `ammo_type != 0` |
+| 86 (`0x14` per the decompiled binding at [`docs/reverse-engineering/decompiled/14_standalone_named.c:298900-298909`](../reverse-engineering/decompiled/14_standalone_named.c#L298900); 86 in `dispatch.rs`) | `requestReload` | SGWPlayer | UINT8 EReloadType | Starts warmup deadline; refill is server-driven |
+
+Server → client ammo updates flow through **`onStatUpdate`** (client method index 20) carrying one or more `AmmoSlot{N}` stat entries (stat IDs 49–53). Active-slot subtype refresh uses **`onEntityProperty`** with `GENERICPROPERTY_AmmoTypeId = 3`. `ActiveSlotUpdate` and `BandolierAmmoUpdate` are internal cell→base messages for persistence and are not sent over the wire to the client.
+
+Full sequence diagrams and the persistence cadence: [docs/gameplay/weapon-ammo-reload.md](../gameplay/weapon-ammo-reload.md).
+
 ## SGWNetworkManager
 
 The `SGWNetworkManager` class (source: `SGWNetworkManager.cpp` at 0x019abbc4) is the central hub that:

--- a/docs/technical/network-messages.md
+++ b/docs/technical/network-messages.md
@@ -624,7 +624,7 @@ The catalog above lists messages by client-side `Event_NetOut_*` / `Event_NetIn_
 |-------------|-------------|-----------|------|-------|
 | 41 (`0x29`) | `requestActiveSlotChange` | SGWInventoryManager | INT32 BagId, INT32 SlotId | Only `BagId == 3` (INV_Bandolier) carries an active slot |
 | 42 (`0x2A`) | `requestAmmoChange` | SGWInventoryManager | INT32 ItemId, INT32 AmmoType | Server validates `ammo_type != 0` |
-| 86 (`0x14` per the decompiled binding at [`docs/reverse-engineering/decompiled/14_standalone_named.c:298900-298909`](../reverse-engineering/decompiled/14_standalone_named.c#L298900); 86 in `dispatch.rs`) | `requestReload` | SGWPlayer | UINT8 EReloadType | Starts warmup deadline; refill is server-driven |
+| 86 (`0x56`) | `requestReload` | SGWPlayer | UINT8 EReloadType | Starts warmup deadline; refill is server-driven. Source: [`REQUEST_RELOAD` in cell/cell_methods/player/constants.rs](../../crates/services/src/cell/cell_methods/player/constants.rs). The decompiled client-side binding at [`14_standalone_named.c:298900-298909`](../reverse-engineering/decompiled/14_standalone_named.c#L298900) shows `0x14` — that is a **registration index** in the `BW__unknown_00438c40` setup call, not the wire opcode. |
 
 Server → client ammo updates flow through **`onStatUpdate`** (client method index 20) carrying one or more `AmmoSlot{N}` stat entries (stat IDs 49–53). Active-slot subtype refresh uses **`onEntityProperty`** with `GENERICPROPERTY_AmmoTypeId = 3`. `ActiveSlotUpdate` and `BandolierAmmoUpdate` are internal cell→base messages for persistence and are not sent over the wire to the client.
 


### PR DESCRIPTION
## Summary

The bandolier ammo bar reads `Stat.AmmoSlot1..5` (IDs 49-53) and re-renders the meter and count whenever `Events.StatUpdated` fires. Authority is fully server-side, mirroring legacy `consumeAmmo() → sendDirtyStats()`. The Rust port had all the supporting infrastructure (stat IDs, dirty tracking, `onStatUpdate` method 20, the reload state machine, a 100ms cell tick, and `sgw_inventory.ammo`) but **never wrote the `AmmoSlot{N}` stats** — instead it tracked ammo in three shadow scalars on `CellEntity` (`current_ammo`, `max_ammo`, `ammo_type`), so the bandolier UI never updated and per-slot ammo wasn't representable.

This PR replaces the shadow with a single source of truth — `bandolier_items[slot].current_ammo` in memory, `Stat[AMMO_SLOT_1+slot]` on the wire, `sgw_inventory.{ammo, cur_ammo_type}` in the DB. It drives reload completion off the existing 100ms cell tick, implements `requestAmmoChange` end-to-end, persists per-slot state across logout/login (graceful and ungraceful), and fixes a separate bug where the world-entry `mapLoaded` packet sent stale `(0, 0, 0)` AmmoSlot stats.

## What works after this PR

- All 5 bandolier slots show correct ammo numbers and meter fill at world entry, including after re-login.
- Fire decrements live: meter shrinks, count updates in real time.
- Reload bar fills mid-animation (warmup elapse → tick refills → `onStatUpdate` → Lua re-renders) — no need to fire first.
- Each slot tracks ammo independently — fire down slot 0, swap to slot 1, fire it, swap back, slot 0 still has its post-fire value.
- Ammo-subtype switches via the bandolier ammo nub work end-to-end.
- Per-slot ammo and selected ammo type persist across logout/login. Ungraceful close (alt-F4 / process kill / network drop) also persists, with up to a 60-second delay until the tick-sync inactivity timeout fires.

## Behavior changes by area

### Server

- **Removed shadow scalars**: `CellEntity.current_ammo`, `max_ammo`, `ammo_type` are gone. Readers go through `entity.active_ammo()`, `active_clip_size()`, `active_ammo_type()` helpers backed by `bandolier_items[active_bandolier_slot]`. Writers go through `set_slot_ammo(slot, value)` which mirrors to `Stat[AMMO_SLOT_1+slot]` and marks the slot dirty.
- **Reload completion is tick-driven**: `requestReload` sets `reload_complete_at = now + warmup`. A new `reload_completion_tick` in the cell's 100ms loop scans elapsed deadlines, calls `refill_active_slot()`, sends `onStatUpdate` to the client, and queues a `BandolierAmmoUpdate` for persistence.
- **Per-slot dirty tracking**: `bandolier_ammo_dirty: HashSet<i32>` on `CellEntity` is the persistence buffer. Drains:
  - Reload completion tick — active slot only
  - `requestActiveSlotChange` — previous slot, if dirty
  - `requestAmmoChange` — mutated slot, immediately
  - Disconnect (`BaseToCellMsg::DisconnectEntity`) — all dirty slots
  - World transition (`handle_dial_gate`) — all dirty slots
- **`requestAmmoChange` implemented**: validates ammo_type is non-zero (loose, matching legacy `pass`), updates `BandolierItem.cur_ammo_type`, persists via `BandolierAmmoUpdate`, sends `onEntityProperty(AmmoTypeId)` if the active slot.

### Wire format

- `mapLoaded`'s `onStatUpdate` now seeds `AmmoSlot1..5` from `data.bandolier_items[*].(current_ammo, clip_size)` before `serialize_all()`. Fixes a bug where every re-login sent `(0, 0, 0)` for ammo and the UI rendered an empty mag until the next reload.
- `onEntityProperty(AmmoTypeId)` sent on slot swap (mirrors legacy `SGWPlayer.py:522`).
- New `CellToBaseMsg::BandolierAmmoUpdate { player_id, slot_id, current_ammo, cur_ammo_type }` for batched per-slot persistence.

### Database

- New column `sgw_inventory.cur_ammo_type integer NOT NULL DEFAULT 0` for per-slot ammo subtype. Migration: `db/scripts/add_bandolier_cur_ammo_type.sql` (idempotent).
- `sgw_inventory.ammo` already existed — no schema change for the count itself.
- `BANDOLIER_ITEMS_QUERY` now selects both columns. A `cur_ammo_type` of 0 is treated as "no override" and falls back to the item template's `default_ammo_type` (Rust-side).
- New SQL helper `update_bandolier_ammo` runs `UPDATE sgw_inventory SET ammo = $1, cur_ammo_type = $2 WHERE character_id = $3 AND container_id = 3 AND slot_id = $4`.

### Content engine

- The `GrantItem` action's weapon-grant path now reads `clip_size` and `default_ammo_type` from a new DB-loaded `space_mgr.item_defs` cache (`spawner::load_item_defs`) instead of a hardcoded fallback for two specific item ids.

## Bug fixes

1. **Persistence lost on logout** — `BaseToCellMsg::DisconnectEntity` is dispatched before `DestroyEntity`, but `space_manager::disconnect_entity` internally calls `destroy_entity`. By the time the `DestroyEntity` flush hook ran, the entity was already gone — the flush was a silent no-op and ammo never persisted. Fix: hoisted the flush into the `DisconnectEntity` cell handler, before `space_mgr.disconnect_entity` runs.
2. **`mapLoaded` UI stuck at 0/0 on re-login** — packet built `onStatUpdate` from a fresh `StatList::new()` with no bandolier seeding, so AmmoSlot stats went out as `(0, 0, 0)`. Cell side seeded them correctly but only after the packet was already on the wire. Fix: seed from `data.bandolier_items` before `serialize_all()`.
3. **`SyncBandolierItems` left stale stats** — vendor purchases / item grants would leave the bandolier bar showing the old weapon's ammo until the next reload. Fix: re-seed AmmoSlot stats and push `onStatUpdate` immediately on sync.

## Database migration

```bash
psql -f db/scripts/add_bandolier_cur_ammo_type.sql
```

Idempotent (`IF NOT EXISTS`). Required before deploying — `BANDOLIER_ITEMS_QUERY` selects the new column and would error on missing-column.

## Test plan

- [x] `cargo check -p cimmeria-services -p cimmeria-entity` — clean (only pre-existing warnings)
- [x] `cargo check --workspace --exclude cimmeria-app --exclude cimmeria-content-editor --exclude cimmeria-scene-editor` — clean
- [x] `cargo test -p cimmeria-services -p cimmeria-entity` — 207 services + 142 entity, 0 failures (was 198 + 142 before)
- [x] In-game: log in, all 5 bandolier slots show correct ammo numbers and meter fills
- [x] In-game: fire equipped weapon — count and meter decrement live
- [x] In-game: press R, bar fills mid-animation
- [x] In-game: graceful logout, log back in, ammo count persists
- [ ] In-game: ungraceful close (alt-F4), wait 60 seconds for inactivity timeout, log back in — ammo persists
- [ ] In-game: swap to F2, fire, swap back to F1 — F1 ammo unchanged
- [ ] In-game: right-click ammo nub, pick a different ammo type, log out and back in — ammo type persists

## New tests

- `consume_ammo_writes_ammoslot_stat_and_marks_dirty` — fire decrements both `bandolier_items[slot].current_ammo` and `Stat[AMMO_SLOT_1+slot]`, marks slot dirty, sends `onStatUpdate`.
- `slot_swap_preserves_per_slot_ammo` — independent ammo per slot survives swap.
- `reload_completion_tick_refills_and_sends_stat` — tick refills active slot at deadline, sends `onStatUpdate` and `BandolierAmmoUpdate`.
- `request_ammo_change_updates_slot_and_sends_property` — full flow.
- `request_ammo_change_rejects_zero` — guard against bad input.
- `init_player_state_seeds_ammo_stats` — world entry seeding from bandolier_items.
- `logout_flushes_all_dirty_bandolier_slots` — `DestroyEntity` path drains dirty set.
- `disconnect_entity_flushes_dirty_ammo_before_destroy` — regression test for the LOG_OFF persistence bug.
- `build_map_loaded_seeds_ammo_slot_stats_from_bandolier_items` — wire-level test for the mapLoaded fix.

Plus updated `dispatch.rs` reload tests to use the new `bandolier_items` + `AmmoSlot` stat fixture pattern instead of the removed shadow scalars.

## Documentation

- New: `docs/gameplay/weapon-ammo-reload.md` — full system writeup with sequence diagrams, persistence cadence table, legacy reference cross-links, and Rust file mapping.
- Updated: `inventory-system.md`, `combat-system.md`, `ability-system.md`, `npc-ai.md`, `stat-system.md`, `gameplay/README.md`, `technical/network-messages.md`.

## Files changed

34 files, +1994 / -135. Highlights:

- **4 new files**: `crates/services/src/base/world_entry_methods/inventory/ammo.rs`, `db/scripts/add_bandolier_cur_ammo_type.sql`, `docs/gameplay/weapon-ammo-reload.md`, `.claude/agent-memory/rust-gameserver-dev/build-environment.md`
- **Largest changes**: `crates/services/src/cell/service.rs` (+429), `crates/services/src/cell/cell_methods/inventory.rs` (+427), `docs/gameplay/weapon-ammo-reload.md` (+278), `crates/entity/src/cell_entity.rs` (+195)

## Caveats / known follow-ups

- `requestAmmoChange` validation is loose (accepts any non-zero ammo_type) — matches legacy `pass`. A TODO in `crates/services/src/cell/cell_methods/inventory.rs` references `crates/entity/src/inventory.rs:81` for adding strict validation against `item.ammo_types`.
- The `.claude/agent-memory/rust-gameserver-dev/build-environment.md` file contains a Windows path under `C:\Users\steven.cady\...`. It's project-scoped agent memory (intended to be committed per the agent definition) but the path is machine-specific. Other devs would need their own equivalent or we could move it to a `.local`-style override.

## Commits

1. `e446bf3` — Wire bandolier ammo through stats system and persist per-slot
2. `16a6bc7` — Seed AmmoSlot stats in mapLoaded from persisted bandolier ammo
3. `55a81f6` — Document ungraceful-disconnect flush path and the 60s detection window

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server-authoritative per-bandolier-slot ammo with mirrored client stat updates and reliable batched persistence (flush on reload, slot swap, disconnect/logout, and world transition).
  * Reloads use a server warmup deadline and refill on a timed tick; firing blocked when insufficient ammo. Active-slot ammo and ammo-type indicator now drive client UI.

* **Documentation**
  * Comprehensive weapon ammo/reload, inventory, NPC, stat, and network message docs; Windows/MSVC build-environment troubleshooting added.

* **Database**
  * Added inventory column to track per-slot ammo subtype.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->