### PR TITLE
Reserve bandolier slot 0 for fist-weapon default (#119)

### DIFF
--- a/crates/services/src/base/character_create.rs
+++ b/crates/services/src/base/character_create.rs
@@ -12,7 +12,7 @@ use crate::mercury::read_wstring;
 use super::ConnectedClientState;
 use super::chardef::chardef_lookup;
 use super::helpers::{drain_acks_and_seq, get_account_entity_id};
-use super::resources::{bag_max_slots, BAG_FILL_ORDER, INV_BANDOLIER};
+use super::resources::{bag_max_slots, bag_min_slot, BAG_FILL_ORDER};
 use super::character::{query_character_list, send_char_create_failed};
 
 /// Handle `createCharacter` (0xC4) -- parse args and INSERT into sgw_player.
@@ -378,9 +378,7 @@ pub(crate) async fn handle_create_character(
                     }
                 };
 
-                let entry = slot_indices.entry(bag_id).or_insert_with(|| {
-                    if bag_id == INV_BANDOLIER { 1 } else { 0 }
-                });
+                let entry = slot_indices.entry(bag_id).or_insert_with(|| bag_min_slot(bag_id));
                 let current_slot = *entry;
                 *entry += 1;
 

--- a/crates/services/src/base/resources.rs
+++ b/crates/services/src/base/resources.rs
@@ -39,6 +39,18 @@ pub(crate) fn bag_max_slots(container_id: i32) -> i32 {
     }
 }
 
+/// Lowest assignable slot for a container. The bandolier reserves slot 0
+/// for the empty/fist default weapon — `active_bandolier_slot = 0` with no
+/// item present is the canonical "fists equipped" state, so any real grant
+/// or move targeting slot 0 of the bandolier would overwrite that fallback
+/// (issue #119). Python parity: `Account.py:191` —
+/// `slotIndices[bagId] = 1 if bagId == Atrea.enums.INV_Bandolier else 0`.
+///
+/// All other containers start at 0.
+pub(crate) fn bag_min_slot(container_id: i32) -> i32 {
+    if container_id == INV_BANDOLIER { 1 } else { 0 }
+}
+
 // ── Resource cache ───────────────────────────────────────────────────────────
 
 /// Per-category cooked data loaded from a PAK file.

--- a/crates/services/src/base/world_entry/methods/inventory/move_.rs
+++ b/crates/services/src/base/world_entry/methods/inventory/move_.rs
@@ -8,7 +8,7 @@ use tokio::sync::mpsc;
 
 use crate::cell::messages::BaseToCellMsg;
 use super::super::super::super::helpers::send_to_witness;
-use super::super::super::super::resources::bag_max_slots;
+use super::super::super::super::resources::{bag_max_slots, bag_min_slot};
 use super::super::super::super::ConnectedClientState;
 use super::core::send_full_inventory_update;
 use super::grant::item_allows_container;
@@ -48,10 +48,19 @@ pub async fn handle_move_inventory_item(
     };
 
     let max_slots = bag_max_slots(target_container_id);
-    if target_container_id <= 0 || target_slot_id < 0 || target_slot_id >= max_slots || quantity <= 0 {
+    let min_slot = bag_min_slot(target_container_id);
+    // Reject sub-min slot targets — for the bandolier this blocks moving
+    // anything into slot 0, which is reserved for the fist-weapon default
+    // (issue #119). Without this guard, a manual drag from the main bag
+    // to bandolier-slot-0 would clobber the fallback.
+    if target_container_id <= 0
+        || target_slot_id < min_slot
+        || target_slot_id >= max_slots
+        || quantity <= 0
+    {
         tracing::warn!(
             player_id, item_id, target_container_id, target_slot_id,
-            quantity, max_slots, "MoveInventoryItem: invalid target or quantity"
+            quantity, min_slot, max_slots, "MoveInventoryItem: invalid target or quantity"
         );
         return;
     }

--- a/crates/services/src/base/world_entry/methods/vendor/serializers.rs
+++ b/crates/services/src/base/world_entry/methods/vendor/serializers.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 
 use sqlx::{PgPool, Postgres, Transaction};
 
-use super::super::super::super::resources::bag_max_slots;
+use super::super::super::super::resources::{bag_max_slots, bag_min_slot};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StoreBuyCost {
@@ -96,20 +96,33 @@ pub fn serialize_store_update(updates: &[StoreItemCostUpdate]) -> Vec<u8> {
 }
 
 /// Find free inventory slots in a container, checking occupancy.
-pub fn free_inventory_slots(max_slots: i32, occupied_slots: &[i32], needed: usize) -> Option<Vec<i32>> {
+///
+/// `min_slot` is the lowest assignable slot (see [`bag_min_slot`]) — for the
+/// bandolier this is 1 because slot 0 is reserved for the empty/fist default
+/// weapon (issue #119). Filtering occupants by `min_slot` matters: if a row
+/// somehow lives in a sub-min slot (manual fixup, legacy data), it's
+/// excluded from the occupancy set so the function can still return real
+/// free slots above the threshold.
+pub fn free_inventory_slots(
+    min_slot: i32,
+    max_slots: i32,
+    occupied_slots: &[i32],
+    needed: usize,
+) -> Option<Vec<i32>> {
     if needed == 0 {
         return Some(Vec::new());
     }
-    if max_slots <= 0 {
+    if max_slots <= 0 || min_slot >= max_slots {
         return None;
     }
+    let min_slot = min_slot.max(0);
 
     let occupied: HashSet<i32> = occupied_slots
         .iter()
         .copied()
-        .filter(|slot| *slot >= 0 && *slot < max_slots)
+        .filter(|slot| *slot >= min_slot && *slot < max_slots)
         .collect();
-    let slots: Vec<i32> = (0..max_slots)
+    let slots: Vec<i32> = (min_slot..max_slots)
         .filter(|slot| !occupied.contains(slot))
         .take(needed)
         .collect();
@@ -153,8 +166,57 @@ pub async fn reserve_free_inventory_slots(
     .await?;
     let occupied_slots: Vec<i32> = rows.into_iter().map(|row| row.slot_id).collect();
     Ok(free_inventory_slots(
+        bag_min_slot(container_id),
         bag_max_slots(container_id),
         &occupied_slots,
         needed,
     ))
+}
+
+#[cfg(test)]
+mod free_inventory_slots_tests {
+    use super::*;
+
+    #[test]
+    fn allocates_from_zero_for_main_bag() {
+        // Main bag (container 1): min_slot = 0, slot 0 fillable.
+        let slots = free_inventory_slots(0, 4, &[], 2).unwrap();
+        assert_eq!(slots, vec![0, 1]);
+    }
+
+    #[test]
+    fn skips_slot_0_for_bandolier() {
+        // Bug #119 regression: bandolier (container 3) must start at slot 1
+        // so the fist-weapon default at slot 0 isn't overwritten.
+        let slots = free_inventory_slots(1, 4, &[], 3).unwrap();
+        assert_eq!(slots, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn bandolier_returns_none_when_only_slot_0_free() {
+        // 3 weapons already occupy slots 1,2,3; slot 0 is reserved.
+        // Asking for 1 more must return None, not [0].
+        let slots = free_inventory_slots(1, 4, &[1, 2, 3], 1);
+        assert!(slots.is_none(), "must not allocate the reserved slot 0");
+    }
+
+    #[test]
+    fn ignores_sub_min_occupants_when_finding_free_slots() {
+        // A stray row at slot 0 (legacy fixup) shouldn't make slot 1 look
+        // occupied — the filter on `occupied_slots` is min/max bounded so
+        // we still hand back the real free slot above the threshold.
+        let slots = free_inventory_slots(1, 4, &[0, 2], 2).unwrap();
+        assert_eq!(slots, vec![1, 3]);
+    }
+
+    #[test]
+    fn returns_empty_when_zero_needed() {
+        assert_eq!(free_inventory_slots(1, 4, &[], 0).unwrap(), Vec::<i32>::new());
+    }
+
+    #[test]
+    fn returns_none_when_min_exceeds_max() {
+        // Defensive: nonsensical min/max combo should not wrap or panic.
+        assert!(free_inventory_slots(5, 4, &[], 1).is_none());
+    }
 }


### PR DESCRIPTION
Closes #119.

## Summary

The bandolier reserves slot 0 for the empty/fist default weapon (python ref: `Account.py:191`, `SGWPlayer.py:454`). Three Rust paths bypassed that reservation:

1. `reserve_free_inventory_slots` iterated from slot 0 — vendor purchases, mission grants, content-engine grants would all land in slot 0 of an empty bandolier.
2. `handle_move_inventory_item` validation accepted any `target_slot_id >= 0` — manual drag could clobber slot 0.
3. `character_create.rs` had the right semantics inline but duplicated the rule.

Centralized as `bag_min_slot(container_id)` in `base/resources.rs`. `free_inventory_slots` now takes `min_slot` and iterates from there; the move validator rejects sub-min targets; character creation uses the shared helper.

## Test plan

- [x] 6 new tests in `free_inventory_slots_tests`: main-bag allocates from 0, bandolier skips slot 0, bandolier returns None when only slot 0 is free (the regression for the bug), sub-min occupant filtering doesn't poison real free slots, zero-needed shortcut, defensive handling of min >= max.
- [x] `cargo test -p cimmeria-services` -> 259 pass (was 253, +6 new).
- [x] `cargo check --workspace` (excl. Tauri apps) clean.
- [ ] Live verification: grant a weapon to a fresh character via vendor/chain; expect it to land in slot 1, not slot 0; expect `active_ammo()` for slot 0 to still resolve to 0/fist. Deferred — exercise on next playtest pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)