### PR TITLE
test(vendor,inventory): unit tests for normalize_item_ids and normalize_item_quantities

### DIFF
--- a/crates/services/src/base/world_entry/methods/inventory/grant.rs
+++ b/crates/services/src/base/world_entry/methods/inventory/grant.rs
@@ -458,3 +458,42 @@ pub async fn handle_grant_item(
         .await;
     }
 }
+
+#[cfg(test)]
+mod normalize_item_ids_tests {
+    use super::normalize_item_ids;
+
+    #[test]
+    fn drops_non_positive_ids() {
+        assert_eq!(normalize_item_ids(vec![-3, 0, 1, 2]), vec![1, 2]);
+    }
+
+    #[test]
+    fn dedupes_repeated_ids() {
+        assert_eq!(normalize_item_ids(vec![5, 5, 5]), vec![5]);
+    }
+
+    #[test]
+    fn sorts_ascending() {
+        assert_eq!(normalize_item_ids(vec![3, 1, 2]), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn empty_input_returns_empty() {
+        assert!(normalize_item_ids(Vec::new()).is_empty());
+    }
+
+    #[test]
+    fn all_invalid_returns_empty() {
+        assert!(normalize_item_ids(vec![-1, 0, -100]).is_empty());
+    }
+
+    #[test]
+    fn combined_dedupe_sort_filter() {
+        // Mixed bag: i32::MIN, zeros, dupes, out-of-order positives. Result
+        // must be sorted, deduped, and contain only the positive ids exactly
+        // once each.
+        let out = normalize_item_ids(vec![10, -1, 5, 10, 0, 5, i32::MIN, 7, 5]);
+        assert_eq!(out, vec![5, 7, 10]);
+    }
+}

--- a/crates/services/src/base/world_entry/methods/vendor/purchase_helpers.rs
+++ b/crates/services/src/base/world_entry/methods/vendor/purchase_helpers.rs
@@ -338,3 +338,59 @@ pub fn normalize_item_quantities(items: Vec<(i32, i32)>, allow_zero_item_id: boo
     }
     normalized
 }
+
+#[cfg(test)]
+mod normalize_item_quantities_tests {
+    use super::normalize_item_quantities;
+
+    #[test]
+    fn drops_non_positive_quantities() {
+        let out = normalize_item_quantities(vec![(1, 5), (2, 0), (3, -7)], false);
+        assert_eq!(out, vec![(1, 5)]);
+    }
+
+    #[test]
+    fn drops_non_positive_item_ids_when_zero_disallowed() {
+        let out = normalize_item_quantities(vec![(0, 5), (-1, 5), (3, 5)], false);
+        assert_eq!(out, vec![(3, 5)], "id 0 and -1 must be dropped when allow_zero_item_id=false");
+    }
+
+    #[test]
+    fn keeps_zero_item_id_when_allowed_but_still_drops_negative() {
+        // The flag allows item_id == 0 (e.g. the "any item" wildcard in some
+        // recipe contexts) but a negative id is always invalid.
+        let out = normalize_item_quantities(vec![(0, 5), (-1, 5), (3, 5)], true);
+        assert_eq!(out, vec![(0, 5), (3, 5)]);
+    }
+
+    #[test]
+    fn dedupes_by_summing_quantities() {
+        let out = normalize_item_quantities(vec![(7, 1), (7, 2), (7, 4)], false);
+        assert_eq!(out, vec![(7, 7)]);
+    }
+
+    #[test]
+    fn preserves_first_occurrence_order() {
+        // Note: function does NOT sort — dedupe-by-linear-scan keeps the order
+        // of the first occurrence. Locking that in so a future "let's sort
+        // these for determinism" refactor would have to be deliberate.
+        let out = normalize_item_quantities(vec![(3, 1), (1, 1), (2, 1)], false);
+        assert_eq!(out, vec![(3, 1), (1, 1), (2, 1)]);
+    }
+
+    #[test]
+    fn dedupe_uses_saturating_add_on_overflow() {
+        // saturating_add prevents a malicious client from wrapping the merged
+        // quantity into a negative — without it, two i32::MAX entries would
+        // sum to -2 and slip past downstream "quantity > 0" guards.
+        let out = normalize_item_quantities(
+            vec![(1, i32::MAX), (1, i32::MAX)], false,
+        );
+        assert_eq!(out, vec![(1, i32::MAX)]);
+    }
+
+    #[test]
+    fn empty_input_returns_empty() {
+        assert!(normalize_item_quantities(Vec::new(), false).is_empty());
+    }
+}


### PR DESCRIPTION
## Summary
- Adds 13 unit tests for the two pure normalization helpers in [vendor/purchase_helpers.rs](crates/services/src/base/world_entry/methods/vendor/purchase_helpers.rs#L320) and [inventory/grant.rs](crates/services/src/base/world_entry/methods/inventory/grant.rs#L18).
- Both are first-line defenses against malformed client input — they get hit on every purchase / grant call, so a regression here is a high-blast-radius silent corruption.
- New \`normalize_item_ids_tests\` and \`normalize_item_quantities_tests\` modules at the bottom of each file.
- File sizes: \`grant.rs\` 459 → 498, \`purchase_helpers.rs\` 339 → 395 (both well under caps).

## What's covered

**\`normalize_item_ids\`** (grant.rs) — drops non-positive ids, sorts, dedupes:
- \`drops_non_positive_ids\` — excludes 0 and negatives
- \`dedupes_repeated_ids\` — collapses dupes
- \`sorts_ascending\` — output is sorted
- \`empty_input_returns_empty\`, \`all_invalid_returns_empty\` — boundary cases
- \`combined_dedupe_sort_filter\` — mixed input including \`i32::MIN\`, dupes, zeros, and out-of-order positives

**\`normalize_item_quantities\`** (purchase_helpers.rs) — drops non-positive quantities + invalid ids, dedupes by summing:
- \`drops_non_positive_quantities\` — quantity \<= 0 always dropped
- \`drops_non_positive_item_ids_when_zero_disallowed\` — \`allow_zero_item_id=false\` drops 0 and negatives
- \`keeps_zero_item_id_when_allowed_but_still_drops_negative\` — \`allow_zero_item_id=true\` lets 0 through but still rejects negatives
- \`dedupes_by_summing_quantities\` — repeated ids merge into one entry with summed quantity
- \`preserves_first_occurrence_order\` — pins the no-sort behavior so a future "let's sort" refactor would have to be deliberate
- \`dedupe_uses_saturating_add_on_overflow\` — regression guard: two \`i32::MAX\` entries don't wrap to a negative that could slip past downstream \`quantity > 0\` guards
- \`empty_input_returns_empty\`

## Note on the issue body
The #79 Group B checklist describes \`normalize_item_quantities\` as having an \`allow_negative\` flag and being sorted. The actual function takes \`allow_zero_item_id\` and preserves insertion order — these tests assert what the code actually does, not the stale description.

\`consume_design_quantity\` is also listed under Group B but is async and takes a \`Transaction\` — its "line consumption math" is interleaved with SQL queries, so it really belongs in Group A (live-DB integration tests). Skipping it here.

## Coordination with #135 / #136
No file overlap with PR #135 (mercury/world_data) or PR #136 (vendor/serializers).

## Test plan
- [x] \`cargo test -p cimmeria-services --lib normalize\` — 13 / 13 pass.
- [x] Compiles clean against \`main\`.