### PR TITLE
test(inventory/grant): live-DB tests for handle_grant_item incl. concurrency guard

### DIFF
--- a/crates/services/src/base/world_entry/methods/inventory/grant.rs
+++ b/crates/services/src/base/world_entry/methods/inventory/grant.rs
@@ -586,14 +586,23 @@ mod handle_grant_item_tests {
             &db_pool, &None, &socket, &conn, &e2a,
         ).await;
 
-        let row: Option<(i32, i32, i32)> = sqlx::query_as(
+        // Assert "exactly one row" structurally rather than via fetch_optional,
+        // which would silently pick whichever row matched first and could
+        // mask a regression that inserted multiple rows.
+        let count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM sgw_inventory \
+             WHERE character_id = $1 AND container_id = 1",
+        ).bind(player_id).fetch_one(&pool).await.unwrap();
+        assert_eq!(count, 1, "grant must INSERT exactly one row");
+
+        let row: (i32, i32, i32) = sqlx::query_as(
             "SELECT type_id, slot_id, stack_size FROM sgw_inventory \
              WHERE character_id = $1 AND container_id = 1",
-        ).bind(player_id).fetch_optional(&pool).await.unwrap();
+        ).bind(player_id).fetch_one(&pool).await.unwrap();
         assert_eq!(
             row,
-            Some((type_id, 0, 3)),
-            "grant must INSERT exactly one row at slot 0 with the requested type_id and count",
+            (type_id, 0, 3),
+            "grant inserted at slot 0 with the requested type_id and count",
         );
 
         cleanup(&pool, account_id, player_id, entity_id).await;
@@ -601,14 +610,25 @@ mod handle_grant_item_tests {
 
     /// Regression guard: pg_advisory_xact_lock on (player_id, container_id)
     /// inside `reserve_free_inventory_slots` must serialize concurrent grants
-    /// so each picks a distinct slot. Without it, both calls see slot 0 free,
-    /// both INSERT into slot 0, and the unique-slot index forces one of them
-    /// to fail — turning a routine grant into a user-visible error.
+    /// so each picks a distinct slot. Without it, multiple calls see the same
+    /// slot free, all INSERT into it, and the unique-slot index forces all
+    /// but one to fail — turning a routine grant into a user-visible error.
     ///
-    /// Runs both grants via tokio::join! so they hold separate connections
-    /// from the pool (test_pool() bounds at 4) and contend for the lock.
-    #[tokio::test]
+    /// Runs four grants on separately-spawned tasks (so the scheduler can't
+    /// trivially serialize them onto a single connection), each holding its
+    /// own pool connection (test_pool() bounds at 4 — exact match). A barrier
+    /// forces all four to call into reserve_free_inventory_slots near
+    /// simultaneously, maximising contention on the advisory lock.
+    ///
+    /// The single-pair version of this test could plausibly false-negative
+    /// when scheduling/DB timing happens to serialize the two futures and
+    /// they pick slots 0 then 1 anyway. Four grants colliding makes a
+    /// no-lock implementation overwhelmingly likely to drop at least one
+    /// row to the unique-slot index.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn concurrent_grants_to_same_container_get_distinct_slots() {
+        use tokio::sync::Barrier;
+
         let pool = require_db_or_skip!();
         let account_id = TEST_BASE + 100;
         let player_id = TEST_BASE + 101;
@@ -619,19 +639,29 @@ mod handle_grant_item_tests {
 
         let (socket, e2a, conn) = make_state(entity_id);
         let db_pool = Some(Arc::new(pool.clone()));
+        const N: usize = 4;
+        let barrier = Arc::new(Barrier::new(N));
 
-        // Two grants race on the same (player_id, container_id) advisory lock.
-        // Both must succeed and end up in different slots — slot 0 and slot 1.
-        tokio::join!(
-            handle_grant_item(
-                entity_id, player_id, type_id, 1, 1,
-                &db_pool, &None, &socket, &conn, &e2a,
-            ),
-            handle_grant_item(
-                entity_id, player_id, type_id, 1, 1,
-                &db_pool, &None, &socket, &conn, &e2a,
-            ),
-        );
+        let mut handles = Vec::with_capacity(N);
+        for _ in 0..N {
+            let db_pool = db_pool.clone();
+            let socket = socket.clone();
+            let conn = conn.clone();
+            let e2a = e2a.clone();
+            let barrier = barrier.clone();
+            handles.push(tokio::spawn(async move {
+                // Synchronise so all N calls hit the slot-reservation lock
+                // attempt at roughly the same moment.
+                barrier.wait().await;
+                handle_grant_item(
+                    entity_id, player_id, type_id, 1, 1,
+                    &db_pool, &None, &socket, &conn, &e2a,
+                ).await;
+            }));
+        }
+        for h in handles {
+            h.await.expect("grant task panicked");
+        }
 
         let slots: Vec<i32> = sqlx::query_scalar(
             "SELECT slot_id FROM sgw_inventory \
@@ -640,14 +670,16 @@ mod handle_grant_item_tests {
         ).bind(player_id).fetch_all(&pool).await.unwrap();
 
         assert_eq!(
-            slots.len(),
-            2,
-            "both concurrent grants must INSERT (got {} rows). \
-             A missing row means the unique-slot index rejected one of them, \
-             which is exactly the regression the advisory lock prevents.",
+            slots.len(), N,
+            "all {N} concurrent grants must INSERT (got {} rows). A missing \
+             row means the unique-slot index rejected one — exactly the \
+             regression the advisory lock prevents.",
             slots.len(),
         );
-        assert_eq!(slots, vec![0, 1], "concurrent grants must pick distinct, sequential free slots");
+        assert_eq!(
+            slots, (0..N as i32).collect::<Vec<_>>(),
+            "concurrent grants must pick distinct, sequential slots 0..{N}",
+        );
 
         cleanup(&pool, account_id, player_id, entity_id).await;
     }

--- a/crates/services/src/base/world_entry/methods/inventory/grant.rs
+++ b/crates/services/src/base/world_entry/methods/inventory/grant.rs
@@ -497,3 +497,158 @@ mod normalize_item_ids_tests {
         assert_eq!(out, vec![5, 7, 10]);
     }
 }
+
+#[cfg(test)]
+mod handle_grant_item_tests {
+    use super::*;
+    use crate::test_support::require_db_or_skip;
+
+    /// Sentinel base for grant-item tests. Distinct from move_inventory
+    /// (0x7000_0200) and grant_cash (0x7000_0100).
+    const TEST_BASE: i32 = 0x7000_0300;
+
+    async fn cleanup(pool: &PgPool, account_id: i32, player_id: i32, entity_id: u32) {
+        let _ = sqlx::query("DELETE FROM cell_event_outbox WHERE entity_id = $1")
+            .bind(entity_id as i32)
+            .execute(pool).await;
+        let _ = sqlx::query("DELETE FROM sgw_inventory WHERE character_id = $1")
+            .bind(player_id)
+            .execute(pool).await;
+        let _ = sqlx::query("DELETE FROM account WHERE account_id = $1")
+            .bind(account_id)
+            .execute(pool).await;
+    }
+
+    async fn insert_account_and_player(pool: &PgPool, account_id: i32, player_id: i32) {
+        sqlx::query(
+            "INSERT INTO account (account_id, account_name, password) \
+             VALUES ($1, $2, '')",
+        )
+        .bind(account_id).bind(format!("grant-item-{account_id}"))
+        .execute(pool).await.expect("insert account");
+
+        sqlx::query(
+            "INSERT INTO sgw_player (\
+                account_id, player_id, level, alignment, archetype, gender, \
+                player_name, extra_name, world_location, bodyset, \
+                pos_x, pos_y, pos_z, skin_color_id, naquadah\
+             ) VALUES ($1, $2, 1, 0, 1, 1, $3, '', 'CombatSim', 'BS_HumanMale.BS_HumanMale', \
+                       0.0, 0.0, 0.0, 0, 0)",
+        )
+        .bind(account_id).bind(player_id).bind(format!("test-{player_id}"))
+        .execute(pool).await.expect("insert player");
+    }
+
+    async fn pick_main_bag_type_id(pool: &PgPool) -> i32 {
+        sqlx::query_scalar::<_, i32>(
+            "SELECT item_id FROM resources.items \
+             WHERE container_sets IS NULL OR 1 = ANY(container_sets) \
+             ORDER BY item_id LIMIT 1",
+        ).fetch_one(pool).await.expect("pick item_id")
+    }
+
+    fn make_state(entity_id: u32) -> (
+        Arc<UdpSocket>,
+        Arc<Mutex<HashMap<u32, SocketAddr>>>,
+        Arc<Mutex<HashMap<SocketAddr, ConnectedClientState>>>,
+    ) {
+        let std_sock = std::net::UdpSocket::bind("127.0.0.1:0").expect("bind UDP");
+        std_sock.set_nonblocking(true).unwrap();
+        let socket = Arc::new(UdpSocket::from_std(std_sock).expect("from_std"));
+        let fake_addr: SocketAddr = "127.0.0.1:65535".parse().unwrap();
+        let entity_to_addr = Arc::new(Mutex::new({
+            let mut m = HashMap::new();
+            m.insert(entity_id, fake_addr);
+            m
+        }));
+        let connected = Arc::new(Mutex::new(HashMap::new()));
+        (socket, entity_to_addr, connected)
+    }
+
+    /// Happy path: a grant inserts exactly one row at the lowest free slot
+    /// in the target container, with the requested type_id and stack size.
+    /// Pins the basic INSERT contract before the concurrency test stresses it.
+    #[tokio::test]
+    async fn grants_single_item_into_lowest_free_slot() {
+        let pool = require_db_or_skip!();
+        let account_id = TEST_BASE;
+        let player_id = TEST_BASE + 1;
+        let entity_id: u32 = 0x7000_0301;
+        cleanup(&pool, account_id, player_id, entity_id).await;
+        insert_account_and_player(&pool, account_id, player_id).await;
+        let type_id = pick_main_bag_type_id(&pool).await;
+
+        let (socket, e2a, conn) = make_state(entity_id);
+        let db_pool = Some(Arc::new(pool.clone()));
+
+        handle_grant_item(
+            entity_id, player_id, type_id, 1, 3,
+            &db_pool, &None, &socket, &conn, &e2a,
+        ).await;
+
+        let row: Option<(i32, i32, i32)> = sqlx::query_as(
+            "SELECT type_id, slot_id, stack_size FROM sgw_inventory \
+             WHERE character_id = $1 AND container_id = 1",
+        ).bind(player_id).fetch_optional(&pool).await.unwrap();
+        assert_eq!(
+            row,
+            Some((type_id, 0, 3)),
+            "grant must INSERT exactly one row at slot 0 with the requested type_id and count",
+        );
+
+        cleanup(&pool, account_id, player_id, entity_id).await;
+    }
+
+    /// Regression guard: pg_advisory_xact_lock on (player_id, container_id)
+    /// inside `reserve_free_inventory_slots` must serialize concurrent grants
+    /// so each picks a distinct slot. Without it, both calls see slot 0 free,
+    /// both INSERT into slot 0, and the unique-slot index forces one of them
+    /// to fail — turning a routine grant into a user-visible error.
+    ///
+    /// Runs both grants via tokio::join! so they hold separate connections
+    /// from the pool (test_pool() bounds at 4) and contend for the lock.
+    #[tokio::test]
+    async fn concurrent_grants_to_same_container_get_distinct_slots() {
+        let pool = require_db_or_skip!();
+        let account_id = TEST_BASE + 100;
+        let player_id = TEST_BASE + 101;
+        let entity_id: u32 = 0x7000_0302;
+        cleanup(&pool, account_id, player_id, entity_id).await;
+        insert_account_and_player(&pool, account_id, player_id).await;
+        let type_id = pick_main_bag_type_id(&pool).await;
+
+        let (socket, e2a, conn) = make_state(entity_id);
+        let db_pool = Some(Arc::new(pool.clone()));
+
+        // Two grants race on the same (player_id, container_id) advisory lock.
+        // Both must succeed and end up in different slots — slot 0 and slot 1.
+        tokio::join!(
+            handle_grant_item(
+                entity_id, player_id, type_id, 1, 1,
+                &db_pool, &None, &socket, &conn, &e2a,
+            ),
+            handle_grant_item(
+                entity_id, player_id, type_id, 1, 1,
+                &db_pool, &None, &socket, &conn, &e2a,
+            ),
+        );
+
+        let slots: Vec<i32> = sqlx::query_scalar(
+            "SELECT slot_id FROM sgw_inventory \
+             WHERE character_id = $1 AND container_id = 1 \
+             ORDER BY slot_id",
+        ).bind(player_id).fetch_all(&pool).await.unwrap();
+
+        assert_eq!(
+            slots.len(),
+            2,
+            "both concurrent grants must INSERT (got {} rows). \
+             A missing row means the unique-slot index rejected one of them, \
+             which is exactly the regression the advisory lock prevents.",
+            slots.len(),
+        );
+        assert_eq!(slots, vec![0, 1], "concurrent grants must pick distinct, sequential free slots");
+
+        cleanup(&pool, account_id, player_id, entity_id).await;
+    }
+}


### PR DESCRIPTION
## Summary
- 2 #79 Group A live-DB tests for [handle_grant_item](crates/services/src/base/world_entry/methods/inventory/grant.rs#L57). The headline test is the **concurrent-grants regression guard** explicitly called out in the issue body.
- Adds a sibling \`handle_grant_item_tests\` module to the existing \`normalize_item_ids_tests\` (merged in #137).
- File grows from 498 → 653 lines (within the 500-700 soft-split zone, but cohesive — all about the \`inventory/grant\` module).

## What's covered

- **\`grants_single_item_into_lowest_free_slot\`** — happy path. One INSERT, lowest free slot in the target container, with the requested type_id and stack size. Pins the basic contract before the concurrency test stresses it.

- **\`concurrent_grants_to_same_container_get_distinct_slots\`** — the regression guard. Two \`handle_grant_item\` calls race via \`tokio::join!\` on the same (player_id, container_id). Without \`pg_advisory_xact_lock\` inside \`reserve_free_inventory_slots\`, both calls see slot 0 free, both INSERT into slot 0, and the unique-slot index forces one to fail. The test asserts both grants succeed and the slots are exactly \`[0, 1]\`.

  Concurrency mechanics: \`test_pool()\` is bounded to 4 connections, and \`tokio::join!\` polls both futures concurrently — each grant holds its own connection, so they actually contend for the advisory lock rather than serializing trivially through a single connection.

## Test infra notes
- Sentinel base \`TEST_BASE = 0x7000_0300\` (distinct from move_inventory at +200, grant_cash at +100, outbox at +000).
- Cleanup also drains \`cell_event_outbox\` rows by entity_id (handle_grant_item enqueues there pre-commit via the outbox pattern).
- \`pick_main_bag_type_id\` reuses the same \`container_sets IS NULL OR 1 = ANY(container_sets)\` filter pattern from the move_inventory tests, so any seeded item that allows container 1 works.
- entity_to_addr populated, connected empty — same pattern as the prior live-DB tests so the function reaches commit and the post-commit witness sends skip gracefully.

## Coordination
- No file overlap with #140, #141, #142, #143, or #144.

## Test plan
- [x] \`cargo test -p cimmeria-services --lib base::world_entry::methods::inventory::grant\` — passes (skip path) without DATABASE_URL.
- [x] \`DATABASE_URL=… cargo test ...\` — 8 / 8 pass against the bundled Postgres (6 existing normalize tests + 2 new).