### PR TITLE
fix(services): address CodeRabbit findings from PR #86

### DIFF
--- a/crates/entity/src/cell_entity.rs
+++ b/crates/entity/src/cell_entity.rs
@@ -9,7 +9,7 @@
 //! This corresponds to the C++ `CellEntity` / `Entity` classes in
 //! `src/server/CellApp/`.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 
 use serde::{Deserialize, Serialize};
 
@@ -192,8 +192,10 @@ pub struct CellEntity {
     /// Ticks until next AI action (count-down from ai tick interval).
     pub ai_cooldown_ticks: u32,
     /// Navmesh path waypoints the NPC is currently following.
-    /// Empty = not moving. Each tick consumes the next waypoint.
-    pub nav_path: Vec<Vector3>,
+    /// Empty = not moving. Each tick pops the next waypoint off the front.
+    /// Stored as `VecDeque` so per-tick `pop_front` is O(1) instead of the
+    /// O(n) shift `Vec::remove(0)` would do.
+    pub nav_path: VecDeque<Vector3>,
     /// Movement speed in world units per tick.
     pub move_speed: f32,
 
@@ -315,7 +317,7 @@ impl CellEntity {
             threat_list: HashMap::new(),
             spawn_position: None,
             ai_cooldown_ticks: 0,
-            nav_path: Vec::new(),
+            nav_path: VecDeque::new(),
             move_speed: 0.6, // ~0.6 world units per 100ms tick = 6 units/sec
             saved_missions_loaded: false,
             loot_table_id: None,

--- a/crates/services/src/base/world_entry/enable_entities.rs
+++ b/crates/services/src/base/world_entry/enable_entities.rs
@@ -44,24 +44,16 @@ pub(crate) async fn handle_enable_entities(
     _cell_tx: &Option<mpsc::Sender<BaseToCellMsg>>,
     _entity_to_addr: &Arc<Mutex<HashMap<u32, SocketAddr>>>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    // Check if we have a pending world entry (create-player step).
+    // Peek at pending world entry without consuming it: we only commit (take)
+    // after the create-player send_to succeeds, so a transient send failure
+    // leaves login state intact for the next ENABLE_ENTITIES retry.
     let pending = {
-        let mut clients = connected.lock().map_err(|_| "connected lock poisoned")?;
-        if let Some(c) = clients.get_mut(&addr) {
-            match (c.pending_player_entity_id.take(), c.pending_world_entry.take()) {
+        let clients = connected.lock().map_err(|_| "connected lock poisoned")?;
+        if let Some(c) = clients.get(&addr) {
+            match (c.pending_player_entity_id, c.pending_world_entry.clone()) {
                 (Some(eid), Some(entry)) => Some((eid, entry)),
                 _ => None,
             }
-        } else {
-            None
-        }
-    };
-
-    // Also retrieve the pending player load data
-    let pending_load = {
-        let mut clients = connected.lock().map_err(|_| "connected lock poisoned")?;
-        if let Some(c) = clients.get_mut(&addr) {
-            c.pending_player_load_data.take()
         } else {
             None
         }
@@ -86,15 +78,18 @@ pub(crate) async fn handle_enable_entities(
         let pkt = build_create_player(&key, seq, &acks, &entry_info);
         socket.send_to(&pkt, addr).await?;
 
-        // Store world entry + player data for the enter-world step (triggered by mapLoaded)
+        // Send succeeded — now commit: take pending state and stage map_loaded data.
         {
-        let mut clients = connected.lock().map_err(|_| "connected lock poisoned")?;
-        if let Some(c) = clients.get_mut(&addr) {
-            c.pending_map_loaded = Some(entry_info);
-            c.pending_player_load_data = pending_load;
-            c.pending_client_ready = None;
+            let mut clients = connected.lock().map_err(|_| "connected lock poisoned")?;
+            if let Some(c) = clients.get_mut(&addr) {
+                c.pending_player_entity_id.take();
+                let entry = c.pending_world_entry.take().unwrap_or(entry_info);
+                let load = c.pending_player_load_data.take();
+                c.pending_map_loaded = Some(entry);
+                c.pending_player_load_data = load;
+                c.pending_client_ready = None;
+            }
         }
-    }
 
         tracing::info!(%addr, "Create player complete -- waiting for client mapLoaded");
         return Ok(());
@@ -103,19 +98,18 @@ pub(crate) async fn handle_enable_entities(
     // -- Phase 4: initial entity creation -- send Account entity + char list --
     // Account entity was already allocated in Phase 3 (handle_login).
 
-    // Guard: only send once per connection.
+    // Guard: only proceed if we haven't already sent the char list.
+    // Note: char_list_sent is flipped only after send_to succeeds below, so a
+    // transient failure permits retry on the next ENABLE_ENTITIES.
     {
-        let mut clients = connected
-            .lock()
-            .map_err(|_| "connected lock poisoned")?;
-        if let Some(c) = clients.get_mut(&addr) {
-            if c.char_list_sent {
-                return Ok(()); // already sent
+        let clients = connected.lock().map_err(|_| "connected lock poisoned")?;
+        match clients.get(&addr) {
+            Some(c) if c.char_list_sent => return Ok(()),
+            Some(_) => {}
+            None => {
+                tracing::warn!(%addr, "enable_entities: addr not in connected map");
+                return Ok(());
             }
-            c.char_list_sent = true;
-        } else {
-            tracing::warn!(%addr, "enable_entities: addr not in connected map");
-            return Ok(());
         }
     }
 
@@ -135,6 +129,14 @@ pub(crate) async fn handle_enable_entities(
     let pkt = build_char_list(&key, seq, &acks, &characters, account_eid);
     tracing::trace!(%addr, len = pkt.len(), seq, hex = %super::super::helpers::to_hex(&pkt), "UDP_OUT char_list");
     socket.send_to(&pkt, addr).await?;
+
+    // Send succeeded -- mark char list as sent so we don't re-send on subsequent ENABLE_ENTITIES.
+    {
+        let mut clients = connected.lock().map_err(|_| "connected lock poisoned")?;
+        if let Some(c) = clients.get_mut(&addr) {
+            c.char_list_sent = true;
+        }
+    }
 
     tracing::info!(%addr, "Phase 4 complete -- char list sent");
 

--- a/crates/services/src/base/world_entry/space_registry.rs
+++ b/crates/services/src/base/world_entry/space_registry.rs
@@ -15,7 +15,12 @@ static SPACE_REGISTRY: std::sync::LazyLock<Mutex<HashMap<String, u32>>> =
 /// Register a space in the global registry (called from CellToBase message handler).
 pub(crate) fn register_space(world_name: String, space_id: u32) {
     tracing::debug!(world = %world_name, space_id, "Registered space in BaseApp registry");
-    SPACE_REGISTRY.lock().unwrap().insert(world_name, space_id);
+    // Recover from a poisoned mutex: a panic mid-mutation would otherwise
+    // wedge every subsequent space registration. The HashMap is in a known
+    // state (insert is atomic from the caller's perspective), so reusing
+    // the inner guard is safe here.
+    let mut guard = SPACE_REGISTRY.lock().unwrap_or_else(|p| p.into_inner());
+    guard.insert(world_name, space_id);
 }
 
 /// Hardcoded space ID fallback (used when CellService oneshot fails or is unavailable).

--- a/crates/services/src/base/world_entry/tests.rs
+++ b/crates/services/src/base/world_entry/tests.rs
@@ -1,16 +1,20 @@
+use super::space_registry::resolve_space_id_fallback;
+
 #[test]
 fn space_id_mapping_known_worlds() {
-    // Verify the three known space IDs are distinct and have high 16 bits == 1.
-    let castle_cellblock: u32 = 65552; // (1 << 16) | 16
-    let sgc_w1: u32 = 65553;           // (1 << 16) | 17
-    let combat_sim: u32 = 65554;       // (1 << 16) | 18
+    // Resolve through the actual fallback table rather than hardcoded literals
+    // so this test stays meaningful if `DEFAULT_SPACE_ID` or the world list
+    // ever shifts. We only assert the structural invariants the rest of the
+    // server relies on: each known world maps to a distinct id, and every id
+    // lives in cell 1's id space (high 16 bits == 1).
+    let castle_cellblock = resolve_space_id_fallback("Castle_CellBlock");
+    let sgc_w1 = resolve_space_id_fallback("SGC_W1");
+    let combat_sim = resolve_space_id_fallback("CombatSim");
 
-    // All distinct
     assert_ne!(castle_cellblock, sgc_w1);
     assert_ne!(sgc_w1, combat_sim);
     assert_ne!(castle_cellblock, combat_sim);
 
-    // High 16 bits == 1 for all three
     assert_eq!(castle_cellblock >> 16, 1);
     assert_eq!(sgc_w1 >> 16, 1);
     assert_eq!(combat_sim >> 16, 1);

--- a/crates/services/src/cell/abilities/loot_drop.rs
+++ b/crates/services/src/cell/abilities/loot_drop.rs
@@ -51,7 +51,20 @@ pub(super) fn generate_loot_on_death(
     for entry in &entries {
         let roll: f32 = rand::random();
         if roll <= entry.probability {
+            // Guard against malformed DB rows where min > max -- the
+            // subtraction would wrap as u32 and produce wildly out-of-range
+            // quantities. Log and fall back to min in that case.
             let quantity = if entry.min_quantity == entry.max_quantity {
+                entry.min_quantity
+            } else if entry.min_quantity > entry.max_quantity {
+                tracing::warn!(
+                    target_eid,
+                    loot_table_id,
+                    design_id = ?entry.design_id,
+                    min = entry.min_quantity,
+                    max = entry.max_quantity,
+                    "loot entry has min_quantity > max_quantity; using min as fallback"
+                );
                 entry.min_quantity
             } else {
                 let range = (entry.max_quantity - entry.min_quantity + 1) as u32;

--- a/crates/services/src/cell/abilities/rng.rs
+++ b/crates/services/src/cell/abilities/rng.rs
@@ -14,5 +14,8 @@ pub(super) fn pseudo_random(entity_id: u32, ability_id: i32, sequence: u32) -> f
     h ^= sequence.wrapping_mul(3266489917);
     h = h.wrapping_mul(668265263);
     h ^= h >> 15;
-    (h as f64) / (u32::MAX as f64)
+    // Divide by 2^32 (one greater than u32::MAX) so the result is strictly
+    // in [0.0, 1.0); using u32::MAX as the divisor would map h == u32::MAX
+    // to 1.0, breaking the half-open invariant the callers rely on.
+    (h as f64) / (u32::MAX as f64 + 1.0)
 }

--- a/crates/services/src/cell/abilities/use_ability.rs
+++ b/crates/services/src/cell/abilities/use_ability.rs
@@ -472,10 +472,16 @@ pub async fn handle_use_ability(
                     attacker = entity_id, target = target_eid,
                     mob_level = target.level, xp, "Granting kill XP"
                 );
-                let _ = tx.send(CellToBaseMsg::GrantXP {
+                if let Err(e) = tx.send(CellToBaseMsg::GrantXP {
                     entity_id,
                     xp_amount: xp,
-                }).await;
+                }).await {
+                    tracing::error!(
+                        attacker = entity_id, target = target_eid, xp,
+                        error = %e,
+                        "GrantXP send to base failed -- player kill credit lost"
+                    );
+                }
             }
         }
 

--- a/crates/services/src/cell/abilities/use_ability.rs
+++ b/crates/services/src/cell/abilities/use_ability.rs
@@ -280,7 +280,11 @@ pub async fn handle_use_ability(
             return;
         }
     };
-    let qr = combat::calculate_qr(&attacker_stats, &target.stats, true);
+    // Use the ability's actual ranged flag for the QR calculation. Defaults
+    // to false when the AbilityDef is missing (unknown ability falls back to
+    // a generic melee swing).
+    let ability_is_ranged = ability_def.as_ref().map(|d| d.is_ranged).unwrap_or(false);
+    let qr = combat::calculate_qr(&attacker_stats, &target.stats, ability_is_ranged);
 
     // Generate random value for this hit (seeded from ability invocation)
     // For now use a deterministic hash to be reproducible in tests.
@@ -288,7 +292,11 @@ pub async fn handle_use_ability(
     let random_value = pseudo_random(entity_id, ability_id, effect_seq as u32);
     let qr_result = combat::calculate_result(qr, random_value);
 
-    // Look up damage values from the ability's effect NVPs.
+    // Look up damage values from the ability's effect NVPs. When the
+    // ability is known but exposes no positive HealthDamage (e.g. focus
+    // drains, heals, buff-only abilities) we keep health_base_damage at 0
+    // so the ability doesn't accidentally read as a 15-HP physical hit.
+    // The 15-HP fallback is reserved for the unknown-ability case.
     let (health_base_damage, focus_base_damage) = if let Some(ref def) = ability_def {
         let mut h_dmg = 0i32;
         let mut f_dmg = 0i32;
@@ -300,7 +308,7 @@ pub async fn handle_use_ability(
                 if fd > 0 { f_dmg = fd; }
             }
         }
-        (if h_dmg > 0 { h_dmg } else { 15 }, f_dmg)
+        (h_dmg, f_dmg)
     } else {
         (15, 0)
     };

--- a/crates/services/src/cell/cell_methods/inventory/bandolier.rs
+++ b/crates/services/src/cell/cell_methods/inventory/bandolier.rs
@@ -23,20 +23,40 @@ pub async fn flush_dirty_bandolier_ammo(
     if entity.bandolier_ammo_dirty.is_empty() {
         return;
     }
-    // Drain into a Vec so we don't hold the borrow on `entity` across awaits.
-    let dirty: Vec<i32> = entity.bandolier_ammo_dirty.drain().collect();
+    // Snapshot dirty slot IDs without draining; we only clear each marker
+    // after its send succeeds, so a transient channel failure leaves the
+    // marker in place and the next flush retries it.
+    let dirty: Vec<i32> = entity.bandolier_ammo_dirty.iter().copied().collect();
     for slot_id in dirty {
         let (item_id, current_ammo, cur_ammo_type) = match entity.bandolier_items.get(&slot_id) {
             Some(item) => (item.item_id, item.current_ammo, item.cur_ammo_type),
-            None => continue,
+            None => {
+                // Dirty slot with no item -- nothing to persist. Drop marker.
+                entity.bandolier_ammo_dirty.remove(&slot_id);
+                continue;
+            }
         };
-        let _ = tx.send(CellToBaseMsg::BandolierAmmoUpdate {
+        match tx.send(CellToBaseMsg::BandolierAmmoUpdate {
             player_id,
             slot_id,
             expected_item_id: item_id,
             current_ammo,
             cur_ammo_type,
-        }).await;
+        }).await {
+            Ok(()) => {
+                entity.bandolier_ammo_dirty.remove(&slot_id);
+            }
+            Err(e) => {
+                tracing::warn!(
+                    player_id, slot_id, item_id, current_ammo, cur_ammo_type,
+                    error = %e,
+                    "BandolierAmmoUpdate send failed; leaving slot dirty for retry"
+                );
+                // Subsequent sends will likely also fail; preserve ordering
+                // by retrying the whole set on the next flush.
+                break;
+            }
+        }
     }
 }
 
@@ -100,9 +120,9 @@ pub(super) async fn handle_request_active_slot_change(
         } else {
             None
         };
-        if prev_persist.is_some() {
-            entity.bandolier_ammo_dirty.remove(&prev_slot);
-        }
+        // Leave the dirty marker in place; phase 2 only clears it after the
+        // BandolierAmmoUpdate send succeeds, so a failed send doesn't lose
+        // pending persistence state.
         // Cancel any in-flight reload only if the swap actually
         // moves to a different slot. A same-slot "swap" (no-op
         // from the client, or replayed packet) must not cancel
@@ -126,18 +146,40 @@ pub(super) async fn handle_request_active_slot_change(
         (prev_persist, new_ammo_type)
     };
 
-    // Phase 2: send messages now that the borrow is released.
+    // Phase 2: send messages now that the borrow is released. Clear the
+    // dirty marker for the previously-active slot only after the persist
+    // message is accepted by the channel.
     if let Some(player_id) = player_id {
         if let Some((p_slot, item_id, current_ammo, cur_ammo_type)) = prev_persist {
-            let _ = tx.send(CellToBaseMsg::BandolierAmmoUpdate {
+            match tx.send(CellToBaseMsg::BandolierAmmoUpdate {
                 player_id,
                 slot_id: p_slot,
                 expected_item_id: item_id,
                 current_ammo,
                 cur_ammo_type,
-            }).await;
+            }).await {
+                Ok(()) => {
+                    if let Some(entity) = space_mgr.get_entity_mut(entity_id) {
+                        entity.bandolier_ammo_dirty.remove(&p_slot);
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        entity_id, player_id, slot_id = p_slot,
+                        expected_item_id = item_id,
+                        error = %e,
+                        "BandolierAmmoUpdate (slot swap) send failed; dirty marker preserved for retry"
+                    );
+                }
+            }
         }
-        let _ = tx.send(CellToBaseMsg::ActiveSlotUpdate { player_id, slot_id }).await;
+        if let Err(e) = tx.send(CellToBaseMsg::ActiveSlotUpdate { player_id, slot_id }).await {
+            tracing::warn!(
+                entity_id, player_id, slot_id,
+                error = %e,
+                "ActiveSlotUpdate send failed"
+            );
+        }
     }
 
     // Stage D: refresh the client's ammo-type indicator for the
@@ -243,15 +285,14 @@ pub(super) async fn handle_request_ammo_change(
                 return;
             }
         }
-        // Mutate the slot. We mark dirty (so any in-flight flush
-        // path sees the change) and immediately drain — the
-        // BandolierAmmoUpdate emitted below persists it now.
+        // Mutate the slot and mark it dirty. The dirty marker stays set
+        // until phase 2 confirms BandolierAmmoUpdate was accepted by the
+        // channel; if the send fails the next flush picks the change up.
         let item = entity.bandolier_items.get_mut(&slot).unwrap();
         item.cur_ammo_type = ammo_type;
         let item_id_for_persist = item.item_id;
         let current_ammo = item.current_ammo;
         entity.bandolier_ammo_dirty.insert(slot);
-        entity.bandolier_ammo_dirty.remove(&slot);
         let is_active = slot == entity.active_bandolier_slot;
         let player_id = entity.player_id;
         (player_id, (slot, item_id_for_persist, current_ammo, ammo_type), is_active)
@@ -260,13 +301,26 @@ pub(super) async fn handle_request_ammo_change(
     // Phase 2: persist + (if active) refresh the client's ammo-type indicator.
     if let Some(player_id) = player_id {
         let (slot_id, expected_item_id, current_ammo, cur_ammo_type) = persist;
-        let _ = tx.send(CellToBaseMsg::BandolierAmmoUpdate {
+        match tx.send(CellToBaseMsg::BandolierAmmoUpdate {
             player_id,
             slot_id,
             expected_item_id,
             current_ammo,
             cur_ammo_type,
-        }).await;
+        }).await {
+            Ok(()) => {
+                if let Some(entity) = space_mgr.get_entity_mut(entity_id) {
+                    entity.bandolier_ammo_dirty.remove(&slot_id);
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    entity_id, player_id, slot_id, expected_item_id, cur_ammo_type,
+                    error = %e,
+                    "BandolierAmmoUpdate (ammo change) send failed; dirty marker preserved for retry"
+                );
+            }
+        }
     } else {
         tracing::warn!(entity_id, "requestAmmoChange: entity has no player_id — skipping persist");
     }

--- a/crates/services/src/cell/cell_methods/inventory/item_ops.rs
+++ b/crates/services/src/cell/cell_methods/inventory/item_ops.rs
@@ -35,9 +35,14 @@ pub(super) async fn handle_remove_item(
         let quantity = i16::from_le_bytes([args[4], args[5]]) as i32;
         tracing::debug!(entity_id, item_id, quantity, "removeItem");
         if let Some(player_id) = resolve_player_id(entity_id, "removeItem", space_mgr) {
-            let _ = tx.send(CellToBaseMsg::RemoveInventoryItem {
+            if let Err(e) = tx.send(CellToBaseMsg::RemoveInventoryItem {
                 entity_id, player_id, item_id, quantity,
-            }).await;
+            }).await {
+                tracing::error!(
+                    entity_id, player_id, item_id, quantity, error = %e,
+                    "RemoveInventoryItem send to base failed"
+                );
+            }
         }
     } else {
         tracing::warn!(entity_id, args_len = args.len(), "removeItem: truncated args");
@@ -51,7 +56,12 @@ pub(super) async fn handle_list_items(
 ) {
     tracing::debug!(entity_id, "listItems");
     if let Some(player_id) = resolve_player_id(entity_id, "listItems", space_mgr) {
-        let _ = tx.send(CellToBaseMsg::ListInventoryItems { entity_id, player_id }).await;
+        if let Err(e) = tx.send(CellToBaseMsg::ListInventoryItems { entity_id, player_id }).await {
+            tracing::error!(
+                entity_id, player_id, error = %e,
+                "ListInventoryItems send to base failed"
+            );
+        }
     }
 }
 
@@ -68,10 +78,17 @@ pub(super) async fn handle_move_item(
         let quantity = i32::from_le_bytes([args[12], args[13], args[14], args[15]]);
         tracing::debug!(entity_id, item_id, target_container_id, target_slot_id, quantity, "moveItem");
         if let Some(player_id) = resolve_player_id(entity_id, "moveItem", space_mgr) {
-            let _ = tx.send(CellToBaseMsg::MoveInventoryItem {
+            if let Err(e) = tx.send(CellToBaseMsg::MoveInventoryItem {
                 entity_id, player_id, item_id,
                 target_container_id, target_slot_id, quantity,
-            }).await;
+            }).await {
+                tracing::error!(
+                    entity_id, player_id, item_id,
+                    target_container_id, target_slot_id, quantity,
+                    error = %e,
+                    "MoveInventoryItem send to base failed"
+                );
+            }
         }
     } else {
         tracing::warn!(entity_id, args_len = args.len(), "moveItem: truncated args");

--- a/crates/services/src/cell/cell_methods/inventory/tests.rs
+++ b/crates/services/src/cell/cell_methods/inventory/tests.rs
@@ -76,10 +76,13 @@ async fn slot_swap_preserves_per_slot_ammo() {
 
     let (tx, mut rx) = mpsc::channel(64);
 
-    // Fire two shots on slot 0 → current_ammo == 28 (cooldown is 1ms,
-    // so the second fire happens past the deadline).
+    // Fire two shots on slot 0 → current_ammo == 28. Reset the cooldown
+    // between shots instead of sleeping past it: a 1ms cooldown plus a 5ms
+    // sleep is enough on a quiet box but flakes under CI scheduler stalls.
     handle_use_ability(1, ability_id, 0, &tx, &mut mgr).await;
-    tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+    if let Some(e) = mgr.get_entity_mut(1) {
+        e.abilities.clear_all_cooldowns();
+    }
     handle_use_ability(1, ability_id, 0, &tx, &mut mgr).await;
     assert_eq!(mgr.get_entity(1).unwrap().bandolier_items[&0].current_ammo, 28);
 
@@ -133,7 +136,9 @@ async fn slot_swap_preserves_per_slot_ammo() {
     }
 
     // Fire once on slot 1 → current_ammo == 11.
-    tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+    if let Some(e) = mgr.get_entity_mut(1) {
+        e.abilities.clear_all_cooldowns();
+    }
     handle_use_ability(1, ability_id, 0, &tx, &mut mgr).await;
     assert_eq!(mgr.get_entity(1).unwrap().bandolier_items[&1].current_ammo, 11);
 

--- a/crates/services/src/cell/cell_methods/player/combat.rs
+++ b/crates/services/src/cell/cell_methods/player/combat.rs
@@ -190,11 +190,17 @@ async fn handle_respawn(
         .unwrap_or_else(|| "Castle_CellBlock".to_string());
     space_mgr.update_entity_position(entity_id, spawn_pos, [0, 0, 0], [0.0; 3]);
 
-    let _ = tx.send(CellToBaseMsg::RespawnReload {
+    if let Err(e) = tx.send(CellToBaseMsg::RespawnReload {
         entity_id,
-        world_name,
+        world_name: world_name.clone(),
         spawn_pos,
-    }).await;
+    }).await {
+        tracing::error!(
+            entity_id, %world_name, ?spawn_pos, error = %e,
+            "RespawnReload send to base failed -- player will not be teleported to spawn"
+        );
+        return;
+    }
     tracing::info!(entity_id, ?spawn_pos, "Sent RespawnReload to BaseApp");
 }
 

--- a/crates/services/src/cell/content/executor.rs
+++ b/crates/services/src/cell/content/executor.rs
@@ -204,24 +204,22 @@ pub(super) async fn execute_actions(
                     None
                 };
 
-                if let Some(world_name) = space_mgr.get_entity_world_name(entity_id) {
-                    if let Some(&target_id) = space_mgr.find_entities_by_template(&world_name, slot).first() {
-                        let target_eid = cimmeria_common::EntityId(target_id as i32);
-                        let in_witness_set = space_mgr.get_entity(entity_id)
-                            .map_or(false, |p| p.witnesses.contains(&target_eid));
+                if let Some(&target_id) = space_mgr.find_entities_by_template(entity_id, slot).first() {
+                    let target_eid = cimmeria_common::EntityId(target_id as i32);
+                    let in_witness_set = space_mgr.get_entity(entity_id)
+                        .map_or(false, |p| p.witnesses.contains(&target_eid));
 
-                        if in_witness_set {
-                            let base_flags = space_mgr.get_entity(target_id)
-                                .map(|e| e.interaction_type_flags).unwrap_or(0);
-                            let merged = base_flags | removed_flags.unwrap_or(0);
+                    if in_witness_set {
+                        let base_flags = space_mgr.get_entity(target_id)
+                            .map(|e| e.interaction_type_flags).unwrap_or(0);
+                        let merged = base_flags | removed_flags.unwrap_or(0);
 
-                            let _ = tx.send(CellToBaseMsg::WitnessEntityMethod {
-                                witness_id: entity_id,
-                                entity_id: target_id,
-                                method_index: 3, // InteractionType
-                                args: (merged as u64).to_le_bytes().to_vec(),
-                            }).await;
-                        }
+                        let _ = tx.send(CellToBaseMsg::WitnessEntityMethod {
+                            witness_id: entity_id,
+                            entity_id: target_id,
+                            method_index: 3, // InteractionType
+                            args: (merged as u64).to_le_bytes().to_vec(),
+                        }).await;
                     }
                 }
             }
@@ -229,40 +227,38 @@ pub(super) async fn execute_actions(
                 tracing::info!(entity_id, item_id, count, chain_id, "Content: removing item");
             }
             Action::SetInteractionType { entity_tag, operation, mask } => {
-                if let Some(world_name) = space_mgr.get_entity_world_name(entity_id) {
-                    if let Some(target_id) = space_mgr.find_entity_by_tag(&world_name, &entity_tag) {
-                        let new_flags = if let Some(target) = space_mgr.get_entity_mut(target_id) {
-                            let old = target.interaction_type_flags;
-                            match operation.as_str() {
-                                "add" | "|" => target.interaction_type_flags |= mask,
-                                "remove" | "~" => target.interaction_type_flags &= !mask,
-                                "set" => target.interaction_type_flags = mask,
-                                _ => tracing::warn!(%operation, "Unknown interaction type operation"),
-                            }
-                            tracing::debug!(
-                                entity_id, %entity_tag, target_id, %operation, mask,
-                                old, new = target.interaction_type_flags, chain_id,
-                                "Content: set interaction type"
-                            );
-                            Some(target.interaction_type_flags)
-                        } else {
-                            None
-                        };
-
-                        if let Some(flags) = new_flags {
-                            let witnesses = space_mgr.get_witnesses_of(target_id);
-                            for witness_id in witnesses {
-                                let _ = tx.send(CellToBaseMsg::WitnessEntityMethod {
-                                    witness_id,
-                                    entity_id: target_id,
-                                    method_index: 3, // InteractionType
-                                    args: (flags as u64).to_le_bytes().to_vec(),
-                                }).await;
-                            }
+                if let Some(target_id) = space_mgr.find_entity_by_tag(entity_id, &entity_tag) {
+                    let new_flags = if let Some(target) = space_mgr.get_entity_mut(target_id) {
+                        let old = target.interaction_type_flags;
+                        match operation.as_str() {
+                            "add" | "|" => target.interaction_type_flags |= mask,
+                            "remove" | "~" => target.interaction_type_flags &= !mask,
+                            "set" => target.interaction_type_flags = mask,
+                            _ => tracing::warn!(%operation, "Unknown interaction type operation"),
                         }
+                        tracing::debug!(
+                            entity_id, %entity_tag, target_id, %operation, mask,
+                            old, new = target.interaction_type_flags, chain_id,
+                            "Content: set interaction type"
+                        );
+                        Some(target.interaction_type_flags)
                     } else {
-                        tracing::debug!(entity_id, %entity_tag, chain_id, "Content: entity tag not found for SetInteractionType");
+                        None
+                    };
+
+                    if let Some(flags) = new_flags {
+                        let witnesses = space_mgr.get_witnesses_of(target_id);
+                        for witness_id in witnesses {
+                            let _ = tx.send(CellToBaseMsg::WitnessEntityMethod {
+                                witness_id,
+                                entity_id: target_id,
+                                method_index: 3, // InteractionType
+                                args: (flags as u64).to_le_bytes().to_vec(),
+                            }).await;
+                        }
                     }
+                } else {
+                    tracing::debug!(entity_id, %entity_tag, chain_id, "Content: entity tag not found for SetInteractionType");
                 }
             }
             Action::StartMinigame { minigame_type, on_victory_chains } => {
@@ -276,26 +272,22 @@ pub(super) async fn execute_actions(
                 }).await;
             }
             Action::SetAggression { entity_tag, level: agg_level } => {
-                if let Some(world_name) = space_mgr.get_entity_world_name(entity_id) {
-                    if let Some(target_id) = space_mgr.find_entity_by_tag(&world_name, &entity_tag) {
-                        tracing::debug!(entity_id, %entity_tag, target_id, agg_level, chain_id, "Content: set aggression");
-                        if let Some(target) = space_mgr.get_entity_mut(target_id) {
-                            target.properties.insert(
-                                "aggression".to_string(),
-                                cimmeria_entity::base_entity::PropertyValue::Int32(agg_level),
-                            );
-                        }
+                if let Some(target_id) = space_mgr.find_entity_by_tag(entity_id, &entity_tag) {
+                    tracing::debug!(entity_id, %entity_tag, target_id, agg_level, chain_id, "Content: set aggression");
+                    if let Some(target) = space_mgr.get_entity_mut(target_id) {
+                        target.properties.insert(
+                            "aggression".to_string(),
+                            cimmeria_entity::base_entity::PropertyValue::Int32(agg_level),
+                        );
                     }
                 }
             }
             Action::DestroyTaggedEntity { entity_tag } => {
-                if let Some(world_name) = space_mgr.get_entity_world_name(entity_id) {
-                    if let Some(target_id) = space_mgr.find_entity_by_tag(&world_name, &entity_tag) {
-                        tracing::info!(entity_id, %entity_tag, target_id, chain_id, "Content: destroying tagged entity");
-                        space_mgr.destroy_entity(target_id);
-                    } else {
-                        tracing::debug!(entity_id, %entity_tag, chain_id, "Content: entity tag not found for DestroyTaggedEntity");
-                    }
+                if let Some(target_id) = space_mgr.find_entity_by_tag(entity_id, &entity_tag) {
+                    tracing::info!(entity_id, %entity_tag, target_id, chain_id, "Content: destroying tagged entity");
+                    space_mgr.destroy_entity(target_id);
+                } else {
+                    tracing::debug!(entity_id, %entity_tag, chain_id, "Content: entity tag not found for DestroyTaggedEntity");
                 }
             }
             Action::TriggerTransporter { region_id } => {
@@ -361,48 +353,42 @@ pub(super) async fn execute_actions(
                 // Generate threat on the NPC (found by tag) from the player.
                 // If no entity_tag, the threat is on the player entity itself (ignored by combat).
                 if let Some(tag) = &entity_tag {
-                    if let Some(world_name) = space_mgr.get_entity_world_name(entity_id) {
-                        if let Some(target_id) = space_mgr.find_entity_by_tag(&world_name, tag) {
-                            tracing::info!(
-                                entity_id, %tag, target_id, threat_level, chain_id,
-                                "Content: generate threat on NPC from player"
-                            );
-                            crate::cell::combat::generate_threat(
-                                space_mgr,
-                                entity_id,  // attacker = the player
-                                target_id,  // target = the NPC
-                                threat_level as f32,
-                            );
-                        }
+                    if let Some(target_id) = space_mgr.find_entity_by_tag(entity_id, tag) {
+                        tracing::info!(
+                            entity_id, %tag, target_id, threat_level, chain_id,
+                            "Content: generate threat on NPC from player"
+                        );
+                        crate::cell::combat::generate_threat(
+                            space_mgr,
+                            entity_id,  // attacker = the player
+                            target_id,  // target = the NPC
+                            threat_level as f32,
+                        );
                     }
                 } else {
                     tracing::debug!(entity_id, threat_level, chain_id, "Content: generate threat (no target tag, skipped)");
                 }
             }
             Action::SetVisible { entity_tag, visible } => {
-                if let Some(world_name) = space_mgr.get_entity_world_name(entity_id) {
-                    if let Some(target_id) = space_mgr.find_entity_by_tag(&world_name, &entity_tag) {
-                        tracing::debug!(entity_id, %entity_tag, target_id, visible, chain_id, "Content: set visible");
-                        let vis_byte: u8 = if visible { 1 } else { 0 };
-                        let _ = tx.send(CellToBaseMsg::EntityMethodCall {
-                            entity_id: target_id,
-                            method_index: 11, // onVisible
-                            args: vec![vis_byte],
-                        }).await;
-                    }
+                if let Some(target_id) = space_mgr.find_entity_by_tag(entity_id, &entity_tag) {
+                    tracing::debug!(entity_id, %entity_tag, target_id, visible, chain_id, "Content: set visible");
+                    let vis_byte: u8 = if visible { 1 } else { 0 };
+                    let _ = tx.send(CellToBaseMsg::EntityMethodCall {
+                        entity_id: target_id,
+                        method_index: 11, // onVisible
+                        args: vec![vis_byte],
+                    }).await;
                 }
             }
             Action::MoveWaypoint { entity_tag, destination, speed: _ } => {
-                if let Some(world_name) = space_mgr.get_entity_world_name(entity_id) {
-                    if let Some(target_id) = space_mgr.find_entity_by_tag(&world_name, &entity_tag) {
-                        tracing::debug!(entity_id, %entity_tag, target_id, ?destination, chain_id, "Content: move waypoint");
-                        space_mgr.update_entity_position(
-                            target_id,
-                            destination,
-                            [0, 0, 0],
-                            [0.0; 3],
-                        );
-                    }
+                if let Some(target_id) = space_mgr.find_entity_by_tag(entity_id, &entity_tag) {
+                    tracing::debug!(entity_id, %entity_tag, target_id, ?destination, chain_id, "Content: move waypoint");
+                    space_mgr.update_entity_position(
+                        target_id,
+                        destination,
+                        [0, 0, 0],
+                        [0.0; 3],
+                    );
                 }
             }
             Action::SetActiveSlot { bag_id, slot } => {
@@ -460,35 +446,33 @@ async fn send_interaction_update_if_visible(
     space_mgr: &SpaceManager,
     label: &str,
 ) {
-    if let Some(world_name) = space_mgr.get_entity_world_name(entity_id) {
-        if let Some(&target_id) = space_mgr.find_entities_by_template(&world_name, slot).first() {
-            let target_eid = cimmeria_common::EntityId(target_id as i32);
-            let in_witness_set = space_mgr.get_entity(entity_id)
-                .map_or(false, |p| p.witnesses.contains(&target_eid));
+    if let Some(&target_id) = space_mgr.find_entities_by_template(entity_id, slot).first() {
+        let target_eid = cimmeria_common::EntityId(target_id as i32);
+        let in_witness_set = space_mgr.get_entity(entity_id)
+            .map_or(false, |p| p.witnesses.contains(&target_eid));
 
-            if in_witness_set {
-                let base_flags = space_mgr.get_entity(target_id)
-                    .map(|e| e.interaction_type_flags).unwrap_or(0);
-                let merged = base_flags | entry.interaction_flags;
+        if in_witness_set {
+            let base_flags = space_mgr.get_entity(target_id)
+                .map(|e| e.interaction_type_flags).unwrap_or(0);
+            let merged = base_flags | entry.interaction_flags;
 
-                tracing::debug!(
-                    entity_id, target_id,
-                    dialog_id = entry.dialog_id, base_flags, merged,
-                    "Sending per-player InteractionType for {}", label
-                );
+            tracing::debug!(
+                entity_id, target_id,
+                dialog_id = entry.dialog_id, base_flags, merged,
+                "Sending per-player InteractionType for {}", label
+            );
 
-                let _ = tx.send(CellToBaseMsg::WitnessEntityMethod {
-                    witness_id: entity_id,
-                    entity_id: target_id,
-                    method_index: 3, // InteractionType
-                    args: (merged as u64).to_le_bytes().to_vec(),
-                }).await;
-            } else {
-                tracing::debug!(
-                    entity_id, target_id,
-                    "NPC not yet in player AoI — deferring InteractionType to AoI create"
-                );
-            }
+            let _ = tx.send(CellToBaseMsg::WitnessEntityMethod {
+                witness_id: entity_id,
+                entity_id: target_id,
+                method_index: 3, // InteractionType
+                args: (merged as u64).to_le_bytes().to_vec(),
+            }).await;
+        } else {
+            tracing::debug!(
+                entity_id, target_id,
+                "NPC not yet in player AoI — deferring InteractionType to AoI create"
+            );
         }
     }
 }

--- a/crates/services/src/cell/content/executor.rs
+++ b/crates/services/src/cell/content/executor.rs
@@ -36,7 +36,7 @@ pub(super) async fn execute_actions(
                     crate::cell::missions::accept_mission(
                         entity_id, mission_id, step_id, objectives, tx, space_mgr,
                     ).await;
-                    let _ = tx.send(CellToBaseMsg::MissionUpdate {
+                    if let Err(e) = tx.send(CellToBaseMsg::MissionUpdate {
                         player_id,
                         mission_id,
                         status: 1,
@@ -45,7 +45,13 @@ pub(super) async fn execute_actions(
                         completed_objective_ids: vec![],
                         active_objective_ids: vec![step_id],
                         failed_objective_ids: vec![],
-                    }).await;
+                    }).await {
+                        tracing::error!(
+                            entity_id, player_id, mission_id, step_id,
+                            chain_id, error = %e,
+                            "MissionUpdate (accept) send to base failed -- mission progress not persisted"
+                        );
+                    }
                 } else {
                     tracing::warn!(mission_id, chain_id, "No mission_defs entry — cannot accept mission");
                 }
@@ -55,7 +61,7 @@ pub(super) async fn execute_actions(
                 crate::cell::missions::complete_mission_direct(
                     entity_id, mission_id, tx, space_mgr,
                 ).await;
-                let _ = tx.send(CellToBaseMsg::MissionUpdate {
+                if let Err(e) = tx.send(CellToBaseMsg::MissionUpdate {
                     player_id,
                     mission_id,
                     status: 2,
@@ -64,7 +70,12 @@ pub(super) async fn execute_actions(
                     completed_objective_ids: vec![],
                     active_objective_ids: vec![],
                     failed_objective_ids: vec![],
-                }).await;
+                }).await {
+                    tracing::error!(
+                        entity_id, player_id, mission_id, chain_id, error = %e,
+                        "MissionUpdate (complete) send to base failed -- mission completion not persisted"
+                    );
+                }
             }
             Action::GrantItem { item_id, count, container_id } => {
                 tracing::info!(entity_id, item_id, count, chain_id, "Content: granting item");
@@ -108,13 +119,19 @@ pub(super) async fn execute_actions(
                     }
                 }
 
-                let _ = tx.send(CellToBaseMsg::GrantItem {
+                if let Err(e) = tx.send(CellToBaseMsg::GrantItem {
                     entity_id,
                     player_id,
                     item_id,
                     container_id: cid,
                     count,
-                }).await;
+                }).await {
+                    tracing::error!(
+                        entity_id, player_id, item_id, container_id = cid,
+                        count, chain_id, error = %e,
+                        "GrantItem send to base failed -- item not persisted to inventory"
+                    );
+                }
 
                 if let Some(payload) = ammo_stat_payload {
                     if !payload.is_empty() {
@@ -148,7 +165,7 @@ pub(super) async fn execute_actions(
             Action::AdvanceStep { mission_id, step_id } => {
                 tracing::info!(entity_id, mission_id, step_id, chain_id, "Content: advancing step");
                 crate::cell::missions::advance_step(entity_id, mission_id, step_id, tx, space_mgr).await;
-                let _ = tx.send(CellToBaseMsg::MissionUpdate {
+                if let Err(e) = tx.send(CellToBaseMsg::MissionUpdate {
                     player_id,
                     mission_id,
                     status: 1,
@@ -157,7 +174,13 @@ pub(super) async fn execute_actions(
                     completed_objective_ids: vec![],
                     active_objective_ids: vec![step_id],
                     failed_objective_ids: vec![],
-                }).await;
+                }).await {
+                    tracing::error!(
+                        entity_id, player_id, mission_id, step_id,
+                        chain_id, error = %e,
+                        "MissionUpdate (advance step) send to base failed -- step progress not persisted"
+                    );
+                }
             }
             Action::AddDialogSet { dialog_set_id, slot, mission_id: _ } => {
                 tracing::info!(entity_id, dialog_set_id, slot, chain_id, "Content: adding dialog set");

--- a/crates/services/src/cell/content/executor.rs
+++ b/crates/services/src/cell/content/executor.rs
@@ -227,7 +227,10 @@ pub(super) async fn execute_actions(
                     None
                 };
 
-                if let Some(&target_id) = space_mgr.find_entities_by_template(entity_id, slot).first() {
+                // Update every entity sharing this template -- `.first()` would
+                // arbitrarily pick one (HashMap iteration order is nondeterministic),
+                // leaving sibling entities with stale interaction flags.
+                for target_id in space_mgr.find_entities_by_template(entity_id, slot) {
                     let target_eid = cimmeria_common::EntityId(target_id as i32);
                     let in_witness_set = space_mgr.get_entity(entity_id)
                         .map_or(false, |p| p.witnesses.contains(&target_eid));
@@ -469,7 +472,10 @@ async fn send_interaction_update_if_visible(
     space_mgr: &SpaceManager,
     label: &str,
 ) {
-    if let Some(&target_id) = space_mgr.find_entities_by_template(entity_id, slot).first() {
+    // Update every entity sharing this template instead of an arbitrary
+    // first match -- spaces with multiple template-equal NPCs would otherwise
+    // get a single nondeterministic update.
+    for target_id in space_mgr.find_entities_by_template(entity_id, slot) {
         let target_eid = cimmeria_common::EntityId(target_id as i32);
         let in_witness_set = space_mgr.get_entity(entity_id)
             .map_or(false, |p| p.witnesses.contains(&target_eid));

--- a/crates/services/src/cell/service/message_loop.rs
+++ b/crates/services/src/cell/service/message_loop.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use sqlx::PgPool;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, Notify};
 
 use cimmeria_content_engine::chain::ChainEngine;
 
@@ -13,6 +13,10 @@ use super::super::space_manager::SpaceManager;
 use super::super::spawner;
 
 /// Main CellService message processing loop.
+///
+/// Exits when `shutdown` is notified, the BaseToCell channel closes, or the
+/// task is dropped. `CellService::stop()` uses the `shutdown` arm to request
+/// a clean exit and then awaits the join handle.
 pub(super) async fn run_cell_loop(
     rx: &mut mpsc::Receiver<BaseToCellMsg>,
     tx: &mpsc::Sender<CellToBaseMsg>,
@@ -20,6 +24,7 @@ pub(super) async fn run_cell_loop(
     mut engine: ChainEngine,
     db_pool: Option<Arc<PgPool>>,
     spawn_records: Vec<spawner::SpawnRecord>,
+    shutdown: Arc<Notify>,
 ) {
     tracing::debug!("Cell service message loop started");
 
@@ -28,6 +33,10 @@ pub(super) async fn run_cell_loop(
 
     loop {
         tokio::select! {
+            _ = shutdown.notified() => {
+                tracing::info!("Cell service received shutdown signal — exiting loop");
+                break;
+            }
             msg = rx.recv() => {
                 match msg {
                     Some(BaseToCellMsg::ReloadContentEngine) => {

--- a/crates/services/src/cell/service/mod.rs
+++ b/crates/services/src/cell/service/mod.rs
@@ -10,7 +10,8 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 
 use sqlx::PgPool;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, Notify};
+use tokio::task::JoinHandle;
 
 use cimmeria_common::ServerConfig;
 
@@ -44,6 +45,15 @@ pub struct CellService {
 
     /// Database pool for content engine loading (set by orchestrator).
     pub(crate) db_pool: Option<Arc<PgPool>>,
+
+    /// Handle to the spawned cell-loop task. `stop()` notifies and awaits it
+    /// so shutdown is deterministic instead of relying on the channel half
+    /// being dropped at some unspecified time.
+    pub(crate) cell_loop_handle: Option<JoinHandle<()>>,
+
+    /// Signal that asks `run_cell_loop` to break out of its select loop.
+    /// Cloned into the task on start; notified by `stop()`.
+    pub(crate) shutdown_signal: Option<Arc<Notify>>,
 }
 
 impl CellService {
@@ -62,6 +72,8 @@ impl CellService {
             cell_to_base_tx: None,
             entities_dir: "entities".to_string(),
             db_pool: None,
+            cell_loop_handle: None,
+            shutdown_signal: None,
         }
     }
 
@@ -86,8 +98,22 @@ impl CellService {
     }
 
     /// Stop the cell service gracefully.
+    ///
+    /// Signals the cell loop to break out, awaits its join handle, then drops
+    /// the channels. Without the await, the task could outlive `stop()` and
+    /// keep poking at shared state during teardown.
     pub async fn stop(&mut self) {
         tracing::info!("Stopping cell service");
+        if let Some(signal) = self.shutdown_signal.take() {
+            signal.notify_waiters();
+        }
+        if let Some(handle) = self.cell_loop_handle.take() {
+            match handle.await {
+                Ok(()) => tracing::trace!("Cell loop joined cleanly"),
+                Err(e) if e.is_cancelled() => tracing::trace!("Cell loop was cancelled"),
+                Err(e) => tracing::warn!(error = %e, "Cell loop task panicked"),
+            }
+        }
         self.base_to_cell_rx = None;
         self.cell_to_base_tx = None;
         self.is_running = false;

--- a/crates/services/src/cell/service/mod.rs
+++ b/crates/services/src/cell/service/mod.rs
@@ -105,7 +105,11 @@ impl CellService {
     pub async fn stop(&mut self) {
         tracing::info!("Stopping cell service");
         if let Some(signal) = self.shutdown_signal.take() {
-            signal.notify_waiters();
+            // notify_one() stores a permit if no waiter is currently parked,
+            // so the next `shutdown.notified().await` in the loop returns
+            // immediately. notify_waiters() would only wake an already-parked
+            // future and could be lost between loop iterations.
+            signal.notify_one();
         }
         if let Some(handle) = self.cell_loop_handle.take() {
             match handle.await {

--- a/crates/services/src/cell/service/npc_ai.rs
+++ b/crates/services/src/cell/service/npc_ai.rs
@@ -131,7 +131,10 @@ async fn npc_ai_fight(
             match npc {
                 Some(e) if !e.nav_path.is_empty() => {
                     // Check if target moved far from the last waypoint
-                    let last_wp = e.nav_path[e.nav_path.len() - 1];
+                    let last_wp = match e.nav_path.back() {
+                        Some(wp) => *wp,
+                        None => return,
+                    };
                     last_wp.distance_to(&target_pos) > 5.0
                 }
                 _ => true, // No path — need one
@@ -141,7 +144,7 @@ async fn npc_ai_fight(
         if needs_repath {
             if let Some(path) = space_mgr.find_path(npc_id, &npc_pos, &target_pos) {
                 if path.len() > 1 {
-                    let waypoints: Vec<_> = path.into_iter().skip(1).collect();
+                    let waypoints: std::collections::VecDeque<_> = path.into_iter().skip(1).collect();
                     if let Some(npc) = space_mgr.get_entity_mut(npc_id) {
                         npc.nav_path = waypoints;
                     }
@@ -161,8 +164,20 @@ async fn npc_ai_fight(
         return;
     }
 
-    // In range — stop moving and attack (LoS check skipped to prevent jittering;
-    // the ability's range check handles the actual validation)
+    // In range — stop moving and attack, but only if we actually have line
+    // of sight to the target. Without this check, NPCs fire through walls
+    // because the ability's range check alone doesn't verify occlusion.
+    if !has_los {
+        if let Some(npc) = space_mgr.get_entity_mut(npc_id) {
+            npc.nav_path.clear();
+        }
+        tracing::debug!(
+            npc_id, target = target_id, distance = dist_to_target,
+            "NPC AI: in range but no line of sight, holding fire"
+        );
+        return;
+    }
+
     if let Some(npc) = space_mgr.get_entity_mut(npc_id) {
         npc.nav_path.clear();
     }

--- a/crates/services/src/cell/service/npc_ai.rs
+++ b/crates/services/src/cell/service/npc_ai.rs
@@ -122,10 +122,11 @@ async fn npc_ai_fight(
     let in_range = dist_to_target <= combat::NPC_ATTACK_RANGE;
     let has_los = space_mgr.has_line_of_sight(npc_id, target_id);
 
-    if !in_range {
-        // Out of range — pathfind toward target, but only recalculate if:
-        // 1. NPC has no active path, OR
-        // 2. Target has moved significantly from the path's destination
+    // Out of range OR occluded — keep pathfinding so the NPC can reposition
+    // to regain line of sight. Treating "in range but blocked" as a stop
+    // condition would freeze the NPC behind walls/corners; making it a repath
+    // condition lets the AI walk around the obstruction.
+    if !in_range || !has_los {
         let needs_repath = {
             let npc = space_mgr.get_entity(npc_id);
             match npc {
@@ -156,7 +157,7 @@ async fn npc_ai_fight(
                 }
             } else {
                 tracing::debug!(
-                    npc_id, target = target_id,
+                    npc_id, target = target_id, in_range, has_los,
                     "NPC AI: no path to target"
                 );
             }
@@ -164,20 +165,7 @@ async fn npc_ai_fight(
         return;
     }
 
-    // In range — stop moving and attack, but only if we actually have line
-    // of sight to the target. Without this check, NPCs fire through walls
-    // because the ability's range check alone doesn't verify occlusion.
-    if !has_los {
-        if let Some(npc) = space_mgr.get_entity_mut(npc_id) {
-            npc.nav_path.clear();
-        }
-        tracing::debug!(
-            npc_id, target = target_id, distance = dist_to_target,
-            "NPC AI: in range but no line of sight, holding fire"
-        );
-        return;
-    }
-
+    // In range and LOS confirmed — stop moving and attack.
     if let Some(npc) = space_mgr.get_entity_mut(npc_id) {
         npc.nav_path.clear();
     }

--- a/crates/services/src/cell/service/startup.rs
+++ b/crates/services/src/cell/service/startup.rs
@@ -1,5 +1,9 @@
 //! CellService startup: load XML world defs, hydrate DB caches, spawn the message loop.
 
+use std::sync::Arc;
+
+use tokio::sync::Notify;
+
 use super::super::content;
 use super::super::messages::CellToBaseMsg;
 use super::super::space_manager::SpaceManager;
@@ -186,9 +190,16 @@ impl CellService {
         let tx = self.cell_to_base_tx.clone();
 
         if let (Some(mut rx), Some(tx)) = (rx, tx) {
-            tokio::spawn(async move {
-                super::message_loop::run_cell_loop(&mut rx, &tx, space_mgr, engine, db_pool, spawn_records).await;
+            // Stash a shutdown signal so `stop()` can ask the loop to exit
+            // without dropping the channel out from under it.
+            let shutdown = Arc::new(Notify::new());
+            self.shutdown_signal = Some(shutdown.clone());
+            let handle = tokio::spawn(async move {
+                super::message_loop::run_cell_loop(
+                    &mut rx, &tx, space_mgr, engine, db_pool, spawn_records, shutdown,
+                ).await;
             });
+            self.cell_loop_handle = Some(handle);
         } else {
             tracing::warn!("Cell service started without channels — operating in stub mode");
         }

--- a/crates/services/src/cell/service/ticks.rs
+++ b/crates/services/src/cell/service/ticks.rs
@@ -144,7 +144,11 @@ pub(super) fn npc_movement_tick(space_mgr: &mut SpaceManager) {
                 Some(e) if !e.nav_path.is_empty() => e,
                 _ => continue,
             };
-            (npc.nav_path[0], npc.move_speed, npc.position, npc.nav_path.len())
+            let next_wp = match npc.nav_path.front() {
+                Some(wp) => *wp,
+                None => continue,
+            };
+            (next_wp, npc.move_speed, npc.position, npc.nav_path.len())
         };
 
         let dx = next_wp.x - cur_pos.x;
@@ -162,7 +166,7 @@ pub(super) fn npc_movement_tick(space_mgr: &mut SpaceManager) {
 
             // Peek at the NEXT waypoint (index 1) to compute velocity toward it
             let next_next_wp = if path_len > 1 {
-                space_mgr.get_entity(npc_id).map(|e| e.nav_path[1])
+                space_mgr.get_entity(npc_id).and_then(|e| e.nav_path.get(1).copied())
             } else {
                 None
             };
@@ -193,7 +197,7 @@ pub(super) fn npc_movement_tick(space_mgr: &mut SpaceManager) {
                 velocity,
             );
             if let Some(npc) = space_mgr.get_entity_mut(npc_id) {
-                npc.nav_path.remove(0);
+                npc.nav_path.pop_front();
                 npc.direction = cimmeria_common::Vector3::new(0.0, yaw, 0.0);
             }
         } else {

--- a/crates/services/src/cell/space_manager/entities.rs
+++ b/crates/services/src/cell/space_manager/entities.rs
@@ -99,24 +99,34 @@ impl SpaceManager {
             if let Some(space) = self.spaces.get_mut(&space_id) {
                 space.players.remove(&entity_id);
 
-                // Notify all entities that had this one in their AoI
-                if let Some(cell_entity) = space.entities.get(&entity_id) {
-                    let witnesses: Vec<u32> = cell_entity.witnesses
-                        .iter()
-                        .map(|eid| eid.0 as u32)
-                        .collect();
-                    for witness_id in witnesses {
-                        let _ = tx.send(CellToBaseMsg::LeftAoI {
-                            witness_id,
-                            entity_id,
-                        }).await;
+                // Notify every entity that had this one in its AoI -- i.e. each
+                // `other` whose `witnesses` set contains the disconnecting id.
+                // `cell_entity.witnesses` holds the entities IT sees, which is
+                // the wrong direction; iterate the space and check inbound
+                // membership instead.
+                let target = EntityId(entity_id as i32);
+                let observers: Vec<u32> = space.entities
+                    .iter()
+                    .filter(|(other_id, other)| {
+                        **other_id != entity_id && other.witnesses.contains(&target)
+                    })
+                    .map(|(other_id, _)| *other_id)
+                    .collect();
+                for witness_id in observers {
+                    if let Err(e) = tx.send(CellToBaseMsg::LeftAoI {
+                        witness_id,
+                        entity_id,
+                    }).await {
+                        tracing::warn!(
+                            witness_id, entity_id, error = %e,
+                            "LeftAoI send to base failed during disconnect"
+                        );
                     }
                 }
 
                 // Remove this entity from all other entities' witness sets
-                let eid = EntityId(entity_id as i32);
                 for other in space.entities.values_mut() {
-                    other.witnesses.remove(&eid);
+                    other.witnesses.remove(&target);
                 }
             }
         }

--- a/crates/services/src/cell/space_manager/entities.rs
+++ b/crates/services/src/cell/space_manager/entities.rs
@@ -99,18 +99,22 @@ impl SpaceManager {
             if let Some(space) = self.spaces.get_mut(&space_id) {
                 space.players.remove(&entity_id);
 
-                // Notify every entity that had this one in its AoI -- i.e. each
-                // `other` whose `witnesses` set contains the disconnecting id.
-                // `cell_entity.witnesses` holds the entities IT sees, which is
-                // the wrong direction; iterate the space and check inbound
-                // membership instead.
+                // Notify every player that had this one in its AoI -- i.e. each
+                // player whose `witnesses` set contains the disconnecting id.
+                // `cell_entity.witnesses` holds the entities IT sees (wrong
+                // direction); iterate `space.players` and check inbound
+                // membership instead. NPCs don't receive LeftAoI, so we skip
+                // scanning them and keep disconnect O(P) rather than O(E).
                 let target = EntityId(entity_id as i32);
-                let observers: Vec<u32> = space.entities
+                let observers: Vec<u32> = space.players
                     .iter()
-                    .filter(|(other_id, other)| {
-                        **other_id != entity_id && other.witnesses.contains(&target)
+                    .copied()
+                    .filter(|other_id| {
+                        *other_id != entity_id
+                            && space.entities
+                                .get(other_id)
+                                .map_or(false, |other| other.witnesses.contains(&target))
                     })
-                    .map(|(other_id, _)| *other_id)
                     .collect();
                 for witness_id in observers {
                     if let Err(e) = tx.send(CellToBaseMsg::LeftAoI {

--- a/crates/services/src/cell/space_manager/queries.rs
+++ b/crates/services/src/cell/space_manager/queries.rs
@@ -97,53 +97,50 @@ impl SpaceManager {
         ids
     }
 
-    /// Find an NPC entity by its spawn tag within a specific world.
+    /// Find an NPC entity by its spawn tag within the same space as `source_entity_id`.
     ///
     /// Used by content chain actions (SetInteractionType, DestroyTaggedEntity, etc.)
-    /// to locate entities by their `spawnlist.tag` value.
-    ///
-    /// Searches all spaces matching `world_name` — works for both non-instanced
-    /// (one space in `world_spaces`) and instanced (multiple spaces) worlds.
-    pub fn find_entity_by_tag(&self, world_name: &str, tag: &str) -> Option<u32> {
-        for space in self.spaces.values() {
-            if space.world_name != world_name {
-                continue;
-            }
-            for (&eid, entity) in &space.entities {
-                if entity.tag.as_deref() == Some(tag) {
-                    return Some(eid);
-                }
-            }
-        }
-        None
+    /// to locate entities by their `spawnlist.tag` value. Restricting the search
+    /// to the source's space prevents instanced worlds from leaking entity
+    /// resolution across instance boundaries.
+    pub fn find_entity_by_tag(&self, source_entity_id: u32, tag: &str) -> Option<u32> {
+        let &space_id = self.entity_space.get(&source_entity_id)?;
+        let space = self.spaces.get(&space_id)?;
+        space.entities.iter().find_map(|(&eid, entity)| {
+            (entity.tag.as_deref() == Some(tag)).then_some(eid)
+        })
     }
 
-    /// Find all entities with a given `template_id` in a specific world.
+    /// Find all entities with a given `template_id` in the same space as
+    /// `source_entity_id`.
     ///
     /// Used by `add_dialog_set` to locate NPC entities that match the slot
     /// (template_id) so per-player InteractionType updates can be sent.
-    ///
-    /// Searches all spaces matching `world_name` — works for both non-instanced
-    /// and instanced worlds.
-    pub fn find_entities_by_template(&self, world_name: &str, template_id: i32) -> Vec<u32> {
-        let mut results = Vec::new();
-        for space in self.spaces.values() {
-            if space.world_name != world_name {
-                continue;
-            }
-            for (&eid, e) in &space.entities {
-                if e.template_id == Some(template_id) {
-                    results.push(eid);
-                }
-            }
-        }
-        results
+    /// Restricted to a single space so instanced worlds don't cross-pollinate.
+    pub fn find_entities_by_template(&self, source_entity_id: u32, template_id: i32) -> Vec<u32> {
+        let Some(&space_id) = self.entity_space.get(&source_entity_id) else {
+            return Vec::new();
+        };
+        let Some(space) = self.spaces.get(&space_id) else {
+            return Vec::new();
+        };
+        space.entities.iter()
+            .filter(|(_, e)| e.template_id == Some(template_id))
+            .map(|(&eid, _)| eid)
+            .collect()
     }
 
     /// Return all player entity IDs that currently have `target_entity_id` in their AoI.
     ///
     /// Used for broadcasting property updates (InteractionType, SetVisible, etc.)
     /// to players who can see the entity.
+    ///
+    /// In this codebase `entity.witnesses` is populated only for players (see
+    /// [`super::aoi::SpaceManager::compute_aoi_changes`]), and stores the set
+    /// of entities the player currently sees. The reverse mapping (observers
+    /// of a target) isn't materialized, so we have to scan player witness
+    /// sets. Restricted to the target's own space, so the scan is bounded by
+    /// players in that space rather than the whole world.
     pub fn get_witnesses_of(&self, target_entity_id: u32) -> Vec<u32> {
         let Some(&space_id) = self.entity_space.get(&target_entity_id) else {
             return vec![];
@@ -152,9 +149,12 @@ impl SpaceManager {
             return vec![];
         };
         let target_eid = EntityId(target_entity_id as i32);
-        space.players.iter().filter(|&&pid| {
-            space.entities.get(&pid)
-                .map_or(false, |p| p.witnesses.contains(&target_eid))
-        }).copied().collect()
+        space.players.iter()
+            .filter(|&&pid| {
+                space.entities.get(&pid)
+                    .map_or(false, |p| p.witnesses.contains(&target_eid))
+            })
+            .copied()
+            .collect()
     }
 }

--- a/crates/services/src/cell/space_manager/xml.rs
+++ b/crates/services/src/cell/space_manager/xml.rs
@@ -40,16 +40,31 @@ impl SpaceManager {
                     let mut min_y: i32 = 0;
                     let mut max_y: i32 = 0;
 
-                    for attr in e.attributes().flatten() {
-                        let key = std::str::from_utf8(attr.key.as_ref()).unwrap_or("");
-                        let val = std::str::from_utf8(&attr.value).unwrap_or("");
+                    for attr_res in e.attributes() {
+                        let attr = attr_res.map_err(|err| {
+                            format!("spaces.xml: malformed Space attribute: {err}")
+                        })?;
+                        let key = std::str::from_utf8(attr.key.as_ref()).map_err(|err| {
+                            format!("spaces.xml: non-UTF8 attribute key: {err}")
+                        })?;
+                        let val = std::str::from_utf8(&attr.value).map_err(|err| {
+                            format!("spaces.xml: non-UTF8 value for {key}: {err}")
+                        })?;
                         match key {
                             "WorldName" => world_name = val.to_string(),
                             "Instanced" => instanced = val == "true",
-                            "MinX" => min_x = val.parse().unwrap_or(0),
-                            "MaxX" => max_x = val.parse().unwrap_or(0),
-                            "MinY" => min_y = val.parse().unwrap_or(0),
-                            "MaxY" => max_y = val.parse().unwrap_or(0),
+                            "MinX" => min_x = val.parse().map_err(|err| {
+                                format!("spaces.xml: MinX={val:?} not a valid i32: {err}")
+                            })?,
+                            "MaxX" => max_x = val.parse().map_err(|err| {
+                                format!("spaces.xml: MaxX={val:?} not a valid i32: {err}")
+                            })?,
+                            "MinY" => min_y = val.parse().map_err(|err| {
+                                format!("spaces.xml: MinY={val:?} not a valid i32: {err}")
+                            })?,
+                            "MaxY" => max_y = val.parse().map_err(|err| {
+                                format!("spaces.xml: MaxY={val:?} not a valid i32: {err}")
+                            })?,
                             _ => {}
                         }
                     }
@@ -93,9 +108,16 @@ impl SpaceManager {
             match reader.read_event_into(&mut buf) {
                 Ok(Event::Empty(ref e)) | Ok(Event::Start(ref e)) if e.name().as_ref() == b"Space" => {
                     let mut world_name = String::new();
-                    for attr in e.attributes().flatten() {
-                        let key = std::str::from_utf8(attr.key.as_ref()).unwrap_or("");
-                        let val = std::str::from_utf8(&attr.value).unwrap_or("");
+                    for attr_res in e.attributes() {
+                        let attr = attr_res.map_err(|err| {
+                            format!("cell_spaces.xml: malformed Space attribute: {err}")
+                        })?;
+                        let key = std::str::from_utf8(attr.key.as_ref()).map_err(|err| {
+                            format!("cell_spaces.xml: non-UTF8 attribute key: {err}")
+                        })?;
+                        let val = std::str::from_utf8(&attr.value).map_err(|err| {
+                            format!("cell_spaces.xml: non-UTF8 value for {key}: {err}")
+                        })?;
                         if key == "WorldName" {
                             world_name = val.to_string();
                         }

--- a/crates/services/src/cell/spawner/respawners.rs
+++ b/crates/services/src/cell/spawner/respawners.rs
@@ -18,15 +18,40 @@ pub struct RespawnerDef {
     pub pos: [f32; 3],
 }
 
+/// Mirror of the SQL projection for `query_as`. The `pos` array on
+/// `RespawnerDef` doesn't have a direct column equivalent, so we map the
+/// three position columns onto separate fields here and assemble the array
+/// in the conversion below. Using `FromRow` rather than manual `Row::get`
+/// turns column-name and type mismatches into compile-/load-time errors
+/// with proper diagnostics instead of mid-query runtime panics.
+#[derive(sqlx::FromRow)]
+struct RespawnerRow {
+    respawner_id: i32,
+    world_name: String,
+    name: String,
+    pos_x: f32,
+    pos_y: f32,
+    pos_z: f32,
+}
+
+impl From<RespawnerRow> for RespawnerDef {
+    fn from(r: RespawnerRow) -> Self {
+        RespawnerDef {
+            respawner_id: r.respawner_id,
+            world_name: r.world_name,
+            name: r.name,
+            pos: [r.pos_x, r.pos_y, r.pos_z],
+        }
+    }
+}
+
 /// Load respawner definitions from the database.
 ///
 /// Joins `resources.respawners` with `resources.worlds` to get world names.
 pub async fn load_respawners(
     pool: &PgPool,
 ) -> Result<Vec<RespawnerDef>, sqlx::Error> {
-    use sqlx::Row;
-
-    let rows = sqlx::query(
+    let rows = sqlx::query_as::<_, RespawnerRow>(
         "SELECT r.respawner_id, w.world AS world_name, r.name, \
                 r.pos_x, r.pos_y, r.pos_z \
          FROM resources.respawners r \
@@ -35,18 +60,7 @@ pub async fn load_respawners(
     .fetch_all(pool)
     .await?;
 
-    let respawners: Vec<RespawnerDef> = rows.iter().map(|r| {
-        RespawnerDef {
-            respawner_id: r.get("respawner_id"),
-            world_name: r.get("world_name"),
-            name: r.get("name"),
-            pos: [
-                r.get::<f32, _>("pos_x"),
-                r.get::<f32, _>("pos_y"),
-                r.get::<f32, _>("pos_z"),
-            ],
-        }
-    }).collect();
+    let respawners: Vec<RespawnerDef> = rows.into_iter().map(RespawnerDef::from).collect();
 
     tracing::info!(count = respawners.len(), "Loaded respawner definitions");
     Ok(respawners)

--- a/crates/services/src/cell/spawner/tests.rs
+++ b/crates/services/src/cell/spawner/tests.rs
@@ -126,9 +126,11 @@ fn find_entity_by_tag_works() {
     let npc_id = mgr.allocate_npc_id();
     mgr.spawn_npc_from_record(npc_id, &record).unwrap();
 
-    let found = mgr.find_entity_by_tag("Agnos", "TestTag");
+    // Use the NPC itself as the source entity -- it lives in Agnos, so the
+    // search runs against that single space.
+    let found = mgr.find_entity_by_tag(npc_id, "TestTag");
     assert_eq!(found, Some(npc_id));
 
-    let not_found = mgr.find_entity_by_tag("Agnos", "NonexistentTag");
+    let not_found = mgr.find_entity_by_tag(npc_id, "NonexistentTag");
     assert_eq!(not_found, None);
 }

--- a/crates/services/src/mercury/protocol/character.rs
+++ b/crates/services/src/mercury/protocol/character.rs
@@ -13,6 +13,23 @@ use super::{
     ACCOUNT_CLASS_ID, CharacterInfo,
 };
 
+/// Serialize one `CharacterInfo` FIXED_DICT into the byte stream. Shared by
+/// `build_char_list` and `build_on_character_list` so the field order can't
+/// drift between the two callers.
+fn write_character_info(buf: &mut Vec<u8>, ch: &CharacterInfo) {
+    buf.extend_from_slice(&ch.player_id.to_le_bytes());
+    write_wstring(buf, &ch.name);
+    write_wstring(buf, &ch.extra_name);
+    buf.push(ch.alignment);
+    buf.push(ch.level);
+    buf.push(ch.gender);
+    write_wstring(buf, &ch.world_location);
+    buf.push(ch.archetype);
+    buf.push(ch.title);
+    buf.extend_from_slice(&ch.player_type.to_le_bytes());
+    buf.push(ch.playable);
+}
+
 /// Build and encrypt the Phase 4 character list response packet.
 ///
 /// Sent immediately after the client confirms login with msg_id=0x01.
@@ -51,19 +68,8 @@ pub fn build_char_list(
     // Array count
     payload.extend_from_slice(&(characters.len() as u32).to_le_bytes());
 
-    // Serialize each CharacterInfo FIXED_DICT
     for ch in characters {
-        payload.extend_from_slice(&ch.player_id.to_le_bytes());
-        write_wstring(&mut payload, &ch.name);
-        write_wstring(&mut payload, &ch.extra_name);
-        payload.push(ch.alignment);
-        payload.push(ch.level);
-        payload.push(ch.gender);
-        write_wstring(&mut payload, &ch.world_location);
-        payload.push(ch.archetype);
-        payload.push(ch.title);
-        payload.extend_from_slice(&ch.player_type.to_le_bytes());
-        payload.push(ch.playable);
+        write_character_info(&mut payload, ch);
     }
 
     body.extend_from_slice(&(payload.len() as u16).to_le_bytes());
@@ -100,19 +106,8 @@ pub fn build_on_character_list(
     // Array count
     payload.extend_from_slice(&(characters.len() as u32).to_le_bytes());
 
-    // Serialize each CharacterInfo FIXED_DICT
     for ch in characters {
-        payload.extend_from_slice(&ch.player_id.to_le_bytes());
-        write_wstring(&mut payload, &ch.name);
-        write_wstring(&mut payload, &ch.extra_name);
-        payload.push(ch.alignment);
-        payload.push(ch.level);
-        payload.push(ch.gender);
-        write_wstring(&mut payload, &ch.world_location);
-        payload.push(ch.archetype);
-        payload.push(ch.title);
-        payload.extend_from_slice(&ch.player_type.to_le_bytes());
-        payload.push(ch.playable);
+        write_character_info(&mut payload, ch);
     }
 
     body.extend_from_slice(&(payload.len() as u16).to_le_bytes());


### PR DESCRIPTION
Closes #87.

## Summary

Addresses the 20 pre-existing CodeRabbit findings deferred from #86 so that PR could stay scope-clean.

### Logic / behavior bugs
- `enable_entities.rs` — peek pending state, only `take()` / flip `char_list_sent` after `send_to` succeeds so a transient send failure leaves login state intact for retry.
- `bandolier.rs` — three sites: dirty markers cleared only after the persist message is accepted by the channel.
- `item_ops.rs` — `Remove`/`List`/`MoveInventoryItem` send failures now log the player/item context instead of being dropped.
- `loot_drop.rs` — guard against malformed `min > max` rows that previously produced wraparound quantities.
- `rng.rs` — divide by `u32::MAX as f64 + 1.0` so the result is strictly half-open `[0, 1)`.
- `use_ability.rs` — pass the ability's actual `is_ranged` flag into `calculate_qr`, and only fall back to 15-HP physical damage when `ability_def` is `None` (heals/focus drains no longer get reinterpreted as melee hits).
- `npc_ai.rs` — NPCs hold fire when in range but without LOS instead of shooting through walls.
- `space_manager/entities.rs` — disconnect now iterates `space.entities` and notifies entities whose `witnesses` set contains the disconnecting id (correct direction).
- `queries.rs` — `find_entity_by_tag` / `find_entities_by_template` now take `source_entity_id` and restrict iteration to that one space, preventing instanced worlds from leaking entity resolution across instances. All callers in `executor.rs` and the spawner test updated.

### Robustness / style
- `space_registry.rs` — recover from a poisoned mutex via `unwrap_or_else(|p| p.into_inner())`.
- `xml.rs` — propagate `quick-xml` / UTF-8 / `parse()` errors instead of swallowing them with `flatten()` / `unwrap_or(0)`.
- `respawners.rs` — derive `sqlx::FromRow` on an intermediate `RespawnerRow` and use `query_as` so column/type mismatches surface earlier.
- `mercury/protocol/character.rs` — extracted `write_character_info` helper shared by `build_char_list` and `build_on_character_list`.

### Test design
- `world_entry/tests.rs` — calls `resolve_space_id_fallback` and asserts the structural invariant (`id >> 16 == 1`) instead of hardcoding three u32 literals.
- `inventory/tests.rs` — replaced two `tokio::time::sleep(5ms)` calls with `clear_all_cooldowns()` between shots so the test isn't wall-clock-sensitive.

### Performance
- `cell_entity.rs` — `nav_path: Vec<Vector3>` → `VecDeque<Vector3>`. `ticks.rs` and `npc_ai.rs` updated to `pop_front()` / `front()` / `back()` / `get(i)`.

### Lifecycle
- `CellService` — added `cell_loop_handle: Option<JoinHandle<()>>` and `shutdown_signal: Option<Arc<Notify>>`. `start()` spawns and stores the handle; `run_cell_loop` adds a `shutdown.notified()` arm to its `select!`; `stop()` notifies and awaits the handle so the loop is wound down deterministically instead of relying on the channel half being dropped.

### Deviation from issue prompt

The `get_witnesses_of` finding suggested reading `target.witnesses` and filtering players. In this codebase `entity.witnesses` is "entities I see" (only populated for players via `aoi.rs:170`), so the suggested rewrite would return empty for NPC targets. Kept the player-scan logic but documented the semantic and added a per-space scope so the scan is bounded.

## Test plan

- [ ] `cargo check -p cimmeria-services`
- [ ] `cargo test -p cimmeria-services` — focus on `slot_swap_preserves_per_slot_ammo`, `find_entity_by_tag_works`, `space_id_mapping_known_worlds`
- [ ] Manual smoke: connect a client, log in, char-select, enter Castle_CellBlock, fire a few weapons, swap bandolier slots — confirm no behavior regression vs. main
- [ ] Verify `CellService::stop()` joins cleanly (no orphan task warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed random number edge-case affecting ability calculations
  * Prevented invalid loot quantity ranges from underflowing
  * NPCs now consider line-of-sight when deciding to re-path or engage

* **Improvements**
  * More robust login/create-player flow that preserves state on transient send failures
  * Inventory and mission/channel sends now surface errors instead of being ignored
  * Persistence of bandolier ammo updates now confirmed before clearing
  * Message loop and service shutdown are now coordinated for clean teardown
  * Lookups scoped to an entity's space to avoid cross-space leakage
  * Stricter XML/config validation and safer concurrent registry access
<!-- end of auto-generated comment: release notes by coderabbit.ai -->