### PR TITLE
test(cell): unit tests for send_store_open bail paths

### DIFF
--- a/crates/services/src/cell/interactions/vendor.rs
+++ b/crates/services/src/cell/interactions/vendor.rs
@@ -49,3 +49,131 @@ pub(super) async fn send_store_open(
         vendor_template_id,
     }).await;
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_space_manager() -> SpaceManager {
+        let mut mgr = SpaceManager::new(1);
+        let spaces_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<Spaces><Space WorldName="Agnos" Instanced="false" MinX="-2400" MaxX="2200" MinY="-3200" MaxY="2800" /></Spaces>"#;
+        let cell_spaces_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<Spaces><Space WorldName="Agnos" /></Spaces>"#;
+        mgr.parse_spaces_xml(spaces_xml).unwrap();
+        mgr.create_startup_spaces(cell_spaces_xml).unwrap();
+        mgr
+    }
+
+    fn collect_open_vendor_messages(
+        rx: &mut mpsc::Receiver<CellToBaseMsg>,
+    ) -> Vec<(u32, i32, i32, Option<i32>)> {
+        let mut out = Vec::new();
+        while let Ok(msg) = rx.try_recv() {
+            if let CellToBaseMsg::OpenVendorStore {
+                entity_id, player_id, vendor_entity_id, vendor_template_id,
+            } = msg
+            {
+                out.push((entity_id, player_id, vendor_entity_id, vendor_template_id));
+            }
+        }
+        out
+    }
+
+    #[tokio::test]
+    async fn happy_path_sends_open_vendor_store_with_template_id() {
+        let mut mgr = make_space_manager();
+        mgr.create_entity(1, "Agnos", [0.0, 0.0, 0.0], [0.0; 3]).unwrap();
+        if let Some(p) = mgr.get_entity_mut(1) {
+            p.player_id = Some(4242);
+        }
+        let vendor_entity_id = mgr.allocate_npc_id();
+        mgr.spawn_npc(vendor_entity_id, "Agnos", [2.0, 0.0, 0.0], [0.0; 3]).unwrap();
+        if let Some(v) = mgr.get_entity_mut(vendor_entity_id) {
+            v.template_id = Some(9001);
+        }
+
+        let (tx, mut rx) = mpsc::channel(8);
+        send_store_open(1, vendor_entity_id, &tx, &mut mgr).await;
+
+        let msgs = collect_open_vendor_messages(&mut rx);
+        assert_eq!(msgs.len(), 1, "happy path must send exactly one OpenVendorStore");
+        let (entity_id, player_db_id, vendor_id_i32, template_id) = msgs[0];
+        assert_eq!(entity_id, 1);
+        assert_eq!(player_db_id, 4242);
+        assert_eq!(vendor_id_i32, vendor_entity_id as i32);
+        assert_eq!(template_id, Some(9001));
+
+        // Side-effect: player.vendor_entity is set so subsequent vendor ops
+        // can resolve the open vendor session via vendor_context.
+        assert_eq!(
+            mgr.get_entity(1).and_then(|p| p.vendor_entity),
+            Some(vendor_entity_id),
+        );
+    }
+
+    #[tokio::test]
+    async fn bails_silently_when_player_id_missing() {
+        let mut mgr = make_space_manager();
+        mgr.create_entity(1, "Agnos", [0.0, 0.0, 0.0], [0.0; 3]).unwrap();
+        // Note: deliberately NOT setting player.player_id — that's the regression.
+        let vendor_entity_id = mgr.allocate_npc_id();
+        mgr.spawn_npc(vendor_entity_id, "Agnos", [2.0, 0.0, 0.0], [0.0; 3]).unwrap();
+        if let Some(v) = mgr.get_entity_mut(vendor_entity_id) {
+            v.template_id = Some(9001);
+        }
+
+        let (tx, mut rx) = mpsc::channel(8);
+        send_store_open(1, vendor_entity_id, &tx, &mut mgr).await;
+
+        // The bug fixed in #77 was that this path sent OpenVendorStore with
+        // player_id: 0 — which then routed to whatever character row had id 0
+        // and corrupted that account's vendor session. The fix bails before
+        // the send. Asserting an empty channel pins that.
+        assert!(
+            collect_open_vendor_messages(&mut rx).is_empty(),
+            "must not send OpenVendorStore when player has no player_id",
+        );
+    }
+
+    #[tokio::test]
+    async fn bails_silently_when_vendor_entity_id_exceeds_i32_max() {
+        let mut mgr = make_space_manager();
+        mgr.create_entity(1, "Agnos", [0.0, 0.0, 0.0], [0.0; 3]).unwrap();
+        if let Some(p) = mgr.get_entity_mut(1) {
+            p.player_id = Some(4242);
+        }
+        // Out-of-range u32 id. We don't need a vendor entity to actually live
+        // at this id — the i32::try_from check fails before the entity lookup
+        // is meaningful, and the function must bail rather than wrap into a
+        // negative i32.
+        let oversized: u32 = (i32::MAX as u32) + 1;
+
+        let (tx, mut rx) = mpsc::channel(8);
+        send_store_open(1, oversized, &tx, &mut mgr).await;
+
+        assert!(
+            collect_open_vendor_messages(&mut rx).is_empty(),
+            "must not send OpenVendorStore for vendor_entity_id > i32::MAX",
+        );
+    }
+
+    #[tokio::test]
+    async fn happy_path_with_vendor_lacking_template_id_sends_none() {
+        let mut mgr = make_space_manager();
+        mgr.create_entity(1, "Agnos", [0.0, 0.0, 0.0], [0.0; 3]).unwrap();
+        if let Some(p) = mgr.get_entity_mut(1) {
+            p.player_id = Some(4242);
+        }
+        let vendor_entity_id = mgr.allocate_npc_id();
+        mgr.spawn_npc(vendor_entity_id, "Agnos", [2.0, 0.0, 0.0], [0.0; 3]).unwrap();
+        // template_id deliberately left None.
+
+        let (tx, mut rx) = mpsc::channel(8);
+        send_store_open(1, vendor_entity_id, &tx, &mut mgr).await;
+
+        let msgs = collect_open_vendor_messages(&mut rx);
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].3, None, "missing vendor template_id must surface as None, not 0");
+    }
+}

--- a/crates/services/src/cell/interactions/vendor.rs
+++ b/crates/services/src/cell/interactions/vendor.rs
@@ -113,7 +113,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn bails_silently_when_player_id_missing() {
+    async fn does_not_send_when_player_id_missing() {
         let mut mgr = make_space_manager();
         mgr.create_entity(1, "Agnos", [0.0, 0.0, 0.0], [0.0; 3]).unwrap();
         // Note: deliberately NOT setting player.player_id — that's the regression.
@@ -126,10 +126,10 @@ mod tests {
         let (tx, mut rx) = mpsc::channel(8);
         send_store_open(1, vendor_entity_id, &tx, &mut mgr).await;
 
-        // The bug fixed in #77 was that this path sent OpenVendorStore with
-        // player_id: 0 — which then routed to whatever character row had id 0
-        // and corrupted that account's vendor session. The fix bails before
-        // the send. Asserting an empty channel pins that.
+        // Without the missing-player_id guard, this path would send
+        // OpenVendorStore { player_id: 0, .. }, which then routes to whatever
+        // character row has id 0 and corrupts that account's vendor session.
+        // The function must return early before reaching the send.
         assert!(
             collect_open_vendor_messages(&mut rx).is_empty(),
             "must not send OpenVendorStore when player has no player_id",
@@ -137,7 +137,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn bails_silently_when_vendor_entity_id_exceeds_i32_max() {
+    async fn does_not_send_when_vendor_entity_id_exceeds_i32_max() {
         let mut mgr = make_space_manager();
         mgr.create_entity(1, "Agnos", [0.0, 0.0, 0.0], [0.0; 3]).unwrap();
         if let Some(p) = mgr.get_entity_mut(1) {


### PR DESCRIPTION
## Summary
- 4 unit tests for [cell/interactions/vendor.rs::send_store_open](crates/services/src/cell/interactions/vendor.rs#L12) covering both regression guards from #79 Group B.
- File grows from 51 → 179 lines (well under cap).
- Branch is rebased onto current main (post-merge of #134/#136/#137).

## What's covered
- **\`happy_path_sends_open_vendor_store_with_template_id\`** — pins the message fields (entity_id, player_id, vendor_id_i32, template_id) and the side-effect of setting \`player.vendor_entity\` for downstream vendor_context lookups.
- **\`bails_silently_when_player_id_missing\`** — regression guard for the pre-fix bug that sent \`OpenVendorStore { player_id: 0, .. }\`, routing the vendor open to whatever character row had id 0. Asserts an empty channel.
- **\`bails_silently_when_vendor_entity_id_exceeds_i32_max\`** — regression guard for the \`as i32\` wrap that would push \`vendor_entity_id\` into negative territory. Uses \`(i32::MAX as u32) + 1\` to fail \`i32::try_from\`.
- **\`happy_path_with_vendor_lacking_template_id_sends_none\`** — pins the \`Option<i32>\` template_id contract so a missing template_id surfaces as \`None\` rather than \`Some(0)\` or \`Some(-1)\`.

Helper \`make_space_manager\` mirrors the pattern from \`cell_methods/player/interaction.rs\`. \`collect_open_vendor_messages\` drains the channel into a flat \`(entity_id, player_db_id, vendor_id_i32, template_id)\` tuple list so each test asserts only on what it cares about.

## Coordination
- Independent file — no overlap with #135 (mercury) or #138 (cell_methods/player).
- PR #136 / #137 already merged. Branch rebased onto current main.

## Test plan
- [x] \`cargo test -p cimmeria-services --lib cell::interactions::vendor\` — 4 / 4 pass.
- [x] Compiles clean against rebased \`main\`.