### PR TITLE
feat(combat): per-player threatened_mobs set drives BSF_InCombat

### DIFF
--- a/crates/entity/src/cell_entity/mod.rs
+++ b/crates/entity/src/cell_entity/mod.rs
@@ -167,6 +167,12 @@ pub struct CellEntity {
     /// Bit 6: BSF_MovementLock, Bit 7: BSF_Walking, Bit 8: BSF_Holster.
     pub state_field: u32,
 
+    /// NPC entity IDs that currently have this player on their threat list.
+    /// Player entities only — `BSF_InCombat` (bit 3 of `state_field`) is set
+    /// while this is non-empty and cleared when it drains. Mirrors the
+    /// `threatenedMobs` list on `python/cell/SGWPlayer.py:944-965`.
+    pub threatened_mobs: HashSet<u32>,
+
     // ── Ammo state ────────────────────────────────────────────────────────────
     //
     // Per-slot ammo lives on `BandolierItem` (`current_ammo`, `cur_ammo_type`)
@@ -329,6 +335,7 @@ impl CellEntity {
             body_set: None,
             components: Vec::new(),
             state_field: 0,
+            threatened_mobs: HashSet::new(),
             reload_complete_at: None,
             reload_slot_id: None,
             ai_state: AiState::Idle,

--- a/crates/services/src/cell/abilities/death.rs
+++ b/crates/services/src/cell/abilities/death.rs
@@ -25,7 +25,6 @@ use super::super::messages::CellToBaseMsg;
 use super::super::space_manager::SpaceManager;
 use super::loot_drop::generate_loot_on_death;
 use super::messaging::send_entity_method;
-use crate::cell::combat::BSF_IN_COMBAT;
 
 /// Apply the death-transition message sequence for a target that just died.
 ///
@@ -41,31 +40,32 @@ pub(super) async fn apply_death_transition(
     tx: &mpsc::Sender<CellToBaseMsg>,
     space_mgr: &mut SpaceManager,
 ) {
-    // 1+2. Attacker side: clear targeting reticle + drop out of combat.
+    // 1. Attacker side: clear targeting reticle.
     if attacker_is_player {
         send_entity_method(
             attacker_id, crate::mercury::method_idx::ON_TARGET_UPDATE,
             0i32.to_le_bytes().to_vec(),
             tx, space_mgr,
         ).await;
+    }
 
-        // Aggressive BSF_InCombat clear on every kill — safe for single-target
-        // fights, wrong under multi-mob aggro. Issue #92 tracks the proper
-        // per-player threatenedMobs set that drives this bit.
-        let attacker_state = if let Some(p) = space_mgr.get_entity_mut(attacker_id) {
-            let old = p.state_field;
-            p.state_field &= !BSF_IN_COMBAT;
-            if p.state_field != old { Some(p.state_field) } else { None }
-        } else {
-            None
-        };
-        if let Some(new_state) = attacker_state {
+    // 2. Drop the dying NPC from EVERY player's threatened_mobs set —
+    //    not just the killer's. Multiple players can have the same mob on
+    //    their threat lists; clearing only the killer's BSF_InCombat would
+    //    leave others stuck in combat-ready cursor mode after the only mob
+    //    they were threatened by died. Mirrors python `SGWPlayer.on
+    //    RemovedFromThreatList` fanout from `SGWMob.onDead`.
+    if !target_is_player {
+        let to_broadcast = crate::cell::combat::clear_dead_npc_from_all_player_threat(
+            space_mgr, target_eid,
+        );
+        for (player_id, new_state) in to_broadcast {
             tracing::debug!(
-                attacker = attacker_id, target = target_eid, new_state,
-                "death: clearing attacker BSF_InCombat (exit combat after kill)"
+                player_id, dying_npc = target_eid, new_state,
+                "death: clearing player BSF_InCombat (last threatened mob died)"
             );
             send_entity_method(
-                attacker_id, crate::mercury::method_idx::ON_STATE_FIELD_UPDATE,
+                player_id, crate::mercury::method_idx::ON_STATE_FIELD_UPDATE,
                 new_state.to_le_bytes().to_vec(),
                 tx, space_mgr,
             ).await;

--- a/crates/services/src/cell/abilities/use_ability.rs
+++ b/crates/services/src/cell/abilities/use_ability.rs
@@ -519,8 +519,19 @@ pub async fn handle_use_ability(
         }
     }
 
-    // Generate threat on surviving NPCs so they aggro back
+    // Generate threat on surviving NPCs so they aggro back. If this hit
+    // is what put the player into combat (their threatened_mobs went
+    // from empty → {target}), broadcast the new state_field so the
+    // client flips its in-combat HUD/cursor routing.
     if !target_died {
-        combat::generate_threat(space_mgr, entity_id, target_eid, _total_health_damage as f32);
+        if let Some(new_state) = combat::generate_threat(
+            space_mgr, entity_id, target_eid, _total_health_damage as f32,
+        ) {
+            super::messaging::send_entity_method(
+                entity_id, crate::mercury::method_idx::ON_STATE_FIELD_UPDATE,
+                new_state.to_le_bytes().to_vec(),
+                tx, space_mgr,
+            ).await;
+        }
     }
 }

--- a/crates/services/src/cell/combat/mod.rs
+++ b/crates/services/src/cell/combat/mod.rs
@@ -14,4 +14,7 @@ pub use state::{
     clear_dead_state, is_dead_state, set_dead_state, BSF_DEAD, BSF_HOLSTER, BSF_IN_COMBAT,
     PLAYER_STATE_DEAD,
 };
-pub use threat::{generate_threat, LEASH_DISTANCE, NPC_ATTACK_RANGE, NPC_DEFAULT_ABILITY};
+pub use threat::{
+    clear_dead_npc_from_all_player_threat, enter_player_combat, exit_player_combat,
+    generate_threat, LEASH_DISTANCE, NPC_ATTACK_RANGE, NPC_DEFAULT_ABILITY,
+};

--- a/crates/services/src/cell/combat/threat.rs
+++ b/crates/services/src/cell/combat/threat.rs
@@ -25,9 +25,10 @@ pub const NPC_DEFAULT_ABILITY: i32 = 592;
 ///
 /// Returns `Some(new_state_field)` when the attacker just entered combat
 /// (i.e., their `threatened_mobs` was empty before this call) — the
-/// caller is responsible for broadcasting `onStateFieldUpdate` to AoI
-/// witnesses so the in-combat HUD/cursor flips. Returns `None` when no
-/// broadcast is needed.
+/// caller is responsible for sending `onStateFieldUpdate` to the player
+/// (via `send_entity_method`, which routes player methods to the player's
+/// own client) so their in-combat HUD/cursor flips. Returns `None` when
+/// no send is needed.
 #[must_use]
 pub fn generate_threat(
     space_mgr: &mut crate::cell::space_manager::SpaceManager,
@@ -131,8 +132,9 @@ pub fn exit_player_combat(
 /// Called when an NPC dies. Iterates the dying NPC's `threat_list` and
 /// removes the NPC from each aggroed player's `threatened_mobs` set.
 /// Returns `(player_id, new_state_field)` pairs for which `BSF_IN_COMBAT`
-/// just cleared so the caller can broadcast `onStateFieldUpdate` to each
-/// affected player's witnesses.
+/// just cleared so the caller can send `onStateFieldUpdate` to each
+/// affected player (via `send_entity_method`, which for player entities
+/// routes to that player's own client — not their AoI witnesses).
 ///
 /// Does NOT clear the NPC's own `threat_list` — caller decides whether to
 /// keep it for damage attribution (XP, loot tagging) or wipe it.

--- a/crates/services/src/cell/combat/threat.rs
+++ b/crates/services/src/cell/combat/threat.rs
@@ -18,30 +18,141 @@ pub const NPC_DEFAULT_ABILITY: i32 = 592;
 
 /// Generate threat on an NPC target from an attacker.
 ///
-/// Transitions the NPC from Idle to Fighting on first hit, and accumulates
-/// threat so the NPC knows who to attack back. The attacker can be any
-/// entity (player or NPC) — only the target's `is_player` flag gates the
-/// state transition.
+/// Transitions the NPC from Idle to Fighting on first hit, accumulates
+/// threat so the NPC knows who to attack back, and (if the attacker is a
+/// player) mirrors the addition into the player's `threatened_mobs` set
+/// so multi-mob aggro tracking stays consistent.
+///
+/// Returns `Some(new_state_field)` when the attacker just entered combat
+/// (i.e., their `threatened_mobs` was empty before this call) — the
+/// caller is responsible for broadcasting `onStateFieldUpdate` to AoI
+/// witnesses so the in-combat HUD/cursor flips. Returns `None` when no
+/// broadcast is needed.
+#[must_use]
 pub fn generate_threat(
     space_mgr: &mut crate::cell::space_manager::SpaceManager,
     attacker_id: u32,
     target_id: u32,
     threat_amount: f32,
-) {
+) -> Option<u32> {
     use cimmeria_entity::cell_entity::AiState;
 
-    if let Some(target) = space_mgr.get_entity_mut(target_id) {
-        if !target.is_player {
-            if target.ai_state == AiState::Idle {
-                target.ai_state = AiState::Fighting;
-                tracing::info!(
-                    npc_id = target_id, attacker = attacker_id,
-                    "NPC aggro: Idle -> Fighting"
-                );
-            }
-            *target.threat_list.entry(attacker_id).or_insert(0.0) += threat_amount;
+    let target_is_npc = if let Some(target) = space_mgr.get_entity_mut(target_id) {
+        if target.is_player {
+            return None;
+        }
+        if target.ai_state == AiState::Idle {
+            target.ai_state = AiState::Fighting;
+            tracing::info!(
+                npc_id = target_id, attacker = attacker_id,
+                "NPC aggro: Idle -> Fighting"
+            );
+        }
+        *target.threat_list.entry(attacker_id).or_insert(0.0) += threat_amount;
+        true
+    } else {
+        false
+    };
+
+    if target_is_npc {
+        enter_player_combat(space_mgr, attacker_id, target_id)
+    } else {
+        None
+    }
+}
+
+/// Mirror an NPC→player threat-list addition onto the player's
+/// `threatened_mobs` set. Idempotent — re-adding an already-tracked mob
+/// is a no-op. Returns `Some(new_state_field)` only when this addition
+/// is the first one and `BSF_IN_COMBAT` flips on; the caller broadcasts.
+///
+/// Reference: `python/cell/SGWPlayer.py:onAddedToThreatList` (944-953).
+pub fn enter_player_combat(
+    space_mgr: &mut crate::cell::space_manager::SpaceManager,
+    player_id: u32,
+    mob_id: u32,
+) -> Option<u32> {
+    let player = space_mgr.get_entity_mut(player_id)?;
+    if !player.is_player {
+        return None;
+    }
+    let was_empty = player.threatened_mobs.is_empty();
+    if !player.threatened_mobs.insert(mob_id) {
+        // Already in the set — no transition.
+        return None;
+    }
+    if was_empty {
+        let old = player.state_field;
+        player.state_field |= super::state::BSF_IN_COMBAT;
+        if player.state_field != old {
+            tracing::debug!(
+                player_id, mob_id, new_state = player.state_field,
+                "enter_player_combat: BSF_InCombat set (first threatened mob)"
+            );
+            return Some(player.state_field);
         }
     }
+    None
+}
+
+/// Inverse of [`enter_player_combat`]: drop a mob from the player's
+/// `threatened_mobs` set. If the set becomes empty and `BSF_IN_COMBAT`
+/// was set, clear it and return the new `state_field` for the caller
+/// to broadcast.
+///
+/// Reference: `python/cell/SGWPlayer.py:onRemovedFromThreatList` (957-965).
+pub fn exit_player_combat(
+    space_mgr: &mut crate::cell::space_manager::SpaceManager,
+    player_id: u32,
+    mob_id: u32,
+) -> Option<u32> {
+    let player = space_mgr.get_entity_mut(player_id)?;
+    if !player.is_player {
+        return None;
+    }
+    if !player.threatened_mobs.remove(&mob_id) {
+        // Wasn't in the set — nothing to do (idempotent).
+        return None;
+    }
+    if player.threatened_mobs.is_empty() {
+        let old = player.state_field;
+        player.state_field &= !super::state::BSF_IN_COMBAT;
+        if player.state_field != old {
+            tracing::debug!(
+                player_id, mob_id, new_state = player.state_field,
+                "exit_player_combat: BSF_InCombat cleared (last threatened mob removed)"
+            );
+            return Some(player.state_field);
+        }
+    }
+    None
+}
+
+/// Called when an NPC dies. Iterates the dying NPC's `threat_list` and
+/// removes the NPC from each aggroed player's `threatened_mobs` set.
+/// Returns `(player_id, new_state_field)` pairs for which `BSF_IN_COMBAT`
+/// just cleared so the caller can broadcast `onStateFieldUpdate` to each
+/// affected player's witnesses.
+///
+/// Does NOT clear the NPC's own `threat_list` — caller decides whether to
+/// keep it for damage attribution (XP, loot tagging) or wipe it.
+pub fn clear_dead_npc_from_all_player_threat(
+    space_mgr: &mut crate::cell::space_manager::SpaceManager,
+    npc_id: u32,
+) -> Vec<(u32, u32)> {
+    // Snapshot the threat list — exit_player_combat takes &mut so we can't
+    // hold a borrow on the NPC while iterating its keys.
+    let aggroed_players: Vec<u32> = space_mgr
+        .get_entity(npc_id)
+        .map(|n| n.threat_list.keys().copied().collect())
+        .unwrap_or_default();
+
+    aggroed_players
+        .into_iter()
+        .filter_map(|player_id| {
+            exit_player_combat(space_mgr, player_id, npc_id).map(|state| (player_id, state))
+        })
+        .collect()
 }
 
 #[cfg(test)]
@@ -59,15 +170,20 @@ mod tests {
         assert_eq!(LEASH_DISTANCE, 50.0);
     }
 
-    fn make_test_space_mgr_with_npc() -> crate::cell::space_manager::SpaceManager {
-        let mut mgr = crate::cell::space_manager::SpaceManager::new(1);
+    use crate::cell::combat::state::BSF_IN_COMBAT;
+    use crate::cell::space_manager::SpaceManager;
+
+    fn make_test_space_mgr_with_npc() -> SpaceManager {
+        let mut mgr = SpaceManager::new(1);
         let xml = r#"<?xml version="1.0"?><Spaces><Space WorldName="Agnos" Instanced="false" MinX="0" MaxX="100" MinY="0" MaxY="100" /></Spaces>"#;
         let cxml = r#"<?xml version="1.0"?><Spaces><Space WorldName="Agnos" /></Spaces>"#;
         mgr.parse_spaces_xml(xml).unwrap();
         mgr.create_startup_spaces(cxml).unwrap();
 
-        // Create a player entity
+        // Create a player entity (mark is_player so the new threat helpers
+        // recognize it; create_entity defaults to is_player=false).
         mgr.create_entity(1, "Agnos", [10.0, 0.0, 10.0], [0.0; 3]).unwrap();
+        mgr.get_entity_mut(1).unwrap().is_player = true;
 
         // Create an NPC entity
         mgr.spawn_npc(100, "Agnos", [15.0, 0.0, 15.0], [0.0; 3]).unwrap();
@@ -75,17 +191,26 @@ mod tests {
         mgr
     }
 
+    fn add_player(mgr: &mut SpaceManager, id: u32, x: f32) {
+        mgr.create_entity(id, "Agnos", [x, 0.0, 10.0], [0.0; 3]).unwrap();
+        mgr.get_entity_mut(id).unwrap().is_player = true;
+    }
+
+    fn add_npc(mgr: &mut SpaceManager, id: u32, x: f32) {
+        mgr.spawn_npc(id, "Agnos", [x, 0.0, 15.0], [0.0; 3]).unwrap();
+    }
+
+    // ── generate_threat: NPC-side state preserved from pre-#92 behavior ────
+
     #[test]
     fn generate_threat_transitions_idle_to_fighting() {
         use cimmeria_entity::cell_entity::AiState;
         let mut mgr = make_test_space_mgr_with_npc();
 
-        // NPC should start Idle
         assert_eq!(mgr.get_entity(100).unwrap().ai_state, AiState::Idle);
 
-        generate_threat(&mut mgr, 1, 100, 50.0);
+        let _ = generate_threat(&mut mgr, 1, 100, 50.0);
 
-        // NPC should now be Fighting
         let npc = mgr.get_entity(100).unwrap();
         assert_eq!(npc.ai_state, AiState::Fighting);
         assert_eq!(npc.threat_list[&1], 50.0);
@@ -95,8 +220,8 @@ mod tests {
     fn generate_threat_accumulates() {
         let mut mgr = make_test_space_mgr_with_npc();
 
-        generate_threat(&mut mgr, 1, 100, 50.0);
-        generate_threat(&mut mgr, 1, 100, 30.0);
+        let _ = generate_threat(&mut mgr, 1, 100, 50.0);
+        let _ = generate_threat(&mut mgr, 1, 100, 30.0);
 
         assert_eq!(mgr.get_entity(100).unwrap().threat_list[&1], 80.0);
     }
@@ -104,18 +229,16 @@ mod tests {
     #[test]
     fn generate_threat_multiple_attackers() {
         let mut mgr = make_test_space_mgr_with_npc();
-        // Add a second player
-        mgr.create_entity(2, "Agnos", [20.0, 0.0, 10.0], [0.0; 3]).unwrap();
+        add_player(&mut mgr, 2, 20.0);
 
-        generate_threat(&mut mgr, 1, 100, 50.0);
-        generate_threat(&mut mgr, 2, 100, 100.0);
+        let _ = generate_threat(&mut mgr, 1, 100, 50.0);
+        let _ = generate_threat(&mut mgr, 2, 100, 100.0);
 
         let npc = mgr.get_entity(100).unwrap();
         assert_eq!(npc.threat_list.len(), 2);
         assert_eq!(npc.threat_list[&1], 50.0);
         assert_eq!(npc.threat_list[&2], 100.0);
 
-        // Top threat should be entity 2
         let top = npc.threat_list.iter()
             .max_by(|a, b| a.1.partial_cmp(b.1).unwrap())
             .map(|(&id, _)| id);
@@ -126,11 +249,11 @@ mod tests {
     fn generate_threat_ignores_player_targets() {
         use cimmeria_entity::cell_entity::AiState;
         let mut mgr = make_test_space_mgr_with_npc();
-        // Mark entity 1 as a player
-        mgr.get_entity_mut(1).unwrap().is_player = true;
 
-        // Try to generate threat on a player entity — should be ignored
-        generate_threat(&mut mgr, 100, 1, 50.0);
+        // NPC entity 100 attacking player entity 1 — should be a no-op on
+        // the player side and return None (no combat-enter broadcast).
+        let result = generate_threat(&mut mgr, 100, 1, 50.0);
+        assert_eq!(result, None);
 
         let player = mgr.get_entity(1).unwrap();
         assert_eq!(player.ai_state, AiState::Idle);
@@ -142,11 +265,267 @@ mod tests {
         use cimmeria_entity::cell_entity::AiState;
         let mut mgr = make_test_space_mgr_with_npc();
 
-        generate_threat(&mut mgr, 1, 100, 50.0);
+        let _ = generate_threat(&mut mgr, 1, 100, 50.0);
         assert_eq!(mgr.get_entity(100).unwrap().ai_state, AiState::Fighting);
 
-        // Second hit should stay Fighting (not re-trigger transition)
-        generate_threat(&mut mgr, 1, 100, 25.0);
+        let _ = generate_threat(&mut mgr, 1, 100, 25.0);
         assert_eq!(mgr.get_entity(100).unwrap().ai_state, AiState::Fighting);
+    }
+
+    // ── enter_player_combat primitives ─────────────────────────────────────
+
+    #[test]
+    fn enter_player_combat_first_mob_sets_bsf_and_returns_state() {
+        let mut mgr = make_test_space_mgr_with_npc();
+
+        let result = enter_player_combat(&mut mgr, 1, 100);
+
+        let player = mgr.get_entity(1).unwrap();
+        assert!(player.threatened_mobs.contains(&100));
+        assert_eq!(player.threatened_mobs.len(), 1);
+        assert_ne!(player.state_field & BSF_IN_COMBAT, 0, "BSF_InCombat must be set");
+        assert_eq!(result, Some(player.state_field));
+    }
+
+    #[test]
+    fn enter_player_combat_subsequent_mob_no_broadcast() {
+        let mut mgr = make_test_space_mgr_with_npc();
+        add_npc(&mut mgr, 101, 25.0);
+
+        let _ = enter_player_combat(&mut mgr, 1, 100);
+        // Second mob enters set; BSF was already set, so no broadcast needed.
+        let result = enter_player_combat(&mut mgr, 1, 101);
+        assert_eq!(result, None);
+
+        let player = mgr.get_entity(1).unwrap();
+        assert_eq!(player.threatened_mobs.len(), 2);
+        assert_ne!(player.state_field & BSF_IN_COMBAT, 0);
+    }
+
+    #[test]
+    fn enter_player_combat_idempotent_for_already_present_mob() {
+        let mut mgr = make_test_space_mgr_with_npc();
+
+        let _ = enter_player_combat(&mut mgr, 1, 100);
+        let result = enter_player_combat(&mut mgr, 1, 100);
+
+        assert_eq!(result, None, "re-adding same mob must not re-broadcast");
+        assert_eq!(mgr.get_entity(1).unwrap().threatened_mobs.len(), 1);
+    }
+
+    #[test]
+    fn enter_player_combat_ignores_non_player_entity() {
+        let mut mgr = make_test_space_mgr_with_npc();
+        // Try to "enter combat" on the NPC (entity 100, is_player=false).
+        let result = enter_player_combat(&mut mgr, 100, 1);
+        assert_eq!(result, None);
+        assert!(mgr.get_entity(100).unwrap().threatened_mobs.is_empty());
+        assert_eq!(mgr.get_entity(100).unwrap().state_field & BSF_IN_COMBAT, 0);
+    }
+
+    // ── exit_player_combat primitives ──────────────────────────────────────
+
+    #[test]
+    fn exit_player_combat_only_mob_clears_bsf_and_returns_state() {
+        let mut mgr = make_test_space_mgr_with_npc();
+        let _ = enter_player_combat(&mut mgr, 1, 100);
+
+        let result = exit_player_combat(&mut mgr, 1, 100);
+
+        let player = mgr.get_entity(1).unwrap();
+        assert!(player.threatened_mobs.is_empty());
+        assert_eq!(player.state_field & BSF_IN_COMBAT, 0, "BSF_InCombat must be cleared");
+        assert_eq!(result, Some(player.state_field));
+    }
+
+    #[test]
+    fn exit_player_combat_one_of_many_no_broadcast() {
+        let mut mgr = make_test_space_mgr_with_npc();
+        add_npc(&mut mgr, 101, 25.0);
+        let _ = enter_player_combat(&mut mgr, 1, 100);
+        let _ = enter_player_combat(&mut mgr, 1, 101);
+
+        // Drop only one — set is still non-empty, no broadcast.
+        let result = exit_player_combat(&mut mgr, 1, 100);
+        assert_eq!(result, None);
+
+        let player = mgr.get_entity(1).unwrap();
+        assert_eq!(player.threatened_mobs.len(), 1);
+        assert!(player.threatened_mobs.contains(&101));
+        assert_ne!(player.state_field & BSF_IN_COMBAT, 0, "BSF must remain set");
+    }
+
+    #[test]
+    fn exit_player_combat_not_in_set_is_idempotent() {
+        let mut mgr = make_test_space_mgr_with_npc();
+        // Player isn't in combat at all.
+        let result = exit_player_combat(&mut mgr, 1, 100);
+        assert_eq!(result, None);
+        assert!(mgr.get_entity(1).unwrap().threatened_mobs.is_empty());
+    }
+
+    #[test]
+    fn exit_player_combat_ignores_non_player_entity() {
+        let mut mgr = make_test_space_mgr_with_npc();
+        let result = exit_player_combat(&mut mgr, 100, 1);
+        assert_eq!(result, None);
+    }
+
+    // ── generate_threat: returns combat-enter state on first add ──────────
+
+    #[test]
+    fn generate_threat_returns_state_on_player_first_aggro() {
+        let mut mgr = make_test_space_mgr_with_npc();
+
+        let result = generate_threat(&mut mgr, 1, 100, 50.0);
+        assert!(result.is_some(), "first aggro must return new state for broadcast");
+
+        let player = mgr.get_entity(1).unwrap();
+        assert!(player.threatened_mobs.contains(&100));
+        assert_ne!(player.state_field & BSF_IN_COMBAT, 0);
+    }
+
+    #[test]
+    fn generate_threat_returns_none_on_subsequent_hits() {
+        let mut mgr = make_test_space_mgr_with_npc();
+
+        let _ = generate_threat(&mut mgr, 1, 100, 50.0);
+        // Second hit on same mob — already in set, no transition.
+        let result = generate_threat(&mut mgr, 1, 100, 30.0);
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn generate_threat_returns_none_when_attacker_is_npc() {
+        let mut mgr = make_test_space_mgr_with_npc();
+        add_npc(&mut mgr, 101, 25.0);
+
+        // NPC 101 attacking NPC 100 (e.g., pet) — NPC 100 enters Fighting,
+        // but no player is involved so no combat-enter broadcast.
+        let result = generate_threat(&mut mgr, 101, 100, 50.0);
+        assert_eq!(result, None);
+
+        // NPC 100's threat_list still got the NPC attacker so AI works.
+        assert!(mgr.get_entity(100).unwrap().threat_list.contains_key(&101));
+    }
+
+    // ── clear_dead_npc_from_all_player_threat ──────────────────────────────
+
+    #[test]
+    fn dead_npc_clears_only_player_with_single_threat_source() {
+        // 1 player aggroed by 1 mob; mob dies → BSF clears for the player.
+        let mut mgr = make_test_space_mgr_with_npc();
+        let _ = generate_threat(&mut mgr, 1, 100, 50.0);
+        assert_ne!(mgr.get_entity(1).unwrap().state_field & BSF_IN_COMBAT, 0);
+
+        let to_broadcast = clear_dead_npc_from_all_player_threat(&mut mgr, 100);
+        assert_eq!(to_broadcast.len(), 1);
+        assert_eq!(to_broadcast[0].0, 1, "player_id must be in the broadcast list");
+
+        let player = mgr.get_entity(1).unwrap();
+        assert!(player.threatened_mobs.is_empty());
+        assert_eq!(player.state_field & BSF_IN_COMBAT, 0);
+    }
+
+    #[test]
+    fn dead_npc_does_not_clear_player_with_remaining_threat_sources() {
+        // 1 player aggroed by 2 mobs; only 1 dies → BSF stays set.
+        let mut mgr = make_test_space_mgr_with_npc();
+        add_npc(&mut mgr, 101, 25.0);
+        let _ = generate_threat(&mut mgr, 1, 100, 50.0);
+        let _ = generate_threat(&mut mgr, 1, 101, 50.0);
+        assert_eq!(mgr.get_entity(1).unwrap().threatened_mobs.len(), 2);
+
+        // NPC 100 dies — player still has 101 on the list.
+        let to_broadcast = clear_dead_npc_from_all_player_threat(&mut mgr, 100);
+        assert!(to_broadcast.is_empty(), "no broadcast: player still in combat");
+
+        let player = mgr.get_entity(1).unwrap();
+        assert_eq!(player.threatened_mobs.len(), 1);
+        assert!(player.threatened_mobs.contains(&101));
+        assert_ne!(player.state_field & BSF_IN_COMBAT, 0, "BSF must remain set");
+
+        // Now kill the second mob — BSF clears.
+        let to_broadcast = clear_dead_npc_from_all_player_threat(&mut mgr, 101);
+        assert_eq!(to_broadcast.len(), 1);
+        assert_eq!(mgr.get_entity(1).unwrap().state_field & BSF_IN_COMBAT, 0);
+    }
+
+    #[test]
+    fn dead_npc_clears_all_aggroed_players() {
+        // 2 players each aggroed by the same 1 mob; mob dies → BSF clears
+        // for both players. Mirrors the multi-attacker scenario the killer-
+        // only fix would have left half-broken (non-killer stays in combat).
+        let mut mgr = make_test_space_mgr_with_npc();
+        add_player(&mut mgr, 2, 20.0);
+        let _ = generate_threat(&mut mgr, 1, 100, 50.0);
+        let _ = generate_threat(&mut mgr, 2, 100, 50.0);
+
+        let to_broadcast = clear_dead_npc_from_all_player_threat(&mut mgr, 100);
+        assert_eq!(to_broadcast.len(), 2);
+        let updated_players: Vec<u32> = to_broadcast.iter().map(|(p, _)| *p).collect();
+        assert!(updated_players.contains(&1));
+        assert!(updated_players.contains(&2));
+
+        assert_eq!(mgr.get_entity(1).unwrap().state_field & BSF_IN_COMBAT, 0);
+        assert_eq!(mgr.get_entity(2).unwrap().state_field & BSF_IN_COMBAT, 0);
+    }
+
+    #[test]
+    fn dead_npc_with_only_npc_threat_entries_emits_no_broadcasts() {
+        // NPC 100's threat list contains only NPC 101 (e.g., pet vs mob).
+        // When 100 dies, no player needs a broadcast.
+        let mut mgr = make_test_space_mgr_with_npc();
+        add_npc(&mut mgr, 101, 25.0);
+        let _ = generate_threat(&mut mgr, 101, 100, 50.0);
+
+        let to_broadcast = clear_dead_npc_from_all_player_threat(&mut mgr, 100);
+        assert!(to_broadcast.is_empty());
+    }
+
+    // ── End-to-end lifecycle ───────────────────────────────────────────────
+
+    #[test]
+    fn lifecycle_one_mob_aggro_kill_clears_combat() {
+        let mut mgr = make_test_space_mgr_with_npc();
+
+        // Aggro
+        let entered = generate_threat(&mut mgr, 1, 100, 50.0);
+        assert!(entered.is_some(), "first aggro should signal combat enter");
+        assert_ne!(mgr.get_entity(1).unwrap().state_field & BSF_IN_COMBAT, 0);
+
+        // Kill
+        let to_broadcast = clear_dead_npc_from_all_player_threat(&mut mgr, 100);
+        assert_eq!(to_broadcast.len(), 1);
+        assert_eq!(mgr.get_entity(1).unwrap().state_field & BSF_IN_COMBAT, 0);
+        assert!(mgr.get_entity(1).unwrap().threatened_mobs.is_empty());
+    }
+
+    #[test]
+    fn lifecycle_two_mobs_kill_one_then_other() {
+        let mut mgr = make_test_space_mgr_with_npc();
+        add_npc(&mut mgr, 101, 25.0);
+
+        // First aggro: combat enters.
+        let entered = generate_threat(&mut mgr, 1, 100, 50.0);
+        assert!(entered.is_some());
+
+        // Second aggro on different mob: no transition, no broadcast.
+        let second = generate_threat(&mut mgr, 1, 101, 30.0);
+        assert_eq!(second, None);
+        assert_eq!(mgr.get_entity(1).unwrap().threatened_mobs.len(), 2);
+
+        // Kill mob 100: still in combat (mob 101 is alive).
+        let after_first_kill = clear_dead_npc_from_all_player_threat(&mut mgr, 100);
+        assert!(after_first_kill.is_empty());
+        let player = mgr.get_entity(1).unwrap();
+        assert_eq!(player.threatened_mobs.len(), 1);
+        assert_ne!(player.state_field & BSF_IN_COMBAT, 0);
+
+        // Kill mob 101: combat clears now.
+        let after_second_kill = clear_dead_npc_from_all_player_threat(&mut mgr, 101);
+        assert_eq!(after_second_kill.len(), 1);
+        assert_eq!(mgr.get_entity(1).unwrap().state_field & BSF_IN_COMBAT, 0);
+        assert!(mgr.get_entity(1).unwrap().threatened_mobs.is_empty());
     }
 }

--- a/crates/services/src/cell/content/executor.rs
+++ b/crates/services/src/cell/content/executor.rs
@@ -433,12 +433,20 @@ pub(super) async fn execute_actions(
                             entity_id, %tag, target_id, threat_level, chain_id,
                             "Content: generate threat on NPC from player"
                         );
-                        crate::cell::combat::generate_threat(
+                        if let Some(new_state) = crate::cell::combat::generate_threat(
                             space_mgr,
                             entity_id,  // attacker = the player
                             target_id,  // target = the NPC
                             threat_level as f32,
-                        );
+                        ) {
+                            // Player just entered combat — broadcast state
+                            // change so the client flips in-combat HUD.
+                            crate::cell::abilities::send_entity_method(
+                                entity_id, crate::mercury::method_idx::ON_STATE_FIELD_UPDATE,
+                                new_state.to_le_bytes().to_vec(),
+                                tx, space_mgr,
+                            ).await;
+                        }
                     }
                 } else {
                     tracing::debug!(entity_id, threat_level, chain_id, "Content: generate threat (no target tag, skipped)");


### PR DESCRIPTION
## Summary

Closes **#92**. The killer-only `BSF_InCombat` clear in `death.rs` was a single-target shortcut that broke under multi-mob aggro. Now mirrors Python's `SGWPlayer.threatenedMobs` model: each player tracks the NPC IDs that have them on a threat list, and `BSF_InCombat` is set/cleared as that set transitions through empty.

## What changed

**Entity model** — added `threatened_mobs: HashSet<u32>` to `CellEntity` (player entities only).

**Helpers in `cell::combat::threat`:**

| Fn | Returns | Behavior |
|---|---|---|
| `enter_player_combat(player, mob)` | `Option<u32>` (new state_field on combat-enter) | Adds mob; if set was empty, sets `BSF_InCombat` |
| `exit_player_combat(player, mob)` | `Option<u32>` (new state_field on combat-exit) | Removes mob; if set is now empty, clears `BSF_InCombat` |
| `clear_dead_npc_from_all_player_threat(npc)` | `Vec<(player_id, state_field)>` | Iterates dying NPC's `threat_list`, exits combat for every aggroed player. Returns the broadcast set. |
| `generate_threat` (modified) | `Option<u32>` (`#[must_use]`) | Now returns the attacker's new state_field when they just entered combat |

**Call sites:**
- `death.rs::apply_death_transition` — replaced killer-only clear with `clear_dead_npc_from_all_player_threat` (broadcasts to every aggroed player, not just the killer — see *Why broader scope* below)
- `use_ability.rs` — handles `generate_threat` return value, broadcasts on combat-enter
- `content::executor::Action::GenerateThreat` — same

## Why broader scope on death

A killer-only fix would have *regressed* non-killer players: with the half-implementation, a player who had aggroed the same mob but didn't land the killing blow would hold a stale entry in their `threatened_mobs` and stay stuck in `BSF_InCombat` even though the only mob threatening them died. The broader clear matches Python's fanout from `SGWMob.onDead`.

## Tests

`cell::combat::threat::tests`: 14 new + 5 existing = 19 tests covering:

- `enter_player_combat`: first mob, subsequent mob, idempotent re-add, non-player no-op
- `exit_player_combat`: only mob, one of many, not in set, non-player
- `generate_threat` return value: first hit, subsequent hits, NPC-attacker no-op
- `clear_dead_npc_*`: single-source player, multi-source player (not cleared until last mob dies), multi-player same mob (all cleared), NPC-only threat list (no broadcasts)
- **Lifecycle**: 1-mob aggro → kill clears combat
- **Lifecycle**: 2-mob aggro, kill one then other — combat stays then clears (the headline scenario this issue tracked)

`cargo test -p cimmeria-services --lib`: **246 passed** (was 227, +19).
`cargo test -p cimmeria-entity --lib`: **145 passed** (no regressions from the new field).

## Out of scope — deferred

The issue's acceptance criteria mention four lifecycle paths for `exit_player_combat`. This PR wires the **death** trigger only. The remaining triggers are mechanical follow-ups but each needs its own broadcast plumbing:

- NPC leashing back to spawn (Fighting → Leash transition in `npc_ai.rs`)
- Player leaves the NPC's AoI (witness drop in `space_manager/aoi.rs`)
- NPC despawn / cell unload

Also deferred: `onThreatenedMobsUpdate(entityId, 0|1)` per-mob client packet — drives the in-combat HUD indicator. `BSF_InCombat` alone covers the cursor-routing bug this issue's title points at; the per-mob update is parity nice-to-have, not a correctness fix.

## Test plan

- [x] cargo test -p cimmeria-services --lib (246/246)
- [x] cargo test -p cimmeria-entity --lib (145/145)
- [ ] CI workspace check
- [ ] Manual UAT: aggro 2 mobs → kill 1 → verify cursor still combat-ready → kill 2 → verify cursor flips back

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed combat indicator not syncing reliably when engaging multiple enemies
  * Improved threat tracking to ensure combat status updates propagate to the client immediately when entering or leaving combat
  * Fixed threat being retained on players after an enemy dies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->