### PR TITLE
test(cell): unit tests for vendor_context resolver

### DIFF
--- a/crates/services/src/cell/cell_methods/player/vendor.rs
+++ b/crates/services/src/cell/cell_methods/player/vendor.rs
@@ -312,3 +312,112 @@ mod read_i32_array_tests {
         assert_eq!(off, 16);
     }
 }
+
+#[cfg(test)]
+mod vendor_context_tests {
+    use super::{vendor_context, VendorSession};
+    use crate::cell::space_manager::SpaceManager;
+
+    fn make_space_manager() -> SpaceManager {
+        let mut mgr = SpaceManager::new(1);
+        let spaces_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<Spaces><Space WorldName="Agnos" Instanced="false" MinX="-2400" MaxX="2200" MinY="-3200" MaxY="2800" /></Spaces>"#;
+        let cell_spaces_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<Spaces><Space WorldName="Agnos" /></Spaces>"#;
+        mgr.parse_spaces_xml(spaces_xml).unwrap();
+        mgr.create_startup_spaces(cell_spaces_xml).unwrap();
+        mgr
+    }
+
+    fn assert_session(
+        session: Option<VendorSession>,
+        expected_player_id: i32,
+        expected_vendor_entity_id: i32,
+        expected_template_id: Option<i32>,
+    ) {
+        let s = session.expect("vendor_context should return Some");
+        assert_eq!(s.player_id, expected_player_id);
+        assert_eq!(s.vendor_entity_id, expected_vendor_entity_id);
+        assert_eq!(s.server_template_id, expected_template_id);
+    }
+
+    #[test]
+    fn returns_none_when_entity_does_not_exist() {
+        let mgr = make_space_manager();
+        assert!(vendor_context(99999, &mgr).is_none());
+    }
+
+    #[test]
+    fn returns_none_when_player_id_missing() {
+        let mut mgr = make_space_manager();
+        mgr.create_entity(1, "Agnos", [0.0, 0.0, 0.0], [0.0; 3]).unwrap();
+        // player.player_id deliberately left None.
+        let vendor = mgr.allocate_npc_id();
+        mgr.spawn_npc(vendor, "Agnos", [2.0, 0.0, 0.0], [0.0; 3]).unwrap();
+        if let Some(p) = mgr.get_entity_mut(1) {
+            p.vendor_entity = Some(vendor);
+        }
+        assert!(vendor_context(1, &mgr).is_none());
+    }
+
+    #[test]
+    fn returns_none_when_vendor_entity_unset() {
+        let mut mgr = make_space_manager();
+        mgr.create_entity(1, "Agnos", [0.0, 0.0, 0.0], [0.0; 3]).unwrap();
+        if let Some(p) = mgr.get_entity_mut(1) {
+            p.player_id = Some(4242);
+            // p.vendor_entity deliberately left None — no vendor opened.
+        }
+        assert!(vendor_context(1, &mgr).is_none());
+    }
+
+    #[test]
+    fn happy_path_returns_session_with_template_id() {
+        let mut mgr = make_space_manager();
+        mgr.create_entity(1, "Agnos", [0.0, 0.0, 0.0], [0.0; 3]).unwrap();
+        let vendor = mgr.allocate_npc_id();
+        mgr.spawn_npc(vendor, "Agnos", [2.0, 0.0, 0.0], [0.0; 3]).unwrap();
+        if let Some(v) = mgr.get_entity_mut(vendor) {
+            v.template_id = Some(9001);
+        }
+        if let Some(p) = mgr.get_entity_mut(1) {
+            p.player_id = Some(4242);
+            p.vendor_entity = Some(vendor);
+        }
+        assert_session(vendor_context(1, &mgr), 4242, vendor as i32, Some(9001));
+    }
+
+    #[test]
+    fn happy_path_returns_session_when_vendor_lacks_template_id() {
+        // The function reads template_id authoritatively from the vendor
+        // entity, falling back to None rather than fabricating a value. A
+        // missing template_id surfaces as `server_template_id: None` —
+        // validate_template_id at the caller treats that as a rejection
+        // (so a client can't open a templateless vendor and submit ops).
+        let mut mgr = make_space_manager();
+        mgr.create_entity(1, "Agnos", [0.0, 0.0, 0.0], [0.0; 3]).unwrap();
+        let vendor = mgr.allocate_npc_id();
+        mgr.spawn_npc(vendor, "Agnos", [2.0, 0.0, 0.0], [0.0; 3]).unwrap();
+        // Deliberately not setting template_id on the vendor.
+        if let Some(p) = mgr.get_entity_mut(1) {
+            p.player_id = Some(4242);
+            p.vendor_entity = Some(vendor);
+        }
+        assert_session(vendor_context(1, &mgr), 4242, vendor as i32, None);
+    }
+
+    #[test]
+    fn returns_none_when_player_id_set_but_vendor_entity_does_not_exist() {
+        // The player has a stale vendor_entity pointing at an id that doesn't
+        // exist (vendor despawned or never spawned). vendor_context still
+        // returns Some with server_template_id: None — the caller's
+        // validate_template_id arm logs and rejects the op.
+        let mut mgr = make_space_manager();
+        mgr.create_entity(1, "Agnos", [0.0, 0.0, 0.0], [0.0; 3]).unwrap();
+        if let Some(p) = mgr.get_entity_mut(1) {
+            p.player_id = Some(4242);
+            p.vendor_entity = Some(123456); // no entity at this id
+        }
+        assert_session(vendor_context(1, &mgr), 4242, 123456, None);
+    }
+}

--- a/crates/services/src/cell/cell_methods/player/vendor.rs
+++ b/crates/services/src/cell/cell_methods/player/vendor.rs
@@ -407,7 +407,7 @@ mod vendor_context_tests {
     }
 
     #[test]
-    fn returns_none_when_player_id_set_but_vendor_entity_does_not_exist() {
+    fn returns_session_with_no_template_when_vendor_entity_id_is_stale() {
         // The player has a stale vendor_entity pointing at an id that doesn't
         // exist (vendor despawned or never spawned). vendor_context still
         // returns Some with server_template_id: None — the caller's


### PR DESCRIPTION
## Summary
- 6 unit tests for the private \`vendor_context\` helper in [cell/cell_methods/player/vendor.rs](crates/services/src/cell/cell_methods/player/vendor.rs#L72) that resolves \`(player_id, vendor_entity_id, server_template_id)\` before every vendor op.
- File grows from 314 → 423 lines.
- Last remaining unit-test item from #79 Group B (after this lands, the burndown moves to Group A live-DB integration).

## What's covered
- **\`returns_none_when_entity_does_not_exist\`** — bogus player entity id.
- **\`returns_none_when_player_id_missing\`** — entity exists but \`player_id\` is None.
- **\`returns_none_when_vendor_entity_unset\`** — entity has player_id but no open vendor.
- **\`happy_path_returns_session_with_template_id\`** — both fields populated, vendor has \`template_id: Some(..)\`.
- **\`happy_path_returns_session_when_vendor_lacks_template_id\`** — vendor has no template_id, \`server_template_id\` surfaces as \`None\` rather than a fabricated default.
- **\`returns_none_when_player_id_set_but_vendor_entity_does_not_exist\`** — pins the "stale vendor_entity" behavior. The player's \`vendor_entity\` points at an id that no longer exists (vendor despawned). \`vendor_context\` still returns \`Some(.., server_template_id: None)\`; \`validate_template_id\` at the caller is what rejects the op. Without this, a despawned-vendor scenario could silently drop ops with no explanation.

\`assert_session\` helper deduplicates the field-by-field check across the three Some-returning cases.

## Coordination
- Touches \`cell/cell_methods/player/vendor.rs\` — same file as merged #138 (read_i32_array tests). My new tests sit in a separate \`vendor_context_tests\` module after the existing \`read_i32_array_tests\`. No overlap with #140 (dispatch.rs).

## Test plan
- [x] \`cargo test -p cimmeria-services --lib cell::cell_methods::player::vendor::vendor_context_tests\` — 6 / 6 pass.
- [x] Compiles clean against current main.