### PR TITLE
Migrate grant/remove/vendor to outbox

### DIFF
--- a/crates/services/src/base/outbox/mod.rs
+++ b/crates/services/src/base/outbox/mod.rs
@@ -45,24 +45,41 @@ mod tests;
 /// Event types persisted in `cell_event_outbox.event_type`. Stable strings —
 /// changing one breaks in-flight rows on existing databases.
 const EVENT_TYPE_ITEM_USED: &str = "item_used";
+const EVENT_TYPE_INVENTORY_ITEM_GRANTED: &str = "inventory_item_granted";
+const EVENT_TYPE_INVENTORY_ITEM_REMOVED: &str = "inventory_item_removed";
 
 /// Strongly-typed payload variants. Serialized as JSON into the
 /// `cell_event_outbox.payload` JSONB column. Adding a new variant requires
 /// only (a) a new enum arm here, (b) a matching `event_type` constant, and
-/// (c) an arm in [`row_to_message`].
+/// (c) an arm in [`row_to_message`] AND in [`try_dispatch_now`].
 ///
 /// Variants intentionally don't carry `entity_id` — it lives in its own
 /// indexed column for ordering / per-entity drainer scoping.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum CellOutboxPayload {
-    ItemUsed { type_id: i32, target_id: i32 },
+    ItemUsed {
+        type_id: i32,
+        target_id: i32,
+    },
+    InventoryItemGranted {
+        item_id: i32,
+        container_id: i32,
+        slot_id: i32,
+        quantity: i32,
+    },
+    InventoryItemRemoved {
+        item_id: i32,
+        source_container_id: i32,
+    },
 }
 
 impl CellOutboxPayload {
     fn event_type(&self) -> &'static str {
         match self {
             CellOutboxPayload::ItemUsed { .. } => EVENT_TYPE_ITEM_USED,
+            CellOutboxPayload::InventoryItemGranted { .. } => EVENT_TYPE_INVENTORY_ITEM_GRANTED,
+            CellOutboxPayload::InventoryItemRemoved { .. } => EVENT_TYPE_INVENTORY_ITEM_REMOVED,
         }
     }
 }
@@ -101,10 +118,10 @@ pub async fn enqueue(
 }
 
 /// INSERT inside a caller-owned transaction so the outbox row commits
-/// atomically with the caller's DB-visible state change. Reserved for
-/// callers that already mutate the DB (grant/remove); `handle_use_inventory_item`
-/// uses [`enqueue`] instead because it has no surrounding tx.
-#[allow(dead_code)]
+/// atomically with the caller's DB-visible state change. Used by grant /
+/// remove / vendor purchase / vendor sell — anything that already opens a
+/// transaction for an inventory mutation. `handle_use_inventory_item` uses
+/// [`enqueue`] instead because it has no surrounding tx.
 pub async fn enqueue_in_tx(
     tx: &mut Transaction<'_, Postgres>,
     entity_id: u32,
@@ -158,14 +175,33 @@ async fn record_failure(pool: &PgPool, id: i64, error: &str) {
 /// on `attempts`. Without this gate, a single bad row turns into a continuous
 /// warn-spam at the 5s drain interval.
 fn row_to_message(row: &OutboxRow) -> Option<BaseToCellMsg> {
+    let entity_id = row.entity_id as u32;
     match (row.event_type.as_str(), &*row.payload) {
         (EVENT_TYPE_ITEM_USED, CellOutboxPayload::ItemUsed { type_id, target_id }) => {
             Some(BaseToCellMsg::ItemUsed {
-                entity_id: row.entity_id as u32,
+                entity_id,
                 type_id: *type_id,
                 target_id: *target_id,
             })
         }
+        (
+            EVENT_TYPE_INVENTORY_ITEM_GRANTED,
+            CellOutboxPayload::InventoryItemGranted { item_id, container_id, slot_id, quantity },
+        ) => Some(BaseToCellMsg::InventoryItemGranted {
+            entity_id,
+            item_id: *item_id,
+            container_id: *container_id,
+            slot_id: *slot_id,
+            quantity: *quantity,
+        }),
+        (
+            EVENT_TYPE_INVENTORY_ITEM_REMOVED,
+            CellOutboxPayload::InventoryItemRemoved { item_id, source_container_id },
+        ) => Some(BaseToCellMsg::InventoryItemRemoved {
+            entity_id,
+            item_id: *item_id,
+            source_container_id: *source_container_id,
+        }),
         _ => None,
     }
 }
@@ -187,6 +223,14 @@ pub async fn try_dispatch_now(
             type_id,
             target_id,
         },
+        CellOutboxPayload::InventoryItemGranted {
+            item_id, container_id, slot_id, quantity,
+        } => BaseToCellMsg::InventoryItemGranted {
+            entity_id, item_id, container_id, slot_id, quantity,
+        },
+        CellOutboxPayload::InventoryItemRemoved { item_id, source_container_id } => {
+            BaseToCellMsg::InventoryItemRemoved { entity_id, item_id, source_container_id }
+        }
     };
     match cell_tx.send(msg).await {
         Ok(()) => {

--- a/crates/services/src/base/outbox/tests.rs
+++ b/crates/services/src/base/outbox/tests.rs
@@ -80,26 +80,45 @@ fn row_to_message_returns_none_for_unknown_event_type() {
 }
 
 #[test]
-fn payload_kind_tags_are_stable_for_all_variants() {
-    // The kind tag is the persistence contract — changing one breaks
-    // every in-flight row on existing databases. Pin them so a future
-    // rename surfaces here, not in production.
-    assert_eq!(
-        CellOutboxPayload::ItemUsed { type_id: 0, target_id: 0 }.event_type(),
-        "item_used",
-    );
-    assert_eq!(
-        CellOutboxPayload::InventoryItemGranted {
-            item_id: 0, container_id: 0, slot_id: 0, quantity: 0,
-        }.event_type(),
-        "inventory_item_granted",
-    );
-    assert_eq!(
-        CellOutboxPayload::InventoryItemRemoved {
-            item_id: 0, source_container_id: 0,
-        }.event_type(),
-        "inventory_item_removed",
-    );
+fn persistence_contract_strings_are_stable_for_all_variants() {
+    // Each variant has TWO persistence contracts that must agree:
+    //   - `event_type()` returns the string written to the
+    //     `cell_event_outbox.event_type` VARCHAR column.
+    //   - serde's `tag = "kind"` writes the same string into the
+    //     payload JSONB body.
+    // `row_to_message` matches on (event_type, payload) so both must
+    // line up; pin them together here. Changing either string breaks
+    // every in-flight row on existing databases.
+    let cases: &[(CellOutboxPayload, &str)] = &[
+        (
+            CellOutboxPayload::ItemUsed { type_id: 0, target_id: 0 },
+            "item_used",
+        ),
+        (
+            CellOutboxPayload::InventoryItemGranted {
+                item_id: 0, container_id: 0, slot_id: 0, quantity: 0,
+            },
+            "inventory_item_granted",
+        ),
+        (
+            CellOutboxPayload::InventoryItemRemoved {
+                item_id: 0, source_container_id: 0,
+            },
+            "inventory_item_removed",
+        ),
+    ];
+
+    for (variant, expected) in cases {
+        assert_eq!(
+            variant.event_type(), *expected,
+            "event_type() drift for {variant:?}",
+        );
+        let json = serde_json::to_value(variant).unwrap();
+        assert_eq!(
+            json["kind"], *expected,
+            "JSON `kind` tag drift for {variant:?}",
+        );
+    }
 }
 
 #[test]

--- a/crates/services/src/base/outbox/tests.rs
+++ b/crates/services/src/base/outbox/tests.rs
@@ -80,6 +80,123 @@ fn row_to_message_returns_none_for_unknown_event_type() {
 }
 
 #[test]
+fn payload_kind_tags_are_stable_for_all_variants() {
+    // The kind tag is the persistence contract — changing one breaks
+    // every in-flight row on existing databases. Pin them so a future
+    // rename surfaces here, not in production.
+    assert_eq!(
+        CellOutboxPayload::ItemUsed { type_id: 0, target_id: 0 }.event_type(),
+        "item_used",
+    );
+    assert_eq!(
+        CellOutboxPayload::InventoryItemGranted {
+            item_id: 0, container_id: 0, slot_id: 0, quantity: 0,
+        }.event_type(),
+        "inventory_item_granted",
+    );
+    assert_eq!(
+        CellOutboxPayload::InventoryItemRemoved {
+            item_id: 0, source_container_id: 0,
+        }.event_type(),
+        "inventory_item_removed",
+    );
+}
+
+#[test]
+fn inventory_item_granted_roundtrips() {
+    let p = CellOutboxPayload::InventoryItemGranted {
+        item_id: 100_001,
+        container_id: 1,
+        slot_id: 5,
+        quantity: 3,
+    };
+    let json = serde_json::to_string(&p).unwrap();
+    let back: CellOutboxPayload = serde_json::from_str(&json).unwrap();
+    assert_eq!(back, p);
+}
+
+#[test]
+fn inventory_item_removed_roundtrips() {
+    let p = CellOutboxPayload::InventoryItemRemoved {
+        item_id: 100_002,
+        source_container_id: 3,
+    };
+    let json = serde_json::to_string(&p).unwrap();
+    let back: CellOutboxPayload = serde_json::from_str(&json).unwrap();
+    assert_eq!(back, p);
+}
+
+#[test]
+fn row_to_message_builds_inventory_item_granted() {
+    let row = OutboxRow {
+        id: 200,
+        entity_id: 42,
+        event_type: "inventory_item_granted".to_string(),
+        payload: sqlx::types::Json(CellOutboxPayload::InventoryItemGranted {
+            item_id: 100_007,
+            container_id: 1,
+            slot_id: 2,
+            quantity: 1,
+        }),
+        attempts: 0,
+    };
+    match row_to_message(&row).expect("known event_type") {
+        BaseToCellMsg::InventoryItemGranted {
+            entity_id, item_id, container_id, slot_id, quantity,
+        } => {
+            assert_eq!(entity_id, 42);
+            assert_eq!(item_id, 100_007);
+            assert_eq!(container_id, 1);
+            assert_eq!(slot_id, 2);
+            assert_eq!(quantity, 1);
+        }
+        _ => panic!("expected InventoryItemGranted"),
+    }
+}
+
+#[test]
+fn row_to_message_builds_inventory_item_removed() {
+    let row = OutboxRow {
+        id: 201,
+        entity_id: 42,
+        event_type: "inventory_item_removed".to_string(),
+        payload: sqlx::types::Json(CellOutboxPayload::InventoryItemRemoved {
+            item_id: 100_008,
+            source_container_id: 3,
+        }),
+        attempts: 0,
+    };
+    match row_to_message(&row).expect("known event_type") {
+        BaseToCellMsg::InventoryItemRemoved {
+            entity_id, item_id, source_container_id,
+        } => {
+            assert_eq!(entity_id, 42);
+            assert_eq!(item_id, 100_008);
+            assert_eq!(source_container_id, 3);
+        }
+        _ => panic!("expected InventoryItemRemoved"),
+    }
+}
+
+#[test]
+fn row_to_message_returns_none_on_event_type_payload_mismatch() {
+    // Defensive: an event_type that says "granted" but a payload that
+    // shape-matches a different variant (legacy data, hand-edited row,
+    // future variant rename half-rolled) must not silently dispatch the
+    // wrong message — drainer should skip and log.
+    let row = OutboxRow {
+        id: 202,
+        entity_id: 1,
+        event_type: "inventory_item_granted".to_string(),
+        payload: sqlx::types::Json(CellOutboxPayload::ItemUsed {
+            type_id: 0, target_id: 0,
+        }),
+        attempts: 0,
+    };
+    assert!(row_to_message(&row).is_none());
+}
+
+#[test]
 fn drain_stats_default_is_all_zero() {
     // The drainer's "no work" path returns `Default` and the periodic-log
     // gate suppresses on all-zero. Pin the default values so a future

--- a/crates/services/src/base/world_entry/methods/inventory/core.rs
+++ b/crates/services/src/base/world_entry/methods/inventory/core.rs
@@ -253,6 +253,31 @@ pub async fn handle_remove_inventory_item(
         }
     }
 
+    // Enqueue the cell-notification BEFORE commit so the outbox row and the
+    // inventory mutation become visible atomically. Only fired on full removal
+    // — partial decrement doesn't change which item-instances exist on the
+    // cell side. If outbox INSERT fails we abort the remove rather than leave
+    // the inventory mutated without a durable notification path.
+    let outbox_payload_id = if removed_all {
+        let payload = CellOutboxPayload::InventoryItemRemoved {
+            item_id,
+            source_container_id: source.container_id,
+        };
+        match outbox::enqueue_in_tx(&mut tx, entity_id, &payload).await {
+            Ok(id) => Some((id, payload)),
+            Err(e) => {
+                let _ = tx.rollback().await;
+                tracing::error!(
+                    player_id, item_id,
+                    "RemoveInventoryItem: outbox enqueue failed, aborting: {e}"
+                );
+                return;
+            }
+        }
+    } else {
+        None
+    };
+
     if let Err(e) = tx.commit().await {
         tracing::error!(player_id, item_id, "RemoveInventoryItem: commit failed: {e}");
         return;
@@ -281,16 +306,8 @@ pub async fn handle_remove_inventory_item(
         "Inventory remove persisted"
     );
 
-    if removed_all {
-        if let Some(cell_tx) = cell_tx {
-            let _ = cell_tx
-                .send(BaseToCellMsg::InventoryItemRemoved {
-                    entity_id,
-                    item_id,
-                    source_container_id: source.container_id,
-                })
-                .await;
-        }
+    if let (Some((outbox_id, payload)), Some(tx)) = (outbox_payload_id, cell_tx) {
+        outbox::try_dispatch_now(pool.as_ref(), tx, outbox_id, entity_id, payload).await;
     }
 
     if source.container_id == 3 {
@@ -549,6 +566,26 @@ pub async fn handle_remove_inventory_item_by_type(
         }
     }
 
+    let outbox_payload_id = if removed_all {
+        let payload = CellOutboxPayload::InventoryItemRemoved {
+            item_id: removed_item_id,
+            source_container_id: source.container_id,
+        };
+        match outbox::enqueue_in_tx(&mut tx, entity_id, &payload).await {
+            Ok(id) => Some((id, payload)),
+            Err(e) => {
+                let _ = tx.rollback().await;
+                tracing::error!(
+                    player_id, type_id,
+                    "RemoveInventoryItemByType: outbox enqueue failed, aborting: {e}"
+                );
+                return;
+            }
+        }
+    } else {
+        None
+    };
+
     if let Err(e) = tx.commit().await {
         tracing::error!(player_id, type_id, "RemoveInventoryItemByType: commit failed: {e}");
         return;
@@ -567,14 +604,8 @@ pub async fn handle_remove_inventory_item_by_type(
         "RemoveInventoryItemByType: persisted"
     );
 
-    if removed_all {
-        if let Some(cell_tx) = cell_tx {
-            let _ = cell_tx.send(BaseToCellMsg::InventoryItemRemoved {
-                entity_id,
-                item_id: removed_item_id,
-                source_container_id: source.container_id,
-            }).await;
-        }
+    if let (Some((outbox_id, payload)), Some(tx)) = (outbox_payload_id, cell_tx) {
+        outbox::try_dispatch_now(pool.as_ref(), tx, outbox_id, entity_id, payload).await;
     }
 
     if source.container_id == 3 {

--- a/crates/services/src/base/world_entry/methods/inventory/grant.rs
+++ b/crates/services/src/base/world_entry/methods/inventory/grant.rs
@@ -6,6 +6,7 @@ use sqlx::PgPool;
 use tokio::net::UdpSocket;
 use tokio::sync::mpsc;
 
+use crate::base::outbox::{self, CellOutboxPayload};
 use crate::base::{ConnectedClientState, helpers, world_entry_appearance};
 use crate::cell::messages::BaseToCellMsg;
 use crate::mercury::{build_entity_method_packet, method_idx};
@@ -220,6 +221,29 @@ pub async fn handle_grant_item(
         }
     }
 
+    // Enqueue the cell-notification BEFORE commit so the outbox row and the
+    // inventory mutation become visible atomically. After commit, try the
+    // in-process dispatch; if the cell receiver is gone, the row stays
+    // undelivered for the background drainer to retry.
+    let outbox_payload = CellOutboxPayload::InventoryItemGranted {
+        item_id,
+        container_id,
+        slot_id: next_slot,
+        quantity: count,
+    };
+    let outbox_id = match outbox::enqueue_in_tx(&mut db_tx, entity_id, &outbox_payload).await {
+        Ok(id) => id,
+        Err(e) => {
+            // Outbox INSERT failed — abort the grant rather than commit
+            // an inventory mutation we can't durably notify the cell about.
+            // The player retries the grant trigger, which is idempotent at
+            // the chain level.
+            let _ = db_tx.rollback().await;
+            tracing::error!(player_id, item_id, "GrantItem: outbox enqueue failed, aborting: {e}");
+            return;
+        }
+    };
+
     if let Err(e) = db_tx.commit().await {
         tracing::error!(player_id, item_id, "GrantItem: commit failed: {e}");
         return;
@@ -243,23 +267,7 @@ pub async fn handle_grant_item(
     );
 
     if let Some(tx) = cell_tx {
-        if let Err(e) = tx
-            .send(BaseToCellMsg::InventoryItemGranted {
-                entity_id,
-                item_id,
-                container_id,
-                slot_id: next_slot,
-                quantity: count,
-            })
-            .await
-        {
-            tracing::warn!(
-                entity_id,
-                player_id,
-                item_id,
-                "GrantItem: cell channel closed while emitting InventoryItemGranted: {e}"
-            );
-        }
+        outbox::try_dispatch_now(pool.as_ref(), tx, outbox_id, entity_id, outbox_payload).await;
     }
 
     let is_equipped = (3..=14).contains(&container_id);

--- a/crates/services/src/base/world_entry/methods/vendor/purchase.rs
+++ b/crates/services/src/base/world_entry/methods/vendor/purchase.rs
@@ -6,6 +6,7 @@ use sqlx::PgPool;
 use tokio::net::UdpSocket;
 use tokio::sync::mpsc;
 
+use crate::base::outbox::{self, CellOutboxPayload};
 use crate::cell::messages::BaseToCellMsg;
 use super::super::super::super::ConnectedClientState;
 use super::super::inventory::core::send_full_inventory_update;
@@ -255,6 +256,32 @@ pub async fn handle_purchase_vendor_items(
         }
     }
 
+    // Enqueue one outbox row per granted item inside the same tx so the
+    // entire purchase (cash debit + N inventory inserts + N cell
+    // notifications) is atomic. If any outbox INSERT fails we abort the
+    // whole purchase.
+    let mut outbox_pending: Vec<(i64, CellOutboxPayload)> =
+        Vec::with_capacity(granted.len());
+    for (design_id, slot_id, quantity) in &granted {
+        let payload = CellOutboxPayload::InventoryItemGranted {
+            item_id: *design_id,
+            container_id: INV_MAIN,
+            slot_id: *slot_id,
+            quantity: *quantity,
+        };
+        match outbox::enqueue_in_tx(&mut tx, entity_id, &payload).await {
+            Ok(id) => outbox_pending.push((id, payload)),
+            Err(e) => {
+                let _ = tx.rollback().await;
+                tracing::error!(
+                    entity_id, player_id, design_id,
+                    "PurchaseVendorItems: outbox enqueue failed, aborting: {e}"
+                );
+                return;
+            }
+        }
+    }
+
     if let Err(e) = tx.commit().await {
         tracing::error!(entity_id, player_id, "PurchaseVendorItems: commit failed: {e}");
         return;
@@ -275,25 +302,8 @@ pub async fn handle_purchase_vendor_items(
     .await;
 
     if let Some(cell_tx) = cell_tx {
-        for (design_id, slot_id, quantity) in &granted {
-            if let Err(e) = cell_tx
-                .send(BaseToCellMsg::InventoryItemGranted {
-                    entity_id,
-                    item_id: *design_id,
-                    container_id: INV_MAIN,
-                    slot_id: *slot_id,
-                    quantity: *quantity,
-                })
-                .await
-            {
-                tracing::warn!(
-                    entity_id,
-                    player_id,
-                    design_id,
-                    "PurchaseVendorItems: cell channel closed during InventoryItemGranted: {e}"
-                );
-                break;
-            }
+        for (outbox_id, payload) in outbox_pending {
+            outbox::try_dispatch_now(pool.as_ref(), cell_tx, outbox_id, entity_id, payload).await;
         }
     }
 

--- a/crates/services/src/base/world_entry/methods/vendor/sell.rs
+++ b/crates/services/src/base/world_entry/methods/vendor/sell.rs
@@ -6,6 +6,7 @@ use sqlx::PgPool;
 use tokio::net::UdpSocket;
 use tokio::sync::mpsc;
 
+use crate::base::outbox::{self, CellOutboxPayload};
 use crate::cell::messages::BaseToCellMsg;
 use super::super::super::super::ConnectedClientState;
 use super::super::inventory::core::send_full_inventory_update;
@@ -372,6 +373,31 @@ pub async fn handle_sell_vendor_items(
         None
     };
 
+    // Enqueue one outbox row per removed item inside the same tx so the
+    // entire sell (cash credit + N inventory removes + N cell notifications)
+    // is atomic. If any outbox INSERT fails we abort the whole sell — better
+    // than committing partial state that leaves the cell with no durable
+    // notification path.
+    let mut outbox_pending: Vec<(i64, CellOutboxPayload)> =
+        Vec::with_capacity(removed_items.len());
+    for (item_id, container_id) in &removed_items {
+        let payload = CellOutboxPayload::InventoryItemRemoved {
+            item_id: *item_id,
+            source_container_id: *container_id,
+        };
+        match outbox::enqueue_in_tx(&mut tx, entity_id, &payload).await {
+            Ok(id) => outbox_pending.push((id, payload)),
+            Err(e) => {
+                let _ = tx.rollback().await;
+                tracing::error!(
+                    entity_id, player_id, item_id,
+                    "SellVendorItems: outbox enqueue failed, aborting: {e}"
+                );
+                return;
+            }
+        }
+    }
+
     if let Err(e) = tx.commit().await {
         tracing::error!(entity_id, player_id, "SellVendorItems: commit failed: {e}");
         return;
@@ -396,14 +422,8 @@ pub async fn handle_sell_vendor_items(
     // incremental price clears we'd compute from `removed_items`.
 
     if let Some(cell_tx) = cell_tx {
-        for (item_id, container_id) in &removed_items {
-            let _ = cell_tx
-                .send(BaseToCellMsg::InventoryItemRemoved {
-                    entity_id,
-                    item_id: *item_id,
-                    source_container_id: *container_id,
-                })
-                .await;
+        for (outbox_id, payload) in outbox_pending {
+            outbox::try_dispatch_now(pool.as_ref(), cell_tx, outbox_id, entity_id, payload).await;
         }
     }
 


### PR DESCRIPTION
PR #124 shipped the outbox infrastructure but only wired \`ItemUsed\`. The other three event types (\`InventoryItemGranted\`, \`InventoryItemRemoved\`) kept their best-effort \`cell_tx.send\` and would silently lose notifications if the cell receiver was dropped. Closes that follow-up.

## Pattern (same at each site)

1. Build the \`CellOutboxPayload\` variant.
2. Inside the existing inventory-mutation tx, \`outbox::enqueue_in_tx(&mut tx, entity_id, &payload)\` inserts the outbox row alongside the inventory write — atomic.
3. After commit, \`outbox::try_dispatch_now(...)\` for the in-process send. On failure the row stays undelivered and the drainer retries.
4. If outbox INSERT fails inside the tx, abort the whole operation rather than committing an inventory mutation we can't durably notify the cell about.

## Migrated

| Site | Rows per call |
|------|--------------|
| \`inventory::grant::handle_grant_item\` | 1 |
| \`inventory::core::handle_remove_inventory_item\` | 1 (only on full removal — partial decrement doesn't change instance existence) |
| \`inventory::core::handle_remove_inventory_item_by_type\` | 1 (same full-removal gate) |
| \`vendor::sell::handle_sell_vendor_items\` | N (one per removed item, all in the same tx) |
| \`vendor::purchase::handle_purchase_vendor_items\` | N (one per granted item) |

## Outbox API additions

- \`CellOutboxPayload::InventoryItemGranted { item_id, container_id, slot_id, quantity }\`
- \`CellOutboxPayload::InventoryItemRemoved { item_id, source_container_id }\`
- \`event_type\` strings: \`inventory_item_granted\`, \`inventory_item_removed\` (persistence contract — pinned in tests)
- \`enqueue_in_tx\` lost its \`#[allow(dead_code)]\` — it now has production callers.

## Test plan

- [x] +6 outbox tests: kind-tag stability for all 3 variants, JSON roundtrip for each new variant, row-to-message dispatch for each new variant, event_type/payload mismatch defense.
- [x] \`cargo test -p cimmeria-services\` -> 286 pass (was 280, +6).
- [x] \`cargo check --workspace\` (excl. Tauri apps) clean.
- [ ] Live-DB verification of the rollback-on-outbox-failure path needs the sqlx::test infra from #79.

🤖 Generated with [Claude Code](https://claude.com/claude-code)