### PR TITLE
test(cell): read_i32_array unit tests + neutral-NPC INTERACT regression guard

### DIFF
--- a/crates/services/src/cell/cell_methods/player/interaction.rs
+++ b/crates/services/src/cell/cell_methods/player/interaction.rs
@@ -359,9 +359,11 @@ mod tests {
         let handled = dispatch(1, INTERACT, &args, &tx, &mut mgr, &engine).await;
         assert!(handled, "INTERACT must always return true (handled)");
 
-        // No combat-side effects. Method 16 = onTargetUpdate (the hostile
-        // reroute marker); useAbility downstream would also surface as a
-        // base->cell ability call. We assert neither appears.
+        // Method 16 = onTargetUpdate is the canonical hostile-reroute marker
+        // emitted at the top of the is_hostile branch (interaction.rs:53-56).
+        // Asserting it never appears is a precise probe for "the hostile
+        // reroute didn't run" — the alive_hostile_reroutes_to_useability test
+        // pins the converse direction, so together they bracket the branch.
         while let Ok(msg) = rx.try_recv() {
             if let CellToBaseMsg::EntityMethodCall { method_index, .. } = msg {
                 assert_ne!(

--- a/crates/services/src/cell/cell_methods/player/interaction.rs
+++ b/crates/services/src/cell/cell_methods/player/interaction.rs
@@ -322,4 +322,53 @@ mod tests {
         }
         assert!(saw_loot_display, "expected onLootDisplay (method 114) for dead lootable corpse");
     }
+
+    /// A neutral NPC (faction != 10) with no dialog/template/tag must NOT be
+    /// rerouted to combat. The is_hostile early branch is gated on faction
+    /// 10 specifically — if a future regression drops the faction check the
+    /// fall-through would silently auto-attack neutral civilians on right-
+    /// click.
+    #[tokio::test]
+    async fn neutral_npc_with_no_interaction_does_not_route_to_combat() {
+        let mut mgr = make_space_manager();
+        mgr.create_entity(1, "Agnos", [0.0, 0.0, 0.0], [0.0; 3]).unwrap();
+        if let Some(p) = mgr.get_entity_mut(1) {
+            p.player_id = Some(42);
+        }
+        let npc_id = mgr.allocate_npc_id();
+        mgr.spawn_npc(npc_id, "Agnos", [2.0, 0.0, 0.0], [0.0; 3]).unwrap();
+        if let Some(npc) = mgr.get_entity_mut(npc_id) {
+            // Neutral / non-hostile faction. Faction 10 is the only value
+            // that enables the hostile reroute — anything else (including
+            // the default 0) must fall through to the dialog/interact path.
+            npc.faction = 0;
+            npc.clear_all_state_flags();
+            // No tag, no template name, no interaction_type configured —
+            // i.e. there's nothing for the dialog/interact path to do
+            // either. The point of the test is that *nothing combat-related*
+            // happens, not that some interaction succeeds.
+            npc.tag = None;
+            npc.npc_name = None;
+            npc.interaction_type = None;
+        }
+
+        let (tx, mut rx) = mpsc::channel(16);
+        let engine = cimmeria_content_engine::chain::ChainEngine::new();
+        let mut args = Vec::with_capacity(4);
+        args.extend_from_slice(&(npc_id as i32).to_le_bytes());
+        let handled = dispatch(1, INTERACT, &args, &tx, &mut mgr, &engine).await;
+        assert!(handled, "INTERACT must always return true (handled)");
+
+        // No combat-side effects. Method 16 = onTargetUpdate (the hostile
+        // reroute marker); useAbility downstream would also surface as a
+        // base->cell ability call. We assert neither appears.
+        while let Ok(msg) = rx.try_recv() {
+            if let CellToBaseMsg::EntityMethodCall { method_index, .. } = msg {
+                assert_ne!(
+                    method_index, 16,
+                    "neutral NPC must not fire onTargetUpdate from INTERACT",
+                );
+            }
+        }
+    }
 }

--- a/crates/services/src/cell/cell_methods/player/vendor.rs
+++ b/crates/services/src/cell/cell_methods/player/vendor.rs
@@ -230,3 +230,85 @@ pub async fn dispatch(
         _ => false,
     }
 }
+
+#[cfg(test)]
+mod read_i32_array_tests {
+    use super::read_i32_array;
+
+    #[test]
+    fn empty_array_returns_empty_vec() {
+        let buf = 0u32.to_le_bytes();
+        let mut off = 0;
+        assert_eq!(read_i32_array(&buf, &mut off), Some(vec![]));
+        assert_eq!(off, 4, "offset must advance past the count prefix");
+    }
+
+    #[test]
+    fn single_pair_parses_in_order() {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&1u32.to_le_bytes());
+        buf.extend_from_slice(&12345i32.to_le_bytes());
+        buf.extend_from_slice(&67i32.to_le_bytes());
+        let mut off = 0;
+        assert_eq!(read_i32_array(&buf, &mut off), Some(vec![(12345, 67)]));
+        assert_eq!(off, 12);
+    }
+
+    #[test]
+    fn multiple_pairs_preserve_input_order() {
+        let pairs: [(i32, i32); 3] = [(10, 1), (20, 2), (30, 3)];
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&(pairs.len() as u32).to_le_bytes());
+        for (id, q) in &pairs {
+            buf.extend_from_slice(&id.to_le_bytes());
+            buf.extend_from_slice(&q.to_le_bytes());
+        }
+        let mut off = 0;
+        let parsed = read_i32_array(&buf, &mut off).expect("parse must succeed");
+        assert_eq!(parsed, pairs.to_vec());
+        assert_eq!(off, 4 + pairs.len() * 8);
+    }
+
+    #[test]
+    fn returns_none_when_too_short_for_count_prefix() {
+        let mut off = 0;
+        assert!(read_i32_array(&[0, 1, 2], &mut off).is_none());
+    }
+
+    #[test]
+    fn returns_none_when_payload_truncated_mid_pair() {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&2u32.to_le_bytes());
+        buf.extend_from_slice(&1i32.to_le_bytes());
+        buf.extend_from_slice(&1i32.to_le_bytes());
+        buf.extend_from_slice(&[0u8, 0u8]); // truncated 2nd pair
+        let mut off = 0;
+        assert!(read_i32_array(&buf, &mut off).is_none());
+    }
+
+    #[test]
+    fn rejects_oversized_count_without_allocating() {
+        // count = u32::MAX with only 4 bytes after the prefix would imply
+        // ~32 GiB of payload. The function must reject up-front so a
+        // malicious packet can't OOM the cell process via Vec::with_capacity.
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&u32::MAX.to_le_bytes());
+        buf.extend_from_slice(&[0u8; 4]); // far less than u32::MAX * 8 bytes
+        let mut off = 0;
+        assert!(read_i32_array(&buf, &mut off).is_none());
+    }
+
+    #[test]
+    fn parses_at_nonzero_offset() {
+        // The function uses `*offset` for both bounds checks and indexing, so
+        // a non-zero starting offset must work the same as a fresh slice.
+        let mut buf = Vec::with_capacity(16);
+        buf.extend_from_slice(&[0xAA, 0xBB, 0xCC, 0xDD]); // junk prefix
+        buf.extend_from_slice(&1u32.to_le_bytes());
+        buf.extend_from_slice(&7i32.to_le_bytes());
+        buf.extend_from_slice(&8i32.to_le_bytes());
+        let mut off = 4;
+        assert_eq!(read_i32_array(&buf, &mut off), Some(vec![(7, 8)]));
+        assert_eq!(off, 16);
+    }
+}


### PR DESCRIPTION
## Summary
- Two cell-side regression guards from #79 Group B, in independent files.
- 7 unit tests for [read_i32_array](crates/services/src/cell/cell_methods/player/vendor.rs#L7) — the wire-format parser hit by every vendor op.
- 1 integration-style test for the [INTERACT neutral-NPC fall-through](crates/services/src/cell/cell_methods/player/interaction.rs#L22) — mirrors the existing alive/dead hostile test pattern in the same file.
- File sizes: \`vendor.rs\` 232 → 314, \`interaction.rs\` 325 → 374. Both under 500.

## What's covered

**\`read_i32_array\`** (private fn — tested via inner module):
- \`empty_array_returns_empty_vec\` — \`u32(0)\` count works and offset advances by 4
- \`single_pair_parses_in_order\` — pins (item_id, quantity) field order
- \`multiple_pairs_preserve_input_order\` — no implicit sort
- \`returns_none_when_too_short_for_count_prefix\` — \<4-byte buffer
- \`returns_none_when_payload_truncated_mid_pair\` — count says 2, only 1.25 pairs of bytes
- \`rejects_oversized_count_without_allocating\` — regression guard: \`count = u32::MAX\` with a tiny payload must NOT call \`Vec::with_capacity(MAX)\` and OOM the cell process
- \`parses_at_nonzero_offset\` — pins the offset semantics (the function uses \`*offset\` for both bounds checks and indexing)

**\`INTERACT\` neutral-NPC fall-through** (\`neutral_npc_with_no_interaction_does_not_route_to_combat\`): spawns a faction-0 NPC with no tag, template, or interaction_type, dispatches INTERACT, and asserts no combat-side message (method 16 / onTargetUpdate) appears in the channel. The hostile reroute is gated specifically on \`faction == 10\`; if a future regression drops that check the fall-through would auto-attack neutrals on right-click.

## Coordination
- No file overlap with #135, #136, or #137. All four PRs touch disjoint files.

## Test plan
- [x] \`cargo test -p cimmeria-services --lib cell_methods::player\` — 10 / 10 pass (7 new + 3 existing).
- [x] Compiles clean against \`main\`.