### PR TITLE
fix: Find Ambernol mission progression and item consumption

### DIFF
--- a/crates/entity/src/cell_entity.rs
+++ b/crates/entity/src/cell_entity.rs
@@ -198,6 +198,9 @@ pub struct CellEntity {
     pub nav_path: VecDeque<Vector3>,
     /// Movement speed in world units per tick.
     pub move_speed: f32,
+    /// Pin this NPC to its spawn position. AI will attack when the target
+    /// is in range + LOS but never pathfind. Loaded from `spawnlist.is_stationary`.
+    pub is_stationary: bool,
 
     // ── Saved mission state (for re-login) ────────────────────────────────────
     /// Saved missions loaded from DB, to be populated before content engine fires.
@@ -319,6 +322,7 @@ impl CellEntity {
             ai_cooldown_ticks: 0,
             nav_path: VecDeque::new(),
             move_speed: 0.6, // ~0.6 world units per 100ms tick = 6 units/sec
+            is_stationary: false,
             saved_missions_loaded: false,
             loot_table_id: None,
             loot: Vec::new(),

--- a/crates/services/src/base/world_entry/cell_dispatch.rs
+++ b/crates/services/src/base/world_entry/cell_dispatch.rs
@@ -26,7 +26,7 @@ use super::methods::{
     handle_open_vendor_store, handle_purchase_vendor_items,
     handle_recharge_inventory_items, handle_remove_inventory_item,
     handle_repair_inventory_item, handle_repair_inventory_items, handle_sell_vendor_items,
-    send_full_inventory_update,
+    handle_use_inventory_item, send_full_inventory_update,
 };
 use super::space_registry::register_space;
 
@@ -321,6 +321,12 @@ pub(crate) async fn handle_cell_message(
         CellToBaseMsg::RemoveInventoryItem { entity_id, player_id, item_id, quantity } => {
             handle_remove_inventory_item(
                 entity_id, player_id, item_id, quantity,
+                &db_pool, cell_tx, socket, connected, entity_to_addr,
+            ).await;
+        }
+        CellToBaseMsg::UseInventoryItem { entity_id, player_id, item_id, target_id } => {
+            handle_use_inventory_item(
+                entity_id, player_id, item_id, target_id,
                 &db_pool, cell_tx, socket, connected, entity_to_addr,
             ).await;
         }

--- a/crates/services/src/base/world_entry/methods/inventory/core.rs
+++ b/crates/services/src/base/world_entry/methods/inventory/core.rs
@@ -111,6 +111,34 @@ pub async fn send_full_inventory_update(
     all_items.len()
 }
 
+/// Tell the player's client to drop an inventory item instance from its
+/// local UI cache.
+///
+/// `onUpdateItem` (used by `send_full_inventory_update`) is upsert-only —
+/// when a stack is fully removed, the client won't drop it just because the
+/// next full-inventory packet omits it. This fires the explicit
+/// `onRemoveItem(ItemIdList)` per the SGWInventoryManager interface so the
+/// slot actually clears in the UI.
+///
+/// Call after the DB commit, before `send_full_inventory_update`.
+async fn send_on_remove_item(
+    entity_id: u32,
+    item_id: i32,
+    socket: &Arc<UdpSocket>,
+    connected: &Arc<Mutex<HashMap<SocketAddr, ConnectedClientState>>>,
+    entity_to_addr: &Arc<Mutex<HashMap<u32, SocketAddr>>>,
+) {
+    let mut args = Vec::with_capacity(8);
+    args.extend_from_slice(&1u32.to_le_bytes()); // ARRAY<INT32> count
+    args.extend_from_slice(&item_id.to_le_bytes());
+    send_to_witness(
+        socket, connected, entity_to_addr, entity_id,
+        |key, seq, acks| {
+            build_entity_method_packet(key, seq, acks, entity_id, method_idx::ON_REMOVE_ITEM, &args)
+        },
+    ).await;
+}
+
 /// Remove an inventory item from player inventory and sync client.
 pub async fn handle_remove_inventory_item(
     entity_id: u32,
@@ -218,6 +246,10 @@ pub async fn handle_remove_inventory_item(
         return;
     }
 
+    if removed_all {
+        send_on_remove_item(entity_id, item_id, socket, connected, entity_to_addr).await;
+    }
+
     let total_items = send_full_inventory_update(
         entity_id,
         player_id,
@@ -260,5 +292,151 @@ pub async fn handle_remove_inventory_item(
             entity_to_addr,
         )
         .await;
+    }
+}
+
+/// Atomically consume one charge of an inventory item, then notify the cell
+/// with the design id (`type_id`) so the content engine can fire `OnItemUse`.
+///
+/// `item_id` here is the inventory **instance id** from the wire (per
+/// `SGWInventoryManager.def`'s `useItem` arg). The cell never knows the
+/// design id at use-time — base resolves it from `sgw_inventory` and sends
+/// it back via `BaseToCellMsg::ItemUsed`.
+///
+/// Mission progression that listens for `OnItemUse` only fires after the
+/// consumption tx commits — if the player doesn't own that instance, or
+/// the tx fails, nothing is sent back and the chain doesn't progress.
+pub async fn handle_use_inventory_item(
+    entity_id: u32,
+    player_id: i32,
+    item_id: i32,
+    target_id: i32,
+    db_pool: &Option<Arc<PgPool>>,
+    cell_tx: &Option<mpsc::Sender<BaseToCellMsg>>,
+    socket: &Arc<UdpSocket>,
+    connected: &Arc<Mutex<HashMap<SocketAddr, ConnectedClientState>>>,
+    entity_to_addr: &Arc<Mutex<HashMap<u32, SocketAddr>>>,
+) {
+    let pool = match db_pool {
+        Some(p) => p,
+        None => {
+            tracing::debug!(player_id, item_id, "UseInventoryItem: no DB pool");
+            return;
+        }
+    };
+
+    let mut tx = match pool.begin().await {
+        Ok(t) => t,
+        Err(e) => {
+            tracing::error!(player_id, item_id, "UseInventoryItem: begin tx failed: {e}");
+            return;
+        }
+    };
+
+    let source = match sqlx::query_as::<_, InventoryInstanceRow>(
+        "SELECT type_id, stack_size, container_id, slot_id, bound, durability, charges \
+         FROM sgw_inventory WHERE character_id = $1 AND item_id = $2 LIMIT 1 FOR UPDATE",
+    )
+    .bind(player_id)
+    .bind(item_id)
+    .fetch_optional(&mut *tx)
+    .await
+    {
+        Ok(opt) => opt,
+        Err(e) => {
+            let _ = tx.rollback().await;
+            tracing::error!(player_id, item_id, "UseInventoryItem: source query failed: {e}");
+            return;
+        }
+    };
+
+    let Some(source) = source else {
+        let _ = tx.rollback().await;
+        tracing::warn!(
+            player_id, item_id,
+            "UseInventoryItem: instance not found for this character — refusing to fire ItemUsed"
+        );
+        return;
+    };
+
+    let consumed_all = source.stack_size <= 1;
+    let result = if consumed_all {
+        sqlx::query("DELETE FROM sgw_inventory WHERE character_id = $1 AND item_id = $2")
+            .bind(player_id)
+            .bind(item_id)
+            .execute(&mut *tx)
+            .await
+    } else {
+        sqlx::query(
+            "UPDATE sgw_inventory SET stack_size = stack_size - 1 \
+             WHERE character_id = $1 AND item_id = $2 AND stack_size > 1",
+        )
+        .bind(player_id)
+        .bind(item_id)
+        .execute(&mut *tx)
+        .await
+    };
+
+    match result {
+        Ok(r) if r.rows_affected() == 1 => {}
+        Ok(_) => {
+            let _ = tx.rollback().await;
+            tracing::warn!(player_id, item_id, "UseInventoryItem: no rows changed");
+            return;
+        }
+        Err(e) => {
+            let _ = tx.rollback().await;
+            tracing::error!(player_id, item_id, "UseInventoryItem: consume failed: {e}");
+            return;
+        }
+    }
+
+    if let Err(e) = tx.commit().await {
+        tracing::error!(player_id, item_id, "UseInventoryItem: commit failed: {e}");
+        return;
+    }
+
+    if consumed_all {
+        send_on_remove_item(entity_id, item_id, socket, connected, entity_to_addr).await;
+    }
+
+    let total_items = send_full_inventory_update(
+        entity_id, player_id, pool, socket, connected, entity_to_addr,
+    ).await;
+
+    tracing::info!(
+        entity_id, player_id, item_id,
+        type_id = source.type_id, target_id, total_items, consumed_all,
+        "UseInventoryItem: consumed, firing ItemUsed back to cell"
+    );
+
+    if let Some(cell_tx) = cell_tx {
+        if let Err(e) = cell_tx.send(BaseToCellMsg::ItemUsed {
+            entity_id,
+            type_id: source.type_id,
+            target_id,
+        }).await {
+            tracing::error!(
+                entity_id, player_id, item_id, error = %e,
+                "UseInventoryItem: cell channel closed sending ItemUsed — content event lost"
+            );
+        }
+
+        if consumed_all && source.container_id != 1 {
+            // Mirror the InventoryItemRemoved emission from `handle_remove_inventory_item`
+            // so any cell-side listeners (e.g., bandolier slot reconciliation) see the
+            // removal. Skipping for the main bag matches the existing remove flow.
+            let _ = cell_tx.send(BaseToCellMsg::InventoryItemRemoved {
+                entity_id,
+                item_id,
+                source_container_id: source.container_id,
+            }).await;
+        }
+    }
+
+    if source.container_id == 3 {
+        sync_bandolier_after_inventory_change(
+            entity_id, player_id, db_pool, cell_tx, socket, connected, entity_to_addr,
+        ).await;
     }
 }

--- a/crates/services/src/base/world_entry/methods/inventory/core.rs
+++ b/crates/services/src/base/world_entry/methods/inventory/core.rs
@@ -307,22 +307,19 @@ pub async fn handle_remove_inventory_item(
 /// consumption tx commits — if the player doesn't own that instance, or
 /// the tx fails, nothing is sent back and the chain doesn't progress.
 ///
-/// TODO(consume-on-use): consumption is currently unconditional. The Python
-/// reference decoupled "fire `item.use::<typeId>` event" from "remove from
-/// inventory" — script callbacks decided per item type. That meant
-/// reusable quest items (radio-style "use on target" objectives, multi-step
-/// items) could fire the event many times. Once content chains start
-/// driving multi-use items, split this into a "resolve type_id + fire
-/// event" path and a separate "consume by design id" base RPC that chain
-/// `Action::RemoveItem` can call. For Ambernol (the only currently-shipped
-/// `OnItemUse` consumer) the always-consume behavior is correct.
+/// TODO(#95 consume-on-use): consumption is currently unconditional. The
+/// Python reference decoupled "fire `item.use::<typeId>` event" from
+/// "remove from inventory" — script callbacks decided per item type.
+/// Reusable quest items (radios, multi-step "use on target" objectives)
+/// silently lose stacks under the current code. For Ambernol (the only
+/// shipped `OnItemUse` consumer) the always-consume behavior is correct,
+/// so the bug is latent until a second consumer ships.
 ///
-/// TODO(delivery durability): the `ItemUsed` send below is best-effort. If
-/// `tx.commit()` succeeds but `cell_tx` is closed (cell service restart,
+/// TODO(#96 delivery durability): the `ItemUsed` send below is best-effort.
+/// If `tx.commit()` succeeds but `cell_tx` is closed (cell service restart,
 /// channel saturation), the item is gone from the DB but `OnItemUse` never
-/// fires — mission progression that gates on it strands the player. For a
-/// single-operator deployment this is acceptable. Production-grade fix is
-/// an outbox row written in the same transaction, drained by a retrier.
+/// fires — mission progression strands the player. Production fix is an
+/// outbox row written in the same transaction, drained by a retrier.
 pub async fn handle_use_inventory_item(
     entity_id: u32,
     player_id: i32,

--- a/crates/services/src/base/world_entry/methods/inventory/core.rs
+++ b/crates/services/src/base/world_entry/methods/inventory/core.rs
@@ -306,6 +306,23 @@ pub async fn handle_remove_inventory_item(
 /// Mission progression that listens for `OnItemUse` only fires after the
 /// consumption tx commits — if the player doesn't own that instance, or
 /// the tx fails, nothing is sent back and the chain doesn't progress.
+///
+/// TODO(consume-on-use): consumption is currently unconditional. The Python
+/// reference decoupled "fire `item.use::<typeId>` event" from "remove from
+/// inventory" — script callbacks decided per item type. That meant
+/// reusable quest items (radio-style "use on target" objectives, multi-step
+/// items) could fire the event many times. Once content chains start
+/// driving multi-use items, split this into a "resolve type_id + fire
+/// event" path and a separate "consume by design id" base RPC that chain
+/// `Action::RemoveItem` can call. For Ambernol (the only currently-shipped
+/// `OnItemUse` consumer) the always-consume behavior is correct.
+///
+/// TODO(delivery durability): the `ItemUsed` send below is best-effort. If
+/// `tx.commit()` succeeds but `cell_tx` is closed (cell service restart,
+/// channel saturation), the item is gone from the DB but `OnItemUse` never
+/// fires — mission progression that gates on it strands the player. For a
+/// single-operator deployment this is acceptable. Production-grade fix is
+/// an outbox row written in the same transaction, drained by a retrier.
 pub async fn handle_use_inventory_item(
     entity_id: u32,
     player_id: i32,
@@ -422,10 +439,12 @@ pub async fn handle_use_inventory_item(
             );
         }
 
-        if consumed_all && source.container_id != 1 {
+        if consumed_all {
             // Mirror the InventoryItemRemoved emission from `handle_remove_inventory_item`
             // so any cell-side listeners (e.g., bandolier slot reconciliation) see the
-            // removal. Skipping for the main bag matches the existing remove flow.
+            // removal. Sent for all containers — the remove path emits unconditionally
+            // on full removal, and any divergence here would silently break listeners
+            // for main-bag consumes.
             let _ = cell_tx.send(BaseToCellMsg::InventoryItemRemoved {
                 entity_id,
                 item_id,

--- a/crates/services/src/base/world_entry/methods/inventory/mod.rs
+++ b/crates/services/src/base/world_entry/methods/inventory/mod.rs
@@ -4,6 +4,6 @@ pub mod grant;
 pub mod move_;
 
 pub use ammo::update_bandolier_ammo;
-pub use core::{send_full_inventory_update, handle_remove_inventory_item};
+pub use core::{send_full_inventory_update, handle_remove_inventory_item, handle_use_inventory_item};
 pub use grant::{normalize_item_ids, item_allows_container, handle_grant_item};
 pub use move_::handle_move_inventory_item;

--- a/crates/services/src/base/world_entry/methods/mod.rs
+++ b/crates/services/src/base/world_entry/methods/mod.rs
@@ -18,7 +18,7 @@ pub use player_load::{query_player_load_data, query_player_load_data_by_account,
 pub use progression::{handle_grant_xp, handle_grant_cash};
 pub use missions::{query_saved_missions, handle_mission_update};
 pub use mail::handle_mail_request;
-pub use inventory::{handle_grant_item, item_allows_container, normalize_item_ids, send_full_inventory_update, handle_remove_inventory_item, handle_move_inventory_item};
+pub use inventory::{handle_grant_item, item_allows_container, normalize_item_ids, send_full_inventory_update, handle_remove_inventory_item, handle_use_inventory_item, handle_move_inventory_item};
 pub use vendor::{
     serialize_store_open, serialize_empty_store_open, serialize_store_item_cost_array,
     serialize_store_update, free_inventory_slots, reserve_free_inventory_slots,

--- a/crates/services/src/cell/cell_methods/inventory/item_ops.rs
+++ b/crates/services/src/cell/cell_methods/inventory/item_ops.rs
@@ -100,17 +100,28 @@ pub(super) async fn handle_use_item(
     args: &[u8],
     tx: &mpsc::Sender<CellToBaseMsg>,
     space_mgr: &mut SpaceManager,
-    engine: &ChainEngine,
+    _engine: &ChainEngine,
 ) {
     if args.len() >= 8 {
+        // The wire `aItemID` is the inventory instance id (per
+        // SGWInventoryManager.def), not the item design id. Forward to base
+        // for atomic consume; base looks up the type_id and, on commit
+        // success, fires `BaseToCellMsg::ItemUsed { type_id, ... }` back so
+        // the cell can fire `OnItemUse` with the design id. This gates
+        // mission progression on actual consumption.
         let item_id = i32::from_le_bytes([args[0], args[1], args[2], args[3]]);
         let target_id = i32::from_le_bytes([args[4], args[5], args[6], args[7]]);
         tracing::info!(entity_id, item_id, target_id, "useItem");
 
         if let Some(player_id) = resolve_player_id(entity_id, "useItem", space_mgr) {
-            crate::cell::content::fire_item_use(
-                entity_id, player_id, item_id, engine, tx, space_mgr,
-            ).await;
+            if let Err(e) = tx.send(CellToBaseMsg::UseInventoryItem {
+                entity_id, player_id, item_id, target_id,
+            }).await {
+                tracing::error!(
+                    entity_id, player_id, item_id, target_id, error = %e,
+                    "UseInventoryItem send to base failed -- item not consumed"
+                );
+            }
         }
     } else {
         tracing::warn!(entity_id, args_len = args.len(), "useItem: truncated args");

--- a/crates/services/src/cell/cell_methods/player/interaction.rs
+++ b/crates/services/src/cell/cell_methods/player/interaction.rs
@@ -61,9 +61,51 @@ pub async fn dispatch(
                         );
                         return true;
                     }
+
+                    // Snapshot alive-before so we only fire the content-engine
+                    // death event on the alive→dead transition caused by this
+                    // call. Mirrors `super::combat::dispatch`'s USE_ABILITY arm.
+                    // Without this, kills via right-click auto-attack (this path)
+                    // never fire `OnEntityDeath` chains — mission progress that
+                    // depends on tagged kills (e.g., FindAmbernol drone → step
+                    // 2144 → 2343) silently stalls.
+                    let was_alive_before = space_mgr.get_entity(target_entity_u32)
+                        .map_or(false, |t| {
+                            !t.is_player
+                                && t.stats.get(cimmeria_entity::stats::HEALTH)
+                                    .map_or(false, |s| s.cur > 0)
+                        });
+
                     crate::cell::abilities::handle_use_ability(
                         entity_id, 592, target_entity_id, tx, space_mgr,
                     ).await;
+
+                    if was_alive_before {
+                        let just_died = space_mgr.get_entity(target_entity_u32)
+                            .map_or(false, |t| {
+                                t.stats.get(cimmeria_entity::stats::HEALTH)
+                                    .map_or(false, |s| s.cur <= 0)
+                            });
+                        if just_died {
+                            let tag = space_mgr.get_entity(target_entity_u32)
+                                .and_then(|t| t.tag.clone());
+                            if let Some(tag) = tag {
+                                match space_mgr.get_entity(entity_id).and_then(|e| e.player_id) {
+                                    Some(player_id) => {
+                                        crate::cell::content::fire_entity_death(
+                                            entity_id, player_id, &tag, engine, tx, space_mgr,
+                                        ).await;
+                                    }
+                                    None => {
+                                        tracing::warn!(
+                                            entity_id, npc_tag = %tag,
+                                            "Skipping entity_death event (interact path): killer entity has no player_id"
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                    }
                     return true;
                 }
 

--- a/crates/services/src/cell/content/executor.rs
+++ b/crates/services/src/cell/content/executor.rs
@@ -250,7 +250,19 @@ pub(super) async fn execute_actions(
                 }
             }
             Action::RemoveItem { item_id, count } => {
-                tracing::info!(entity_id, item_id, count, chain_id, "Content: removing item");
+                // TODO: Action::RemoveItem here gets a design id (type_id) from
+                // the chain, but `RemoveInventoryItem` expects the inventory
+                // instance id. Resolving that requires either a cell-side
+                // instance↔design cache or a new "remove by type_id" base
+                // handler. For the FindAmbernol use-item path we route
+                // consumption through `UseInventoryItem` instead, which is
+                // atomic on the base side, so this stub doesn't block that
+                // mission. Revisit when chain-driven removals (turn-ins, etc.)
+                // come up.
+                tracing::warn!(
+                    entity_id, item_id, count, chain_id,
+                    "Content: RemoveItem stub — chain-driven item removal by design id not yet wired"
+                );
             }
             Action::SetInteractionType { entity_tag, operation, mask } => {
                 if let Some(target_id) = space_mgr.find_entity_by_tag(entity_id, &entity_tag) {

--- a/crates/services/src/cell/messages.rs
+++ b/crates/services/src/cell/messages.rs
@@ -185,6 +185,17 @@ pub enum BaseToCellMsg {
         quantity: i32,
     },
 
+    /// Inventory item was consumed atomically by base (in response to
+    /// `CellToBaseMsg::UseInventoryItem`). The cell should fire the
+    /// `OnItemUse` content event with `type_id` (item design id). Only sent
+    /// after the consumption tx commits — if the player didn't own that
+    /// instance or the tx failed, this message is not emitted.
+    ItemUsed {
+        entity_id: u32,
+        type_id: i32,
+        target_id: i32,
+    },
+
     /// Reload the content engine from the database (triggered by admin API / Content Editor).
     ReloadContentEngine,
 
@@ -360,6 +371,23 @@ pub enum CellToBaseMsg {
         player_id: i32,
         item_id: i32,
         quantity: i32,
+    },
+
+    /// Consume one charge/stack of an inventory item instance, then fire the
+    /// content-engine `OnItemUse` event back to the cell with the resolved
+    /// `type_id` (item design id). Mission progression that depends on item
+    /// use is gated on the consumption committing successfully — if the row
+    /// can't be found or the tx fails, no event fires and the mission does
+    /// not advance.
+    ///
+    /// `item_id` is the inventory instance id from the wire (`useItem` arg
+    /// per `SGWInventoryManager.def` — "Player inventory id"). The type_id is
+    /// looked up server-side and returned via `BaseToCellMsg::ItemUsed`.
+    UseInventoryItem {
+        entity_id: u32,
+        player_id: i32,
+        item_id: i32,
+        target_id: i32,
     },
 
     /// Repair an owned inventory item instance by a durability ratio.

--- a/crates/services/src/cell/service/base_messages.rs
+++ b/crates/services/src/cell/service/base_messages.rs
@@ -304,5 +304,25 @@ pub(super) async fn handle_base_message(
         BaseToCellMsg::InventoryItemGranted { entity_id, item_id, container_id, slot_id, quantity } => {
             tracing::debug!(entity_id, item_id, container_id, slot_id, quantity, "Item granted to player");
         }
+
+        BaseToCellMsg::ItemUsed { entity_id, type_id, target_id } => {
+            // Base committed the consumption transaction; fire `OnItemUse` so
+            // any chain conditioned on `item_use::<type_id>` can run. Mission
+            // progression that gates on this only advances after the vial is
+            // actually consumed — if base failed to consume, this event never
+            // arrives.
+            let player_id = match space_mgr.get_entity(entity_id).and_then(|e| e.player_id) {
+                Some(pid) => pid,
+                None => {
+                    tracing::warn!(
+                        entity_id, type_id,
+                        "ItemUsed: entity has no player_id — content event dropped"
+                    );
+                    return;
+                }
+            };
+            tracing::debug!(entity_id, player_id, type_id, target_id, "ItemUsed: firing OnItemUse");
+            content::fire_item_use(entity_id, player_id, type_id, engine, tx, space_mgr).await;
+        }
     }
 }

--- a/crates/services/src/cell/service/npc_ai.rs
+++ b/crates/services/src/cell/service/npc_ai.rs
@@ -49,7 +49,7 @@ async fn npc_ai_fight(
     use super::super::combat;
 
     // Read NPC state (immutable borrow)
-    let (top_target, spawn_pos, npc_pos) = {
+    let (top_target, spawn_pos, npc_pos, is_stationary) = {
         let npc = match space_mgr.get_entity(npc_id) {
             Some(e) => e,
             None => return,
@@ -60,7 +60,7 @@ async fn npc_ai_fight(
             .max_by(|a, b| a.1.partial_cmp(b.1).unwrap_or(std::cmp::Ordering::Equal))
             .map(|(&eid, _)| eid);
 
-        (top, npc.spawn_position, npc.position)
+        (top, npc.spawn_position, npc.position, npc.is_stationary)
     };
 
     let target_id = match top_target {
@@ -126,7 +126,15 @@ async fn npc_ai_fight(
     // to regain line of sight. Treating "in range but blocked" as a stop
     // condition would freeze the NPC behind walls/corners; making it a repath
     // condition lets the AI walk around the obstruction.
+    //
+    // Stationary NPCs (turrets, fixed defenders) skip pathfinding entirely:
+    // they hold position and only fire when the target enters range + LOS.
+    // The leash check above still resets them if the target wanders past
+    // LEASH_DISTANCE.
     if !in_range || !has_los {
+        if is_stationary {
+            return;
+        }
         let needs_repath = {
             let npc = space_mgr.get_entity(npc_id);
             match npc {

--- a/crates/services/src/cell/space_manager/spawn.rs
+++ b/crates/services/src/cell/space_manager/spawn.rs
@@ -127,6 +127,7 @@ impl SpaceManager {
         e.body_set = Some(record.body_set.clone());
         e.components = record.components.clone().unwrap_or_default();
         e.spawn_position = Some(pos);
+        e.is_stationary = record.is_stationary;
         e.loot_table_id = record.loot_table_id;
 
         // Give NPCs a default combat ability and stats so they can fight back

--- a/crates/services/src/cell/space_manager/tests.rs
+++ b/crates/services/src/cell/space_manager/tests.rs
@@ -273,6 +273,7 @@ fn spawn_npc_from_record_sets_template_fields() {
         body_set: "BS_NID_Soldier.BS_NID_Soldier".to_string(),
         components: Some(vec!["Comp1".to_string()]),
         loot_table_id: Some(2),
+        is_stationary: false,
     };
 
     mgr.spawn_npc_from_record(600, &record).unwrap();

--- a/crates/services/src/cell/spawner/npcs.rs
+++ b/crates/services/src/cell/spawner/npcs.rs
@@ -37,6 +37,7 @@ pub struct SpawnRecord {
     pub static_interaction_sets: Vec<i32>,
     pub has_dynamic_properties: bool,
     pub loot_table_id: Option<i32>,
+    pub is_stationary: bool,
 }
 
 /// Map the DB `entity_templates.class` column to the wire class_id.
@@ -63,6 +64,7 @@ pub async fn load_spawns_from_db(pool: &PgPool) -> Result<Vec<SpawnRecord>, sqlx
 
     let rows = sqlx::query(
         "SELECT s.spawn_id, w.world AS world_name, s.x, s.y, s.z, s.heading, s.tag, \
+               s.is_stationary, \
                t.template_id, t.template_name, t.class, t.static_mesh, t.body_set, \
                t.components, t.flags, t.interaction_type, t.event_set_id, t.level, \
                t.alignment, t.faction, t.name_id, t.speaker_id, \
@@ -103,6 +105,7 @@ pub async fn load_spawns_from_db(pool: &PgPool) -> Result<Vec<SpawnRecord>, sqlx
             static_interaction_sets: r.get("static_interaction_sets"),
             has_dynamic_properties: r.get("has_dynamic_properties"),
             loot_table_id: r.get("loot_table_id"),
+            is_stationary: r.get("is_stationary"),
         })
         .collect();
 

--- a/crates/services/src/cell/spawner/tests.rs
+++ b/crates/services/src/cell/spawner/tests.rs
@@ -43,6 +43,7 @@ fn make_test_record(world_name: &str, tag: Option<&str>, class: &str) -> SpawnRe
         static_interaction_sets: vec![],
         has_dynamic_properties: true,
         loot_table_id: None,
+        is_stationary: false,
     }
 }
 

--- a/crates/services/src/mercury/mod.rs
+++ b/crates/services/src/mercury/mod.rs
@@ -175,6 +175,7 @@ pub mod method_idx {
     // SGWInventoryManager interface (69–75)
     pub const ON_BAG_INFO: u16 = 69;
     pub const ON_ACTIVE_SLOT_UPDATE: u16 = 70;
+    pub const ON_REMOVE_ITEM: u16 = 71;
     pub const ON_UPDATE_ITEM: u16 = 72;
     pub const ON_CASH_CHANGED: u16 = 75;
 

--- a/db/resources/Content/Seed/castle_cellblock_chains.sql
+++ b/db/resources/Content/Seed/castle_cellblock_chains.sql
@@ -269,9 +269,9 @@ VALUES
   (1032, 'destroy_entity', NULL, 'ArmYourself_AmbernolVial', '{}', 0, 1),
   (1032, 'set_aggression', NULL, 'ArmYourself_PrisonerRetrievalUnit', '{"level": 1}', 0, 2),
   (1032, 'play_sequence', 10001, NULL, '{}', 0, 3),
-  (1032, 'advance_step', 639, '2344', '{}', 0, 4);
+  (1032, 'advance_step', 639, '2144', '{}', 0, 4);
 
--- Chain 1033: entity dead tag for guard (space-scoped) while step 2344 active → advance to 2343
+-- Chain 1033: entity dead tag for guard (space-scoped) while step 2144 active → advance to 2343
 INSERT INTO content_chains (chain_id, description, scope_type, scope_id, enabled, priority)
 VALUES (1033, '639 - Guard killed: advance step to 2343', 'mission', 639, true, 0);
 
@@ -279,12 +279,16 @@ INSERT INTO content_triggers (chain_id, event_type, event_key, scope, once, sort
 VALUES (1033, 'entity_dead_tag', 'ArmYourself_PrisonerRetrievalUnit', 'space', false, 0);
 
 INSERT INTO content_conditions (chain_id, condition_type, target_id, target_key, operator, value, sort_order)
-VALUES (1033, 'step_status', 639, '2344', 'eq', 'active', 0);
+VALUES (1033, 'step_status', 639, '2144', 'eq', 'active', 0);
 
 INSERT INTO content_actions (chain_id, action_type, target_id, target_key, params, delay_ms, sort_order)
 VALUES (1033, 'advance_step', 639, '2343', '{}', 0, 0);
 
--- Chain 1034: use item 19 (ambernol) while step 2343 active → remove item, complete 639, accept 640
+-- Chain 1034: use item 19 (ambernol) while step 2343 active → complete 639, accept 640.
+--   The vial is consumed atomically by the base service before this fires
+--   (CellToBaseMsg::UseInventoryItem → BaseToCellMsg::ItemUsed → fire_item_use),
+--   so no `remove_item` action is needed — and including one would double-consume
+--   if the player happened to have a stack >1.
 INSERT INTO content_chains (chain_id, description, scope_type, scope_id, enabled, priority)
 VALUES (1034, '639 - Use ambernol: complete 639, accept 640', 'mission', 639, true, 0);
 
@@ -296,9 +300,8 @@ VALUES (1034, 'step_status', 639, '2343', 'eq', 'active', 0);
 
 INSERT INTO content_actions (chain_id, action_type, target_id, target_key, params, delay_ms, sort_order)
 VALUES
-  (1034, 'remove_item',    19, NULL, '{"qty": 1}', 0, 0),
-  (1034, 'complete_mission', 639, NULL, '{}', 0, 1),
-  (1034, 'accept_mission',   640, NULL, '{}', 0, 2);
+  (1034, 'complete_mission', 639, NULL, '{}', 0, 0),
+  (1034, 'accept_mission',   640, NULL, '{}', 0, 1);
 
 -- ============================================================
 -- MISSION 640 — Hack the Rings

--- a/db/resources/Worlds/Seed/spawnlist.sql
+++ b/db/resources/Worlds/Seed/spawnlist.sql
@@ -42,7 +42,7 @@ INSERT INTO spawnlist (spawn_id, x, y, z, heading, world_id, template_id, tag, s
 
 INSERT INTO spawnlist (spawn_id, x, y, z, heading, world_id, template_id, tag, set_name) VALUES (11, -201.25, 56.079998, -131.610001, 1.57079637, 12, 8, 'Preparation_SMG1A', NULL);
 
-INSERT INTO spawnlist (spawn_id, x, y, z, heading, world_id, template_id, tag, set_name) VALUES (10, -220.257004, 66.7440033, -121.375, 4.71238899, 12, 4, 'ArmYourself_PrisonerRetrievalUnit', NULL);
+INSERT INTO spawnlist (spawn_id, x, y, z, heading, world_id, template_id, tag, set_name, is_stationary) VALUES (10, -220.257004, 66.7440033, -121.375, 4.71238899, 12, 4, 'ArmYourself_PrisonerRetrievalUnit', NULL, true);
 
 INSERT INTO spawnlist (spawn_id, x, y, z, heading, world_id, template_id, tag, set_name) VALUES (79, -54.8799973, 26.0799999, -163.839996, 1.04607904, 12, 3, 'Cellblock_FakeRingSwitch', NULL);
 

--- a/db/resources/Worlds/Tables/spawnlist.sql
+++ b/db/resources/Worlds/Tables/spawnlist.sql
@@ -12,7 +12,8 @@ CREATE TABLE spawnlist (
     world_id integer NOT NULL,
     template_id integer NOT NULL,
     tag character varying(100),
-    set_name character varying(100)
+    set_name character varying(100),
+    is_stationary boolean DEFAULT false NOT NULL
 );
 
 --


### PR DESCRIPTION
## Summary

End-to-end fixes for the "Find Ambernol" tutorial mission. None of these bugs were catchable individually because each one masked the next; the mission stalled at every step from drone kill onward.

**Mission chain progression**
- `castle_cellblock_chains.sql`: chains 1032/1033 referenced step `2344` (which belongs to mission 680, "Find a way out of the Castle!"), breaking the 2144 → 2343 transition. Fixed to `2144`.
- Chain 1034: dropped the now-redundant `remove_item` action — base consumes atomically before the chain fires (see use-item flow below).

**Drone-kill content event wiring**
- `cell_methods/player/interaction.rs`: the right-click auto-attack path called `handle_use_ability` without firing `fire_entity_death` afterward, so chain 1033 never saw the drone die. Logs across 6 NPC kills had zero `fire_entity_death: matched` entries despite explicit `Target killed!` lines. Mirrored the alive-before / just-died / fire-event wiring from `cell_methods/player/combat.rs`.

**Use-item flow (base-authoritative)**
- The wire `useItem(aItemID)` carries the inventory **instance id**, not the item design id (per `SGWInventoryManager.def`: "Player inventory id"). Chain 1034's trigger key `'19'` was the design id, so it never matched the wire id of `10245`.
- Reworked the path: new `CellToBaseMsg::UseInventoryItem` forwards the instance id to base. Base resolves `type_id` via `SELECT … FOR UPDATE`, decrements/deletes the row in a transaction, and **only on commit success** sends `BaseToCellMsg::ItemUsed { type_id, … }` back. The cell fires `OnItemUse` with the design id. Mission progression is now gated on actual consumption — if the player doesn't own the instance or the tx fails, no event is emitted and the chain doesn't advance.
- `Action::RemoveItem` in the cell executor reduced to a stub with a TODO. The use-item path no longer needs it; chain-driven removals by design id (turn-ins, etc.) are a follow-up.

**Inventory UI refresh**
- `send_full_inventory_update` uses `onUpdateItem`, which is upsert-only — it doesn't tell the client to drop items missing from the list. After a full-stack consume, the DB row was gone and the chain progressed, but the vial stayed visible in the client UI.
- Added `send_on_remove_item` helper that emits the explicit `onRemoveItem(ItemIdList)` per `SGWInventoryManager.def`. Called from both `handle_use_inventory_item` and `handle_remove_inventory_item` when a stack hits zero. Stack-decrement paths intentionally skip it — `onUpdateItem`'s upsert is correct there.

**Drone leashing (`is_stationary`)**
- New `is_stationary boolean DEFAULT false NOT NULL` column on `resources.spawnlist`, set `true` for `spawn_id = 10` (the Find Ambernol drone). Plumbed through `SpawnRecord` → `CellEntity`. `npc_ai_fight` short-circuits pathfinding for stationary NPCs: they fire when the target enters range + LOS, hold position otherwise. Existing `LEASH_DISTANCE` reset logic still applies.
- Future turret-style NPCs just flip the flag in spawnlist; no code changes.

## Test plan

- [x] Reseed DB and rebuild the server.
- [x] Run mission 639 from a fresh character: spawn → walk into Region11 (step advances 2117 → 2145) → interact with Ambernol vial (step advances 2145 → 2144, drone aggros from spawn) → kill drone (step advances 2144 → 2343, "Take cover" sub-objective auto-completes via existing `advance_step` behavior) → use vial from inventory (vial removed from UI, mission 639 completes, mission 640 "Hack the Rings" accepted).
- [x] Verified the log sequence: `useItem ... item_id=10245` → `UseInventoryItem: consumed, firing ItemUsed back to cell ... type_id=19` → `fire_item_use: matched ... item_id=19 actions=2` → `Content: completing mission ... mission_id=639` → `Content: accepting mission ... mission_id=640`.
- [x] Drone holds position at spawn while shooting back.

## Follow-ups

- True crouch + region detection for the "Take cover behind the desk!" sub-objective (currently auto-completes on step advance via `advance_step`'s objective sweep — matches the Python reference, but if we ever want the gameplay feel of "must crouch in the marker" that needs a new content-engine `is_crouching` condition + `OnStanceChange` event).
- Chain-driven `Action::RemoveItem` by design id (currently a stub) — needs either a cell-side instance↔design cache or a new `RemoveInventoryItemByType` base handler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * NPCs can now be designated as stationary, remaining anchored to their spawn locations.

* **Bug Fixes**
  * Enhanced inventory item consumption: clients now receive explicit notifications when items are removed.
  * Improved NPC defeat tracking to properly record hostile entity deaths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->