### PR TITLE
test(interaction): seed real loot in dead_hostile test + assert non-zero count

### DIFF
--- a/crates/services/src/cell/cell_methods/player/interaction.rs
+++ b/crates/services/src/cell/cell_methods/player/interaction.rs
@@ -295,10 +295,24 @@ mod tests {
         while let Ok(msg) = rx.try_recv() {
             if let CellToBaseMsg::EntityMethodCall { entity_id, method_index, args } = msg {
                 if entity_id == 1 && method_index == 114 {
+                    // We seeded exactly one LootItem; assert the encoded count
+                    // matches that, not just `> 0`. A future bug that
+                    // duplicated entries or announced the wrong length would
+                    // otherwise still pass this regression guard.
                     let count = u32::from_le_bytes(args[4..8].try_into().unwrap());
-                    assert!(
-                        count > 0,
-                        "onLootDisplay must announce a non-empty loot list when npc.loot has entries"
+                    assert_eq!(
+                        count, 1,
+                        "onLootDisplay must announce exactly the seeded loot count (1)"
+                    );
+                    // The trailing byte is the `initial` flag from
+                    // send_loot_display: 1 for the first display (opens the
+                    // loot window) and 0 for refresh-only packets. The
+                    // first-open path is the one a right-click on a corpse
+                    // takes, so this must be 1.
+                    let initial = *args.last().expect("onLootDisplay payload missing trailing initial byte");
+                    assert_eq!(
+                        initial, 1,
+                        "first-display onLootDisplay must set initial=1 to open the loot window client-side"
                     );
                     saw_loot_display = true;
                 }

--- a/crates/services/src/cell/cell_methods/player/interaction.rs
+++ b/crates/services/src/cell/cell_methods/player/interaction.rs
@@ -261,13 +261,24 @@ mod tests {
             npc.faction = 10; // hostile
             crate::cell::combat::set_dead_state(&mut npc.state_field);
             npc.interaction_type = Some(NpcInteractionType::Loot);
+            // Seed real loot. Without this, the test only proves dispatch
+            // routes to method 114 — the corpse could be empty and the test
+            // would still pass. With a real LootItem in place, asserting
+            // count > 0 below catches a future "empty list short-circuit"
+            // regression in handle_interact (e.g., if it grows a guard like
+            // `interaction_type = Some(Loot) AND target.loot non-empty`).
+            npc.loot.push(cimmeria_entity::cell_entity::LootItem {
+                design_id: None, // None = naquadah (cash)
+                quantity: 50,
+                index: 1,
+            });
         }
 
         let (tx, mut rx) = mpsc::channel(16);
         let engine = cimmeria_content_engine::chain::ChainEngine::new();
-        let mut args = Vec::with_capacity(4);
-        args.extend_from_slice(&(npc_id as i32).to_le_bytes());
-        let handled = dispatch(1, INTERACT, &args, &tx, &mut mgr, &engine).await;
+        let mut dispatch_args = Vec::with_capacity(4);
+        dispatch_args.extend_from_slice(&(npc_id as i32).to_le_bytes());
+        let handled = dispatch(1, INTERACT, &dispatch_args, &tx, &mut mgr, &engine).await;
         assert!(handled);
 
         // Player should now be marked as looting this corpse.
@@ -277,11 +288,18 @@ mod tests {
             "interact handler must set looting_entity on the player"
         );
 
-        // onLootDisplay (method 114) must have been queued for the player.
+        // onLootDisplay (method 114) must have been queued for the player AND
+        // the encoded loot count must be non-zero. Wire layout from
+        // send_loot_display: `entity_id:i32, count:u32, items[..], initial:u8`.
         let mut saw_loot_display = false;
         while let Ok(msg) = rx.try_recv() {
-            if let CellToBaseMsg::EntityMethodCall { entity_id, method_index, .. } = msg {
+            if let CellToBaseMsg::EntityMethodCall { entity_id, method_index, args } = msg {
                 if entity_id == 1 && method_index == 114 {
+                    let count = u32::from_le_bytes(args[4..8].try_into().unwrap());
+                    assert!(
+                        count > 0,
+                        "onLootDisplay must announce a non-empty loot list when npc.loot has entries"
+                    );
                     saw_loot_display = true;
                 }
                 // useAbility / target reticle must NOT have been sent.


### PR DESCRIPTION
## Summary

Closes #93. One-line scope expansion of an existing test that left a regression hole.

The current `dead_hostile_with_loot_routes_to_interact` test sets the NPC's `interaction_type = Some(Loot)` but leaves `npc.loot` empty. Method 114 (onLootDisplay) gets dispatched either way under today's code — so the test only proves dispatch routing, not that the corpse is actually lootable.

If `handle_interact` ever grows a defensive guard like "only fire onLootDisplay if `interaction_type = Some(Loot)` **AND** `target.loot` is non-empty" — which would be a sensible check — the current test still passes against the broken branch. This makes it load-bearing.

## Change

- Push one cash `LootItem` (`design_id: None`, `quantity: 50`, `index: 1`) onto `npc.loot` before the dispatch call
- Capture `args` in the `EntityMethodCall` destructure (was `..`), decode bytes `4..8` as the `u32` loot-count per the wire layout in `send_loot_display`, assert `count > 0`
- Renamed the local `args` to `dispatch_args` to avoid shadowing

Wire layout from [`send_loot_display`](crates/services/src/cell/interactions/loot.rs):
```
bytes 0..4   — entity ID (i32 LE)
bytes 4..8   — array count (u32 LE)  ← assert this > 0
bytes 8..N   — repeated 14-byte LootItemQuantity records
byte  N      — initial:u8
```

## Tests

`cargo test -p cimmeria-services --lib dead_hostile`: **1 passed**.

## Test plan

- [x] cargo test -p cimmeria-services --lib dead_hostile
- [ ] CI workspace check

🤖 Generated with [Claude Code](https://claude.com/claude-code)