### PR TITLE
feat(inventory): decouple useItem event from consumption (consume-on-use)

### DIFF
--- a/.github/instructions/content-chains.instructions.md
+++ b/.github/instructions/content-chains.instructions.md
@@ -33,7 +33,13 @@ For mission progression, also add a `player_loaded`-triggered chain that re-appl
 
 ## Inventory consumption
 
-`UseInventoryItem` on the base side consumes the item *before* `fire_item_use` reaches the cell. Don't add `remove_item` actions to chains triggered on `item_use` — they'll double-consume any stack >1. The current `Action::RemoveItem` executor is a stub, so today the bug is latent, but new chains should not rely on the stub.
+`UseInventoryItem` fires `OnItemUse` as a pure event — the base no longer auto-consumes the stack. Chains that need to consume (consumable vials, mission objects) must include an explicit `remove_item` action. This is the correct pattern for `item_use`-triggered chains:
+
+```sql
+(chain_id, 'remove_item', <design_id>, NULL, '{"qty": 1}', 0, 0),
+```
+
+`Action::RemoveItem` routes through `CellToBaseMsg::RemoveInventoryItemByType`, which resolves the player's first matching stack (ordered by `container_id, slot_id` to prefer the main bag over the bandolier) and applies the full wire-update sequence. Non-consumable items (radios, multi-step "use on target" objectives) simply omit the `remove_item` action.
 
 ## Auto-generated `space_*_chains.sql` (chain IDs 5xxx)
 

--- a/crates/services/src/base/world_entry/cell_dispatch.rs
+++ b/crates/services/src/base/world_entry/cell_dispatch.rs
@@ -27,8 +27,9 @@ use super::methods::{
     handle_mail_request, handle_mission_update, handle_move_inventory_item,
     handle_open_vendor_store, handle_purchase_vendor_items,
     handle_recharge_inventory_items, handle_remove_inventory_item,
-    handle_repair_inventory_item, handle_repair_inventory_items, handle_sell_vendor_items,
-    handle_use_inventory_item, send_full_inventory_update,
+    handle_remove_inventory_item_by_type, handle_repair_inventory_item,
+    handle_repair_inventory_items, handle_sell_vendor_items, handle_use_inventory_item,
+    send_full_inventory_update,
 };
 use super::space_registry::register_space;
 
@@ -344,6 +345,12 @@ pub(crate) async fn handle_cell_message(
         CellToBaseMsg::UseInventoryItem { entity_id, player_id, item_id, target_id } => {
             handle_use_inventory_item(
                 entity_id, player_id, item_id, target_id,
+                &db_pool, cell_tx,
+            ).await;
+        }
+        CellToBaseMsg::RemoveInventoryItemByType { entity_id, player_id, type_id, count } => {
+            handle_remove_inventory_item_by_type(
+                entity_id, player_id, type_id, count,
                 &db_pool, cell_tx, socket, connected, entity_to_addr,
             ).await;
         }

--- a/crates/services/src/base/world_entry/methods/inventory/core.rs
+++ b/crates/services/src/base/world_entry/methods/inventory/core.rs
@@ -53,6 +53,17 @@ struct InventoryInstanceRow {
     charges: i32,
 }
 
+/// Lighter row for [`handle_remove_inventory_item_by_type`], which needs
+/// `item_id` (for the targeted `onRemoveItem` packet) but not the
+/// `bound` / `durability` / `charges` metadata.
+#[derive(sqlx::FromRow)]
+struct InventoryInstanceWithIdRow {
+    item_id: i32,
+    stack_size: i32,
+    container_id: i32,
+    slot_id: i32,
+}
+
 /// Send full inventory update to player, refreshing all items on the client.
 pub async fn send_full_inventory_update(
     entity_id: u32,
@@ -424,9 +435,23 @@ pub async fn handle_remove_inventory_item_by_type(
     // because we're about to mutate; LIMIT 1 because we only consume from
     // a single stack — multi-stack draining isn't the chain semantic
     // (mission removes are always 1 from a specific stack).
-    let source = match sqlx::query_as::<_, InventoryInstanceRow>(
-        "SELECT type_id, stack_size, container_id, slot_id, bound, durability, charges \
-         FROM sgw_inventory WHERE character_id = $1 AND type_id = $2 LIMIT 1 FOR UPDATE",
+    //
+    // ORDER BY (container_id, slot_id) is load-bearing — without it, sqlx
+    // returns whichever row PG felt like; for a player with stacks of the
+    // same design in both the main bag (container 1) and the bandolier
+    // (container 3), an unordered LIMIT 1 might consume the equipped
+    // stack instead of the main-bag one. The ascending order biases
+    // toward main bag (container 1) which is the desired default for
+    // chain-driven consumes (vials, mission objects) — bandolier stacks
+    // are touched by explicit equip/unequip flows, not by chains.
+    //
+    // The SELECT also pulls `item_id` so we don't need a second roundtrip
+    // to look it up before sending the targeted onRemoveItem packet on
+    // full removal.
+    let source = match sqlx::query_as::<_, InventoryInstanceWithIdRow>(
+        "SELECT item_id, stack_size, container_id, slot_id \
+         FROM sgw_inventory WHERE character_id = $1 AND type_id = $2 \
+         ORDER BY container_id, slot_id LIMIT 1 FOR UPDATE",
     )
     .bind(player_id)
     .bind(type_id)
@@ -450,29 +475,20 @@ pub async fn handle_remove_inventory_item_by_type(
         return;
     };
 
-    // Need item_id to fire the targeted onRemoveItem packet on full removal.
-    let removed_item_id: i32 = match sqlx::query_scalar::<_, i32>(
-        "SELECT item_id FROM sgw_inventory \
-         WHERE character_id = $1 AND container_id = $2 AND slot_id = $3 LIMIT 1",
-    )
-    .bind(player_id)
-    .bind(source.container_id)
-    .bind(source.slot_id)
-    .fetch_optional(&mut *tx)
-    .await
-    {
-        Ok(Some(id)) => id,
-        Ok(None) => {
-            let _ = tx.rollback().await;
-            tracing::warn!(player_id, type_id, "RemoveInventoryItemByType: source row vanished mid-tx");
-            return;
-        }
-        Err(e) => {
-            let _ = tx.rollback().await;
-            tracing::error!(player_id, type_id, "RemoveInventoryItemByType: item_id lookup failed: {e}");
-            return;
-        }
-    };
+    let removed_item_id = source.item_id;
+
+    if count > source.stack_size {
+        // Visible warning — caller asked for more than this stack holds.
+        // We still proceed (treating it as "remove the whole stack"),
+        // matching the existing handle_remove_inventory_item semantic
+        // for `quantity >= stack_size`. If a future caller actually
+        // needs multi-stack draining, that's a new RPC variant, not a
+        // silent extension of this one.
+        tracing::warn!(
+            player_id, type_id, requested = count, available = source.stack_size,
+            "RemoveInventoryItemByType: requested count exceeds stack size; removing whole stack"
+        );
+    }
 
     let removed_all = count >= source.stack_size;
     let result = if removed_all {

--- a/crates/services/src/base/world_entry/methods/inventory/core.rs
+++ b/crates/services/src/base/world_entry/methods/inventory/core.rs
@@ -295,31 +295,28 @@ pub async fn handle_remove_inventory_item(
     }
 }
 
-/// Atomically consume one charge of an inventory item, then notify the cell
-/// with the design id (`type_id`) so the content engine can fire `OnItemUse`.
+/// Resolve an inventory instance's design id and fire the cell-side
+/// content-engine `OnItemUse` event. **Does not consume the item.**
 ///
 /// `item_id` here is the inventory **instance id** from the wire (per
 /// `SGWInventoryManager.def`'s `useItem` arg). The cell never knows the
 /// design id at use-time — base resolves it from `sgw_inventory` and sends
-/// it back via `BaseToCellMsg::ItemUsed`.
+/// it back via `BaseToCellMsg::ItemUsed`. Per-item consumption (if any) is
+/// the chain's responsibility via `Action::RemoveItem`, which routes through
+/// [`handle_remove_inventory_item_by_type`] — mirrors python's
+/// `Inventory.useItem` (`python/cell/Inventory.py:419-432`) which fires
+/// `item.use::<typeId>` as a pure event and lets per-mission handlers decide
+/// whether to remove the stack (e.g., `FindAmbernol.py:115` calls
+/// `removeItemByDesign(19, 1, False)` while radios just don't remove).
 ///
-/// Mission progression that listens for `OnItemUse` only fires after the
-/// consumption tx commits — if the player doesn't own that instance, or
-/// the tx fails, nothing is sent back and the chain doesn't progress.
+/// Refusing to fire when the instance isn't owned by this character keeps
+/// content events tied to actual inventory state — a malicious client
+/// can't spam `useItem(any id)` to trigger arbitrary chain actions.
 ///
-/// TODO(#95 consume-on-use): consumption is currently unconditional. The
-/// Python reference decoupled "fire `item.use::<typeId>` event" from
-/// "remove from inventory" — script callbacks decided per item type.
-/// Reusable quest items (radios, multi-step "use on target" objectives)
-/// silently lose stacks under the current code. For Ambernol (the only
-/// shipped `OnItemUse` consumer) the always-consume behavior is correct,
-/// so the bug is latent until a second consumer ships.
-///
-/// TODO(#96 delivery durability): the `ItemUsed` send below is best-effort.
-/// If `tx.commit()` succeeds but `cell_tx` is closed (cell service restart,
-/// channel saturation), the item is gone from the DB but `OnItemUse` never
-/// fires — mission progression strands the player. Production fix is an
-/// outbox row written in the same transaction, drained by a retrier.
+/// TODO(#96 delivery durability): the `ItemUsed` send is best-effort. If
+/// `cell_tx` is closed (cell service restart, channel saturation) the
+/// chain never fires — mission progression strands the player. Production
+/// fix is the outbox pattern in #96.
 pub async fn handle_use_inventory_item(
     entity_id: u32,
     player_id: i32,
@@ -327,9 +324,6 @@ pub async fn handle_use_inventory_item(
     target_id: i32,
     db_pool: &Option<Arc<PgPool>>,
     cell_tx: &Option<mpsc::Sender<BaseToCellMsg>>,
-    socket: &Arc<UdpSocket>,
-    connected: &Arc<Mutex<HashMap<SocketAddr, ConnectedClientState>>>,
-    entity_to_addr: &Arc<Mutex<HashMap<u32, SocketAddr>>>,
 ) {
     let pool = match db_pool {
         Some(p) => p,
@@ -339,27 +333,110 @@ pub async fn handle_use_inventory_item(
         }
     };
 
-    let mut tx = match pool.begin().await {
-        Ok(t) => t,
+    // Read-only ownership lookup. No FOR UPDATE — we don't mutate. The
+    // simple SELECT also avoids the per-call transaction overhead the
+    // pre-#95 consume-on-use code paid.
+    let type_id: i32 = match sqlx::query_scalar::<_, i32>(
+        "SELECT type_id FROM sgw_inventory \
+         WHERE character_id = $1 AND item_id = $2 LIMIT 1",
+    )
+    .bind(player_id)
+    .bind(item_id)
+    .fetch_optional(pool.as_ref())
+    .await
+    {
+        Ok(Some(tid)) => tid,
+        Ok(None) => {
+            tracing::warn!(
+                player_id, item_id,
+                "UseInventoryItem: instance not found for this character — refusing to fire ItemUsed"
+            );
+            return;
+        }
         Err(e) => {
-            tracing::error!(player_id, item_id, "UseInventoryItem: begin tx failed: {e}");
+            tracing::error!(player_id, item_id, "UseInventoryItem: lookup failed: {e}");
             return;
         }
     };
 
+    tracing::info!(
+        entity_id, player_id, item_id, type_id, target_id,
+        "UseInventoryItem: firing ItemUsed (no consumption — chain decides)"
+    );
+
+    if let Some(cell_tx) = cell_tx {
+        if let Err(e) = cell_tx.send(BaseToCellMsg::ItemUsed {
+            entity_id,
+            type_id,
+            target_id,
+        }).await {
+            tracing::error!(
+                entity_id, player_id, item_id, error = %e,
+                "UseInventoryItem: cell channel closed sending ItemUsed — content event lost"
+            );
+        }
+    }
+}
+
+/// Resolve a player's first inventory instance with the given design
+/// `type_id` and remove `count` from it (delete the row when the stack is
+/// fully drained). Used by `Action::RemoveItem` in the cell content
+/// executor — chains know item design ids, not instance ids.
+///
+/// Sends the same client wire-update sequence as
+/// [`handle_remove_inventory_item`]: `onRemoveItem` (when the row is
+/// deleted) → full inventory refresh → `BaseToCellMsg::InventoryItemRemoved`
+/// (when the row is deleted). Bandolier sync runs when the source row was
+/// in container 3.
+pub async fn handle_remove_inventory_item_by_type(
+    entity_id: u32,
+    player_id: i32,
+    type_id: i32,
+    count: i32,
+    db_pool: &Option<Arc<PgPool>>,
+    cell_tx: &Option<mpsc::Sender<BaseToCellMsg>>,
+    socket: &Arc<UdpSocket>,
+    connected: &Arc<Mutex<HashMap<SocketAddr, ConnectedClientState>>>,
+    entity_to_addr: &Arc<Mutex<HashMap<u32, SocketAddr>>>,
+) {
+    let pool = match db_pool {
+        Some(p) => p,
+        None => {
+            tracing::debug!(player_id, type_id, "RemoveInventoryItemByType: no DB pool");
+            return;
+        }
+    };
+
+    if count <= 0 {
+        tracing::warn!(player_id, type_id, count, "RemoveInventoryItemByType: invalid count");
+        return;
+    }
+
+    let mut tx = match pool.begin().await {
+        Ok(t) => t,
+        Err(e) => {
+            tracing::error!(player_id, type_id, "RemoveInventoryItemByType: begin tx failed: {e}");
+            return;
+        }
+    };
+
+    // Resolve the first matching instance for this design id. FOR UPDATE
+    // because we're about to mutate; LIMIT 1 because we only consume from
+    // a single stack — multi-stack draining isn't the chain semantic
+    // (mission removes are always 1 from a specific stack).
     let source = match sqlx::query_as::<_, InventoryInstanceRow>(
         "SELECT type_id, stack_size, container_id, slot_id, bound, durability, charges \
-         FROM sgw_inventory WHERE character_id = $1 AND item_id = $2 LIMIT 1 FOR UPDATE",
+         FROM sgw_inventory WHERE character_id = $1 AND type_id = $2 LIMIT 1 FOR UPDATE",
     )
     .bind(player_id)
-    .bind(item_id)
+    .bind(type_id)
     .fetch_optional(&mut *tx)
     .await
     {
         Ok(opt) => opt,
         Err(e) => {
             let _ = tx.rollback().await;
-            tracing::error!(player_id, item_id, "UseInventoryItem: source query failed: {e}");
+            tracing::error!(player_id, type_id, "RemoveInventoryItemByType: source query failed: {e}");
             return;
         }
     };
@@ -367,26 +444,56 @@ pub async fn handle_use_inventory_item(
     let Some(source) = source else {
         let _ = tx.rollback().await;
         tracing::warn!(
-            player_id, item_id,
-            "UseInventoryItem: instance not found for this character — refusing to fire ItemUsed"
+            player_id, type_id,
+            "RemoveInventoryItemByType: no instance of this design id owned by character"
         );
         return;
     };
 
-    let consumed_all = source.stack_size <= 1;
-    let result = if consumed_all {
-        sqlx::query("DELETE FROM sgw_inventory WHERE character_id = $1 AND item_id = $2")
-            .bind(player_id)
-            .bind(item_id)
-            .execute(&mut *tx)
-            .await
-    } else {
+    // Need item_id to fire the targeted onRemoveItem packet on full removal.
+    let removed_item_id: i32 = match sqlx::query_scalar::<_, i32>(
+        "SELECT item_id FROM sgw_inventory \
+         WHERE character_id = $1 AND container_id = $2 AND slot_id = $3 LIMIT 1",
+    )
+    .bind(player_id)
+    .bind(source.container_id)
+    .bind(source.slot_id)
+    .fetch_optional(&mut *tx)
+    .await
+    {
+        Ok(Some(id)) => id,
+        Ok(None) => {
+            let _ = tx.rollback().await;
+            tracing::warn!(player_id, type_id, "RemoveInventoryItemByType: source row vanished mid-tx");
+            return;
+        }
+        Err(e) => {
+            let _ = tx.rollback().await;
+            tracing::error!(player_id, type_id, "RemoveInventoryItemByType: item_id lookup failed: {e}");
+            return;
+        }
+    };
+
+    let removed_all = count >= source.stack_size;
+    let result = if removed_all {
         sqlx::query(
-            "UPDATE sgw_inventory SET stack_size = stack_size - 1 \
-             WHERE character_id = $1 AND item_id = $2 AND stack_size > 1",
+            "DELETE FROM sgw_inventory \
+             WHERE character_id = $1 AND container_id = $2 AND slot_id = $3",
         )
         .bind(player_id)
-        .bind(item_id)
+        .bind(source.container_id)
+        .bind(source.slot_id)
+        .execute(&mut *tx)
+        .await
+    } else {
+        sqlx::query(
+            "UPDATE sgw_inventory SET stack_size = stack_size - $1 \
+             WHERE character_id = $2 AND container_id = $3 AND slot_id = $4 AND stack_size > $1",
+        )
+        .bind(count)
+        .bind(player_id)
+        .bind(source.container_id)
+        .bind(source.slot_id)
         .execute(&mut *tx)
         .await
     };
@@ -395,23 +502,23 @@ pub async fn handle_use_inventory_item(
         Ok(r) if r.rows_affected() == 1 => {}
         Ok(_) => {
             let _ = tx.rollback().await;
-            tracing::warn!(player_id, item_id, "UseInventoryItem: no rows changed");
+            tracing::warn!(player_id, type_id, "RemoveInventoryItemByType: no rows changed");
             return;
         }
         Err(e) => {
             let _ = tx.rollback().await;
-            tracing::error!(player_id, item_id, "UseInventoryItem: consume failed: {e}");
+            tracing::error!(player_id, type_id, "RemoveInventoryItemByType: update failed: {e}");
             return;
         }
     }
 
     if let Err(e) = tx.commit().await {
-        tracing::error!(player_id, item_id, "UseInventoryItem: commit failed: {e}");
+        tracing::error!(player_id, type_id, "RemoveInventoryItemByType: commit failed: {e}");
         return;
     }
 
-    if consumed_all {
-        send_on_remove_item(entity_id, item_id, socket, connected, entity_to_addr).await;
+    if removed_all {
+        send_on_remove_item(entity_id, removed_item_id, socket, connected, entity_to_addr).await;
     }
 
     let total_items = send_full_inventory_update(
@@ -419,32 +526,15 @@ pub async fn handle_use_inventory_item(
     ).await;
 
     tracing::info!(
-        entity_id, player_id, item_id,
-        type_id = source.type_id, target_id, total_items, consumed_all,
-        "UseInventoryItem: consumed, firing ItemUsed back to cell"
+        entity_id, player_id, type_id, count, removed_all, total_items,
+        "RemoveInventoryItemByType: persisted"
     );
 
-    if let Some(cell_tx) = cell_tx {
-        if let Err(e) = cell_tx.send(BaseToCellMsg::ItemUsed {
-            entity_id,
-            type_id: source.type_id,
-            target_id,
-        }).await {
-            tracing::error!(
-                entity_id, player_id, item_id, error = %e,
-                "UseInventoryItem: cell channel closed sending ItemUsed — content event lost"
-            );
-        }
-
-        if consumed_all {
-            // Mirror the InventoryItemRemoved emission from `handle_remove_inventory_item`
-            // so any cell-side listeners (e.g., bandolier slot reconciliation) see the
-            // removal. Sent for all containers — the remove path emits unconditionally
-            // on full removal, and any divergence here would silently break listeners
-            // for main-bag consumes.
+    if removed_all {
+        if let Some(cell_tx) = cell_tx {
             let _ = cell_tx.send(BaseToCellMsg::InventoryItemRemoved {
                 entity_id,
-                item_id,
+                item_id: removed_item_id,
                 source_container_id: source.container_id,
             }).await;
         }

--- a/crates/services/src/base/world_entry/methods/inventory/mod.rs
+++ b/crates/services/src/base/world_entry/methods/inventory/mod.rs
@@ -4,6 +4,9 @@ pub mod grant;
 pub mod move_;
 
 pub use ammo::update_bandolier_ammo;
-pub use core::{send_full_inventory_update, handle_remove_inventory_item, handle_use_inventory_item};
+pub use core::{
+    handle_remove_inventory_item, handle_remove_inventory_item_by_type,
+    handle_use_inventory_item, send_full_inventory_update,
+};
 pub use grant::{normalize_item_ids, item_allows_container, handle_grant_item};
 pub use move_::handle_move_inventory_item;

--- a/crates/services/src/base/world_entry/methods/mod.rs
+++ b/crates/services/src/base/world_entry/methods/mod.rs
@@ -18,7 +18,11 @@ pub use player_load::{query_player_load_data, query_player_load_data_by_account,
 pub use progression::{handle_grant_xp, handle_grant_cash};
 pub use missions::{query_saved_missions, handle_mission_update};
 pub use mail::handle_mail_request;
-pub use inventory::{handle_grant_item, item_allows_container, normalize_item_ids, send_full_inventory_update, handle_remove_inventory_item, handle_use_inventory_item, handle_move_inventory_item};
+pub use inventory::{
+    handle_grant_item, handle_move_inventory_item, handle_remove_inventory_item,
+    handle_remove_inventory_item_by_type, handle_use_inventory_item, item_allows_container,
+    normalize_item_ids, send_full_inventory_update,
+};
 pub use vendor::{
     serialize_store_open, serialize_empty_store_open, serialize_store_item_cost_array,
     serialize_store_update, free_inventory_slots, reserve_free_inventory_slots,

--- a/crates/services/src/cell/content/executor.rs
+++ b/crates/services/src/cell/content/executor.rs
@@ -260,12 +260,24 @@ pub(super) async fn execute_actions(
                     entity_id, player_id, type_id = item_id, count, chain_id,
                     "Content: RemoveItem → RemoveInventoryItemByType"
                 );
-                let _ = tx.send(CellToBaseMsg::RemoveInventoryItemByType {
+                if let Err(e) = tx.send(CellToBaseMsg::RemoveInventoryItemByType {
                     entity_id,
                     player_id,
                     type_id: item_id,
                     count,
-                }).await;
+                }).await {
+                    // Saturated/closed channel — the consume silently
+                    // skips otherwise. Surface it loudly so missions
+                    // that depend on the removal (e.g., FindAmbernol
+                    // chain 1034 consumes the vial) don't silently
+                    // strand the player with the item still in their
+                    // bag while the chain reports completion.
+                    tracing::error!(
+                        entity_id, player_id, type_id = item_id, count, chain_id,
+                        error = %e,
+                        "Content: RemoveItem cell→base channel send failed — item NOT removed"
+                    );
+                }
             }
             Action::SetInteractionType { entity_tag, operation, mask } => {
                 if let Some(target_id) = space_mgr.find_entity_by_tag(entity_id, &entity_tag) {

--- a/crates/services/src/cell/content/executor.rs
+++ b/crates/services/src/cell/content/executor.rs
@@ -251,19 +251,21 @@ pub(super) async fn execute_actions(
                 }
             }
             Action::RemoveItem { item_id, count } => {
-                // TODO: Action::RemoveItem here gets a design id (type_id) from
-                // the chain, but `RemoveInventoryItem` expects the inventory
-                // instance id. Resolving that requires either a cell-side
-                // instance↔design cache or a new "remove by type_id" base
-                // handler. For the FindAmbernol use-item path we route
-                // consumption through `UseInventoryItem` instead, which is
-                // atomic on the base side, so this stub doesn't block that
-                // mission. Revisit when chain-driven removals (turn-ins, etc.)
-                // come up.
-                tracing::warn!(
-                    entity_id, item_id, count, chain_id,
-                    "Content: RemoveItem stub — chain-driven item removal by design id not yet wired"
+                // Chains carry the item's design id (type_id), not an
+                // inventory instance id. Route through the cell→base
+                // RemoveInventoryItemByType RPC, which resolves the
+                // player's first matching instance and applies the same
+                // wire-update sequence as a normal remove.
+                tracing::info!(
+                    entity_id, player_id, type_id = item_id, count, chain_id,
+                    "Content: RemoveItem → RemoveInventoryItemByType"
                 );
+                let _ = tx.send(CellToBaseMsg::RemoveInventoryItemByType {
+                    entity_id,
+                    player_id,
+                    type_id: item_id,
+                    count,
+                }).await;
             }
             Action::SetInteractionType { entity_tag, operation, mask } => {
                 if let Some(target_id) = space_mgr.find_entity_by_tag(entity_id, &entity_tag) {
@@ -551,6 +553,50 @@ async fn send_interaction_update_if_visible(
                 entity_id, target_id,
                 "NPC not yet in player AoI — deferring InteractionType to AoI create"
             );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cimmeria_content_engine::chain::{ChainEngine, ResolvedActions};
+
+    fn make_space_mgr() -> SpaceManager {
+        let mut mgr = SpaceManager::new(1);
+        let xml = r#"<?xml version="1.0"?><Spaces><Space WorldName="Agnos" Instanced="false" MinX="0" MaxX="100" MinY="0" MaxY="100" /></Spaces>"#;
+        let cxml = r#"<?xml version="1.0"?><Spaces><Space WorldName="Agnos" /></Spaces>"#;
+        mgr.parse_spaces_xml(xml).unwrap();
+        mgr.create_startup_spaces(cxml).unwrap();
+        mgr
+    }
+
+    /// Regression for #95: `Action::RemoveItem` must route through the new
+    /// `RemoveInventoryItemByType` cell→base RPC, not the silently-ignored
+    /// stub it used to be. Locks in the chain-driven removal path that
+    /// chain 1034 (FindAmbernol consume) depends on.
+    #[tokio::test]
+    async fn remove_item_action_emits_remove_inventory_by_type() {
+        let mut mgr = make_space_mgr();
+        mgr.create_entity(1, "Agnos", [0.0, 0.0, 0.0], [0.0; 3]).unwrap();
+
+        let (tx, mut rx) = mpsc::channel(8);
+        let engine = ChainEngine::new();
+        let resolved = ResolvedActions {
+            actions: vec![(1034, Action::RemoveItem { item_id: 19, count: 1 })],
+        };
+
+        execute_actions(resolved, 1, 42, &tx, &mut mgr, &engine).await;
+
+        let msg = rx.try_recv().expect("expected RemoveInventoryItemByType");
+        match msg {
+            CellToBaseMsg::RemoveInventoryItemByType { entity_id, player_id, type_id, count } => {
+                assert_eq!(entity_id, 1);
+                assert_eq!(player_id, 42);
+                assert_eq!(type_id, 19);
+                assert_eq!(count, 1);
+            }
+            other => panic!("expected RemoveInventoryItemByType, got {:?}", other),
         }
     }
 }

--- a/crates/services/src/cell/messages/cell_to_base.rs
+++ b/crates/services/src/cell/messages/cell_to_base.rs
@@ -168,6 +168,19 @@ pub enum CellToBaseMsg {
         quantity: i32,
     },
 
+    /// Remove `count` of an item by **design id** (`type_id`) — chains know
+    /// design ids, not instance ids. Base resolves the player's first
+    /// matching instance and applies the same wire-update sequence as
+    /// `RemoveInventoryItem`. Used by `Action::RemoveItem` in the cell
+    /// content executor (e.g., chain 1034 consumes the Ambernol vial after
+    /// `OnItemUse` fires).
+    RemoveInventoryItemByType {
+        entity_id: u32,
+        player_id: i32,
+        type_id: i32,
+        count: i32,
+    },
+
     /// Consume one charge/stack of an inventory item instance, then fire the
     /// content-engine `OnItemUse` event back to the cell with the resolved
     /// `type_id` (item design id). Mission progression that depends on item

--- a/db/resources/Content/Seed/castle_cellblock_chains.sql
+++ b/db/resources/Content/Seed/castle_cellblock_chains.sql
@@ -285,10 +285,12 @@ INSERT INTO content_actions (chain_id, action_type, target_id, target_key, param
 VALUES (1033, 'advance_step', 639, '2343', '{}', 0, 0);
 
 -- Chain 1034: use item 19 (ambernol) while step 2343 active → complete 639, accept 640.
---   The vial is consumed atomically by the base service before this fires
---   (CellToBaseMsg::UseInventoryItem → BaseToCellMsg::ItemUsed → fire_item_use),
---   so no `remove_item` action is needed — and including one would double-consume
---   if the player happened to have a stack >1.
+--   The chain is responsible for consumption via `remove_item`. Mirrors python
+--   `FindAmbernol.py:115` which calls `inventory.removeItemByDesign(19, 1, False)`
+--   from a per-mission script callback — pure `useItem` events fire without
+--   consuming, and per-item handlers decide whether to remove the stack
+--   (#95 reverted the global consume-on-use that would silently drain reusable
+--   items like radios).
 INSERT INTO content_chains (chain_id, description, scope_type, scope_id, enabled, priority)
 VALUES (1034, '639 - Use ambernol: complete 639, accept 640', 'mission', 639, true, 0);
 
@@ -300,13 +302,17 @@ VALUES (1034, 'step_status', 639, '2343', 'eq', 'active', 0);
 
 INSERT INTO content_actions (chain_id, action_type, target_id, target_key, params, delay_ms, sort_order)
 VALUES
-  (1034, 'complete_mission', 639, NULL, '{}', 0, 0),
-  (1034, 'accept_mission',   640, NULL, '{}', 0, 1),
+  -- Consume the vial first — the step-status condition is locked in by the
+  -- time the chain fires, so subsequent actions can't double-trigger off the
+  -- removal's wire updates.
+  (1034, 'remove_item',      19,  NULL, '{"qty": 1}', 0, 0),
+  (1034, 'complete_mission', 639, NULL, '{}',         0, 1),
+  (1034, 'accept_mission',   640, NULL, '{}',         0, 2),
   -- Make the ring switch right-clickable with the Livewire icon so the player can hack it.
   -- The classic Python script (HackTheRings.py) didn't set this bit; the original Atrea editor
   -- presumably wired it implicitly off the Event_EntityInteract node. We do it explicitly here.
   (1034, 'set_interaction_type', NULL, 'HackTheRings_Switch',
-   '{"op": "|", "mask": 256}', 0, 2);
+   '{"op": "|", "mask": 256}', 0, 3);
 
 -- ============================================================
 -- MISSION 640 — Hack the Rings

--- a/db/resources/Content/Seed/castle_cellblock_chains.sql
+++ b/db/resources/Content/Seed/castle_cellblock_chains.sql
@@ -288,9 +288,10 @@ VALUES (1033, 'advance_step', 639, '2343', '{}', 0, 0);
 --   The chain is responsible for consumption via `remove_item`. Mirrors python
 --   `FindAmbernol.py:115` which calls `inventory.removeItemByDesign(19, 1, False)`
 --   from a per-mission script callback — pure `useItem` events fire without
---   consuming, and per-item handlers decide whether to remove the stack
---   (#95 reverted the global consume-on-use that would silently drain reusable
---   items like radios).
+--   consuming, and per-item handlers decide whether to remove the stack.
+--   The previous global consume-on-use behavior was wrong for reusable items
+--   (radios, multi-step "use on target" objectives) which silently lost stacks
+--   on every use.
 INSERT INTO content_chains (chain_id, description, scope_type, scope_id, enabled, priority)
 VALUES (1034, '639 - Use ambernol: complete 639, accept 640', 'mission', 639, true, 0);
 


### PR DESCRIPTION
## Summary

Closes **#95**. The pre-#95 server unconditionally consumed one charge on every `useItem` call. Correct for Ambernol (single-shot consumable) but a latent regression for any reusable quest item — radios, multi-step \"use on target\" objectives, etc. would silently lose stacks.

This restores Python's `Inventory.useItem` semantics: `useItem` fires `OnItemUse` as a pure event, and per-item handlers (chains in our case) decide whether to remove the stack. Chain 1034 (FindAmbernol) explicitly consumes via the new path so end-to-end behavior is preserved.

## Changes

| File | What |
|---|---|
| [`inventory/core.rs`](crates/services/src/base/world_entry/methods/inventory/core.rs) | `handle_use_inventory_item` → pure read-and-fire (no DELETE/UPDATE, no wire packets, dropped 4 args). New `handle_remove_inventory_item_by_type` that resolves the player's first matching instance by design id and applies the existing client wire-update sequence. |
| [`messages/cell_to_base.rs`](crates/services/src/cell/messages/cell_to_base.rs) | New `RemoveInventoryItemByType { entity_id, player_id, type_id, count }` variant |
| [`world_entry/cell_dispatch.rs`](crates/services/src/base/world_entry/cell_dispatch.rs) | Routes the new variant to the new handler; drops the now-unused args from the `UseInventoryItem` call |
| [`content/executor.rs`](crates/services/src/cell/content/executor.rs) | `Action::RemoveItem` was a warn-log stub — now sends `CellToBaseMsg::RemoveInventoryItemByType` |
| [`castle_cellblock_chains.sql`](db/resources/Content/Seed/castle_cellblock_chains.sql) | Chain 1034 re-adds `(1034, 'remove_item', 19, '{\"qty\": 1}')` as the first action so the vial consumes before mission-state updates fire |

## Tests

`remove_item_action_emits_remove_inventory_by_type` — new unit test in `executor.rs` that builds a `ResolvedActions` with `Action::RemoveItem`, runs `execute_actions`, and asserts the resulting `CellToBaseMsg::RemoveInventoryItemByType` carries the correct entity_id / player_id / type_id / count tuple. Locks in that the stub-removal didn't quietly turn into another stub.

`cargo test -p cimmeria-services --lib`: **230 passed** (+1 new, no regressions).

## What's not tested here

The AC asks for an integration test that proves a `useItem` call without a `remove_item` chain leaves the stack intact. That requires the `sqlx::test` fixture #79 / #84 are designing — deferred to that infra work.

## Test plan

- [x] cargo test -p cimmeria-services --lib (230/230)
- [x] cargo check -p cimmeria-services
- [ ] CI workspace check
- [ ] Manual UAT: Find Ambernol still completes (use-vial → mission progresses → vial gone from inventory)
- [ ] Manual UAT: pick a non-consumable test item and verify a useItem call doesn't decrement its stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential double-consumption of items when using inventory items in content chains
  * Item usage now properly separates the "use" action from the "consume" action, preventing unintended stack removal

* **New Features**
  * Enhanced item removal system with improved type-based inventory management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->