### PR TITLE
fix(interactions): protect dialog-open and lootItem from invalid players

### DIFF
--- a/crates/services/src/cell/interactions/dispatch.rs
+++ b/crates/services/src/cell/interactions/dispatch.rs
@@ -143,11 +143,21 @@ pub async fn handle_initial_response(
             None
         });
 
-    let player_id = space_mgr.get_entity(entity_id)
-        .and_then(|e| e.player_id)
-        .unwrap_or(0);
-
     if let Some(dialog_id) = dialog_id {
+        // Resolve player_id only after we know we have a dialog to fire.
+        // Falling back to 0 here would attribute the resulting content-engine
+        // side effects (mission progress, chain triggers) to a non-existent
+        // player. Mirrors the existing protection in `send_store_open`.
+        let player_id = match space_mgr.get_entity(entity_id).and_then(|e| e.player_id) {
+            Some(id) => id,
+            None => {
+                tracing::warn!(
+                    entity_id, interaction_set_map_id, dialog_id,
+                    "handle_initial_response: missing player_id; aborting dialog open"
+                );
+                return;
+            }
+        };
         tracing::info!(
             entity_id, interaction_set_map_id, dialog_id,
             "handle_initial_response: found dialog, sending onDialogDisplay"

--- a/crates/services/src/cell/interactions/dispatch.rs
+++ b/crates/services/src/cell/interactions/dispatch.rs
@@ -294,4 +294,45 @@ mod tests {
         // No response for hostile NPCs
         assert!(rx.try_recv().is_err());
     }
+
+    /// Regression for #105 + Copilot review on PR #108: handle_initial_response
+    /// must NOT fall back to `player_id = 0` when forwarding into the content
+    /// engine. If the player_id is missing, the warn-and-return path must
+    /// fire and no onDialogDisplay packet should be queued.
+    #[tokio::test]
+    async fn initial_response_skips_when_player_id_missing() {
+        let mut mgr = crate::cell::space_manager::SpaceManager::new(1);
+        let spaces_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<Spaces><Space WorldName="Agnos" Instanced="false" MinX="-2400" MaxX="2200" MinY="-3200" MaxY="2800" /></Spaces>"#;
+        let cell_spaces_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<Spaces><Space WorldName="Agnos" /></Spaces>"#;
+        mgr.parse_spaces_xml(spaces_xml).unwrap();
+        mgr.create_startup_spaces(cell_spaces_xml).unwrap();
+
+        // Create a player but DO NOT set player_id — default is None.
+        mgr.create_entity(1, "Agnos", [0.0, 0.0, 0.0], [0.0; 3]).unwrap();
+
+        // Seed an available_interactions entry so dialog lookup succeeds —
+        // the test only fails if the function bails on missing player_id
+        // BEFORE firing the dialog. Wire format of the value tuple is
+        // (dialog_set_map_id, dialog_id, _).
+        const TEMPLATE_ID: i32 = 7;
+        const DIALOG_SET_MAP_ID: i32 = 99;
+        const DIALOG_ID: i32 = 42;
+        if let Some(p) = mgr.get_entity_mut(1) {
+            assert!(p.player_id.is_none(), "default CellEntity must have no player_id for this test");
+            p.available_interactions.insert(TEMPLATE_ID, vec![(DIALOG_SET_MAP_ID, DIALOG_ID, 0)]);
+        }
+
+        let (tx, mut rx) = mpsc::channel(16);
+        let engine = ChainEngine::new();
+        handle_initial_response(1, DIALOG_SET_MAP_ID, &engine, &tx, &mut mgr).await;
+
+        // Nothing must have been queued — the function should have warn-and-
+        // returned before send_dialog_display or fire_dialog_open ran.
+        assert!(
+            rx.try_recv().is_err(),
+            "initial_response must not send onDialogDisplay when player_id is missing"
+        );
+    }
 }

--- a/crates/services/src/cell/interactions/loot.rs
+++ b/crates/services/src/cell/interactions/loot.rs
@@ -85,6 +85,21 @@ pub async fn handle_loot_item(
         }
     };
 
+    // Validate the looter has a player_id BEFORE mutating the corpse loot
+    // list. The earlier ordering removed the item first and only then
+    // checked, so an invalid looter (no player_id) lost the drop forever
+    // — the corpse table was already mutated.
+    let player_id = match space_mgr.get_entity(entity_id).and_then(|e| e.player_id) {
+        Some(id) => id,
+        None => {
+            tracing::warn!(
+                entity_id, target_eid,
+                "lootItem: dropping loot grant — looter has no player_id (would otherwise misroute to player_id=0)"
+            );
+            return;
+        }
+    };
+
     // Find and remove the loot item from the NPC
     let removed_item = {
         let target = match space_mgr.get_entity_mut(target_eid) {
@@ -111,18 +126,6 @@ pub async fn handle_loot_item(
         quantity = removed_item.quantity,
         "Player looted item"
     );
-
-    // Grant the loot to the player via BaseApp persistence handlers
-    let player_id = match space_mgr.get_entity(entity_id).and_then(|e| e.player_id) {
-        Some(id) => id,
-        None => {
-            tracing::warn!(
-                entity_id, target_eid,
-                "lootItem: dropping loot grant — looter has no player_id (would otherwise misroute to player_id=0)"
-            );
-            return;
-        }
-    };
 
     if removed_item.design_id.is_none() {
         // Cash (naquadah) — send GrantCash to base for persistence + onCashChanged

--- a/crates/services/src/cell/interactions/loot.rs
+++ b/crates/services/src/cell/interactions/loot.rs
@@ -94,7 +94,7 @@ pub async fn handle_loot_item(
         None => {
             tracing::warn!(
                 entity_id, target_eid,
-                "lootItem: dropping loot grant — looter has no player_id (would otherwise misroute to player_id=0)"
+                "lootItem: looter has no player_id; aborting without removing the drop"
             );
             return;
         }
@@ -205,5 +205,58 @@ mod tests {
         assert_eq!(args.len(), 9);
         assert_eq!(u32::from_le_bytes([args[4], args[5], args[6], args[7]]), 0);
         assert_eq!(args[8], 1);
+    }
+
+    /// Regression for #106 + Copilot review on PR #108: validate looter
+    /// has a player_id BEFORE removing the loot from the corpse. If the
+    /// player_id check ever moves back below the mutation, the drop is
+    /// gone and no grant fires.
+    #[tokio::test]
+    async fn loot_item_with_no_player_id_preserves_corpse_loot() {
+        use super::super::super::space_manager::SpaceManager;
+        use super::*;
+        use cimmeria_entity::cell_entity::LootItem;
+        use tokio::sync::mpsc;
+
+        let mut mgr = SpaceManager::new(1);
+        let spaces_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<Spaces><Space WorldName="Agnos" Instanced="false" MinX="-2400" MaxX="2200" MinY="-3200" MaxY="2800" /></Spaces>"#;
+        let cell_spaces_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<Spaces><Space WorldName="Agnos" /></Spaces>"#;
+        mgr.parse_spaces_xml(spaces_xml).unwrap();
+        mgr.create_startup_spaces(cell_spaces_xml).unwrap();
+
+        // Looter — leave player_id as the default (None).
+        mgr.create_entity(1, "Agnos", [0.0, 0.0, 0.0], [0.0; 3]).unwrap();
+        let npc_id = mgr.allocate_npc_id();
+        mgr.spawn_npc(npc_id, "Agnos", [2.0, 0.0, 0.0], [0.0; 3]).unwrap();
+
+        // Seed loot on the corpse and mark the player as looting it.
+        if let Some(npc) = mgr.get_entity_mut(npc_id) {
+            npc.loot.push(LootItem { design_id: None, quantity: 50, index: 1 });
+        }
+        if let Some(p) = mgr.get_entity_mut(1) {
+            p.looting_entity = Some(npc_id);
+            assert!(p.player_id.is_none(), "default CellEntity must have no player_id for this test");
+        }
+
+        let (tx, mut rx) = mpsc::channel(16);
+        handle_loot_item(1, 1, &tx, &mut mgr).await;
+
+        // Corpse loot must still be present (the bug removed it before the
+        // player_id check, leaving the player with nothing AND the corpse
+        // empty).
+        let loot_after = mgr.get_entity(npc_id).map(|e| e.loot.len()).unwrap_or(0);
+        assert_eq!(loot_after, 1, "corpse loot must be intact when looter has no player_id");
+
+        // No GrantCash / GrantItem must have been queued.
+        while let Ok(msg) = rx.try_recv() {
+            match msg {
+                CellToBaseMsg::GrantCash { .. } | CellToBaseMsg::GrantItem { .. } => {
+                    panic!("no grant message should fire when looter has no player_id");
+                }
+                _ => {}
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

Two correctness bugs surfaced by CodeRabbit on PR #99. Both live in `crates/services/src/cell/interactions/*` and follow the same pattern: a missing `player_id` was silently coerced into bad state instead of cleanly aborting.

| Closes | Bug |
|---|---|
| #105 | `handle_initial_response` did `.unwrap_or(0)` on the player_id lookup, then passed that 0 into `fire_dialog_open` — attributing dialog side effects (mission progress, content chains) to a non-existent player |
| #106 | `handle_loot_item` did `target.loot.remove(i)` *before* checking `player_id`. If the looter had no player_id, the corpse table was already mutated when the function bailed — item gone, no compensation |

Both fixes mirror the existing protection in `send_store_open` (vendor.rs): warn-and-return on missing player_id, and only after we know we have something to do (#105 hoists the check inside the `if let Some(dialog_id)` block to avoid the lookup on the no-dialog path).

## Tests

`cargo test -p cimmeria-services --lib interactions`: **7 passed** (no regressions).

The acceptance criteria from #105 / #106 suggest dedicated regression tests for the warn-and-skip paths. Those need a partially-initialized `SpaceManager` fixture (entities with `player_id = None`) which the existing test infra doesn't have — leaving the test additions for a focused follow-up rather than expanding this PR's scope.

## Test plan

- [x] cargo test -p cimmeria-services --lib interactions
- [x] cargo check -p cimmeria-services (passed during test build)
- [ ] CI workspace check

🤖 Generated with [Claude Code](https://claude.com/claude-code)