### PR TITLE
fix(stats): preserve invariants in Stat bounds + StatList level scaling

### DIFF
--- a/crates/entity/src/stats/stat.rs
+++ b/crates/entity/src/stats/stat.rs
@@ -71,21 +71,27 @@ impl Stat {
         self.change(delta)
     }
 
-    /// Set dynamic maximum, clamping current if needed.
+    /// Set dynamic maximum. Pulls `min` down with it if it would otherwise
+    /// exceed the new max, then clamps `cur` into the resulting `[min, max]`.
+    /// Preserves the `min ≤ cur ≤ max` invariant the wire format depends on.
     pub fn set_max(&mut self, max: i32) {
         self.max = max;
-        if self.cur > self.max {
-            self.cur = self.max;
+        if self.min > self.max {
+            self.min = self.max;
         }
+        self.cur = self.cur.clamp(self.min, self.max);
         self.dirty = true;
     }
 
-    /// Set dynamic minimum, clamping current if needed.
+    /// Set dynamic minimum. Pushes `max` up with it if it would otherwise
+    /// fall below the new min, then clamps `cur` into the resulting
+    /// `[min, max]`. Preserves the `min ≤ cur ≤ max` invariant.
     pub fn set_min(&mut self, min: i32) {
         self.min = min;
-        if self.cur < self.min {
-            self.cur = self.min;
+        if self.max < self.min {
+            self.max = self.min;
         }
+        self.cur = self.cur.clamp(self.min, self.max);
         self.dirty = true;
     }
 

--- a/crates/entity/src/stats/stat_list.rs
+++ b/crates/entity/src/stats/stat_list.rs
@@ -178,12 +178,12 @@ impl StatList {
             (HEALTH_RES,   0, 30,                  2000),
             (DEPLOYMENT_BAR_AMMO, 0, 0,            1),
         ] {
-            if let Some(stat) = self.stats.get_mut(&id) {
-                stat.update(min, cur, max);
-                stat.set_base(min, cur, max);
-                stat.dirty = false;
-                stat.base_dirty = false;
-            }
+            let stat = self.stats.get_mut(&id)
+                .expect("apply_archetype: core stat missing from StatList::new()");
+            stat.update(min, cur, max);
+            stat.set_base(min, cur, max);
+            stat.dirty = false;
+            stat.base_dirty = false;
         }
     }
 
@@ -294,15 +294,17 @@ impl StatList {
     pub fn scale_for_level(&mut self, level: u32, arch: &ArchetypeStatValues) {
         let bonus_health = arch.health_per_level * (level as i32 - 1);
         let new_health_max = arch.health + bonus_health;
-        if let Some(stat) = self.stats.get_mut(&HEALTH) {
-            stat.update(0, new_health_max, new_health_max);
-        }
+        let stat = self.stats.get_mut(&HEALTH)
+            .expect("scale_for_level: HEALTH missing from StatList::new()");
+        stat.update(0, new_health_max, new_health_max);
+        stat.set_base(0, new_health_max, new_health_max);
 
         let bonus_focus = arch.focus_per_level * (level as i32 - 1);
         let new_focus_max = arch.focus + bonus_focus;
-        if let Some(stat) = self.stats.get_mut(&FOCUS) {
-            stat.update(0, new_focus_max, new_focus_max);
-        }
+        let stat = self.stats.get_mut(&FOCUS)
+            .expect("scale_for_level: FOCUS missing from StatList::new()");
+        stat.update(0, new_focus_max, new_focus_max);
+        stat.set_base(0, new_focus_max, new_focus_max);
     }
 
     /// Returns true if any stat has dirty or base_dirty set.

--- a/crates/entity/src/stats/stat_list.rs
+++ b/crates/entity/src/stats/stat_list.rs
@@ -289,9 +289,16 @@ impl StatList {
     /// Formula: `max = base + per_level * (level - 1)`
     /// Current value is restored to the new max (full heal on level-up).
     ///
+    /// Levels are 1-based; `python/cell/SGWBeing.setLevel` asserts `>= 1`.
+    /// We clamp to 1 here to keep the bonus non-negative — the DB schema
+    /// permits `level = 0` but feeding that through the formula would
+    /// compute `(level - 1) = -1` and shrink max below the archetype base.
+    ///
     /// Reference: Missing `setLevel()` in Python — this is the implementation
     /// that `python/cell/SGWPlayer.py:794` called but never defined.
     pub fn scale_for_level(&mut self, level: u32, arch: &ArchetypeStatValues) {
+        let level = level.max(1);
+
         let bonus_health = arch.health_per_level * (level as i32 - 1);
         let new_health_max = arch.health + bonus_health;
         let stat = self.stats.get_mut(&HEALTH)

--- a/crates/entity/src/stats/tests.rs
+++ b/crates/entity/src/stats/tests.rs
@@ -342,3 +342,23 @@ fn scale_for_level_1_is_base() {
     assert_eq!(list.get(HEALTH).unwrap().max, 760);
     assert_eq!(list.get(FOCUS).unwrap().max, 1570);
 }
+
+#[test]
+fn scale_for_level_0_treated_as_1() {
+    // Regression: level == 0 must not produce a negative bonus.
+    // The DB column allows 0 but the formula needs a 1-based level —
+    // without the clamp, max would be base - per_level (smaller than the
+    // archetype baseline) and propagate that incorrect value into the
+    // stat state. Copilot caught this on PR #107.
+    let mut list = StatList::new();
+    let arch = ArchetypeStatValues {
+        coordination: 5, engagement: 4, fortitude: 3, morale: 4,
+        perception: 3, intelligence: 2, health: 760, focus: 1570,
+        health_per_level: 10, focus_per_level: 70,
+    };
+    list.apply_archetype(&arch);
+    list.scale_for_level(0, &arch);
+    // Same result as level 1: no bonus, max == archetype base.
+    assert_eq!(list.get(HEALTH).unwrap().max, 760);
+    assert_eq!(list.get(FOCUS).unwrap().max, 1570);
+}

--- a/crates/entity/src/stats/tests.rs
+++ b/crates/entity/src/stats/tests.rs
@@ -60,6 +60,29 @@ fn stat_set_min_clamps_current() {
 }
 
 #[test]
+fn stat_set_max_below_min_pulls_min_down() {
+    // Regression for #102: set_max below current min must pull min down
+    // and keep `min ≤ cur ≤ max` so we never serialize min > max.
+    let mut s = Stat::new(80, 90, 100, 80, 90, 100);
+    s.set_max(50);
+    assert_eq!(s.min, 50);
+    assert_eq!(s.cur, 50);
+    assert_eq!(s.max, 50);
+    assert!(s.min <= s.cur && s.cur <= s.max);
+}
+
+#[test]
+fn stat_set_min_above_max_pushes_max_up() {
+    // Regression for #102: set_min above current max must push max up.
+    let mut s = Stat::new(0, 50, 100, 0, 50, 100);
+    s.set_min(200);
+    assert_eq!(s.min, 200);
+    assert_eq!(s.cur, 200);
+    assert_eq!(s.max, 200);
+    assert!(s.min <= s.cur && s.cur <= s.max);
+}
+
+#[test]
 fn stat_change_by_percent() {
     let mut s = Stat::new(0, 200, 1000, 0, 200, 1000);
     let delta = s.change_by_percent(0.5); // 50% of 200 = 100
@@ -289,10 +312,18 @@ fn scale_for_level_increases_health_and_focus() {
 
     // Scale to level 5: health = 760 + 10*(5-1) = 800, focus = 1570 + 70*(5-1) = 1850
     list.scale_for_level(5, &arch);
-    assert_eq!(list.get(HEALTH).unwrap().max, 800);
-    assert_eq!(list.get(HEALTH).unwrap().cur, 800);
-    assert_eq!(list.get(FOCUS).unwrap().max, 1850);
-    assert_eq!(list.get(FOCUS).unwrap().cur, 1850);
+    let health = list.get(HEALTH).unwrap();
+    assert_eq!(health.max, 800);
+    assert_eq!(health.cur, 800);
+    // Regression for #104: base values must track the new max on level-up,
+    // otherwise serialize_all_base / serialize_dirty_base report stale data.
+    assert_eq!(health.base_max, 800);
+    assert_eq!(health.base_cur, 800);
+    let focus = list.get(FOCUS).unwrap();
+    assert_eq!(focus.max, 1850);
+    assert_eq!(focus.cur, 1850);
+    assert_eq!(focus.base_max, 1850);
+    assert_eq!(focus.base_cur, 1850);
     assert!(list.has_dirty());
 }
 


### PR DESCRIPTION
## Summary

Three small CodeRabbit findings from PR #99, batched into one PR since all three live in `crates/entity/src/stats/*` and are mechanical fixes.

| Closes | Bug |
|---|---|
| #102 | `Stat::set_max` / `set_min` only clamped `cur`, not the opposite bound — `set_max(50)` on a stat with `min=80` left `min > max` and sent that over the `StatUpdateList` wire format |
| #103 | `StatList::apply_archetype` used `if let Some(stat)` for the 12 guaranteed-present core stats; replaced with `.expect()` per the coding guideline (\"trust internal guarantees; only validate at system boundaries\") |
| #104 | `StatList::scale_for_level` updated dynamic min/cur/max on level-up but never called `set_base`, so `serialize_all_base()` reported stale pre-scale values to the client |

## Tests

Added 2 regression tests for #102 (cross-bound scenarios) and extended the existing `scale_for_level_increases_health_and_focus` test to assert `base_max` / `base_cur` track the new max — covering #104.

`cargo test -p cimmeria-entity --lib stats`: **23 passed** (was 21 before).

## Test plan

- [x] cargo test -p cimmeria-entity --lib stats
- [x] cargo check -p cimmeria-entity (passed during test build)
- [ ] CI workspace check

🤖 Generated with [Claude Code](https://claude.com/claude-code)