### PR TITLE
fix(services): route corpse right-click to loot handler, not auto-attack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -193,3 +193,5 @@ game/sgw/*
 game/patches/*
 !game/sgw/.gitkeep
 !game/sgw/README.md
+
+ghidra/*

--- a/crates/services/src/cell/abilities/death.rs
+++ b/crates/services/src/cell/abilities/death.rs
@@ -1,0 +1,98 @@
+//! Death-transition wire protocol — the ordered burst of methods sent to the
+//! client when an entity's HEALTH drops to zero. Extracted from `use_ability`
+//! so the protocol ordering invariants are visible in one place.
+//!
+//! The order on the wire is **load-bearing**:
+//!
+//! 1. (attacker only) `onTargetUpdate(0)` — drop the targeting reticle.
+//! 2. (attacker only) `onStateFieldUpdate` with `BSF_InCombat` cleared — stops
+//!    the client routing right-click on selected entities to `useAbility`.
+//! 3. (NPC target only) `generate_loot_on_death` + `InteractionType` — the
+//!    `InteractionType` update MUST land before the dead-state bit, otherwise
+//!    the client locks in "shootable" cursor state on dead-state arrival and
+//!    ignores the later flag change. Mirrors python `SGWMob.onDead()` which
+//!    calls `setInteractionType` before the state field flip propagates.
+//! 4. `onStateFieldUpdate` with the corpse's new state (dead bit set) — flips
+//!    visuals + cursor.
+//!
+//! Caller is responsible for the death-side state mutations on the entity
+//! itself (HEALTH=0, BSF_Dead set, AI state Dead, etc.) — this module only
+//! handles outbound messages and the attacker's BSF_InCombat clear.
+
+use tokio::sync::mpsc;
+
+use super::super::messages::CellToBaseMsg;
+use super::super::space_manager::SpaceManager;
+use super::loot_drop::generate_loot_on_death;
+use super::messaging::send_entity_method;
+
+/// `BSF_InCombat` bit position. Cleared on the attacker on every kill while
+/// multi-mob threat tracking (#92) is unimplemented.
+const BSF_IN_COMBAT: u32 = 1 << 3;
+
+/// Apply the death-transition message sequence for a target that just died.
+///
+/// Ordering and side effects are described at the module level. `target_state`
+/// is the corpse's already-mutated `state_field` (with `BSF_Dead` set), passed
+/// in by the caller because the caller already had a mutable borrow.
+pub(super) async fn apply_death_transition(
+    target_eid: u32,
+    attacker_id: u32,
+    target_state: u32,
+    attacker_is_player: bool,
+    target_is_player: bool,
+    tx: &mpsc::Sender<CellToBaseMsg>,
+    space_mgr: &mut SpaceManager,
+) {
+    // 1+2. Attacker side: clear targeting reticle + drop out of combat.
+    if attacker_is_player {
+        send_entity_method(
+            attacker_id, crate::mercury::method_idx::ON_TARGET_UPDATE,
+            0i32.to_le_bytes().to_vec(),
+            tx, space_mgr,
+        ).await;
+
+        // Aggressive BSF_InCombat clear on every kill — safe for single-target
+        // fights, wrong under multi-mob aggro. Issue #92 tracks the proper
+        // per-player threatenedMobs set that drives this bit.
+        let attacker_state = if let Some(p) = space_mgr.get_entity_mut(attacker_id) {
+            let old = p.state_field;
+            p.state_field &= !BSF_IN_COMBAT;
+            if p.state_field != old { Some(p.state_field) } else { None }
+        } else {
+            None
+        };
+        if let Some(new_state) = attacker_state {
+            tracing::debug!(
+                attacker = attacker_id, target = target_eid, new_state,
+                "death: clearing attacker BSF_InCombat (exit combat after kill)"
+            );
+            send_entity_method(
+                attacker_id, crate::mercury::method_idx::ON_STATE_FIELD_UPDATE,
+                new_state.to_le_bytes().to_vec(),
+                tx, space_mgr,
+            ).await;
+        }
+    }
+
+    // 3. Target side: roll loot then push interaction flags. Player targets
+    //    don't loot or change interaction type.
+    if !target_is_player {
+        generate_loot_on_death(target_eid, space_mgr);
+
+        let interaction_flags = space_mgr.get_entity(target_eid)
+            .map_or(0i64, |e| e.interaction_type_flags);
+        send_entity_method(
+            target_eid, crate::mercury::method_idx::INTERACTION_TYPE,
+            (interaction_flags as u64).to_le_bytes().to_vec(),
+            tx, space_mgr,
+        ).await;
+    }
+
+    // 4. Flip dead-state bit on the corpse — visuals + cursor change client-side.
+    send_entity_method(
+        target_eid, crate::mercury::method_idx::ON_STATE_FIELD_UPDATE,
+        target_state.to_le_bytes().to_vec(),
+        tx, space_mgr,
+    ).await;
+}

--- a/crates/services/src/cell/abilities/loot_drop.rs
+++ b/crates/services/src/cell/abilities/loot_drop.rs
@@ -84,7 +84,7 @@ pub(super) fn generate_loot_on_death(
                 let name = entry.design_id
                     .map(|id| format!("item_{id}"))
                     .unwrap_or_else(|| "naquadah".to_string());
-                tracing::info!(
+                tracing::debug!(
                     target_eid, %name, quantity, index,
                     probability = entry.probability,
                     "Loot generated"
@@ -94,10 +94,12 @@ pub(super) fn generate_loot_on_death(
     }
 
     if !target.loot.is_empty() {
-        // Set INT_NormalLoot so the client shows the loot cursor
-        target.interaction_type_flags = INT_NORMAL_LOOT;
+        // Set INT_NormalLoot so the client shows the loot cursor. OR-preserve to match
+        // the Python reference (`setInteractionType(self.interactionType | INT_NormalLoot)`)
+        // — keeps any bits a content chain set pre-death.
+        target.interaction_type_flags |= INT_NORMAL_LOOT;
         target.interaction_type = Some(cimmeria_entity::cell_entity::NpcInteractionType::Loot);
-        tracing::info!(
+        tracing::debug!(
             target_eid, items = target.loot.len(),
             "NPC has loot — set INT_NormalLoot interaction"
         );

--- a/crates/services/src/cell/abilities/loot_drop.rs
+++ b/crates/services/src/cell/abilities/loot_drop.rs
@@ -11,7 +11,7 @@ use super::super::space_manager::SpaceManager;
 /// INT_NormalLoot interaction type flag (1 << 62).
 /// From `python/Atrea/enums.py: INT_NormalLoot = 4611686018427387904`.
 /// This is the interaction bitflag that tells the client to show the loot cursor.
-const INT_NORMAL_LOOT: i64 = 4611686018427387904;
+pub(crate) const INT_NORMAL_LOOT: i64 = 4611686018427387904;
 
 /// Generate loot from the NPC's loot table and store it on the entity.
 ///

--- a/crates/services/src/cell/abilities/mod.rs
+++ b/crates/services/src/cell/abilities/mod.rs
@@ -7,12 +7,14 @@
 //! Submodule layout:
 //! - `dispatch` — ground-targeted auto-aim entry point.
 //! - `use_ability` — main `handle_use_ability` flow (validate → consume → fire → resolve).
+//! - `death` — ordered wire protocol burst when a target dies.
 //! - `messaging` — entity-method routing (player vs witness) + dirty-stat flush.
 //! - `loot_drop` — on-death loot generation + interaction-flag updates.
 //! - `rng` — deterministic pseudo-random for combat rolls.
 //!
 //! Reference: `python/cell/AbilityManager.py:1004-1056`
 
+mod death;
 mod dispatch;
 mod loot_drop;
 mod messaging;
@@ -25,4 +27,5 @@ mod tests;
 // Public re-exports — keep `crate::cell::abilities::Foo` paths stable for callers.
 pub use dispatch::handle_use_ability_on_ground;
 pub use use_ability::handle_use_ability;
+pub(crate) use loot_drop::INT_NORMAL_LOOT;
 pub(crate) use messaging::send_entity_method;

--- a/crates/services/src/cell/abilities/use_ability.rs
+++ b/crates/services/src/cell/abilities/use_ability.rs
@@ -20,7 +20,7 @@ use super::super::combat;
 use super::super::messages::CellToBaseMsg;
 use super::super::space_manager::SpaceManager;
 
-use super::loot_drop::{generate_loot_on_death, kill_xp};
+use super::loot_drop::kill_xp;
 use super::messaging::{flush_attacker_ammo_stat, send_entity_method};
 use super::rng::pseudo_random;
 
@@ -354,7 +354,11 @@ pub async fn handle_use_ability(
             target.threat_list.clear();
             target.nav_path.clear();
             target.velocity = [0.0; 3]; // Stop movement interpolation
-            target.interaction_type_flags = 0; // Clear attackable flags; loot generation below may re-set
+            // NOTE: do NOT zero `interaction_type_flags` here. Python `SGWMob.onDead()`
+            // OR-merges `INT_NormalLoot` and preserves all other bits — content-driven
+            // bits (quest tags, mission interactions) must survive death. The dead-state
+            // bit handles cursor distinction client-side; we don't need to clear
+            // `INT_Attackable` to suppress the shootable cursor.
             target.state_field &= !(1 << 3); // BSF_InCombat — clear so witnesses' clients stop
                                              // treating this NPC as a combat target. Mirrors
                                              // python `unsetStateFlag(BSF_InCombat)` at
@@ -414,77 +418,15 @@ pub async fn handle_use_ability(
     }
 
     // ── Death side effects ──
-    //
-    // Order on the wire matters. The InteractionType update (method 3) must arrive
-    // BEFORE the dead-state bit (method 19); otherwise the client locks in
-    // "shootable" cursor state on dead-state arrival and ignores the later flag
-    // change. Mirrors the Python reference where setInteractionType runs inside
-    // SGWMob.onDead() before the state field flip propagates.
+    // Wire-protocol burst (target reticle, BSF_InCombat clear, loot + InteractionType,
+    // dead-state flip) lives in `death::apply_death_transition` so the ordering
+    // constraints documented there stay in one place.
 
     if target_died {
-        // Clear the attacker's target so the targeting reticle disappears.
-        // The reticle stays at the NPC's last standing position otherwise.
-        if attacker_is_player {
-            send_entity_method(
-                entity_id, crate::mercury::method_idx::ON_TARGET_UPDATE,
-                0i32.to_le_bytes().to_vec(),
-                tx, space_mgr,
-            ).await;
-
-            // Drop the attacker out of combat so the client stops routing
-            // right-click on selected entities to `useAbility`. Mirrors python
-            // SGWPlayer.py:961-965 where, when the threatenedMobs list empties,
-            // the player's BSF_InCombat bit is unset and the new stateField is
-            // pushed to the client. We're being aggressive here (clear on every
-            // kill), which is safe for the single-target Cellblock fights we're
-            // testing; multi-mob aggro needs the per-player threatenedMobs set
-            // tracked in issue #92 before this can stay correct under multiple
-            // attackers.
-            const BSF_IN_COMBAT: u32 = 1 << 3;
-            let attacker_state = if let Some(p) = space_mgr.get_entity_mut(entity_id) {
-                let old = p.state_field;
-                p.state_field &= !BSF_IN_COMBAT;
-                if p.state_field != old { Some(p.state_field) } else { None }
-            } else {
-                None
-            };
-            if let Some(new_state) = attacker_state {
-                tracing::debug!(
-                    attacker = entity_id, target = target_eid, new_state,
-                    "death: clearing attacker BSF_InCombat (exit combat after kill)"
-                );
-                send_entity_method(
-                    entity_id, crate::mercury::method_idx::ON_STATE_FIELD_UPDATE,
-                    new_state.to_le_bytes().to_vec(),
-                    tx, space_mgr,
-                ).await;
-            }
-        }
-
-        // Generate loot from the NPC's loot table, then update interaction type
-        // so the client renders the loot cursor on the corpse.
-        // Reference: python/cell/SGWMob.py:onDead() + Lootable.generateLoot()
-        if !target_is_player {
-            generate_loot_on_death(target_eid, space_mgr);
-
-            // Send InteractionType: INT_NormalLoot if loot was generated, 0 otherwise.
-            // The client's mInteractionType field at GameEntity+0x50 drives the
-            // loot cursor via `onInteractionType` handler.
-            let interaction_flags = space_mgr.get_entity(target_eid)
-                .map_or(0i64, |e| e.interaction_type_flags);
-            send_entity_method(
-                target_eid, crate::mercury::method_idx::INTERACTION_TYPE,
-                (interaction_flags as u64).to_le_bytes().to_vec(),
-                tx, space_mgr,
-            ).await;
-        }
-
-        // Now flip the dead-state bit so the client transitions visuals + cursor.
-        let mut state_args = Vec::with_capacity(4);
-        state_args.extend_from_slice(&target_state.to_le_bytes());
-        send_entity_method(
-            target_eid, crate::mercury::method_idx::ON_STATE_FIELD_UPDATE,
-            state_args, tx, space_mgr,
+        super::death::apply_death_transition(
+            target_eid, entity_id, target_state,
+            attacker_is_player, target_is_player,
+            tx, space_mgr,
         ).await;
 
         // Send death animation via onSequence (Entity_Death = event_id 5001)

--- a/crates/services/src/cell/abilities/use_ability.rs
+++ b/crates/services/src/cell/abilities/use_ability.rs
@@ -355,6 +355,10 @@ pub async fn handle_use_ability(
             target.nav_path.clear();
             target.velocity = [0.0; 3]; // Stop movement interpolation
             target.interaction_type_flags = 0; // Clear attackable flags; loot generation below may re-set
+            target.state_field &= !(1 << 3); // BSF_InCombat — clear so witnesses' clients stop
+                                             // treating this NPC as a combat target. Mirrors
+                                             // python `unsetStateFlag(BSF_InCombat)` at
+                                             // SGWMob.py:292 when the threat list empties.
         }
         tracing::info!(
             attacker = entity_id, target = target_eid,
@@ -409,37 +413,78 @@ pub async fn handle_use_ability(
         flush_attacker_ammo_stat(entity_id, tx, space_mgr).await;
     }
 
-    // ── Send state field update if target died ──
+    // ── Death side effects ──
+    //
+    // Order on the wire matters. The InteractionType update (method 3) must arrive
+    // BEFORE the dead-state bit (method 19); otherwise the client locks in
+    // "shootable" cursor state on dead-state arrival and ignores the later flag
+    // change. Mirrors the Python reference where setInteractionType runs inside
+    // SGWMob.onDead() before the state field flip propagates.
 
     if target_died {
-        let mut state_args = Vec::with_capacity(4);
-        state_args.extend_from_slice(&target_state.to_le_bytes());
-        send_entity_method(target_eid, 19, state_args, tx, space_mgr).await;
-
         // Clear the attacker's target so the targeting reticle disappears.
         // The reticle stays at the NPC's last standing position otherwise.
         if attacker_is_player {
             send_entity_method(
-                entity_id, 16, // onTargetUpdate(INT32 targetId = 0)
+                entity_id, crate::mercury::method_idx::ON_TARGET_UPDATE,
                 0i32.to_le_bytes().to_vec(),
                 tx, space_mgr,
             ).await;
+
+            // Drop the attacker out of combat so the client stops routing
+            // right-click on selected entities to `useAbility`. Mirrors python
+            // SGWPlayer.py:961-965 where, when the threatenedMobs list empties,
+            // the player's BSF_InCombat bit is unset and the new stateField is
+            // pushed to the client. We're being aggressive here (clear on every
+            // kill), which is safe for the single-target Cellblock fights we're
+            // testing; multi-mob aggro will need proper threat-tracking before
+            // generalizing.
+            const BSF_IN_COMBAT: u32 = 1 << 3;
+            let attacker_state = if let Some(p) = space_mgr.get_entity_mut(entity_id) {
+                let old = p.state_field;
+                p.state_field &= !BSF_IN_COMBAT;
+                if p.state_field != old { Some(p.state_field) } else { None }
+            } else {
+                None
+            };
+            if let Some(new_state) = attacker_state {
+                tracing::debug!(
+                    attacker = entity_id, target = target_eid, new_state,
+                    "death: clearing attacker BSF_InCombat (exit combat after kill)"
+                );
+                send_entity_method(
+                    entity_id, crate::mercury::method_idx::ON_STATE_FIELD_UPDATE,
+                    new_state.to_le_bytes().to_vec(),
+                    tx, space_mgr,
+                ).await;
+            }
         }
 
-        // Generate loot from the NPC's loot table, then update interaction type.
+        // Generate loot from the NPC's loot table, then update interaction type
+        // so the client renders the loot cursor on the corpse.
         // Reference: python/cell/SGWMob.py:onDead() + Lootable.generateLoot()
         if !target_is_player {
             generate_loot_on_death(target_eid, space_mgr);
 
-            // Send InteractionType: INT_NormalLoot if loot was generated, 0 otherwise
+            // Send InteractionType: INT_NormalLoot if loot was generated, 0 otherwise.
+            // The client's mInteractionType field at GameEntity+0x50 drives the
+            // loot cursor via `onInteractionType` handler.
             let interaction_flags = space_mgr.get_entity(target_eid)
                 .map_or(0i64, |e| e.interaction_type_flags);
             send_entity_method(
-                target_eid, 3,
-                interaction_flags.to_le_bytes().to_vec(),
+                target_eid, crate::mercury::method_idx::INTERACTION_TYPE,
+                (interaction_flags as u64).to_le_bytes().to_vec(),
                 tx, space_mgr,
             ).await;
         }
+
+        // Now flip the dead-state bit so the client transitions visuals + cursor.
+        let mut state_args = Vec::with_capacity(4);
+        state_args.extend_from_slice(&target_state.to_le_bytes());
+        send_entity_method(
+            target_eid, crate::mercury::method_idx::ON_STATE_FIELD_UPDATE,
+            state_args, tx, space_mgr,
+        ).await;
 
         // Send death animation via onSequence (Entity_Death = event_id 5001)
         // Look up the death sequence from the target's event set via sequence_map

--- a/crates/services/src/cell/abilities/use_ability.rs
+++ b/crates/services/src/cell/abilities/use_ability.rs
@@ -437,8 +437,9 @@ pub async fn handle_use_ability(
             // the player's BSF_InCombat bit is unset and the new stateField is
             // pushed to the client. We're being aggressive here (clear on every
             // kill), which is safe for the single-target Cellblock fights we're
-            // testing; multi-mob aggro will need proper threat-tracking before
-            // generalizing.
+            // testing; multi-mob aggro needs the per-player threatenedMobs set
+            // tracked in issue #92 before this can stay correct under multiple
+            // attackers.
             const BSF_IN_COMBAT: u32 = 1 << 3;
             let attacker_state = if let Some(p) = space_mgr.get_entity_mut(entity_id) {
                 let old = p.state_field;

--- a/crates/services/src/cell/cell_methods/player/interaction.rs
+++ b/crates/services/src/cell/cell_methods/player/interaction.rs
@@ -34,8 +34,18 @@ pub async fn dispatch(
                     }
                 };
 
+                // Reroute interact→useAbility for ALIVE hostile NPCs only. A dead
+                // hostile NPC is a lootable corpse — its right-click MUST reach
+                // `handle_interact` so the loot window opens. Without the dead check,
+                // every right-click on a corpse silently became an auto-attack and
+                // the loot interaction never fired (proven via x32dbg trace at
+                // FUN_00e84b20: client correctly sent interact, server intercepted).
                 let is_hostile = space_mgr.get_entity(target_entity_u32)
-                    .map_or(false, |t| !t.is_player && t.faction == 10);
+                    .map_or(false, |t| {
+                        !t.is_player
+                            && t.faction == 10
+                            && !crate::cell::combat::is_dead_state(t.state_field)
+                    });
                 if is_hostile {
                     tracing::info!(entity_id, target_entity_id, "interact: targeting hostile NPC for combat");
                     let mut reply = Vec::with_capacity(4);
@@ -134,5 +144,108 @@ pub async fn dispatch(
         }
 
         _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cimmeria_entity::cell_entity::NpcInteractionType;
+
+    /// Standard test space setup: SpaceManager with a single Agnos space.
+    fn make_space_manager() -> SpaceManager {
+        let mut mgr = SpaceManager::new(1);
+        let spaces_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<Spaces><Space WorldName="Agnos" Instanced="false" MinX="-2400" MaxX="2200" MinY="-3200" MaxY="2800" /></Spaces>"#;
+        let cell_spaces_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<Spaces><Space WorldName="Agnos" /></Spaces>"#;
+        mgr.parse_spaces_xml(spaces_xml).unwrap();
+        mgr.create_startup_spaces(cell_spaces_xml).unwrap();
+        mgr
+    }
+
+    /// Right-clicking an ALIVE hostile NPC reroutes interact → useAbility.
+    /// Baseline for the dead-corpse regression test below.
+    #[tokio::test]
+    async fn alive_hostile_reroutes_to_useability() {
+        let mut mgr = make_space_manager();
+        mgr.create_entity(1, "Agnos", [0.0, 0.0, 0.0], [0.0; 3]).unwrap();
+        let npc_id = mgr.allocate_npc_id();
+        mgr.spawn_npc(npc_id, "Agnos", [2.0, 0.0, 0.0], [0.0; 3]).unwrap();
+        if let Some(npc) = mgr.get_entity_mut(npc_id) {
+            npc.faction = 10;            // hostile
+            npc.state_field = 0;          // alive
+        }
+
+        let (tx, mut rx) = mpsc::channel(16);
+        let engine = cimmeria_content_engine::chain::ChainEngine::new();
+        let mut args = Vec::with_capacity(4);
+        args.extend_from_slice(&(npc_id as i32).to_le_bytes());
+        let handled = dispatch(1, INTERACT, &args, &tx, &mut mgr, &engine).await;
+        assert!(handled);
+
+        // Hostile reroute path sends method 16 (onTargetUpdate) first, then
+        // useAbility flows downstream. We just check at least one message
+        // came through and that NO loot/dialog message did.
+        let mut saw_target_update = false;
+        while let Ok(msg) = rx.try_recv() {
+            if let CellToBaseMsg::EntityMethodCall { method_index, .. } = msg {
+                if method_index == 16 {
+                    saw_target_update = true;
+                }
+                // Loot display would be method 114 — must not appear.
+                assert_ne!(method_index, 114, "loot must not fire for an alive hostile");
+            }
+        }
+        assert!(saw_target_update, "expected onTargetUpdate from hostile reroute");
+    }
+
+    /// Right-clicking a DEAD hostile corpse with loot must reach
+    /// `handle_interact`, set `looting_entity` on the player, and emit
+    /// `onLootDisplay` (method 114). Regression for the
+    /// "right-click on corpse silently rerouted to useAbility" bug —
+    /// see [docs/reverse-engineering/findings/right-click-routing-on-corpse.md]
+    /// and [interaction.rs:37-49] (the `is_dead_state` guard).
+    #[tokio::test]
+    async fn dead_hostile_with_loot_routes_to_interact() {
+        let mut mgr = make_space_manager();
+        mgr.create_entity(1, "Agnos", [0.0, 0.0, 0.0], [0.0; 3]).unwrap();
+        if let Some(p) = mgr.get_entity_mut(1) {
+            p.player_id = Some(42);
+        }
+        let npc_id = mgr.allocate_npc_id();
+        mgr.spawn_npc(npc_id, "Agnos", [2.0, 0.0, 0.0], [0.0; 3]).unwrap();
+        if let Some(npc) = mgr.get_entity_mut(npc_id) {
+            npc.faction = 10; // hostile
+            crate::cell::combat::set_dead_state(&mut npc.state_field);
+            npc.interaction_type = Some(NpcInteractionType::Loot);
+        }
+
+        let (tx, mut rx) = mpsc::channel(16);
+        let engine = cimmeria_content_engine::chain::ChainEngine::new();
+        let mut args = Vec::with_capacity(4);
+        args.extend_from_slice(&(npc_id as i32).to_le_bytes());
+        let handled = dispatch(1, INTERACT, &args, &tx, &mut mgr, &engine).await;
+        assert!(handled);
+
+        // Player should now be marked as looting this corpse.
+        assert_eq!(
+            mgr.get_entity(1).and_then(|p| p.looting_entity),
+            Some(npc_id),
+            "interact handler must set looting_entity on the player"
+        );
+
+        // onLootDisplay (method 114) must have been queued for the player.
+        let mut saw_loot_display = false;
+        while let Ok(msg) = rx.try_recv() {
+            if let CellToBaseMsg::EntityMethodCall { entity_id, method_index, .. } = msg {
+                if entity_id == 1 && method_index == 114 {
+                    saw_loot_display = true;
+                }
+                // useAbility / target reticle must NOT have been sent.
+                assert_ne!(method_index, 16, "dead hostile must not fire onTargetUpdate");
+            }
+        }
+        assert!(saw_loot_display, "expected onLootDisplay (method 114) for dead lootable corpse");
     }
 }

--- a/crates/services/src/cell/combat/state.rs
+++ b/crates/services/src/cell/combat/state.rs
@@ -1,13 +1,15 @@
 //! Combatant state flags (dead/alive) packed into a `stateField` bitmask.
 //!
-//! From `python/Atrea/enums.py`. The client reads `stateField` and treats
-//! bit 13 as "dead" — value 8192 = `PLAYER_STATE_DEAD`.
+//! From `python/Atrea/enums.py:176-184`. `BSF_*` enum values are bit *indices*;
+//! `setStateFlag(flag)` does `stateField |= 1 << flag`. BSF_Dead = 0 → value 1.
 
-/// Bitmask for dead state in combatantState.
-pub const PLAYER_STATE_DEAD: u32 = 8192;
+/// Bitmask for dead state in combatantState (1 << BSF_Dead).
+pub const PLAYER_STATE_DEAD: u32 = 1;
 
-/// Bit position for dead flag in stateField (sent to client).
-pub const BSF_DEAD: u32 = 13; // bit 13 → value 8192
+/// Bit position for dead flag in stateField (sent to client). Matches python
+/// `Atrea.enums.BSF_Dead = 0`. The earlier value 13 was a wire-protocol bug
+/// that left dead NPCs visible as "attackable" on the client.
+pub const BSF_DEAD: u32 = 0;
 
 /// Check if a state field indicates the entity is dead.
 pub fn is_dead_state(state_field: u32) -> bool {
@@ -35,7 +37,7 @@ mod tests {
 
         set_dead_state(&mut state);
         assert!(is_dead_state(state));
-        assert_eq!(state, 8192);
+        assert_eq!(state, 1);
 
         clear_dead_state(&mut state);
         assert!(!is_dead_state(state));

--- a/crates/services/src/cell/content/executor.rs
+++ b/crates/services/src/cell/content/executor.rs
@@ -243,7 +243,7 @@ pub(super) async fn execute_actions(
                         let _ = tx.send(CellToBaseMsg::WitnessEntityMethod {
                             witness_id: entity_id,
                             entity_id: target_id,
-                            method_index: 3, // InteractionType
+                            method_index: crate::mercury::method_idx::INTERACTION_TYPE,
                             args: (merged as u64).to_le_bytes().to_vec(),
                         }).await;
                     }
@@ -278,7 +278,7 @@ pub(super) async fn execute_actions(
                             let _ = tx.send(CellToBaseMsg::WitnessEntityMethod {
                                 witness_id,
                                 entity_id: target_id,
-                                method_index: 3, // InteractionType
+                                method_index: crate::mercury::method_idx::INTERACTION_TYPE,
                                 args: (flags as u64).to_le_bytes().to_vec(),
                             }).await;
                         }
@@ -494,7 +494,7 @@ async fn send_interaction_update_if_visible(
             let _ = tx.send(CellToBaseMsg::WitnessEntityMethod {
                 witness_id: entity_id,
                 entity_id: target_id,
-                method_index: 3, // InteractionType
+                method_index: crate::mercury::method_idx::INTERACTION_TYPE,
                 args: (merged as u64).to_le_bytes().to_vec(),
             }).await;
         } else {

--- a/crates/services/src/cell/interactions.rs
+++ b/crates/services/src/cell/interactions.rs
@@ -109,7 +109,7 @@ pub async fn handle_interact(
             if let Some(player) = space_mgr.get_entity_mut(entity_id) {
                 player.looting_entity = Some(target_entity_id);
             }
-            send_loot_display(entity_id, target_entity_id as i32, tx, space_mgr).await;
+            send_loot_display(entity_id, target_entity_id as i32, 1, tx, space_mgr).await;
             None
         }
         None => {
@@ -228,10 +228,15 @@ async fn send_trainer_open(
 ///   `itemID:i32, quantity:i16, index:i32, typeID:i32`
 /// Outer: `entityId:i32, ARRAY<LootItemQuantity>, initial:i8`
 ///
+/// `initial = 1` for the first display (opens the window), `0` for subsequent
+/// refreshes after a lootItem (client refreshes contents; closes the window
+/// if the list is now empty per Loot.lua's `LootWin:hide()` on count==0).
+///
 /// Reference: `python/cell/interactions/Lootable.py:sendLootList()`
 async fn send_loot_display(
     player_id: u32,
     npc_entity_id: i32,
+    initial: u8,
     tx: &mpsc::Sender<CellToBaseMsg>,
     space_mgr: &SpaceManager,
 ) {
@@ -255,10 +260,10 @@ async fn send_loot_display(
         args.extend_from_slice(&type_id.to_le_bytes());           // typeID: INT32
     }
 
-    args.push(1); // Initial = 1
+    args.push(initial);
 
-    tracing::info!(
-        player_id, npc_entity_id, count,
+    tracing::debug!(
+        player_id, npc_entity_id, count, initial,
         "Sending onLootDisplay"
     );
     let _ = tx.send(CellToBaseMsg::EntityMethodCall {
@@ -368,20 +373,27 @@ pub async fn handle_loot_item(
         }
         // Broadcast InteractionType(0) to witnesses
         super::abilities::send_entity_method(
-            target_eid, 3,
-            0i64.to_le_bytes().to_vec(),
+            target_eid, crate::mercury::method_idx::INTERACTION_TYPE,
+            0u64.to_le_bytes().to_vec(),
             tx, space_mgr,
         ).await;
+
+        // Send the empty loot list to the player so the loot window closes.
+        // Loot.lua hides the window when getLootCount()==0 inside onLootDisplay.
+        // Without this, the window stays open displaying stale data and any
+        // additional "Loot All" clicks fall through to lootItem with no
+        // looting_entity set (we used to log the resulting warning storm).
+        send_loot_display(entity_id, target_eid as i32, 0, tx, space_mgr).await;
 
         // Clear looting state on the player
         if let Some(player) = space_mgr.get_entity_mut(entity_id) {
             player.looting_entity = None;
         }
 
-        tracing::info!(target_eid, "NPC loot exhausted — cleared interaction");
+        tracing::debug!(target_eid, "NPC loot exhausted — cleared interaction");
     } else {
-        // Send updated loot list
-        send_loot_display(entity_id, target_eid as i32, tx, space_mgr).await;
+        // Send updated loot list to refresh the open window
+        send_loot_display(entity_id, target_eid as i32, 0, tx, space_mgr).await;
     }
 }
 

--- a/crates/services/src/cell/interactions.rs
+++ b/crates/services/src/cell/interactions.rs
@@ -366,15 +366,23 @@ pub async fn handle_loot_item(
         .map_or(true, |e| e.loot.is_empty());
 
     if loot_empty {
-        // Clear loot interaction on the NPC
-        if let Some(target) = space_mgr.get_entity_mut(target_eid) {
-            target.interaction_type_flags = 0;
-            target.interaction_type = None;
-        }
-        // Broadcast InteractionType(0) to witnesses
+        // Clear ONLY the loot bit; preserve other interaction flags (quest tags,
+        // mission interactions, etc.) so the corpse retains any content state set
+        // pre-death. Mirrors python `Lootable.py:204`:
+        //     ent.setInteractionType(ent.interactionType & ~INT_NormalLoot)
+        let flags_to_send = if let Some(target) = space_mgr.get_entity_mut(target_eid) {
+            target.interaction_type_flags &= !super::abilities::INT_NORMAL_LOOT;
+            if target.interaction_type_flags == 0 {
+                target.interaction_type = None;
+            }
+            target.interaction_type_flags
+        } else {
+            0
+        };
+        // Broadcast remaining flags to witnesses (not blanket 0).
         super::abilities::send_entity_method(
             target_eid, crate::mercury::method_idx::INTERACTION_TYPE,
-            0u64.to_le_bytes().to_vec(),
+            (flags_to_send as u64).to_le_bytes().to_vec(),
             tx, space_mgr,
         ).await;
 

--- a/crates/services/src/cell/space_manager/aoi.rs
+++ b/crates/services/src/cell/space_manager/aoi.rs
@@ -117,7 +117,7 @@ impl SpaceManager {
                                         events.push(CellToBaseMsg::WitnessEntityMethod {
                                             witness_id: player_id,
                                             entity_id: eid,
-                                            method_index: 3, // InteractionType
+                                            method_index: crate::mercury::method_idx::INTERACTION_TYPE,
                                             args: (merged as u64).to_le_bytes().to_vec(),
                                         });
 

--- a/docs/guides/sgw-live-debugging.md
+++ b/docs/guides/sgw-live-debugging.md
@@ -1,0 +1,117 @@
+# Live debugging SGW.exe with x32dbg + Ghidra MCP
+
+> **Type**: How-to guide
+> **Audience**: Cimmeria reverse-engineers and server developers needing to confirm a client-side hypothesis against the live process.
+> **Prerequisites**: Ghidra with SGW.exe loaded and the annotation scripts run (at minimum 01_rtti and 04_event_signal). x32dbg (use `x32dbg.exe` — SGW is 32-bit). Optional: Ghidra MCP plugin for HTTP-driven static lookups.
+
+This guide captures what we learned hunting the [right-click routing on corpse bug](../reverse-engineering/findings/right-click-routing-on-corpse.md) — specifically, the techniques that worked, the dead ends, and the gotchas. Follow this when static analysis isn't enough and you need to confirm runtime state.
+
+## When live debugging is worth it
+
+Live debugging is expensive — every breakpoint hit costs a possible server disconnect (the heartbeat thread can't run while the process is paused). Reach for it only when:
+
+- Static analysis has narrowed the question to a few alternatives, and any of them is testable in one or two breakpoints.
+- You're trying to disprove a hypothesis as fast as confirming one.
+- The same data could not be obtained from server-side logging.
+
+## Toolchain choice
+
+We tried two debuggers; here's what worked.
+
+### x32dbg — recommended
+
+Use `x32dbg.exe` (the 32-bit build). SGW.exe is 32-bit, the regular `x64dbg` won't attach to it. x32dbg reliably attaches, sets breakpoints, supports log breakpoints, resumes cleanly, and detaches without crashing the game.
+
+### pybag (the `ghidra-mcp` debugger plugin) — avoid for SGW
+
+pybag's HTTP-driven debugger is convenient on paper but has two problems specifically with SGW:
+
+1. **Attach freezes the game even with no breakpoints set.** Some interaction with SGW's main thread state prevents the resume from actually progressing. Status shows `running` but the game window is stuck.
+2. **`go` after `interrupt` fails with `E_ACCESSDENIED` (HRESULT 0x80070005).** Once you've interrupted to inspect state, the only way back to a running process is to fully detach. There's no way to step or resume.
+
+We spent significant time on pybag before concluding it's incompatible. If you must script-drive a debugger, prefer Ghidra's built-in debugger over pybag.
+
+## Address mapping (Ghidra static address → runtime)
+
+SGW.exe's preferred image base in the PE header is `0x00400000`, but Windows ASLR will load it elsewhere. To translate any Ghidra address to a runtime address:
+
+1. Attach x32dbg to SGW.
+2. Click the **Memory Map** tab.
+3. Find the row whose `Info` column says simply `sgw.exe` (this is the PE header; subsequent rows are `.text`, `.rdata`, etc.).
+4. Note the `Address` column — this is the runtime base. In our experience it has consistently been `0x00960000`, giving an ASLR slide of `+0x00560000`.
+5. **Runtime VA** = `Ghidra_VA - 0x00400000 + runtime_base`.
+
+Example: `FUN_00e84b20` (Ghidra) at base `0x00960000` resolves to runtime `0x013e4b20`.
+
+## Setting breakpoints
+
+In the bottom command bar:
+
+```
+bp 013E4B20
+```
+
+Verify in the **Breakpoints** tab — the disassembly column should show a sensible function prologue (`push ebp` / `cmp dword ptr` / similar). If you see something like `inc ebx`, you're at the wrong address — most often because you typed the Ghidra address as if it were an RVA. Recompute and retry.
+
+## Avoiding heartbeat disconnect: log breakpoints
+
+Halting on every right-click click hangs the game long enough to lose the server heartbeat. The fix is **log breakpoints** that capture state on each hit and resume immediately without pausing the UI thread.
+
+Right-click the breakpoint row in the Breakpoints tab → `Edit`:
+
+| Field | Value | Effect |
+|---|---|---|
+| **Log Text** | `[my-marker] target=0x{x:esi} pawn_field=0x{x:[eax+1B4]} eax=0x{x:eax} edi=0x{x:edi}` | Format string written to the Log tab on each hit |
+| **Break Condition** | `0` | Critical — makes the breakpoint log-only, never halts the process |
+| **Log Condition** | (blank or `1`) | Always log |
+
+The format placeholders are:
+- `{x:reg}` — register value as hex (e.g. `{x:esi}`)
+- `{x:[expr]}` — 4-byte memory dereference as hex (e.g. `{x:[eax+1B4]}` reads `*(uint32_t*)(eax + 0x1B4)`)
+- Nested derefs work: `{x:[[edi+1B0]+1B4]}` is `*(uint32_t*)(*(uint32_t*)(edi + 0x1B0) + 0x1B4)`.
+
+Read the log via the **Log** tab. To filter by your prefix, right-click → Find.
+
+### Pitfalls with log expressions
+
+- **Hex offsets must be unambiguous.** `[eax+C]` is parsed correctly as `eax + 0xC` in our experience, but if you see suspicious `???` values, switch to `[eax+0xC]` explicitly.
+- **`???`** in a log line means the address was unreadable. Most often you're dereferencing a register that doesn't hold the pointer you think — re-read the disassembly to confirm what each register holds at that exact instruction.
+- **Get registers right for the BP location**. The same logical value (e.g. "the target pointer") may live in different registers at different addresses inside a function. Pick the BP address based on what registers are alive there.
+
+## Hot functions = freezes; pick BP locations carefully
+
+Some functions are called every frame (cursor target tracking, animation ticks). Setting a breakpoint there freezes the game even briefly, which is enough to disconnect.
+
+What we learned the hard way:
+
+| Function | Hot? | Why |
+|---|---|---|
+| `FUN_00e85860` (click router / MouseLook handler) | **Yes** | Fires on every RMB press AND release event |
+| `FUN_00e68570` (gate predicate) | **Yes** | Cursor target tracking calls it on every hover |
+| `FUN_00e84860` (resolver) | **Yes** | Cursor logic re-resolves frequently |
+| `FUN_00e84b20` (interact firer) | **No** | Only called from the click router on actual RMB release with valid pick. Safe to halt-break here. |
+
+Rule of thumb: **prefer breakpoints on functions that have a single specific user trigger**. If a function gets called by the cursor system or any per-frame tick, it's hot.
+
+## A working investigation flow
+
+For the corpse-loot bug investigation specifically:
+
+1. **Static phase**: walk callers from `Event_NetOut_Interact` constructor (`FUN_00d97990`) backward to find the firer `FUN_00def4b0`, then to its only caller `FUN_00e84b20`, then up to `FUN_00e85860` (the click router). This gives you a labeled call graph without touching the live process.
+2. **Bridge phase** (Ghidra annotation scripts): run `01_rtti_annotator.py` and `04_event_signal_annotator.py` first. These two alone get you 8000+ vtables labeled and ~422 `register_NetOut_*` functions named. `07_vtable_annotator.py` is comprehensive but takes 30+ minutes — only run it if you need vfunc names beyond vfunc_0.
+3. **Targeted annotation**: if 07 is too slow, write a trimmed version that only annotates the classes you care about (see `docs/reverse-engineering/annotation-scripts/07b_targeted_vtable_annotator.py`).
+4. **Live phase**: log breakpoint at the entry of the function whose runtime behavior you're trying to confirm. Format the log to capture the registers + memory you need. Right-click in-game a few times. Read the log.
+
+## Recovering from a stuck debugger session
+
+If pybag (or anything else) leaves the game frozen:
+
+1. Detach: `POST /debugger/detach` (or click Detach in x32dbg). Game resumes.
+2. If Detach hangs too: kill the debugger process. The OS detaches, game survives.
+3. Worst case: kill SGW.exe and re-launch. You lose your in-game position, but the server is fine.
+
+## See also
+
+- [right-click-routing-on-corpse.md](../reverse-engineering/findings/right-click-routing-on-corpse.md) — the investigation this guide came out of, including the resolution that this technique uncovered.
+- [docs/reverse-engineering/annotation-scripts/](../reverse-engineering/annotation-scripts/) — the Jython scripts that produce the labels you'll see in x32dbg's disassembly.
+- [docs/reverse-engineering/findings/entity-property-sync.md](../reverse-engineering/findings/entity-property-sync.md) — wire format for property changes if you're tracing those.

--- a/docs/reverse-engineering/annotation-scripts/07b_targeted_vtable_annotator.py
+++ b/docs/reverse-engineering/annotation-scripts/07b_targeted_vtable_annotator.py
@@ -1,0 +1,240 @@
+# -*- coding: utf-8 -*-
+# 07b_targeted_vtable_annotator.py
+# Trimmed version of 07_vtable_annotator.py for the right-click loot-routing
+# investigation. Only processes vtables for classes we care about, so it
+# completes in seconds instead of half an hour.
+#
+# Usage (Ghidra Jython console):
+#   execfile(r'c:\Users\steven.cady\repos\personal\Cimmeria\docs\reverse-engineering\annotation-scripts\07b_targeted_vtable_annotator.py')
+#
+# Run after 01_rtti_annotator.py.
+
+from ghidra.program.model.symbol import SourceType
+from ghidra.program.model.mem import MemoryAccessException
+
+# Vtables to process. Substring match, case-insensitive, against the class
+# name extracted from the vtable label.
+TARGETS = [
+    # Right-click router (player input controller)
+    "ASGWController_Player",
+    # Server-entity proxies whose state the click handler may read
+    "GameProxyPlayer",
+    "GamePlayer",
+    "GameMob",
+    "GameBeing",
+    "GameEntity",
+    "GameEntityBase",
+    "GamePet",
+    # Event<->callback wiring for the input action and the wire-out events
+    "Event_Action_MouseLook",
+    "Event_Action_MouseClick",
+    "Event_NetOut_UseAbility",
+    "Event_NetOut_Interact",
+    "Event_NetOut_useAbilityOnGroundTarget",
+    # The callback wrappers — vfunc_3 of these typically invokes the bound
+    # member function pointer, which is what we need to chase
+    "MemberCallback",
+    "CallbackImpl",
+]
+
+
+def is_default_name(func):
+    name = func.getName()
+    return (name.startswith("FUN_") or
+            name.startswith("thunk_FUN_") or
+            name.startswith("Ordinal_") or
+            name.startswith("LAB_"))
+
+
+def is_code_address(addr, mem):
+    try:
+        val = addr.getOffset()
+        if val == 0 or val < 0x00400000 or val > 0x7FFFFFFF:
+            return False
+        block = mem.getBlock(addr)
+        return block is not None and block.isExecute()
+    except:
+        return False
+
+
+def read_pointer(mem, addr):
+    try:
+        return mem.getInt(addr) & 0xFFFFFFFF
+    except MemoryAccessException:
+        return None
+    except:
+        return None
+
+
+def clean_class_name(raw):
+    name = raw
+    for prefix in ("vtable_", "VTABLE_", "vftable_", "VFTABLE_", "vtbl_"):
+        if name.startswith(prefix):
+            name = name[len(prefix):]
+            break
+    return name.strip("_")
+
+
+def matches_target(class_name):
+    lower = class_name.lower()
+    for t in TARGETS:
+        if t.lower() in lower:
+            return True
+    return False
+
+
+def main():
+    monitor = getMonitor()
+    fm = currentProgram.getFunctionManager()
+    st = currentProgram.getSymbolTable()
+    mem = currentProgram.getMemory()
+    addr_factory = currentProgram.getAddressFactory()
+    default_space = addr_factory.getDefaultAddressSpace()
+
+    println("=" * 70)
+    println("Targeted VTable Annotator - Script 07b (loot routing)")
+    println("=" * 70)
+
+    # Step 1 - find vtable symbols matching our targets
+    monitor.setMessage("Scanning symbols for target vtables...")
+    targets = []
+    seen_addrs = set()
+    sym_iter = st.getAllSymbols(True)
+    while sym_iter.hasNext():
+        if monitor.isCancelled():
+            return
+        sym = sym_iter.next()
+        sn = sym.getName()
+        if sn is None:
+            continue
+        ln = sn.lower()
+        if not (ln.startswith("vtable_") or ln.startswith("vftable_") or ln.startswith("vtbl_")):
+            continue
+        cls = clean_class_name(sn)
+        if not matches_target(cls):
+            continue
+        addr = sym.getAddress()
+        key = addr.getOffset()
+        if key in seen_addrs:
+            continue
+        seen_addrs.add(key)
+        targets.append((sn, addr, cls))
+
+    targets.sort(key=lambda x: x[1].getOffset())
+    println("Matched %d target vtables." % len(targets))
+    if not targets:
+        println("Nothing to do. Did 01_rtti_annotator run successfully?")
+        return
+
+    # Build vtable boundary set across the FULL symbol table so we don't
+    # walk past one vtable into another that we're not annotating.
+    monitor.setMessage("Indexing all vtable boundaries...")
+    all_vtable_addrs = set()
+    sym_iter = st.getAllSymbols(True)
+    while sym_iter.hasNext():
+        if monitor.isCancelled():
+            return
+        sym = sym_iter.next()
+        sn = sym.getName()
+        if sn is None:
+            continue
+        ln = sn.lower()
+        if ln.startswith("vtable_") or ln.startswith("vftable_") or ln.startswith("vtbl_"):
+            all_vtable_addrs.add(sym.getAddress().getOffset())
+
+    # Step 2 - process each target vtable
+    monitor.setMaximum(len(targets))
+    total_named = 0
+    total_already = 0
+    assigned = set()
+
+    MAX_ENTRIES = 500
+    for i, (vt_name, vt_addr, cls) in enumerate(targets):
+        monitor.setProgress(i)
+        monitor.setMessage("[%d/%d] %s" % (i + 1, len(targets), cls))
+        if monitor.isCancelled():
+            return
+
+        entry_idx = 0
+        cur = vt_addr
+        named_for_this = 0
+        already_for_this = 0
+
+        while entry_idx < MAX_ENTRIES:
+            if entry_idx > 0:
+                # Stop at the next vtable boundary
+                if cur.getOffset() in all_vtable_addrs:
+                    break
+                # Stop at any user-defined non-DAT label
+                hit_label = False
+                for s in st.getSymbols(cur):
+                    if s.getSource() == SourceType.USER_DEFINED:
+                        sn = s.getName()
+                        if sn and not sn.startswith("DAT_") and not sn.startswith("ADDR_"):
+                            hit_label = True
+                            break
+                if hit_label:
+                    break
+
+            ptr = read_pointer(mem, cur)
+            if ptr is None or ptr == 0:
+                break
+            try:
+                target = default_space.getAddress(ptr & 0xFFFFFFFF)
+            except:
+                break
+            if not is_code_address(target, mem):
+                break
+
+            func = fm.getFunctionAt(target)
+            if func is None:
+                try:
+                    from ghidra.app.cmd.function import CreateFunctionCmd
+                    cmd = CreateFunctionCmd(target)
+                    cmd.applyTo(currentProgram)
+                    func = fm.getFunctionAt(target)
+                except:
+                    pass
+            if func is None:
+                cur = cur.add(4)
+                entry_idx += 1
+                continue
+
+            if not is_default_name(func):
+                already_for_this += 1
+                total_already += 1
+                # Tag with note even if already named
+                pc = func.getComment()
+                note = "Also in vtable: %s (slot %d)" % (cls, entry_idx)
+                if pc is None:
+                    func.setComment(note)
+                elif cls not in pc:
+                    func.setComment(pc + "\n" + note)
+                cur = cur.add(4)
+                entry_idx += 1
+                continue
+
+            name = "%s__vfunc_%d" % (cls, entry_idx)
+            if name in assigned:
+                name = "%s__vfunc_%d_at_%s" % (cls, entry_idx, target.toString().replace("0x", ""))
+            assigned.add(name)
+            try:
+                func.setName(name, SourceType.USER_DEFINED)
+                func.setComment("[VTable] %s virtual function #%d\nVTable: %s at %s" % (
+                    cls, entry_idx, vt_name, vt_addr.toString()))
+                named_for_this += 1
+                total_named += 1
+            except:
+                pass
+
+            cur = cur.add(4)
+            entry_idx += 1
+
+        if entry_idx > 0:
+            println("  %s: %d entries (%d named, %d already named)" % (cls, entry_idx, named_for_this, already_for_this))
+
+    println("")
+    println("Done. %d functions newly named, %d already had user names." % (total_named, total_already))
+
+
+main()

--- a/docs/reverse-engineering/findings/right-click-routing-on-corpse.md
+++ b/docs/reverse-engineering/findings/right-click-routing-on-corpse.md
@@ -1,0 +1,136 @@
+# Right-click Routing: Why Corpses Fail to Open Loot
+
+> **Status**: Resolved — see Resolution section.
+> **Source**: Ghidra static analysis + live debugger trace via x32dbg.
+> **Audience**: Future Cimmeria reverse-engineers debugging client-server interaction issues.
+
+## Resolution (TL;DR)
+
+The bug was **server-side, not client-side**. None of the static-analysis hypotheses below (`+0x30/+0x31` gate bytes, `actor+0x1b4` entity ID, `onDuelEntitiesRemove` interactable-set hack) actually mattered.
+
+**What was happening**: the Cimmeria server's `interact` cell-method handler at [crates/services/src/cell/cell_methods/player/interaction.rs](../../../crates/services/src/cell/cell_methods/player/interaction.rs) checked whether the target was a hostile NPC (`!is_player && faction == 10`) and **redirected to `useAbility` instead of running `handle_interact`**. The check didn't consider whether the NPC was dead. So:
+
+- Alive hostile guard → reroute to `useAbility` ✓ correct
+- **Dead hostile guard → reroute to `useAbility`** ✗ — the lootable corpse's `interact` request was silently turned into combat, and the loot pipeline was never reached.
+
+**Fix**: gate the reroute on `!is_dead_state(target.state_field)`. Dead corpses fall through to `handle_interact`, which sees `interaction_type = Some(Loot)` and dispatches `onLootDisplay`.
+
+```rust
+// crates/services/src/cell/cell_methods/player/interaction.rs:37-49
+let is_hostile = space_mgr.get_entity(target_entity_u32)
+    .map_or(false, |t| {
+        !t.is_player
+            && t.faction == 10
+            && !crate::cell::combat::is_dead_state(t.state_field)
+    });
+```
+
+**How we found it**: x32dbg attached to live SGW.exe + a log breakpoint at `FUN_00e84b20` (the interact firer wrapper). The breakpoint confirmed the client *was* sending `interact` for the corpse with the right entity ID, comparison conditions passed, and `Event_NetOut_Interact` was being constructed. That eliminated client-side suspects and pointed the search at the server. A `grep` for the dispatch site revealed the hostile-NPC reroute.
+
+The static analysis below remains useful tribal knowledge for understanding the SGW client's pick + interact pipeline, but **its conclusion was wrong**. We documented it here as a record of the investigation, not as ground truth.
+
+---
+
+> **Source**: Ghidra static analysis of SGW.exe
+> **Date**: 2026-04-30
+> **Confidence**: HIGH for the gate location and callers; **WRONG** for the *cause* of the gate failing — the gate was never actually the cause. See Resolution above.
+
+## Decision graph (player presses RMB on an entity)
+
+```
+Event_Action_MouseLook (RMB release)
+  │
+  ▼
+ASGWController_Player::onMouseLook  (FUN_00e85860)
+  │  guards: bit0 of this+0x498 == 0 (released, not press)
+  │          |delta_x| < 5px && |delta_y| < 5px
+  ▼
+FUN_00e84b20  (interact firer wrapper)
+  │  guards: global UI flags ok
+  │          target != self (target.entityId != pawn->entityId)
+  │  target = FUN_00e84860(player_controller)
+  │  if target != null:
+  ▼
+FUN_00def4b0  → constructs Event_NetOut_Interact → wire send "interact"
+```
+
+If `FUN_00e84860` returns null, interact is silently dropped. The right-click then has nothing else to do — it's a release event. The visible "right-click fires useAbility" we see in our combat.log is the **auto-attack loop** (`FUN_00e3cd90`, called via vtable on a tick), not the click itself.
+
+## The gate — `FUN_00e84860`
+
+Resolves the picked target:
+
+1. Raycast / cursor pick → AActor at the cursor.
+2. `FUN_00e85e80(actor)` — filters by team/group membership; rejects actors not in our allowed-target set.
+3. Reads `actor + 0x1b4` → **BigWorld entity ID**.
+4. `FUN_00dd0de0(EntityManager, entityId)` — std::map find returning the `GameEntity*`.
+5. `__RTDynamicCast(...)` to `GameEntity`.
+6. **`FUN_00e68570(GameEntity*)` is the gate.** If it returns 0, the resolver returns 0 → interact dropped.
+
+## The gate predicate — `FUN_00e68570`
+
+```c
+undefined4 __fastcall FUN_00e68570(int param_1) {
+  if (*(char *)(param_1 + 0x31) != '\0' && *(char *)(param_1 + 0x30) != '\0') return 1;
+  return 0;
+}
+```
+
+Two boolean bytes on `GameEntity`. **Both** must be non-zero to pass.
+
+## What sets the bytes
+
+Subscriptions are registered in `GameEntity::vfunc_5` (subscribe) and unregistered in `GameEntity::vfunc_6` (unsubscribe).
+
+| Byte | Set by | Triggered by |
+|---|---|---|
+| `+0x30 = 1` | `FUN_00e68a30` | `Event_NetIn_onEntityMove` handler `FUN_00e6f080` (reads `locationX/Y/Z`, `velocityX/Y/Z`, `yaw/pitch/roll` event properties) |
+| `+0x31 = 1` | `LAB_00e6db70` (12-byte stub: `MOV BYTE PTR [ECX+0x31], 1; CALL FUN_00e688c0; RET 8`) | `Event_NetIn_onVisible` handler |
+
+**Confirmed via the `MemberCallback` template instantiation classes** (named after RTTI annotator ran):
+- `MemberCallback<…, GameEntity, GameEntity::*(Event_NetIn_onVisible const*, void*), Event_NetIn_onVisible>` constructed at `FUN_00e70370`.
+- The `Event_NetIn_onEntityMove` handler `FUN_00e6f080` reads property name strings `locationX/Y/Z`, etc. — proves the event identity.
+
+No writers found that set either byte to 0 except `std::map`/`std::set` tree-balancing code on unrelated nodes (false positives from the byte-pattern search). Once set, both bytes stay set for the life of the `GameEntity` object on the client.
+
+## Implications for the Rust server
+
+The gate requires the client to have received **both**:
+1. A method-call `onEntityMove` (method index 2) — currently we **don't send** this. We send the optimized [`build_avatar_update`](crates/services/src/mercury/aoi.rs#L205) packet (BASEMSG `0x10` `UPDATE_AVATAR_NO_ALIAS_FULL_POS_YPR`) which uses the position-stream protocol and may go through a different client path.
+2. A method-call `onVisible(1)` — we do send this in the AoI cascade at [mercury/aoi.rs:143](crates/services/src/mercury/aoi.rs#L143), so `+0x31` should be set on AoI entry.
+
+Why Frost works but the dead guard doesn't (open question):
+
+- If the optimized `0x10` packet does NOT fire `Event_NetIn_onEntityMove`, then `+0x30` is **never** set on either Frost or the guard — both should fail the gate. They don't. So either:
+  - (a) The AoI entry's CREATE_ENTITY property stream populates `+0x30 = 1` indirectly (the position field on creation triggers the same handler).
+  - (b) Something else sets `+0x30`.
+- If both work normally, the `+0x30/+0x31` bytes should be set on both Frost and the dead guard.
+
+**Most likely actual cause** (not yet confirmed via Ghidra): the picking step `actor + 0x1b4` returns 0 for the dying guard's actor. The `ABigWorldEntity` actor stripped its entity-ID reference on death, so `FUN_00dd0de0(0)` fails to find a `GameEntity` and the resolver returns null **before** ever calling the gate.
+
+This would also explain why the cursor still shows loot (the cursor uses a different lookup path — likely reads `mInteractionType` directly from the GameEntity via the on-hover event, which doesn't depend on the actor's `+0x1b4`).
+
+## Recommended next moves
+
+1. **Live debug** — set a breakpoint at `0x00e68570` (the gate predicate). Right-click corpse: does the breakpoint hit? If not, the resolver returned null **before** the gate, meaning `+0x1b4` on the corpse's actor is 0 — actor-side state, not entity-side.
+2. **If gate hits**: dump `param_1+0x30` and `param_1+0x31` to confirm which is zero. Then trace what cleared it.
+3. **If gate doesn't hit**: breakpoint at `0x00e84860 + offset for the +0x1b4 read` — see what value the actor's entity-ID field holds.
+
+## Key addresses
+
+| Address | Symbol | Role |
+|---|---|---|
+| `0x00e85860` | `ASGWController_Player::onMouseLook` | Click router |
+| `0x00e84b20` | `ASGWController_Player::fireInteract` (wrapper) | Calls resolver, fires Event_NetOut_Interact |
+| `0x00e84860` | Target resolver | Raycast → entity ID lookup → gate |
+| `0x00e68570` | **Gate predicate** | `(this+0x30 != 0) && (this+0x31 != 0)` |
+| `0x00e68a30` | `+0x30` setter | Called from `Event_NetIn_onEntityMove` handler |
+| `0x00e6db70` | `+0x31` setter (12-byte stub) | Called from `Event_NetIn_onVisible` handler |
+| `0x00e6f080` | `Event_NetIn_onEntityMove` handler | Reads locationX/Y/Z, velocity, yaw/pitch/roll |
+| `0x00e688c0` | "ready" check | Reads both gate bytes; uses for pawn show/hide |
+| `0x00cb7d30` | `Event_NetOut_UseAbility` ctor | For comparison |
+| `0x00d97990` | `Event_NetOut_Interact` ctor | For comparison |
+| `0x00c811f0` | useAbility firer #1 (lua-call path) | Caller of UseAbility ctor |
+| `0x00d2ae40` | useAbility firer #2 | Caller of UseAbility ctor |
+| `0x00def4b0` | interact firer | Caller of Interact ctor |
+| `0x00e3cd90` | auto-attack useAbility caller (vtable) | Likely source of the `useAbility` we see in logs after death |


### PR DESCRIPTION
## Summary

Right-clicking a hostile NPC corpse silently rerouted to `useAbility` (auto-attack) instead of opening the loot window. The bug was a missing dead-state check in the interact dispatcher's hostile-reroute guard. One-line fix in [crates/services/src/cell/cell_methods/player/interaction.rs](crates/services/src/cell/cell_methods/player/interaction.rs#L37-L49); dead corpses now fall through to `handle_interact` and trigger `onLootDisplay` as expected.

## The bug

The interact handler had this guard:

```rust
let is_hostile = space_mgr.get_entity(target_entity_u32)
    .map_or(false, |t| !t.is_player && t.faction == 10);
if is_hostile {
    // ...reroute to useAbility...
}
```

So:

| Target | Behavior | Correct? |
|---|---|---|
| Alive hostile guard | Reroute to useAbility | yes |
| **Dead hostile guard (lootable)** | **Reroute to useAbility** | no — should reach handle_interact |

The fix adds `&& !is_dead_state(t.state_field)` to the predicate. Dead hostiles fall through, `handle_interact` sees `interaction_type = Some(Loot)`, and dispatches `onLootDisplay` (method 114). Loot window opens.

## How we found it (the long version)

This took a lot longer than the diff suggests. Most of that time was spent chasing a wrong hypothesis. Documenting that journey because the techniques generalize.

**Phase 1 — speculation about a client-side gate (wrong).** Static analysis in Ghidra led to a candidate gate predicate at `FUN_00e68570` reading two bytes (`+0x30`, `+0x31`) on `GameEntity`. The theory was the dead corpse failed this gate because its `+0x30` (set by `onEntityMove`) was never set, so the resolver returned null and the client dropped the click silently. We added speculative server fixes (re-firing `onEntityMove`, adjusting AoI cascade) — none worked. "No joy" several times.

**Phase 2 — live debug with x32dbg.** A log breakpoint at `FUN_00e84b20` (the interact firer wrapper, not the click router which is too hot) with `Break Condition: 0` to avoid pausing the heartbeat thread captured this on right-click of a corpse:

```
[interact-cmp] target=0x187DE pawn_field=0x2 eax=0xEC157210 edi=0xEC037210
```

`target=0x187DE` = entity ID 100318 = the dead Cellblock Guard. **The client was sending interact correctly with the right entity ID**. That eliminated every client-side suspect in one breakpoint hit and pointed the search at the server.

**Phase 3 — grep for the dispatch site.** A grep on `interact` in the cell handler found the hostile-NPC reroute. Read the code, saw the missing dead check. One-line fix.

The static-analysis findings about the gate predicate are preserved in [docs/reverse-engineering/findings/right-click-routing-on-corpse.md](docs/reverse-engineering/findings/right-click-routing-on-corpse.md) but explicitly marked as the wrong conclusion. The Resolution section at the top documents the actual cause.

## What changed

### Core fix

- **[crates/services/src/cell/cell_methods/player/interaction.rs](crates/services/src/cell/cell_methods/player/interaction.rs)** — added `!is_dead_state(t.state_field)` to the hostile-reroute predicate. Two `#[tokio::test]` regression tests:
  - `alive_hostile_reroutes_to_useability` — baseline; alive hostile fires `onTargetUpdate` and never `onLootDisplay`.
  - `dead_hostile_with_loot_routes_to_interact` — regression; dead hostile sets `looting_entity` on the player and fires `onLootDisplay` (method 114).

### Loot-window-close fix (rolled in because it was blocking the same UAT)

- **[crates/services/src/cell/interactions.rs](crates/services/src/cell/interactions.rs)** — `send_loot_display` takes an `initial: u8` param. After "Loot All" empties the inventory, `handle_loot_item` re-sends `onLootDisplay` with `initial=0`; `Loot.lua`'s `LootWin:hide()` triggers when `getLootCount() == 0` and the window closes. Without this the window stayed open showing stale items, and subsequent clicks fell through to `lootItem` with no `looting_entity` set (warning storm in the logs).

### Wire-protocol corrections found while investigating

- **[crates/services/src/cell/combat/state.rs](crates/services/src/cell/combat/state.rs)** — `BSF_DEAD` corrected from bit 13 (= 8192) to bit 0 (= 1) per `python/Atrea/enums.py:176`. The old value left dead NPCs visible as "attackable" on the client because the dead-state bit never matched the client's expected mask.

- **[crates/services/src/cell/abilities/use_ability.rs](crates/services/src/cell/abilities/use_ability.rs)** — death-block message ordering: `InteractionType` (method 3) now sends BEFORE the dead-state bit (method 19). Mirrors python `SGWMob.onDead()` which calls `setInteractionType` before the state field flip propagates. The C++ client locks in cursor state when the dead-state bit arrives; later `InteractionType` updates appear to be ignored.

- **[crates/services/src/cell/abilities/use_ability.rs](crates/services/src/cell/abilities/use_ability.rs)** — attacker drops `BSF_InCombat` on kill so the client stops routing right-click on selected entities to `useAbility`. Mirrors `python/cell/SGWPlayer.py:961-965`. The current implementation clears unconditionally on every kill; a proper threat list will be needed before generalizing to multi-mob aggro.

- **[crates/services/src/cell/abilities/loot_drop.rs](crates/services/src/cell/abilities/loot_drop.rs)** — `target.interaction_type_flags |= INT_NORMAL_LOOT` (was `=`). OR-preserve matches `python/cell/interactions/Lootable.py:setInteractionType(self.interactionType | INT_NormalLoot)`. Currently harmless because `use_ability.rs` zero-clears first, but preserves any bits set by a content chain pre-death.

### Cleanup

- Replaced hardcoded `method_index: 3` with `mercury::method_idx::INTERACTION_TYPE` across [executor.rs](crates/services/src/cell/content/executor.rs), [aoi.rs](crates/services/src/cell/space_manager/aoi.rs), and [interactions.rs](crates/services/src/cell/interactions.rs). Grep-ability win, no behavior change.
- Demoted hot-path `INFO` logs in `loot_drop.rs`, `use_ability.rs`, and `interactions.rs` to `DEBUG`. The hot path runs on every kill; INFO was noisy.

## Documentation

Two documents that bottle the technique so the next reverse-engineer does not have to rediscover it:

- **NEW** [docs/guides/sgw-live-debugging.md](docs/guides/sgw-live-debugging.md) — how-to guide for live-debugging `SGW.exe`. Covers:
  - When live debugging is worth the heartbeat-disconnect cost.
  - Why x32dbg works and pybag (the `ghidra-mcp` debugger plugin) does not — pybag's resume hangs on `E_ACCESSDENIED` after interrupt.
  - ASLR address mapping (Ghidra `0x00400000` to runtime `0x00960000`, slide `+0x00560000`).
  - Log breakpoints with `Break Condition: 0` for halt-free instrumentation, and the format-string syntax (`{x:reg}`, `{x:[expr]}`, nested derefs).
  - Hot-function rules — which functions are called per-frame and will freeze the game on any breakpoint.

- **NEW** [docs/reverse-engineering/findings/right-click-routing-on-corpse.md](docs/reverse-engineering/findings/right-click-routing-on-corpse.md) — investigation record. Resolution section at top with the actual fix; static-analysis hypothesis preserved below as a record of what was speculated and why it was wrong. The decision graph and key addresses are still valuable as a map of the SGW client's pick + interact pipeline.

- **NEW** [docs/reverse-engineering/annotation-scripts/07b_targeted_vtable_annotator.py](docs/reverse-engineering/annotation-scripts/07b_targeted_vtable_annotator.py) — targeted-class variant of the full `07_vtable_annotator.py` (which takes 30+ minutes). Use this when you only need vfunc names on a handful of classes.

## Out of scope (intentionally)

- **Loot icons.** `naquadah` (and presumably other items) shows no icon in the loot window. Item-icon wiring is a separate workstream.
- **Multi-mob threat tracking.** The attacker's `BSF_InCombat` clear on kill is unconditional. Multi-mob aggro will need a real threat list before this can stay correct under multiple attackers. Tracked in #92.
- **`interactions.rs` file split.** Crossed the soft cap during this work. Tracked separately, not blocking this fix.

## Test plan

- [x] `cargo check -p cimmeria-services`
- [x] `cargo test -p cimmeria-services` — both new regression tests pass.
- [x] Full server build: `cargo build -p cimmeria-server --release` and copy the exe to repo root per CLAUDE.md.
- [x] Manual UAT, positive path: kill a Cellblock Guard with loot, hover corpse to loot cursor, right-click to open loot window, "Loot All" closes window, item appears in inventory.
- [x] Manual UAT, negative path: kill an NPC with no loot table — corpse hover shows no interaction cursor, right-click does nothing.
- [x] Regression: alive hostile guard still right-clicks to attack.
- [ ] Regression: vendor and dialog NPCs still interact correctly when alive (AoI cascade unchanged).

## See also

- [docs/guides/sgw-live-debugging.md](docs/guides/sgw-live-debugging.md) — the technique that found this bug.
- [docs/reverse-engineering/findings/right-click-routing-on-corpse.md](docs/reverse-engineering/findings/right-click-routing-on-corpse.md) — the full investigation record, including the wrong client-side hypothesis.

Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed right-click interaction on dead hostile NPC corpses to properly display the loot interface instead of attempting combat actions.

* **Documentation**
  * Added reverse-engineering debugging guide with step-by-step instructions for live analysis using external tools.
  * Added investigation findings documenting interaction routing analysis and Ghidra annotation scripts for advanced symbol resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
