### PR TITLE
test(missions): live-DB tests for handle_mission_update + query_saved_missions

### DIFF
--- a/crates/services/src/base/world_entry/methods/missions.rs
+++ b/crates/services/src/base/world_entry/methods/missions.rs
@@ -191,14 +191,21 @@ mod tests {
             &db_pool,
         ).await;
 
-        let row: Option<(i32, i32, Option<i32>, Vec<i32>, Vec<i32>, Vec<i32>, Vec<i32>, i32)> = sqlx::query_as(
+        // Filter on (player_id, mission_id) and use fetch_one so a regression
+        // that inserted multiple rows would surface either as the count check
+        // failing or as fetch_one's "expected one row" error.
+        let row_count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM sgw_mission WHERE player_id = $1 AND mission_id = $2",
+        ).bind(player_id).bind(12345).fetch_one(&pool).await.unwrap();
+        assert_eq!(row_count, 1, "INSERT must produce exactly one row");
+
+        let row: (i32, i32, Option<i32>, Vec<i32>, Vec<i32>, Vec<i32>, Vec<i32>, i32) = sqlx::query_as(
             "SELECT mission_id, status, current_step_id, \
                     completed_step_ids, completed_objective_ids, \
                     active_objective_ids, failed_objective_ids, repeats \
-             FROM sgw_mission WHERE player_id = $1",
+             FROM sgw_mission WHERE player_id = $1 AND mission_id = $2",
         )
-        .bind(player_id).fetch_optional(&pool).await.unwrap();
-        let row = row.expect("INSERT should have produced a row");
+        .bind(player_id).bind(12345).fetch_one(&pool).await.unwrap();
         assert_eq!(row.0, 12345, "mission_id");
         assert_eq!(row.1, 2, "status");
         assert_eq!(row.2, Some(7), "current_step_id");

--- a/crates/services/src/base/world_entry/methods/missions.rs
+++ b/crates/services/src/base/world_entry/methods/missions.rs
@@ -131,3 +131,191 @@ pub async fn handle_mission_update(
         Err(e) => tracing::error!(player_id, mission_id, "Failed to persist mission: {e}"),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::require_db_or_skip;
+
+    /// Sentinel base for mission tests. Distinct from grant_cash (0x7000_0100),
+    /// move_inventory (0x7000_0200), grant_item (0x7000_0300).
+    const TEST_PLAYER_BASE: i32 = 0x7000_0400;
+
+    /// sgw_mission has a FK to sgw_player. Cleanup deletes the account, which
+    /// cascades sgw_player rows; sgw_mission rows go away when the player rows
+    /// they reference are deleted (or via the FK rule). Mission rows are also
+    /// deleted explicitly first to avoid relying on cascade ordering.
+    async fn cleanup(pool: &PgPool, account_id: i32, player_id: i32) {
+        let _ = sqlx::query("DELETE FROM sgw_mission WHERE player_id = $1")
+            .bind(player_id)
+            .execute(pool).await;
+        let _ = sqlx::query("DELETE FROM account WHERE account_id = $1")
+            .bind(account_id)
+            .execute(pool).await;
+    }
+
+    async fn insert_account_and_player(pool: &PgPool, account_id: i32, player_id: i32) {
+        sqlx::query(
+            "INSERT INTO account (account_id, account_name, password) \
+             VALUES ($1, $2, '')",
+        )
+        .bind(account_id).bind(format!("mission-test-{account_id}"))
+        .execute(pool).await.expect("insert account");
+
+        sqlx::query(
+            "INSERT INTO sgw_player (\
+                account_id, player_id, level, alignment, archetype, gender, \
+                player_name, extra_name, world_location, bodyset, \
+                pos_x, pos_y, pos_z, skin_color_id, naquadah\
+             ) VALUES ($1, $2, 1, 0, 1, 1, $3, '', 'CombatSim', 'BS_HumanMale.BS_HumanMale', \
+                       0.0, 0.0, 0.0, 0, 0)",
+        )
+        .bind(account_id).bind(player_id).bind(format!("test-{player_id}"))
+        .execute(pool).await.expect("insert player");
+    }
+
+    /// Happy path: handle_mission_update INSERTs a row with all fields present.
+    #[tokio::test]
+    async fn inserts_new_mission_row_with_all_fields() {
+        let pool = require_db_or_skip!();
+        let account_id = TEST_PLAYER_BASE;
+        let player_id = TEST_PLAYER_BASE + 1;
+        cleanup(&pool, account_id, player_id).await;
+        insert_account_and_player(&pool, account_id, player_id).await;
+        let db_pool = Some(Arc::new(pool.clone()));
+
+        handle_mission_update(
+            player_id, 12345, 2, Some(7),
+            &[1, 2, 3], &[10, 20], &[30], &[],
+            5,
+            &db_pool,
+        ).await;
+
+        let row: Option<(i32, i32, Option<i32>, Vec<i32>, Vec<i32>, Vec<i32>, Vec<i32>, i32)> = sqlx::query_as(
+            "SELECT mission_id, status, current_step_id, \
+                    completed_step_ids, completed_objective_ids, \
+                    active_objective_ids, failed_objective_ids, repeats \
+             FROM sgw_mission WHERE player_id = $1",
+        )
+        .bind(player_id).fetch_optional(&pool).await.unwrap();
+        let row = row.expect("INSERT should have produced a row");
+        assert_eq!(row.0, 12345, "mission_id");
+        assert_eq!(row.1, 2, "status");
+        assert_eq!(row.2, Some(7), "current_step_id");
+        assert_eq!(row.3, vec![1, 2, 3], "completed_step_ids");
+        assert_eq!(row.4, vec![10, 20], "completed_objective_ids");
+        assert_eq!(row.5, vec![30], "active_objective_ids");
+        assert_eq!(row.6, Vec::<i32>::new(), "failed_objective_ids");
+        assert_eq!(row.7, 5, "repeats");
+
+        cleanup(&pool, account_id, player_id).await;
+    }
+
+    /// Regression guard: the prior UPSERT omitted `repeats = EXCLUDED.repeats`,
+    /// so re-completing a repeatable mission would appear to reset the counter
+    /// on relog instead of advancing it. This test seeds a row with repeats=3,
+    /// then runs an UPSERT with repeats=4 — the row must persist 4, not 3.
+    #[tokio::test]
+    async fn upsert_propagates_repeats_column_on_conflict() {
+        let pool = require_db_or_skip!();
+        let account_id = TEST_PLAYER_BASE + 100;
+        let player_id = TEST_PLAYER_BASE + 101;
+        cleanup(&pool, account_id, player_id).await;
+        insert_account_and_player(&pool, account_id, player_id).await;
+        let db_pool = Some(Arc::new(pool.clone()));
+
+        // Seed: mission already at repeats=3, status=1.
+        handle_mission_update(
+            player_id, 9999, 1, None, &[], &[], &[], &[], 3,
+            &db_pool,
+        ).await;
+
+        // Re-complete: cell now sends status=2, repeats=4.
+        handle_mission_update(
+            player_id, 9999, 2, None, &[], &[], &[], &[], 4,
+            &db_pool,
+        ).await;
+
+        let (status, repeats): (i32, i32) = sqlx::query_as(
+            "SELECT status, repeats FROM sgw_mission \
+             WHERE player_id = $1 AND mission_id = $2",
+        )
+        .bind(player_id).bind(9999).fetch_one(&pool).await.unwrap();
+        assert_eq!(status, 2, "status must update on conflict");
+        assert_eq!(
+            repeats, 4,
+            "repeats must propagate via EXCLUDED.repeats on conflict — \
+             a 3 here means the UPSERT regressed to omitting the column",
+        );
+
+        cleanup(&pool, account_id, player_id).await;
+    }
+
+    /// Regression guard: query_saved_missions uses i8::try_from(r.status) with
+    /// a clamp fallback. A pathological row whose `status` column doesn't fit
+    /// in i8 must clamp to i8::MIN/MAX rather than wrap modulo 256 via `as i8`
+    /// (which would silently turn a 200 into -56). Done at the query layer
+    /// because the `status` column is `integer` so legitimate writes can
+    /// outpace the i8 wire/cell representation.
+    #[tokio::test]
+    async fn query_saved_missions_clamps_out_of_range_status_to_i8_max() {
+        let pool = require_db_or_skip!();
+        let account_id = TEST_PLAYER_BASE + 200;
+        let player_id = TEST_PLAYER_BASE + 201;
+        cleanup(&pool, account_id, player_id).await;
+        insert_account_and_player(&pool, account_id, player_id).await;
+
+        // Insert directly via SQL so we can write a status that handle_mission_update
+        // (which takes i8) couldn't produce. 500 is well outside i8 range.
+        sqlx::query(
+            "INSERT INTO sgw_mission \
+                (player_id, mission_id, status, current_step_id, \
+                 completed_step_ids, completed_objective_ids, \
+                 active_objective_ids, failed_objective_ids, repeats) \
+             VALUES ($1, 1, 500, NULL, '{}', '{}', '{}', '{}', 0)",
+        )
+        .bind(player_id).execute(&pool).await.expect("insert oversize-status mission");
+
+        let db_pool = Some(Arc::new(pool.clone()));
+        let missions = query_saved_missions(&db_pool, player_id).await;
+        assert_eq!(missions.len(), 1);
+        assert_eq!(
+            missions[0].status,
+            i8::MAX,
+            "status 500 (outside i8) must clamp to i8::MAX, not wrap modulo 256 to -12",
+        );
+
+        cleanup(&pool, account_id, player_id).await;
+    }
+
+    /// Companion: clamp on the negative side too. A status of -200 must
+    /// clamp to i8::MIN (-128), not wrap to +56.
+    #[tokio::test]
+    async fn query_saved_missions_clamps_out_of_range_status_to_i8_min() {
+        let pool = require_db_or_skip!();
+        let account_id = TEST_PLAYER_BASE + 300;
+        let player_id = TEST_PLAYER_BASE + 301;
+        cleanup(&pool, account_id, player_id).await;
+        insert_account_and_player(&pool, account_id, player_id).await;
+
+        sqlx::query(
+            "INSERT INTO sgw_mission \
+                (player_id, mission_id, status, current_step_id, \
+                 completed_step_ids, completed_objective_ids, \
+                 active_objective_ids, failed_objective_ids, repeats) \
+             VALUES ($1, 1, -200, NULL, '{}', '{}', '{}', '{}', 0)",
+        )
+        .bind(player_id).execute(&pool).await.expect("insert negative-status mission");
+
+        let db_pool = Some(Arc::new(pool.clone()));
+        let missions = query_saved_missions(&db_pool, player_id).await;
+        assert_eq!(missions.len(), 1);
+        assert_eq!(
+            missions[0].status,
+            i8::MIN,
+            "status -200 must clamp to i8::MIN, not wrap modulo 256 to +56",
+        );
+
+        cleanup(&pool, account_id, player_id).await;
+    }
+}


### PR DESCRIPTION
## Summary
- 4 #79 Group A live-DB tests for [missions.rs](crates/services/src/base/world_entry/methods/missions.rs) — both \`handle_mission_update\` and \`query_saved_missions\`.
- File grows from 133 → 313 lines.
- Tests skip cleanly without DATABASE_URL; pass against bundled Postgres.

## What's covered

**\`handle_mission_update\` (UPSERT)**
- **\`inserts_new_mission_row_with_all_fields\`** — happy path INSERT. Pins all 8 columns make it to the row.
- **\`upsert_propagates_repeats_column_on_conflict\`** — regression guard. The pre-fix UPSERT omitted \`repeats = EXCLUDED.repeats\`, so re-completing a repeatable mission appeared to reset the counter on relog instead of advancing it. Test seeds \`repeats=3\`, runs UPSERT with \`repeats=4\`, asserts the row persists 4.

**\`query_saved_missions\` (i8 clamp)**
- **\`query_saved_missions_clamps_out_of_range_status_to_i8_max\`** — a stored \`status\` of 500 must clamp to \`i8::MAX\` (127), not wrap via \`as i8\` to -12. Inserts directly via SQL since \`handle_mission_update\` takes \`i8\` and can't produce the out-of-range scenario.
- **\`query_saved_missions_clamps_out_of_range_status_to_i8_min\`** — symmetric guard on the negative side: -200 clamps to \`i8::MIN\` (-128), not +56.

## Test infra notes
- \`sgw_mission\` has a FK to \`sgw_player\` (\`missions_player_id_fkey\`) — \`grep\` for the constraint name in \`db/sgw/_foreign_keys.sql\` had missed it earlier; the failing test caught it. Each test now sets up an account+player row.
- Sentinel base \`TEST_PLAYER_BASE = 0x7000_0400\` (distinct from grant_cash +0x100, move_inventory +0x200, grant_item +0x300).

## Coordination
- Independent file — no overlap with #140, #141, #142, #143, #144, or #145.

## Test plan
- [x] \`cargo test -p cimmeria-services --lib base::world_entry::methods::missions\` — passes (skip path) without DATABASE_URL.
- [x] \`DATABASE_URL=… cargo test ...\` — 4 / 4 pass against the bundled Postgres.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for mission persistence and status handling to ensure mission data is reliably stored and retrieved correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->