### PR TITLE
Durable ItemUsed delivery via cell_event_outbox (#96)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ tower = "0.5"
 tower-http = { version = "0.6", features = ["cors"] }
 
 # Database
-sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "macros"] }
+sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "macros", "json"] }
 
 # Serialization
 serde = { version = "1", features = ["derive"] }

--- a/crates/services/src/base/mod.rs
+++ b/crates/services/src/base/mod.rs
@@ -24,6 +24,7 @@ pub(crate) mod login;
 pub(crate) mod character;
 pub(crate) mod character_create;
 pub(crate) mod cooked_data;
+pub(crate) mod outbox;
 mod service;
 pub(crate) mod world_entry;
 pub(crate) mod world_entry_appearance;

--- a/crates/services/src/base/outbox/mod.rs
+++ b/crates/services/src/base/outbox/mod.rs
@@ -1,4 +1,4 @@
-//! Durable base→cell content event delivery (issue #96).
+//! Durable base→cell content event delivery.
 //!
 //! Closes the gap between "base committed a DB change" and "cell fires the
 //! corresponding `OnItemUse` / inventory chain event". The previous
@@ -156,7 +156,7 @@ async fn record_failure(pool: &PgPool, id: i64, error: &str) {
 /// No logging here — the drainer is the only caller and decides whether to
 /// log (first encounter) or stay quiet (already-flagged poison row), based
 /// on `attempts`. Without this gate, a single bad row turns into a continuous
-/// warn-spam at the 5s drain interval. (Copilot review on #124.)
+/// warn-spam at the 5s drain interval.
 fn row_to_message(row: &OutboxRow) -> Option<BaseToCellMsg> {
     match (row.event_type.as_str(), &*row.payload) {
         (EVENT_TYPE_ITEM_USED, CellOutboxPayload::ItemUsed { type_id, target_id }) => {
@@ -233,9 +233,8 @@ pub(crate) struct DrainStats {
 
 /// Drain a single batch of undelivered rows. Returns per-outcome counts
 /// rather than just `rows.len()` — the loop breaks early on a closed cell
-/// channel, so a raw row count would overstate progress (Copilot review
-/// on #124). Exposed pub(crate) so the periodic loop and tests can both
-/// call it.
+/// channel, so a raw row count would overstate progress. Exposed
+/// `pub(crate)` so the periodic loop and tests can both call it.
 pub(crate) async fn drain_undelivered(
     pool: &PgPool,
     cell_tx: &mpsc::Sender<BaseToCellMsg>,
@@ -244,7 +243,7 @@ pub(crate) async fn drain_undelivered(
     // increasing per insert across all entities, so per-entity ordering is
     // implied by global ordering). LIMIT bounds the batch so we don't
     // hold the channel under a backlog. No FOR UPDATE SKIP LOCKED yet —
-    // single-writer base assumption (#96 out-of-scope: multi-instance HA).
+    // single-writer base assumption; multi-instance HA is out of scope here.
     let rows: Vec<OutboxRow> = sqlx::query_as::<_, OutboxRow>(
         "SELECT id, entity_id, event_type, payload, attempts \
          FROM cell_event_outbox \
@@ -263,7 +262,7 @@ pub(crate) async fn drain_undelivered(
             // Poison row — log loud once (first encounter) then drop to
             // debug for subsequent retries. Without the rate-limit, the
             // 5s drainer interval turns one bad row into permanent warn
-            // spam (Copilot review on #124).
+            // spam.
             if row.attempts == 0 {
                 tracing::warn!(
                     outbox_id = id, event_type = %row.event_type, attempts = row.attempts,

--- a/crates/services/src/base/outbox/mod.rs
+++ b/crates/services/src/base/outbox/mod.rs
@@ -2,9 +2,12 @@
 //!
 //! Closes the gap between "base committed a DB change" and "cell fires the
 //! corresponding `OnItemUse` / inventory chain event". The previous
-//! best-effort `cell_tx.send(...)` could lose events on a closed/saturated
-//! channel — for `OnItemUse` that strands mission progression with no
-//! recovery path.
+//! best-effort `cell_tx.send(...)` could lose events when the receiver
+//! was dropped (cell task panic / shut down) — for `OnItemUse` that
+//! strands mission progression with no recovery path. (Note: tokio mpsc
+//! `send().await` does not error on a full channel — it backpressures —
+//! so this guards specifically against a torn-down receiver, not
+//! saturation.)
 //!
 //! Two write paths:
 //!   * [`enqueue`] — INSERT a row in its own short-lived statement. Used by
@@ -71,6 +74,10 @@ struct OutboxRow {
     entity_id: i32,
     event_type: String,
     payload: Json<CellOutboxPayload>,
+    /// Used to rate-limit poison-row warnings — first encounter logs WARN,
+    /// subsequent retries log DEBUG so a single bad row doesn't spam the
+    /// log every drain interval.
+    attempts: i32,
 }
 
 /// INSERT a fresh outbox row using a one-shot statement (no caller tx).
@@ -144,8 +151,12 @@ async fn record_failure(pool: &PgPool, id: i64, error: &str) {
 
 /// Build the `BaseToCellMsg` for a stored outbox row. Returns `None` if the
 /// row's `event_type` is unknown (forward-compat: a newer base wrote an event
-/// type this version doesn't understand). Such rows are left undelivered for
-/// a redeploy / rollback to handle.
+/// type this version doesn't understand) or doesn't match the payload shape.
+///
+/// No logging here — the drainer is the only caller and decides whether to
+/// log (first encounter) or stay quiet (already-flagged poison row), based
+/// on `attempts`. Without this gate, a single bad row turns into a continuous
+/// warn-spam at the 5s drain interval. (Copilot review on #124.)
 fn row_to_message(row: &OutboxRow) -> Option<BaseToCellMsg> {
     match (row.event_type.as_str(), &*row.payload) {
         (EVENT_TYPE_ITEM_USED, CellOutboxPayload::ItemUsed { type_id, target_id }) => {
@@ -155,17 +166,7 @@ fn row_to_message(row: &OutboxRow) -> Option<BaseToCellMsg> {
                 target_id: *target_id,
             })
         }
-        // event_type / payload variant mismatch — should not happen unless
-        // someone hand-edited the table or the JSON shape drifted from the
-        // event_type tag. Logged so it's visible.
-        _ => {
-            tracing::warn!(
-                outbox_id = row.id,
-                event_type = %row.event_type,
-                "outbox: row event_type/payload mismatch; leaving undelivered"
-            );
-            None
-        }
+        _ => None,
     }
 }
 
@@ -213,21 +214,39 @@ pub async fn try_dispatch_now(
 /// from monopolising the channel under a backlog spike.
 const DRAIN_BATCH_SIZE: i64 = 64;
 
-/// Drain a single batch of undelivered rows. Returns the number of rows
-/// the drainer handled (whether dispatched, marked delivered, or skipped
-/// due to row→message mismatch). Exposed pub(crate) so the periodic loop
-/// and tests can both call it.
+/// Outcome of a single drain pass — separates "rows successfully delivered"
+/// from "rows skipped without action" so the operator log isn't misleading
+/// when the drainer breaks early on a closed channel. Returned via
+/// [`drain_undelivered`].
+#[derive(Debug, Default, PartialEq, Eq)]
+pub(crate) struct DrainStats {
+    /// Rows whose `delivered_at` was set during this pass.
+    pub delivered: usize,
+    /// Rows skipped because `row_to_message` rejected them (unknown
+    /// event_type / payload mismatch).
+    pub skipped_bad: usize,
+    /// Rows that hit a send error this pass — the loop breaks on the first
+    /// such row, so this is at most 1 today, but it's a count so future
+    /// "keep going on transient errors" changes don't change the API shape.
+    pub send_failed: usize,
+}
+
+/// Drain a single batch of undelivered rows. Returns per-outcome counts
+/// rather than just `rows.len()` — the loop breaks early on a closed cell
+/// channel, so a raw row count would overstate progress (Copilot review
+/// on #124). Exposed pub(crate) so the periodic loop and tests can both
+/// call it.
 pub(crate) async fn drain_undelivered(
     pool: &PgPool,
     cell_tx: &mpsc::Sender<BaseToCellMsg>,
-) -> Result<usize, sqlx::Error> {
+) -> Result<DrainStats, sqlx::Error> {
     // ORDER BY id keeps per-entity FIFO (id is BIGSERIAL — strictly
     // increasing per insert across all entities, so per-entity ordering is
     // implied by global ordering). LIMIT bounds the batch so we don't
     // hold the channel under a backlog. No FOR UPDATE SKIP LOCKED yet —
     // single-writer base assumption (#96 out-of-scope: multi-instance HA).
     let rows: Vec<OutboxRow> = sqlx::query_as::<_, OutboxRow>(
-        "SELECT id, entity_id, event_type, payload \
+        "SELECT id, entity_id, event_type, payload, attempts \
          FROM cell_event_outbox \
          WHERE delivered_at IS NULL \
          ORDER BY id \
@@ -237,11 +256,30 @@ pub(crate) async fn drain_undelivered(
     .fetch_all(pool)
     .await?;
 
-    let count = rows.len();
+    let mut stats = DrainStats::default();
     for row in rows {
         let id = row.id;
         let Some(msg) = row_to_message(&row) else {
-            // row_to_message logs the mismatch; skip to next.
+            // Poison row — log loud once (first encounter) then drop to
+            // debug for subsequent retries. Without the rate-limit, the
+            // 5s drainer interval turns one bad row into permanent warn
+            // spam (Copilot review on #124).
+            if row.attempts == 0 {
+                tracing::warn!(
+                    outbox_id = id, event_type = %row.event_type, attempts = row.attempts,
+                    "outbox: row event_type/payload mismatch — left undelivered for redeploy/rollback"
+                );
+            } else {
+                tracing::debug!(
+                    outbox_id = id, event_type = %row.event_type, attempts = row.attempts,
+                    "outbox: row event_type/payload mismatch (already flagged)"
+                );
+            }
+            // Bump attempts so the next pass can stay quiet, and so
+            // operators have a count for dead-letter triage when that
+            // ships.
+            record_failure(pool, id, &format!("unknown event_type: {}", row.event_type)).await;
+            stats.skipped_bad += 1;
             continue;
         };
         match cell_tx.send(msg).await {
@@ -252,21 +290,23 @@ pub(crate) async fn drain_undelivered(
                         "outbox: drainer dispatch succeeded but mark_delivered failed: {e}"
                     );
                 }
+                stats.delivered += 1;
             }
             Err(e) => {
                 tracing::warn!(
                     outbox_id = id,
-                    "outbox: drainer cell channel send failed; will retry next pass: {e}"
+                    "outbox: drainer cell channel send failed (receiver dropped); will retry next pass: {e}"
                 );
                 record_failure(pool, id, &format!("drainer send: {e}")).await;
-                // Channel is closed — stop the batch; subsequent rows would
+                stats.send_failed += 1;
+                // Receiver is gone — stop the batch; subsequent rows would
                 // hit the same error. The next periodic pass will retry
-                // when (if) the channel is rebuilt.
+                // if (when) the channel is rebuilt.
                 break;
             }
         }
     }
-    Ok(count)
+    Ok(stats)
 }
 
 /// Default drainer interval. Fast enough that a transient channel hiccup
@@ -293,7 +333,13 @@ pub fn spawn_drainer(pool: Arc<PgPool>, cell_tx: mpsc::Sender<BaseToCellMsg>) {
         loop {
             ticker.tick().await;
             match drain_undelivered(&pool, &cell_tx).await {
-                Ok(n) if n > 0 => tracing::debug!(drained = n, "outbox: periodic drain"),
+                Ok(s) if s.delivered > 0 || s.skipped_bad > 0 || s.send_failed > 0 => {
+                    tracing::debug!(
+                        delivered = s.delivered, skipped_bad = s.skipped_bad,
+                        send_failed = s.send_failed,
+                        "outbox: periodic drain"
+                    );
+                }
                 Ok(_) => {}
                 Err(e) => tracing::warn!("outbox: periodic drain failed: {e}"),
             }

--- a/crates/services/src/base/outbox/mod.rs
+++ b/crates/services/src/base/outbox/mod.rs
@@ -1,0 +1,302 @@
+//! Durable base→cell content event delivery (issue #96).
+//!
+//! Closes the gap between "base committed a DB change" and "cell fires the
+//! corresponding `OnItemUse` / inventory chain event". The previous
+//! best-effort `cell_tx.send(...)` could lose events on a closed/saturated
+//! channel — for `OnItemUse` that strands mission progression with no
+//! recovery path.
+//!
+//! Two write paths:
+//!   * [`enqueue`] — INSERT a row in its own short-lived statement. Used by
+//!     [`crate::base::world_entry::methods::inventory::handle_use_inventory_item`],
+//!     which has no surrounding tx because it doesn't mutate inventory.
+//!   * [`enqueue_in_tx`] — INSERT inside a caller-owned transaction so the
+//!     event row is committed atomically with the caller's DB write. Future
+//!     callers (grant/remove) will use this; not yet wired here.
+//!
+//! Two delivery paths:
+//!   * [`try_dispatch_now`] — fired immediately after enqueue. On a healthy
+//!     in-process channel this clears the row before the drainer ever
+//!     looks at it.
+//!   * [`drain_undelivered`] — periodic + startup sweep that resends
+//!     anything still undelivered (channel was closed at the time, base
+//!     restarted before the row could be marked delivered, etc.).
+//!
+//! Cell-side handlers must be idempotent because retries can fan out a
+//! second copy after a crash. `OnItemUse` already is — chain conditions
+//! self-gate on `step_status = active`, and `Action::RemoveItem` handles
+//! consumption.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use sqlx::{PgPool, Postgres, Transaction, types::Json};
+use tokio::sync::mpsc;
+
+use crate::cell::messages::BaseToCellMsg;
+
+#[cfg(test)]
+mod tests;
+
+/// Event types persisted in `cell_event_outbox.event_type`. Stable strings —
+/// changing one breaks in-flight rows on existing databases.
+const EVENT_TYPE_ITEM_USED: &str = "item_used";
+
+/// Strongly-typed payload variants. Serialized as JSON into the
+/// `cell_event_outbox.payload` JSONB column. Adding a new variant requires
+/// only (a) a new enum arm here, (b) a matching `event_type` constant, and
+/// (c) an arm in [`row_to_message`].
+///
+/// Variants intentionally don't carry `entity_id` — it lives in its own
+/// indexed column for ordering / per-entity drainer scoping.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum CellOutboxPayload {
+    ItemUsed { type_id: i32, target_id: i32 },
+}
+
+impl CellOutboxPayload {
+    fn event_type(&self) -> &'static str {
+        match self {
+            CellOutboxPayload::ItemUsed { .. } => EVENT_TYPE_ITEM_USED,
+        }
+    }
+}
+
+/// Single undelivered row pulled by the drainer.
+#[derive(sqlx::FromRow)]
+struct OutboxRow {
+    id: i64,
+    entity_id: i32,
+    event_type: String,
+    payload: Json<CellOutboxPayload>,
+}
+
+/// INSERT a fresh outbox row using a one-shot statement (no caller tx).
+/// Returns the assigned `id` so the caller can mark it delivered after a
+/// successful in-process send.
+pub async fn enqueue(
+    pool: &PgPool,
+    entity_id: u32,
+    payload: &CellOutboxPayload,
+) -> Result<i64, sqlx::Error> {
+    let id: i64 = sqlx::query_scalar(
+        "INSERT INTO cell_event_outbox (entity_id, event_type, payload) \
+         VALUES ($1, $2, $3) RETURNING id",
+    )
+    .bind(entity_id as i32)
+    .bind(payload.event_type())
+    .bind(Json(payload))
+    .fetch_one(pool)
+    .await?;
+    Ok(id)
+}
+
+/// INSERT inside a caller-owned transaction so the outbox row commits
+/// atomically with the caller's DB-visible state change. Reserved for
+/// callers that already mutate the DB (grant/remove); `handle_use_inventory_item`
+/// uses [`enqueue`] instead because it has no surrounding tx.
+#[allow(dead_code)]
+pub async fn enqueue_in_tx(
+    tx: &mut Transaction<'_, Postgres>,
+    entity_id: u32,
+    payload: &CellOutboxPayload,
+) -> Result<i64, sqlx::Error> {
+    let id: i64 = sqlx::query_scalar(
+        "INSERT INTO cell_event_outbox (entity_id, event_type, payload) \
+         VALUES ($1, $2, $3) RETURNING id",
+    )
+    .bind(entity_id as i32)
+    .bind(payload.event_type())
+    .bind(Json(payload))
+    .fetch_one(&mut **tx)
+    .await?;
+    Ok(id)
+}
+
+/// Mark a row delivered. Called after a successful `cell_tx.send(...)`.
+async fn mark_delivered(pool: &PgPool, id: i64) -> Result<(), sqlx::Error> {
+    sqlx::query("UPDATE cell_event_outbox SET delivered_at = NOW() WHERE id = $1")
+        .bind(id)
+        .execute(pool)
+        .await
+        .map(|_| ())
+}
+
+/// Bump attempts + capture the failure string for operator diagnostics.
+/// Best-effort: a failure here is logged but does not propagate, since the
+/// drainer will simply pick the row up again on its next pass.
+async fn record_failure(pool: &PgPool, id: i64, error: &str) {
+    let res = sqlx::query(
+        "UPDATE cell_event_outbox \
+         SET attempts = attempts + 1, last_error = $2 \
+         WHERE id = $1",
+    )
+    .bind(id)
+    .bind(error)
+    .execute(pool)
+    .await;
+    if let Err(e) = res {
+        tracing::warn!(outbox_id = id, "outbox: failed to record dispatch failure: {e}");
+    }
+}
+
+/// Build the `BaseToCellMsg` for a stored outbox row. Returns `None` if the
+/// row's `event_type` is unknown (forward-compat: a newer base wrote an event
+/// type this version doesn't understand). Such rows are left undelivered for
+/// a redeploy / rollback to handle.
+fn row_to_message(row: &OutboxRow) -> Option<BaseToCellMsg> {
+    match (row.event_type.as_str(), &*row.payload) {
+        (EVENT_TYPE_ITEM_USED, CellOutboxPayload::ItemUsed { type_id, target_id }) => {
+            Some(BaseToCellMsg::ItemUsed {
+                entity_id: row.entity_id as u32,
+                type_id: *type_id,
+                target_id: *target_id,
+            })
+        }
+        // event_type / payload variant mismatch — should not happen unless
+        // someone hand-edited the table or the JSON shape drifted from the
+        // event_type tag. Logged so it's visible.
+        _ => {
+            tracing::warn!(
+                outbox_id = row.id,
+                event_type = %row.event_type,
+                "outbox: row event_type/payload mismatch; leaving undelivered"
+            );
+            None
+        }
+    }
+}
+
+/// Try to deliver a freshly-enqueued event over the in-process channel.
+/// On success, marks the row delivered. On failure, leaves the row for the
+/// drainer to retry. Errors are logged, never propagated — the durability
+/// guarantee is "row exists in DB", not "send succeeded".
+pub async fn try_dispatch_now(
+    pool: &PgPool,
+    cell_tx: &mpsc::Sender<BaseToCellMsg>,
+    id: i64,
+    entity_id: u32,
+    payload: CellOutboxPayload,
+) {
+    let msg = match payload {
+        CellOutboxPayload::ItemUsed { type_id, target_id } => BaseToCellMsg::ItemUsed {
+            entity_id,
+            type_id,
+            target_id,
+        },
+    };
+    match cell_tx.send(msg).await {
+        Ok(()) => {
+            if let Err(e) = mark_delivered(pool, id).await {
+                // Row will be redelivered by the drainer — cell handler
+                // must be idempotent. Logged because a chronic mark-delivered
+                // failure means the drainer is doing redundant sends.
+                tracing::warn!(
+                    outbox_id = id,
+                    "outbox: dispatch succeeded but mark_delivered failed: {e}"
+                );
+            }
+        }
+        Err(e) => {
+            tracing::warn!(
+                outbox_id = id,
+                "outbox: cell channel send failed; left for drainer retry: {e}"
+            );
+            record_failure(pool, id, &format!("send: {e}")).await;
+        }
+    }
+}
+
+/// Default batch size for the drainer. Bounded to keep one drainer pass
+/// from monopolising the channel under a backlog spike.
+const DRAIN_BATCH_SIZE: i64 = 64;
+
+/// Drain a single batch of undelivered rows. Returns the number of rows
+/// the drainer handled (whether dispatched, marked delivered, or skipped
+/// due to row→message mismatch). Exposed pub(crate) so the periodic loop
+/// and tests can both call it.
+pub(crate) async fn drain_undelivered(
+    pool: &PgPool,
+    cell_tx: &mpsc::Sender<BaseToCellMsg>,
+) -> Result<usize, sqlx::Error> {
+    // ORDER BY id keeps per-entity FIFO (id is BIGSERIAL — strictly
+    // increasing per insert across all entities, so per-entity ordering is
+    // implied by global ordering). LIMIT bounds the batch so we don't
+    // hold the channel under a backlog. No FOR UPDATE SKIP LOCKED yet —
+    // single-writer base assumption (#96 out-of-scope: multi-instance HA).
+    let rows: Vec<OutboxRow> = sqlx::query_as::<_, OutboxRow>(
+        "SELECT id, entity_id, event_type, payload \
+         FROM cell_event_outbox \
+         WHERE delivered_at IS NULL \
+         ORDER BY id \
+         LIMIT $1",
+    )
+    .bind(DRAIN_BATCH_SIZE)
+    .fetch_all(pool)
+    .await?;
+
+    let count = rows.len();
+    for row in rows {
+        let id = row.id;
+        let Some(msg) = row_to_message(&row) else {
+            // row_to_message logs the mismatch; skip to next.
+            continue;
+        };
+        match cell_tx.send(msg).await {
+            Ok(()) => {
+                if let Err(e) = mark_delivered(pool, id).await {
+                    tracing::warn!(
+                        outbox_id = id,
+                        "outbox: drainer dispatch succeeded but mark_delivered failed: {e}"
+                    );
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    outbox_id = id,
+                    "outbox: drainer cell channel send failed; will retry next pass: {e}"
+                );
+                record_failure(pool, id, &format!("drainer send: {e}")).await;
+                // Channel is closed — stop the batch; subsequent rows would
+                // hit the same error. The next periodic pass will retry
+                // when (if) the channel is rebuilt.
+                break;
+            }
+        }
+    }
+    Ok(count)
+}
+
+/// Default drainer interval. Fast enough that a transient channel hiccup
+/// doesn't strand a player for long; slow enough that a quiet outbox costs
+/// nothing.
+const DRAIN_INTERVAL: Duration = Duration::from_secs(5);
+
+/// Spawn the background drainer task. Runs immediately on startup
+/// (delivers any rows left over from a previous process), then every
+/// [`DRAIN_INTERVAL`]. The task lives for the life of the process — there's
+/// no shutdown signal because base service shutdown drops the cell_tx
+/// which makes the next send fail and the loop continues retrying until
+/// the runtime is itself dropped.
+pub fn spawn_drainer(pool: Arc<PgPool>, cell_tx: mpsc::Sender<BaseToCellMsg>) {
+    tokio::spawn(async move {
+        tracing::debug!("cell_event_outbox drainer started");
+        // Startup pass — replay any rows orphaned by a previous shutdown.
+        if let Err(e) = drain_undelivered(&pool, &cell_tx).await {
+            tracing::warn!("outbox: startup drain failed: {e}");
+        }
+        let mut ticker = tokio::time::interval(DRAIN_INTERVAL);
+        // Skip the immediate first tick — we just drained above.
+        ticker.tick().await;
+        loop {
+            ticker.tick().await;
+            match drain_undelivered(&pool, &cell_tx).await {
+                Ok(n) if n > 0 => tracing::debug!(drained = n, "outbox: periodic drain"),
+                Ok(_) => {}
+                Err(e) => tracing::warn!("outbox: periodic drain failed: {e}"),
+            }
+        }
+    });
+}

--- a/crates/services/src/base/outbox/tests.rs
+++ b/crates/services/src/base/outbox/tests.rs
@@ -48,6 +48,7 @@ fn row_to_message_builds_item_used() {
             type_id: 19,
             target_id: 5,
         }),
+        attempts: 0,
     };
     let msg = row_to_message(&row).expect("known event_type should produce message");
     match msg {
@@ -63,8 +64,8 @@ fn row_to_message_builds_item_used() {
 #[test]
 fn row_to_message_returns_none_for_unknown_event_type() {
     // Forward-compat: a future base might enqueue an event_type this
-    // build doesn't know. Drainer must skip it (logged via warn), not
-    // panic / mis-dispatch.
+    // build doesn't know. Drainer must skip it (and rate-limit logging
+    // off `attempts`), not panic / mis-dispatch.
     let row = OutboxRow {
         id: 100,
         entity_id: 1,
@@ -73,6 +74,18 @@ fn row_to_message_returns_none_for_unknown_event_type() {
             type_id: 0,
             target_id: 0,
         }),
+        attempts: 0,
     };
     assert!(row_to_message(&row).is_none());
+}
+
+#[test]
+fn drain_stats_default_is_all_zero() {
+    // The drainer's "no work" path returns `Default` and the periodic-log
+    // gate suppresses on all-zero. Pin the default values so a future
+    // refactor doesn't accidentally turn an empty drain into spam.
+    let s = DrainStats::default();
+    assert_eq!(s.delivered, 0);
+    assert_eq!(s.skipped_bad, 0);
+    assert_eq!(s.send_failed, 0);
 }

--- a/crates/services/src/base/outbox/tests.rs
+++ b/crates/services/src/base/outbox/tests.rs
@@ -1,0 +1,78 @@
+//! Outbox tests that don't need a live database.
+//!
+//! The DB-touching paths (`enqueue`, `enqueue_in_tx`, `mark_delivered`,
+//! `record_failure`, `drain_undelivered`) are tested via the integration
+//! suite gated on `sqlx::test` infra (issue #79). This file covers the
+//! pure logic: payload serialization shape and row→message conversion.
+
+use super::*;
+
+#[test]
+fn payload_serializes_with_kind_tag() {
+    let p = CellOutboxPayload::ItemUsed { type_id: 42, target_id: 17 };
+    let json = serde_json::to_value(&p).unwrap();
+    // kind tag matters: it's how a future variant gets disambiguated on
+    // deserialize, and an accidental rename would silently break in-flight
+    // rows on production databases.
+    assert_eq!(json["kind"], "item_used");
+    assert_eq!(json["type_id"], 42);
+    assert_eq!(json["target_id"], 17);
+}
+
+#[test]
+fn payload_roundtrips_through_json() {
+    let p = CellOutboxPayload::ItemUsed { type_id: -7, target_id: 0 };
+    let json = serde_json::to_string(&p).unwrap();
+    let back: CellOutboxPayload = serde_json::from_str(&json).unwrap();
+    assert_eq!(back, p);
+}
+
+#[test]
+fn event_type_string_is_stable() {
+    // This string is persisted in the `event_type` column. Changing it
+    // breaks any in-flight rows on existing databases — the test exists
+    // to make that breakage loud at refactor time.
+    assert_eq!(
+        CellOutboxPayload::ItemUsed { type_id: 0, target_id: 0 }.event_type(),
+        "item_used",
+    );
+}
+
+#[test]
+fn row_to_message_builds_item_used() {
+    let row = OutboxRow {
+        id: 99,
+        entity_id: 1234,
+        event_type: "item_used".to_string(),
+        payload: sqlx::types::Json(CellOutboxPayload::ItemUsed {
+            type_id: 19,
+            target_id: 5,
+        }),
+    };
+    let msg = row_to_message(&row).expect("known event_type should produce message");
+    match msg {
+        BaseToCellMsg::ItemUsed { entity_id, type_id, target_id } => {
+            assert_eq!(entity_id, 1234);
+            assert_eq!(type_id, 19);
+            assert_eq!(target_id, 5);
+        }
+        _ => panic!("expected ItemUsed"),
+    }
+}
+
+#[test]
+fn row_to_message_returns_none_for_unknown_event_type() {
+    // Forward-compat: a future base might enqueue an event_type this
+    // build doesn't know. Drainer must skip it (logged via warn), not
+    // panic / mis-dispatch.
+    let row = OutboxRow {
+        id: 100,
+        entity_id: 1,
+        event_type: "future_event_v2".to_string(),
+        payload: sqlx::types::Json(CellOutboxPayload::ItemUsed {
+            type_id: 0,
+            target_id: 0,
+        }),
+    };
+    assert!(row_to_message(&row).is_none());
+}

--- a/crates/services/src/base/service.rs
+++ b/crates/services/src/base/service.rs
@@ -195,7 +195,7 @@ impl BaseService {
             });
         }
 
-        // Spawn the cell_event_outbox drainer (issue #96). The startup pass
+        // Spawn the cell_event_outbox drainer. The startup pass
         // replays any rows orphaned by the previous shutdown; the periodic
         // ticker covers transient channel failures during steady-state.
         // Requires both a DB pool and a cell channel — gated on both.

--- a/crates/services/src/base/service.rs
+++ b/crates/services/src/base/service.rs
@@ -18,6 +18,7 @@ use crate::minigame::SessionRegistry;
 use super::{
     BaseError, ConnectedClientState, OnlinePlayer, archetype_name,
     connect_loop::run_connect_loop,
+    outbox,
     resources::ResourceCache,
     world_entry::handle_cell_message,
 };
@@ -192,6 +193,18 @@ impl BaseService {
                 }
                 tracing::debug!("Base service CellToBase message handler exited");
             });
+        }
+
+        // Spawn the cell_event_outbox drainer (issue #96). The startup pass
+        // replays any rows orphaned by the previous shutdown; the periodic
+        // ticker covers transient channel failures during steady-state.
+        // Requires both a DB pool and a cell channel — gated on both.
+        if let (Some(pool), Some(tx)) = (self.db_pool.clone(), cell_tx.clone()) {
+            outbox::spawn_drainer(pool, tx);
+        } else {
+            tracing::debug!(
+                "Skipping cell_event_outbox drainer: db_pool or cell_tx not configured"
+            );
         }
 
         self.is_running = true;

--- a/crates/services/src/base/world_entry/methods/inventory/core.rs
+++ b/crates/services/src/base/world_entry/methods/inventory/core.rs
@@ -327,11 +327,15 @@ pub async fn handle_remove_inventory_item(
 ///
 /// Delivery durability (issue #96): the `ItemUsed` event is enqueued in
 /// `cell_event_outbox` first, then dispatched on the in-process channel.
-/// If the channel is closed/saturated the row stays undelivered and the
-/// background drainer ([`crate::base::outbox::spawn_drainer`]) retries it.
-/// The cell-side `BaseToCellMsg::ItemUsed` handler is idempotent — chain
-/// conditions self-gate on `step_status = active` so a duplicate fire
-/// from a drainer retry is harmless.
+/// `tokio::sync::mpsc::Sender::send().await` only fails when the receiver
+/// is dropped (e.g., cell task panicked / shut down) — full channels
+/// backpressure rather than error — so this guards specifically against
+/// a torn-down receiver. The undelivered row is replayed by the
+/// background drainer ([`crate::base::outbox::spawn_drainer`]) once a
+/// healthy cell channel is back. The cell-side `BaseToCellMsg::ItemUsed`
+/// handler is idempotent — chain conditions self-gate on
+/// `step_status = active` so a duplicate fire from a drainer retry is
+/// harmless.
 pub async fn handle_use_inventory_item(
     entity_id: u32,
     player_id: i32,

--- a/crates/services/src/base/world_entry/methods/inventory/core.rs
+++ b/crates/services/src/base/world_entry/methods/inventory/core.rs
@@ -6,6 +6,7 @@ use sqlx::PgPool;
 use tokio::net::UdpSocket;
 use tokio::sync::mpsc;
 
+use crate::base::outbox::{self, CellOutboxPayload};
 use crate::cell::messages::BaseToCellMsg;
 use crate::mercury::{build_entity_method_packet, method_idx};
 use super::super::super::super::helpers::send_to_witness;
@@ -324,10 +325,13 @@ pub async fn handle_remove_inventory_item(
 /// content events tied to actual inventory state — a malicious client
 /// can't spam `useItem(any id)` to trigger arbitrary chain actions.
 ///
-/// TODO(#96 delivery durability): the `ItemUsed` send is best-effort. If
-/// `cell_tx` is closed (cell service restart, channel saturation) the
-/// chain never fires — mission progression strands the player. Production
-/// fix is the outbox pattern in #96.
+/// Delivery durability (issue #96): the `ItemUsed` event is enqueued in
+/// `cell_event_outbox` first, then dispatched on the in-process channel.
+/// If the channel is closed/saturated the row stays undelivered and the
+/// background drainer ([`crate::base::outbox::spawn_drainer`]) retries it.
+/// The cell-side `BaseToCellMsg::ItemUsed` handler is idempotent — chain
+/// conditions self-gate on `step_status = active` so a duplicate fire
+/// from a drainer retry is harmless.
 pub async fn handle_use_inventory_item(
     entity_id: u32,
     player_id: i32,
@@ -375,17 +379,30 @@ pub async fn handle_use_inventory_item(
         "UseInventoryItem: firing ItemUsed (no consumption — chain decides)"
     );
 
-    if let Some(cell_tx) = cell_tx {
-        if let Err(e) = cell_tx.send(BaseToCellMsg::ItemUsed {
-            entity_id,
-            type_id,
-            target_id,
-        }).await {
+    let payload = CellOutboxPayload::ItemUsed { type_id, target_id };
+    let outbox_id = match outbox::enqueue(pool.as_ref(), entity_id, &payload).await {
+        Ok(id) => id,
+        Err(e) => {
+            // Outbox INSERT failed — cannot guarantee delivery, so do NOT
+            // attempt the in-process send (a successful send without an
+            // outbox row would lose its retry safety net on next failure).
+            // The player can re-use the item; ownership lookup above is
+            // idempotent.
             tracing::error!(
-                entity_id, player_id, item_id, error = %e,
-                "UseInventoryItem: cell channel closed sending ItemUsed — content event lost"
+                entity_id, player_id, item_id, type_id,
+                "UseInventoryItem: outbox enqueue failed; ItemUsed not dispatched: {e}"
             );
+            return;
         }
+    };
+
+    if let Some(cell_tx) = cell_tx {
+        outbox::try_dispatch_now(pool.as_ref(), cell_tx, outbox_id, entity_id, payload).await;
+    } else {
+        tracing::debug!(
+            entity_id, outbox_id,
+            "UseInventoryItem: no cell channel; row left for drainer"
+        );
     }
 }
 

--- a/crates/services/src/base/world_entry/methods/inventory/core.rs
+++ b/crates/services/src/base/world_entry/methods/inventory/core.rs
@@ -325,7 +325,7 @@ pub async fn handle_remove_inventory_item(
 /// content events tied to actual inventory state — a malicious client
 /// can't spam `useItem(any id)` to trigger arbitrary chain actions.
 ///
-/// Delivery durability (issue #96): the `ItemUsed` event is enqueued in
+/// Delivery durability: the `ItemUsed` event is enqueued in
 /// `cell_event_outbox` first, then dispatched on the in-process channel.
 /// `tokio::sync::mpsc::Sender::send().await` only fails when the receiver
 /// is dropped (e.g., cell task panicked / shut down) — full channels

--- a/db/database.sql
+++ b/db/database.sql
@@ -369,6 +369,7 @@
 \ir sgw/Players/Tables/sgw_player.sql
 \ir sgw/Shards/Tables/shards.sql
 \ir sgw/Audit/Tables/login_audit.sql
+\ir sgw/Outbox/Tables/cell_event_outbox.sql
 
 \ir sgw/_sequence_ownership.sql
 

--- a/db/scripts/add_cell_event_outbox.sql
+++ b/db/scripts/add_cell_event_outbox.sql
@@ -1,0 +1,18 @@
+-- Migration: add cell_event_outbox table for durable base→cell content events.
+-- Safe to run on existing databases (uses IF NOT EXISTS).
+-- See db/sgw/Outbox/Tables/cell_event_outbox.sql for the canonical definition
+-- and rationale (issue #96).
+
+CREATE TABLE IF NOT EXISTS cell_event_outbox (
+    id              BIGSERIAL PRIMARY KEY,
+    entity_id       INTEGER     NOT NULL,
+    event_type      VARCHAR(48) NOT NULL,
+    payload         JSONB       NOT NULL,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    delivered_at    TIMESTAMPTZ,
+    attempts        INTEGER     NOT NULL DEFAULT 0,
+    last_error      TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_cell_event_outbox_undelivered
+    ON cell_event_outbox (id) WHERE delivered_at IS NULL;

--- a/db/scripts/add_cell_event_outbox.sql
+++ b/db/scripts/add_cell_event_outbox.sql
@@ -1,7 +1,7 @@
 -- Migration: add cell_event_outbox table for durable base→cell content events.
 -- Safe to run on existing databases (uses IF NOT EXISTS).
 -- See db/sgw/Outbox/Tables/cell_event_outbox.sql for the canonical definition
--- and rationale (issue #96).
+-- and rationale.
 
 CREATE TABLE IF NOT EXISTS cell_event_outbox (
     id              BIGSERIAL PRIMARY KEY,

--- a/db/sgw/Outbox/Tables/cell_event_outbox.sql
+++ b/db/sgw/Outbox/Tables/cell_event_outbox.sql
@@ -5,7 +5,7 @@
 -- this, an mpsc send failure (receiver dropped — cell task panic / shut
 -- down, or panic between commit and send) would silently strand chains
 -- that gate on the event — most notably mission progression on
--- `OnItemUse`. See issue #96.
+-- `OnItemUse`.
 --
 -- (Note: `tokio::mpsc::Sender::send().await` does not error on a full
 -- channel — it backpressures. The failure mode this protects against is

--- a/db/sgw/Outbox/Tables/cell_event_outbox.sql
+++ b/db/sgw/Outbox/Tables/cell_event_outbox.sql
@@ -1,0 +1,39 @@
+-- cell_event_outbox — durable queue for base→cell content notifications.
+--
+-- Bridges the gap between "base committed a DB change" and "cell fires the
+-- corresponding content event over the in-process mpsc channel". Without
+-- this, an mpsc send failure (cell restart, channel saturation, panic
+-- between commit and send) would silently strand chains that gate on the
+-- event — most notably mission progression on `OnItemUse`. See issue #96.
+--
+-- Lifecycle:
+--   1. Base writes a row inside the same tx as (or alongside) the
+--      DB-visible state change.
+--   2. Base immediately attempts an in-process `cell_tx.send(...)`.
+--   3. On success → row is marked `delivered_at = NOW()`.
+--   4. On failure (channel closed, full, etc.) → row stays undelivered;
+--      a background drainer retries on a periodic timer + on startup.
+--
+-- The cell-side handler must be idempotent because retries can fan out
+-- after a crash + restart. `OnItemUse` already is — chain conditions like
+-- `step_status = active` self-gate, and the chain's own
+-- `Action::RemoveItem` is the consumption path.
+--
+-- attempts/last_error are advisory diagnostics for operators; the drainer
+-- does not gate retries on attempts today (single-operator deployment).
+-- A future hardening step can add a dead-letter threshold here.
+CREATE TABLE cell_event_outbox (
+    id              BIGSERIAL PRIMARY KEY,
+    entity_id       INTEGER     NOT NULL,
+    event_type      VARCHAR(48) NOT NULL,
+    payload         JSONB       NOT NULL,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    delivered_at    TIMESTAMPTZ,
+    attempts        INTEGER     NOT NULL DEFAULT 0,
+    last_error      TEXT
+);
+
+-- Drainer scans only undelivered rows, ordered by id. Partial index keeps
+-- the working set small even after months of delivered traffic.
+CREATE INDEX idx_cell_event_outbox_undelivered
+    ON cell_event_outbox (id) WHERE delivered_at IS NULL;

--- a/db/sgw/Outbox/Tables/cell_event_outbox.sql
+++ b/db/sgw/Outbox/Tables/cell_event_outbox.sql
@@ -2,16 +2,21 @@
 --
 -- Bridges the gap between "base committed a DB change" and "cell fires the
 -- corresponding content event over the in-process mpsc channel". Without
--- this, an mpsc send failure (cell restart, channel saturation, panic
--- between commit and send) would silently strand chains that gate on the
--- event — most notably mission progression on `OnItemUse`. See issue #96.
+-- this, an mpsc send failure (receiver dropped — cell task panic / shut
+-- down, or panic between commit and send) would silently strand chains
+-- that gate on the event — most notably mission progression on
+-- `OnItemUse`. See issue #96.
+--
+-- (Note: `tokio::mpsc::Sender::send().await` does not error on a full
+-- channel — it backpressures. The failure mode this protects against is
+-- specifically a torn-down receiver, not saturation.)
 --
 -- Lifecycle:
 --   1. Base writes a row inside the same tx as (or alongside) the
 --      DB-visible state change.
 --   2. Base immediately attempts an in-process `cell_tx.send(...)`.
 --   3. On success → row is marked `delivered_at = NOW()`.
---   4. On failure (channel closed, full, etc.) → row stays undelivered;
+--   4. On failure (receiver dropped) → row stays undelivered;
 --      a background drainer retries on a periodic timer + on startup.
 --
 -- The cell-side handler must be idempotent because retries can fan out


### PR DESCRIPTION
Closes #96.

## Summary

- New `cell_event_outbox` table persists base→cell content events so an in-process channel failure can't strand mission progression.
- New `crates/services/src/base/outbox` module with `enqueue` (one-shot), `enqueue_in_tx` (caller-owned tx — reserved for grant/remove follow-up), `try_dispatch_now` (immediate send + mark-delivered), and `spawn_drainer` (5s ticker + startup replay).
- `handle_use_inventory_item` now writes the outbox row first, then attempts the in-process send. If the send fails the row stays undelivered and the drainer retries.
- Drainer is wired into `BaseService::start()` and gated on both `db_pool` and `cell_tx` being configured.

## Scope

Only `ItemUsed` is migrated in this PR — that's the highest-stakes case named in the issue (mission progression depends on it). `InventoryItemGranted` / `InventoryItemRemoved` keep their existing best-effort send for now; the same `enqueue_in_tx` helper will let them migrate cleanly in a follow-up since they already run inside a transaction.

Out-of-scope per #96: multi-instance HA / FOR UPDATE SKIP LOCKED. The single-base assumption holds.

## Idempotency

Cell-side `BaseToCellMsg::ItemUsed` is already idempotent — chain conditions self-gate on `step_status = active` and `Action::RemoveItem` is the consumption path. A duplicate retry from the drainer (after a crash that lost the mark-delivered) is harmless.

## Migration

- Schema: `db/sgw/Outbox/Tables/cell_event_outbox.sql` (canonical, included in `db/database.sql`).
- Migration script for existing DBs: `db/scripts/add_cell_event_outbox.sql` (idempotent — `IF NOT EXISTS`).

## Test plan

- [x] 5 new unit tests in `outbox::tests` cover payload serde shape, event_type string stability (load-bearing — changing it breaks in-flight rows), row→message conversion, and unknown-event-type forward-compat skip.
- [x] `cargo test -p cimmeria-services` → 258 passed (was 253, +5 new).
- [x] `cargo check --workspace` (excl. Tauri apps) clean.
- [ ] Live-DB paths (`enqueue`, `drain_undelivered`, `mark_delivered`, `record_failure`) need integration coverage gated on #79's sqlx::test infra. Tracked there.
- [ ] End-to-end smoke: use a vial with the cell channel intact → expect `delivered_at` populated; with the channel torn down → expect row stays undelivered, drainer replays after channel reconnect. Manual verification deferred until a PR exercises live runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented a durable message delivery system that persists item usage events and automatically retries delivery if initial attempts fail, improving system reliability.

* **Database**
  * Added outbox table schema to track pending and delivered events with retry metadata and error logging.

* **Tests**
  * Added comprehensive test coverage for message serialization and payload conversion logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->