### PR TITLE
ci: add live-DB job that runs the regression guards against real Postgres

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,12 +98,13 @@ jobs:
       - name: cargo build
         run: cargo build --workspace ${{ env.WORKSPACE_EXCLUDES }} --all-targets
 
-  # cargo test: live-DB tests use test_support::require_db_or_skip! and
-  # self-skip when DATABASE_URL is unset, so this baseline exercises only
-  # the unit + non-DB integration tests. A follow-up will add a postgres
-  # service container and run the DB-integration suite under DATABASE_URL.
+  # cargo test (no DB). Live-DB tests in cimmeria-services use
+  # test_support::require_db_or_skip! and self-skip when DATABASE_URL is
+  # unset, so this job covers the unit + non-DB integration tests across
+  # the whole workspace (mercury, content-engine, services unit tests, etc.).
+  # The live-DB suite runs in the dedicated `test-live-db` job below.
   test:
-    name: cargo test (workspace)
+    name: cargo test (workspace, no DB)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -124,3 +125,59 @@ jobs:
           shared-key: test
       - name: cargo test
         run: cargo test --workspace ${{ env.WORKSPACE_EXCLUDES }}
+
+  # cargo test against a live Postgres. Schema is loaded from
+  # db/database.sql (which `\ir`-includes everything in db/sgw and
+  # db/resources, including seed data). The live-DB regression guards
+  # we've written for vendor / inventory / progression / mail / missions
+  # actually fire in this job — the prior `test` job's
+  # require_db_or_skip! short-circuits without DATABASE_URL.
+  #
+  # --test-threads=1 because some live-DB tests share sentinel id ranges
+  # and collide under parallel execution against a single shared DB.
+  # That's a fixture-design constraint, not a bug in the handlers.
+  test-live-db:
+    name: cargo test -p cimmeria-services (live DB)
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        # Match the bundled local Postgres in external/postgresql_server/.
+        image: postgres:17.9
+        env:
+          POSTGRES_USER: w-testing
+          POSTGRES_PASSWORD: w-testing
+          POSTGRES_DB: sgw
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      DATABASE_URL: postgres://w-testing:w-testing@localhost:5432/sgw
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: install clang + mold + psql
+        run: sudo apt-get update && sudo apt-get install -y clang mold postgresql-client
+      - name: hydrate external/recast
+        run: |
+          mkdir -p external
+          curl -sL --retry 3 \
+            -o /tmp/recast.zip \
+            "https://github.com/recastnavigation/recastnavigation/archive/refs/tags/v${RECAST_VERSION}.zip"
+          unzip -q /tmp/recast.zip -d /tmp/recast_extract
+          mv "/tmp/recast_extract/recastnavigation-${RECAST_VERSION}" external/recast
+          test -f external/recast/Detour/Source/DetourAssert.cpp
+      - name: load schema + seeds
+        env:
+          PGPASSWORD: w-testing
+        run: |
+          psql -h localhost -U w-testing -d sgw -v ON_ERROR_STOP=1 -f db/database.sql
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: test-live-db
+      - name: cargo test (live DB)
+        run: |
+          cargo test -p cimmeria-services --lib -- --test-threads=1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ Solution: `W-NG.sln` (VS2026, MSVC v145). Bootstrap via `setup.ps1` (wraps the `
 
 ## Pre-PR checklist
 
-CI (`.github/workflows/test.yml`) gates four checks on every PR — run all four locally before pushing or the pipeline will fail and you'll round-trip:
+CI (`.github/workflows/test.yml`) gates five checks on every PR — run all five locally before pushing or the pipeline will fail and you'll round-trip:
 
 ```bash
 cargo fmt --all -- --check
@@ -80,12 +80,17 @@ cargo build --workspace \
 cargo test --workspace \
   --exclude cimmeria-app --exclude cimmeria-content-editor \
   --exclude cimmeria-scene-editor --exclude sgw-launcher
+
+# Live-DB tests — start the bundled Postgres first, then:
+DATABASE_URL=postgres://w-testing:w-testing@localhost:5433/sgw \
+  cargo test -p cimmeria-services --lib -- --test-threads=1
 ```
 
 - **fmt fails** → `cargo fmt --all` and commit the result. The CI job tells you exactly that.
 - **clippy fails** → fix the warning. Project-level thresholds for `too_many_arguments` (14) and `type_complexity` (500) live in `clippy.toml`; bumping those further requires the same kind of justification any other lint suppression would. Don't sprinkle `#[allow(clippy::…)]` per call site.
 - **build fails** → typically a stale path or unused-symbol cleanup needed; check matches `cargo check`.
-- **test fails** → live-DB tests in `crates/services` self-skip when `DATABASE_URL` is unset, so CI exercises only the unit + non-DB integration suite. To run the live-DB suite locally, point `DATABASE_URL` at the bundled Postgres; under heavy parallelism some live-DB tests will collide on shared sentinel ranges, so use `cargo test … -- --test-threads=1` if you see flakes.
+- **test fails (no DB)** → unit + non-DB integration tests. Live-DB tests in `crates/services` self-skip via `require_db_or_skip!` when `DATABASE_URL` is unset, so this run can be green even with broken DB code.
+- **test-live-db fails** → CI runs `cargo test -p cimmeria-services --lib -- --test-threads=1` against a fresh `postgres:17.9` service container loaded from `db/database.sql`. `--test-threads=1` is required: some live-DB tests share sentinel id ranges and would collide under parallel execution against a single shared DB. To repro locally, start the bundled Postgres on `:5433` and run the command in the snippet above.
 
 ## File organization
 


### PR DESCRIPTION
## Summary

The existing `test` job runs `cargo test --workspace` without `DATABASE_URL`, so every live-DB test under `crates/services` skips via `require_db_or_skip!`. That means the ~25 vendor / inventory / progression / mail / missions regression guards we've written so far were honor-system gates: they only fire if a developer remembers to run the live-DB suite locally before pushing.

This adds a dedicated **`test-live-db`** job that runs them on every PR.

## Layout

\`\`\`yaml
jobs:
  fmt          # cargo fmt --check
  clippy       # cargo clippy --workspace ... -- -D warnings
  build        # cargo build --workspace --all-targets
  test         # cargo test --workspace (no DB; live-DB tests self-skip)
  test-live-db # NEW — postgres:17.9 service + DATABASE_URL set
\`\`\`

## What the new job does

- Spins up a `postgres:17.9` service container with the bundled test creds (\`w-testing\` / \`w-testing\` / \`sgw\`) — same shape the local bundled Postgres at \`external/postgresql_server/\` produces.
- Loads \`db/database.sql\`, which \`\ir\`-includes every table / type / sequence / constraint / seed under \`db/sgw\` and \`db/resources\` — including the seed rows the live-DB tests depend on (\`resources.items\`, \`resources.entity_templates 25\`'s repair list, etc.).
- Runs \`cargo test -p cimmeria-services --lib -- --test-threads=1\` with \`DATABASE_URL\` set. \`--test-threads=1\` is required: some live-DB tests share sentinel id ranges (\`TEST_BASE + 0x100\` etc.) and would collide under parallel execution against a single shared DB. That's a fixture-design constraint, not a bug in the handlers.

## Net effect

Every regression guard from #135 onward gates PRs automatically. A developer who breaks one of (e.g.) the multi-character mail-isolation guards now sees a red CI check instead of a clean baseline that papered over the regression.

## Other changes

- Renamed the existing \`test\` job to **\"cargo test (workspace, no DB)\"** so the two test jobs are distinguishable in the PR checks list.
- Updated CLAUDE.md's Pre-PR checklist to document the fifth gate and how to repro locally.

## Test plan

This PR is its own test plan — the new \`test-live-db\` job runs against this branch's CI, so a green build proves the schema load + DATABASE_URL wiring works. Currently 7+ live-DB tests should run (~30s on top of the workspace build).