### PR TITLE
fix(progression): persist XP/level on grant + cosmetic cleanups from PR #77

### DIFF
--- a/crates/services/src/base/world_entry/cell_dispatch.rs
+++ b/crates/services/src/base/world_entry/cell_dispatch.rs
@@ -125,7 +125,7 @@ pub(crate) async fn handle_cell_message(
             ).await;
         }
         CellToBaseMsg::GrantXP { entity_id, xp_amount } => {
-            handle_grant_xp(entity_id, xp_amount, socket, connected, entity_to_addr).await;
+            handle_grant_xp(entity_id, xp_amount, db_pool, socket, connected, entity_to_addr).await;
         }
         CellToBaseMsg::GrantItem { entity_id, player_id, item_id, container_id, count } => {
             handle_grant_item(

--- a/crates/services/src/base/world_entry/methods/player_load/meta.rs
+++ b/crates/services/src/base/world_entry/methods/player_load/meta.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use sqlx::PgPool;
 
 use cimmeria_entity::abilities::AbilityTreeData;
@@ -113,7 +115,7 @@ fn map_bandolier_rows(
 ///
 /// Returns tuples of (slot_id, BandolierItem) containing equipped weapon info.
 pub async fn query_bandolier_items(
-    db_pool: &Option<std::sync::Arc<PgPool>>,
+    db_pool: &Option<Arc<PgPool>>,
     player_id: i32,
 ) -> Vec<(i32, cimmeria_entity::cell_entity::BandolierItem)> {
     let pool = match db_pool {

--- a/crates/services/src/base/world_entry/methods/progression.rs
+++ b/crates/services/src/base/world_entry/methods/progression.rs
@@ -50,14 +50,20 @@ pub async fn handle_grant_xp(
         }
     };
 
+    // Read current state and compute the new values WITHOUT mutating state
+    // yet. We defer the in-memory update until after DB persistence succeeds
+    // — Copilot caught that the previous order (mutate-then-persist) leaked
+    // a failed grant onto the next successful one: the next GrantXP would
+    // saturate-add on top of the unpersisted value and then write the
+    // combined sum, effectively persisting the grant we tried to drop.
     let (player_id, total_xp, new_level, training_points, levels_gained) = {
         // Tolerate poison instead of panicking — another thread crashing the
         // mutex shouldn't stop XP grants from continuing on the recovered state.
-        let mut map = match connected.lock() {
+        let map = match connected.lock() {
             Ok(g) => g,
             Err(p) => p.into_inner(),
         };
-        let state = match map.get_mut(&addr) {
+        let state = match map.get(&addr) {
             Some(s) => s,
             None => {
                 tracing::warn!(entity_id, "GrantXP: no connected state for entity");
@@ -66,14 +72,14 @@ pub async fn handle_grant_xp(
         };
 
         let player_id = state.active_player_id;
-        let mut xp = state.player_xp.unwrap_or(0);
+        let prev_xp = state.player_xp.unwrap_or(0);
         let mut level = state.player_level.unwrap_or(1) as u32;
         let mut tp = state.player_training_points.unwrap_or(0);
 
         // Saturate to prevent a pathological grant (e.g., from a corrupted
         // GrantXP message) wrapping the accumulator and producing a negative
         // wire value or a phantom delevel.
-        xp = xp.saturating_add(xp_amount);
+        let xp = prev_xp.saturating_add(xp_amount);
 
         let mut gained = Vec::new();
         while level < MAX_LEVEL && xp > LEVEL_XP[level as usize] {
@@ -82,30 +88,25 @@ pub async fn handle_grant_xp(
             gained.push(level);
         }
 
-        state.player_xp = Some(xp);
-        state.player_level = Some(level as i32);
-        state.player_training_points = Some(tp);
-
         (player_id, xp, level, tp, gained)
     };
 
-    // Persist before wire packets — same ordering invariant `handle_grant_cash`
-    // relies on. On DB failure we drop the wire send so the client doesn't
-    // display unpersisted state. The in-memory state mutation above is
-    // tolerable as a single-process leak: it gets rebuilt from sgw_player on
-    // the next world entry.
+    // Persist first. On DB failure we return WITHOUT mutating in-memory
+    // state and WITHOUT emitting wire packets — the next GrantXP will then
+    // recompute from the truly persisted values rather than compounding the
+    // failure.
     match (db_pool, player_id) {
         (Some(pool), Some(player_id)) => {
-            // Wire format is i32 for exp; saturate so a u64 total exceeding
-            // 2^31-1 doesn't wrap negative. The DB column is bigint, so this
-            // only protects future reads/writes that round-trip via i32.
-            let exp_i64 = total_xp.min(i32::MAX as u64) as i64;
+            // `sgw_player.exp` is `integer`; saturate to i32::MAX so a u64
+            // total exceeding 2^31-1 doesn't wrap negative on either the
+            // column or the wire payload (also i32).
+            let exp_i32 = total_xp.min(i32::MAX as u64) as i32;
             match sqlx::query(
                 "UPDATE sgw_player \
                     SET exp = $1, level = $2, training_points = $3 \
                   WHERE player_id = $4",
             )
-            .bind(exp_i64)
+            .bind(exp_i32)
             .bind(new_level as i32)
             .bind(training_points as i32)
             .bind(player_id)
@@ -142,6 +143,20 @@ pub async fn handle_grant_xp(
                 entity_id, total_xp, new_level,
                 "GrantXP: no DB pool — XP/level not persisted, will be lost on reconnect"
             );
+        }
+    }
+
+    // DB write succeeded (or we're in a no-persist best-effort branch).
+    // Apply the in-memory mutation now so subsequent reads see the new state.
+    {
+        let mut map = match connected.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        if let Some(state) = map.get_mut(&addr) {
+            state.player_xp = Some(total_xp);
+            state.player_level = Some(new_level as i32);
+            state.player_training_points = Some(training_points);
         }
     }
 

--- a/crates/services/src/base/world_entry/methods/progression.rs
+++ b/crates/services/src/base/world_entry/methods/progression.rs
@@ -25,12 +25,16 @@ const _: () = assert!(
 
 const GENERICPROPERTY_TRAINING_POINTS: i32 = 1;
 
-/// Handle XP grant from CellService -- compute level-ups and send client notifications.
+/// Handle XP grant from CellService -- compute level-ups, persist, and send
+/// client notifications.
 ///
-/// Matches the Python `giveExperience()` flow: add XP, send updates, fire level-up events.
+/// Matches the Python `giveExperience()` flow: add XP, send updates, fire
+/// level-up events. Persists exp/level/training_points to `sgw_player` before
+/// emitting wire packets so a relog after a grant doesn't roll the player back.
 pub async fn handle_grant_xp(
     entity_id: u32,
     xp_amount: u64,
+    db_pool: &Option<Arc<PgPool>>,
     socket: &Arc<UdpSocket>,
     connected: &Arc<Mutex<HashMap<SocketAddr, ConnectedClientState>>>,
     entity_to_addr: &Arc<Mutex<HashMap<u32, SocketAddr>>>,
@@ -46,7 +50,7 @@ pub async fn handle_grant_xp(
         }
     };
 
-    let (total_xp, new_level, training_points, levels_gained) = {
+    let (player_id, total_xp, new_level, training_points, levels_gained) = {
         // Tolerate poison instead of panicking — another thread crashing the
         // mutex shouldn't stop XP grants from continuing on the recovered state.
         let mut map = match connected.lock() {
@@ -61,6 +65,7 @@ pub async fn handle_grant_xp(
             }
         };
 
+        let player_id = state.active_player_id;
         let mut xp = state.player_xp.unwrap_or(0);
         let mut level = state.player_level.unwrap_or(1) as u32;
         let mut tp = state.player_training_points.unwrap_or(0);
@@ -81,8 +86,64 @@ pub async fn handle_grant_xp(
         state.player_level = Some(level as i32);
         state.player_training_points = Some(tp);
 
-        (xp, level, tp, gained)
+        (player_id, xp, level, tp, gained)
     };
+
+    // Persist before wire packets — same ordering invariant `handle_grant_cash`
+    // relies on. On DB failure we drop the wire send so the client doesn't
+    // display unpersisted state. The in-memory state mutation above is
+    // tolerable as a single-process leak: it gets rebuilt from sgw_player on
+    // the next world entry.
+    match (db_pool, player_id) {
+        (Some(pool), Some(player_id)) => {
+            // Wire format is i32 for exp; saturate so a u64 total exceeding
+            // 2^31-1 doesn't wrap negative. The DB column is bigint, so this
+            // only protects future reads/writes that round-trip via i32.
+            let exp_i64 = total_xp.min(i32::MAX as u64) as i64;
+            match sqlx::query(
+                "UPDATE sgw_player \
+                    SET exp = $1, level = $2, training_points = $3 \
+                  WHERE player_id = $4",
+            )
+            .bind(exp_i64)
+            .bind(new_level as i32)
+            .bind(training_points as i32)
+            .bind(player_id)
+            .execute(pool.as_ref())
+            .await
+            {
+                Ok(r) if r.rows_affected() == 0 => {
+                    tracing::warn!(
+                        entity_id, player_id, total_xp, new_level,
+                        "GrantXP: 0 rows updated (player_id missing from sgw_player); dropping wire emit"
+                    );
+                    return;
+                }
+                Ok(_) => {}
+                Err(e) => {
+                    tracing::error!(entity_id, player_id, "GrantXP: persistence UPDATE failed: {e}");
+                    return;
+                }
+            }
+        }
+        (Some(_), None) => {
+            // No active character (play-character flow incomplete). Skip
+            // persistence; the in-memory grant will be lost on reconnect, but
+            // we shouldn't be granting XP before character selection anyway.
+            tracing::warn!(
+                entity_id, total_xp, new_level,
+                "GrantXP: no active_player_id — skipping persist (likely a pre-character-select grant)"
+            );
+        }
+        (None, _) => {
+            // Mirrors the no-DB branch in handle_grant_cash: the in-memory
+            // state is updated but un-authoritative. Log loudly.
+            tracing::warn!(
+                entity_id, total_xp, new_level,
+                "GrantXP: no DB pool — XP/level not persisted, will be lost on reconnect"
+            );
+        }
+    }
 
     tracing::info!(
         entity_id,

--- a/crates/services/src/cell/abilities/death.rs
+++ b/crates/services/src/cell/abilities/death.rs
@@ -25,10 +25,7 @@ use super::super::messages::CellToBaseMsg;
 use super::super::space_manager::SpaceManager;
 use super::loot_drop::generate_loot_on_death;
 use super::messaging::send_entity_method;
-
-/// `BSF_InCombat` bit position. Cleared on the attacker on every kill while
-/// multi-mob threat tracking (#92) is unimplemented.
-const BSF_IN_COMBAT: u32 = 1 << 3;
+use crate::cell::combat::BSF_IN_COMBAT;
 
 /// Apply the death-transition message sequence for a target that just died.
 ///

--- a/crates/services/src/cell/cell_methods/player/dispatch.rs
+++ b/crates/services/src/cell/cell_methods/player/dispatch.rs
@@ -30,9 +30,13 @@ pub async fn dispatch(
             super::world::dispatch(entity_id, method_index, args, tx, space_mgr, engine).await
         }
         super::constants::ORG_CREATION..=super::constants::CANCEL_MOVIE => {
-            if method_index >= super::constants::ORG_CREATION && method_index <= super::constants::SPEND_APPLIED_SCIENCE_POINTS {
-                super::social::dispatch(entity_id, method_index, args, tx, space_mgr).await
-            } else if method_index >= super::constants::CRAFT && method_index <= super::constants::RESPEC_CRAFTING {
+            // The outer arm already pins method_index into [ORG_CREATION,
+            // CANCEL_MOVIE]. Only the [CRAFT, RESPEC_CRAFTING] sub-range
+            // routes to crafting; everything else in the outer range is
+            // social. Implicit constant ordering:
+            //   ORG_CREATION ≤ SPEND_APPLIED_SCIENCE_POINTS < CRAFT
+            //   ≤ RESPEC_CRAFTING ≤ CANCEL_MOVIE
+            if (super::constants::CRAFT..=super::constants::RESPEC_CRAFTING).contains(&method_index) {
                 super::crafting::dispatch(entity_id, method_index, args, tx, space_mgr).await
             } else {
                 super::social::dispatch(entity_id, method_index, args, tx, space_mgr).await

--- a/crates/services/src/cell/cell_methods/player/world.rs
+++ b/crates/services/src/cell/cell_methods/player/world.rs
@@ -191,8 +191,7 @@ async fn handle_reload(
     }).await;
 
     {
-        const BSF_IN_COMBAT: u32 = 1 << 3;
-        const BSF_HOLSTER: u32 = 1 << 8;
+        use crate::cell::combat::{BSF_HOLSTER, BSF_IN_COMBAT};
         if let Some(e) = space_mgr.get_entity_mut(entity_id) {
             let old = e.state_field;
             e.state_field |= BSF_IN_COMBAT;

--- a/crates/services/src/cell/combat/mod.rs
+++ b/crates/services/src/cell/combat/mod.rs
@@ -11,6 +11,7 @@ pub mod threat;
 
 pub use damage::{calculate_damage, calculate_qr, calculate_result, QrResult};
 pub use state::{
-    clear_dead_state, is_dead_state, set_dead_state, BSF_DEAD, PLAYER_STATE_DEAD,
+    clear_dead_state, is_dead_state, set_dead_state, BSF_DEAD, BSF_HOLSTER, BSF_IN_COMBAT,
+    PLAYER_STATE_DEAD,
 };
 pub use threat::{generate_threat, LEASH_DISTANCE, NPC_ATTACK_RANGE, NPC_DEFAULT_ABILITY};

--- a/crates/services/src/cell/combat/state.rs
+++ b/crates/services/src/cell/combat/state.rs
@@ -11,6 +11,20 @@ pub const PLAYER_STATE_DEAD: u32 = 1;
 /// that left dead NPCs visible as "attackable" on the client.
 pub const BSF_DEAD: u32 = 0;
 
+/// `BSF_InCombat` mask. The client uses this bit to route right-click on
+/// selected entities to `useAbility` (auto-attack) instead of `interact`.
+/// From python `Atrea.enums.BSF_InCombat = 3`.
+///
+/// Per-player threat-set management (#92) is the long-term setter; today the
+/// flag is set on weapon-fire/reload and cleared on the kill that drops the
+/// last (single-target) aggro source.
+pub const BSF_IN_COMBAT: u32 = 1 << 3;
+
+/// `BSF_Holster` mask. Set while the weapon is holstered. Cleared when the
+/// player enters combat-ready (e.g., on reload or first attack).
+/// From python `Atrea.enums.BSF_Holster = 8`.
+pub const BSF_HOLSTER: u32 = 1 << 8;
+
 /// Check if a state field indicates the entity is dead.
 pub fn is_dead_state(state_field: u32) -> bool {
     state_field & (1 << BSF_DEAD) != 0


### PR DESCRIPTION
## Summary

The substantive part of Wave 2: closes the pre-existing XP-loss bug from PR #77 review (#80) and bundles in three of the six cosmetic cleanups from #78 that were truly mechanical.

## Closed

| Closes | What |
|---|---|
| **#80** | `handle_grant_xp` now persists `exp` / `level` / `training_points` to `sgw_player` before emitting wire packets. Plumbed `db_pool` through the message path the same way `handle_grant_cash` already does. On DB failure we drop the wire emit (avoids the delta-as-total client desync the cash path already protects against). |
| #78 [6] | meta.rs — added `use std::sync::Arc;` so `query_bandolier_items` uses unqualified `Arc` like the rest of the file |
| #78 [25] | dispatch.rs — collapsed the redundant inner range checks in the `ORG_CREATION..=CANCEL_MOVIE` arm to a single `(CRAFT..=RESPEC_CRAFTING).contains(&method_index)` |
| #78 [30] | world.rs / death.rs — hoisted the duplicate inline `BSF_IN_COMBAT` and `BSF_HOLSTER` constants into `combat/state.rs` (alongside the existing `BSF_DEAD`); removed the drift hazard |

## Deferred from #78 — out of scope here

Filing focused issues for these:

| Item | Why deferred |
|---|---|
| #78 [5] | `archetype_resource_name` hardcoded mapping — issue says "derive from DB or centralize"; that's a real design decision, not a cosmetic |
| #78 [29] | `handle_reload` magic indices — 3 of 4 already exist in `mercury::method_idx` (ON_STATE_FIELD_UPDATE, ON_ENTITY_PROPERTY, ON_SEQUENCE) but method_index 12 needs verification against `entities/defs/SGWPlayer.def` before naming it |
| #78 [39] | `REFACTORING_CANDIDATES.md` — file no longer exists in the repo |

## #80 implementation note

The issue body assumed `handle_grant_xp` already took `player_id` (cited the cash-grant fix), but on current main the signature only had `entity_id`. Read it from `state.active_player_id` inside the connected-state lock — that's the field the `playCharacter` flow populates. If `active_player_id` is `None` (pre-character-select grant — should never happen but cheap to handle), we warn and skip persistence rather than wedging.

## Tests

`cargo test -p cimmeria-services --lib`: **227 passed** (no regressions). No new test was added for #80 — the integration test the issue suggests requires a sqlx::test fixture which #79 / #84 are designing.

## Test plan

- [x] cargo check -p cimmeria-services
- [x] cargo test -p cimmeria-services --lib (227/227)
- [ ] Manual UAT: kill an NPC, disconnect, reconnect, verify XP persisted (per #80 acceptance)
- [ ] CI workspace check

🤖 Generated with [Claude Code](https://claude.com/claude-code)