### PR TITLE
fix(defs/build): propagate XML errors and capture both entity tag styles

### DIFF
--- a/crates/defs/build/def_parser.rs
+++ b/crates/defs/build/def_parser.rs
@@ -151,7 +151,11 @@ pub fn parse_def_file(path: &Path, type_name: &str) -> Result<EntityDef, String>
                 }
             }
             Ok(Event::Text(ref e)) => {
-                let text = e.unescape().unwrap_or_default().trim().to_string();
+                let text = e
+                    .unescape()
+                    .map_err(|err| format!("XML unescape error: {}", err))?
+                    .trim()
+                    .to_string();
                 if text.is_empty() {
                     continue;
                 }

--- a/crates/defs/build/entities_xml.rs
+++ b/crates/defs/build/entities_xml.rs
@@ -39,24 +39,20 @@ pub fn parse_entities_xml(path: &Path) -> Vec<String> {
         match reader.read_event() {
             Ok(Event::Start(ref e)) => {
                 depth += 1;
-                // Depth 1 = inside <root>. Self-closing tags at depth 1 are
-                // entity types, but Start + End pairs at depth 1 could also be
-                // entity types (the XML may use either style).
-                if depth == 1 {
+                // After increment, direct children of <root> sit at depth == 2.
+                // The Start branch catches the `<Account></Account>` form;
+                // the Empty branch below catches the `<Account/>` form.
+                if depth == 2 {
                     let tag = String::from_utf8_lossy(e.name().as_ref()).to_string();
-                    if tag != "root" {
-                        names.push(tag);
-                    }
+                    names.push(tag);
                 }
             }
             Ok(Event::Empty(ref e)) => {
-                // Self-closing tags inside <root>.
-                if depth == 0 || (depth == 1 && String::from_utf8_lossy(e.name().as_ref()) != "root") {
-                    // depth == 0 means we haven't seen <root> yet, which
-                    // shouldn't happen, but handle gracefully. depth == 1
-                    // means we're inside <root>.
-                    if depth >= 1 {
-                        let tag = String::from_utf8_lossy(e.name().as_ref()).to_string();
+                // Self-closing tag — depth doesn't advance, so direct
+                // children of <root> fire here at depth == 1.
+                if depth == 1 {
+                    let tag = String::from_utf8_lossy(e.name().as_ref()).to_string();
+                    if tag != "root" {
                         names.push(tag);
                     }
                 }


### PR DESCRIPTION
## Summary

Two CodeRabbit findings from PR #99, batched into one PR since both live in `crates/defs/build/*` (the entity-definition build script).

| Closes | Bug |
|---|---|
| #100 | `parse_def_file` used `e.unescape().unwrap_or_default()` — every XML decode failure became an empty string and silently propagated into the generated entity registry |
| #101 | `parse_entities_xml` depth check was `depth == 1` in the `Start` branch, but direct children of `<root>` sit at depth 2 after increment — every `<Account></Account>`-style entry was silently skipped |

For #100: switched to `?` propagation via `map_err`. `parse_def_file` already returns `Result<EntityDef, String>`, so the error reaches `main.rs` and becomes a `cargo:warning=Failed to parse <name>.def: ...`.

For #101: fixed `Start` to check `depth == 2`, simplified `Empty` to `depth == 1` for direct root children, dropped the dead `depth == 0` defensive arm. **Today's `entities/entities.xml` uses only self-closing entries**, so this is forward-protection — the current generated registry is unchanged. The bug would have silently corrupted the registry the moment anyone wrote `<Foo></Foo>` instead of `<Foo/>`.

## Tests

`cargo check -p cimmeria-defs`: clean. Build script ran successfully, `generated_entities.rs` populated as before with the same entity count.

The acceptance criteria from #101 suggest a fixture-XML test exercising both tag styles. The build script doesn't currently have unit tests (it's invoked via Cargo, not via cargo test) — that scaffolding is its own follow-up.

## Test plan

- [x] cargo check -p cimmeria-defs (build script ran)
- [ ] CI workspace check
- [ ] Generated entity count unchanged (verified manually via the entities.xml self-closing-only audit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)