### PR TITLE
test(vendor): live-DB regression guards for sync_bandolier_after_inventory_change

### DIFF
--- a/crates/services/src/base/world_entry/methods/vendor/helpers.rs
+++ b/crates/services/src/base/world_entry/methods/vendor/helpers.rs
@@ -193,3 +193,282 @@ pub async fn sync_bandolier_after_inventory_change(
             .await;
     }
 }
+
+#[cfg(test)]
+mod sync_bandolier_tests {
+    //! Live-DB integration tests for sync_bandolier_after_inventory_change.
+    //!
+    //! Skip cleanly when DATABASE_URL is unset; against the bundled
+    //! local Postgres they exercise the active-slot reconciliation
+    //! ladder: vacated-slot fixup, still-valid passthrough, and the
+    //! empty-bandolier path.
+
+    use super::*;
+    use crate::test_support::require_db_or_skip;
+
+    /// Sentinel base for sync_bandolier tests. Distinct from prior
+    /// live-DB sentinels (outbox 0x000 / grant_cash +0x100 /
+    /// move +0x200 / grant_item +0x300 / missions +0x400 / mail +0x500 /
+    /// vendor/repair +0x600 / paid_repair +0x700 / sell +0x800 /
+    /// buyback +0x900 / purchase +0x0A00 / ammo +0x0B00 /
+    /// vendor_data +0x0C00 / player_load +0x0D00).
+    const TEST_BASE: i32 = 0x7000_0E00;
+
+    /// Bandolier-allowed weapon. Picked deliberately: must satisfy
+    /// the JOIN to resources.items in query_bandolier_items_tx.
+    const WEAPON_TYPE_ID: i32 = 3241;
+    const INV_BANDOLIER: i32 = 3;
+
+    async fn cleanup(pool: &PgPool, account_id: i32, player_id: i32) {
+        let _ = sqlx::query("DELETE FROM sgw_inventory WHERE character_id = $1")
+            .bind(player_id)
+            .execute(pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM account WHERE account_id = $1")
+            .bind(account_id)
+            .execute(pool)
+            .await;
+    }
+
+    async fn insert_account_and_player(
+        pool: &PgPool,
+        account_id: i32,
+        player_id: i32,
+        bandolier_slot: i32,
+    ) {
+        sqlx::query(
+            "INSERT INTO account (account_id, account_name, password) \
+             VALUES ($1, $2, '')",
+        )
+        .bind(account_id)
+        .bind(format!("sync-band-{account_id}"))
+        .execute(pool)
+        .await
+        .expect("insert account");
+
+        sqlx::query(
+            "INSERT INTO sgw_player (\
+                account_id, player_id, level, alignment, archetype, gender, \
+                player_name, extra_name, world_location, bodyset, \
+                pos_x, pos_y, pos_z, skin_color_id, naquadah, bandolier_slot\
+             ) VALUES ($1, $2, 1, 0, 1, 1, $3, '', 'CombatSim', 'BS_HumanMale.BS_HumanMale', \
+                       0.0, 0.0, 0.0, 0, 0, $4)",
+        )
+        .bind(account_id)
+        .bind(player_id)
+        .bind(format!("test-{player_id}"))
+        .bind(bandolier_slot)
+        .execute(pool)
+        .await
+        .expect("insert player");
+    }
+
+    async fn insert_bandolier_row(pool: &PgPool, player_id: i32, slot_id: i32) {
+        sqlx::query(
+            "INSERT INTO sgw_inventory \
+                (character_id, type_id, stack_size, slot_id, container_id, \
+                 bound, durability, charges) \
+             VALUES ($1, $2, 1, $3, $4, false, 100, 0)",
+        )
+        .bind(player_id)
+        .bind(WEAPON_TYPE_ID)
+        .bind(slot_id)
+        .bind(INV_BANDOLIER)
+        .execute(pool)
+        .await
+        .expect("insert bandolier row");
+    }
+
+    async fn bandolier_slot_of(pool: &PgPool, player_id: i32) -> i32 {
+        sqlx::query_scalar("SELECT bandolier_slot FROM sgw_player WHERE player_id = $1")
+            .bind(player_id)
+            .fetch_one(pool)
+            .await
+            .expect("read bandolier_slot")
+    }
+
+    fn make_state(
+        entity_id: u32,
+    ) -> (
+        Arc<UdpSocket>,
+        Arc<Mutex<HashMap<u32, SocketAddr>>>,
+        Arc<Mutex<HashMap<SocketAddr, ConnectedClientState>>>,
+    ) {
+        let std_sock = std::net::UdpSocket::bind("127.0.0.1:0").expect("bind UDP");
+        std_sock.set_nonblocking(true).unwrap();
+        let socket = Arc::new(UdpSocket::from_std(std_sock).expect("from_std"));
+        let fake_addr: SocketAddr = "127.0.0.1:65535".parse().unwrap();
+        let entity_to_addr = Arc::new(Mutex::new({
+            let mut m = HashMap::new();
+            m.insert(entity_id, fake_addr);
+            m
+        }));
+        let connected = Arc::new(Mutex::new(HashMap::new()));
+        (socket, entity_to_addr, connected)
+    }
+
+    /// Active-slot fixup: the player's persisted bandolier_slot points
+    /// at a vacated slot (e.g., the equipped weapon was sold). The
+    /// function must pick min(remaining slots) and UPDATE sgw_player
+    /// to that. Bug shape this catches: the previous-bandolier-slot
+    /// preservation regressing to "leave bandolier_slot pointing at a
+    /// vacated entry" — which the cell-side then renders as no
+    /// active weapon.
+    #[tokio::test]
+    async fn vacated_active_slot_falls_back_to_min_remaining_slot() {
+        let pool = require_db_or_skip!();
+        let account_id = TEST_BASE;
+        let player_id = TEST_BASE + 1;
+        cleanup(&pool, account_id, player_id).await;
+        // bandolier_slot=1 — but we will only seed slots 2 and 3.
+        insert_account_and_player(&pool, account_id, player_id, 1).await;
+        insert_bandolier_row(&pool, player_id, 3).await;
+        insert_bandolier_row(&pool, player_id, 2).await;
+
+        let (socket, e2a, conn) = make_state(0x7000_0E01);
+        let db_pool = Some(Arc::new(pool.clone()));
+        let (cell_tx, mut cell_rx) = mpsc::channel::<BaseToCellMsg>(4);
+
+        sync_bandolier_after_inventory_change(
+            0x7000_0E01,
+            player_id,
+            &db_pool,
+            &Some(cell_tx),
+            &socket,
+            &conn,
+            &e2a,
+        )
+        .await;
+
+        assert_eq!(
+            bandolier_slot_of(&pool, player_id).await,
+            2,
+            "vacated active slot must be replaced with min() of remaining slots",
+        );
+
+        match cell_rx.try_recv() {
+            Ok(BaseToCellMsg::SyncBandolierItems {
+                active_bandolier_slot,
+                bandolier_items,
+                ..
+            }) => {
+                assert_eq!(active_bandolier_slot, 2);
+                assert_eq!(bandolier_items.len(), 2);
+            }
+            Ok(_) => panic!("expected SyncBandolierItems, got a different cell-tx variant"),
+            Err(e) => panic!("expected SyncBandolierItems, channel error: {e}"),
+        }
+
+        cleanup(&pool, account_id, player_id).await;
+    }
+
+    /// Active-slot still valid: the persisted bandolier_slot still has
+    /// an entry, so no UPDATE fires and no witness packet is emitted.
+    /// The cell tx still receives SyncBandolierItems so the cell-side
+    /// cache stays in sync after any inventory mutation.
+    #[tokio::test]
+    async fn valid_active_slot_passes_through_unchanged() {
+        let pool = require_db_or_skip!();
+        let account_id = TEST_BASE + 100;
+        let player_id = TEST_BASE + 101;
+        cleanup(&pool, account_id, player_id).await;
+        insert_account_and_player(&pool, account_id, player_id, 2).await;
+        // Slots 1, 2, 3 — slot 2 is the active one and remains valid.
+        insert_bandolier_row(&pool, player_id, 1).await;
+        insert_bandolier_row(&pool, player_id, 2).await;
+        insert_bandolier_row(&pool, player_id, 3).await;
+
+        let (socket, e2a, conn) = make_state(0x7000_0E11);
+        let db_pool = Some(Arc::new(pool.clone()));
+        let (cell_tx, mut cell_rx) = mpsc::channel::<BaseToCellMsg>(4);
+
+        sync_bandolier_after_inventory_change(
+            0x7000_0E11,
+            player_id,
+            &db_pool,
+            &Some(cell_tx),
+            &socket,
+            &conn,
+            &e2a,
+        )
+        .await;
+
+        assert_eq!(
+            bandolier_slot_of(&pool, player_id).await,
+            2,
+            "active slot must NOT change when the slot is still occupied",
+        );
+
+        match cell_rx.try_recv() {
+            Ok(BaseToCellMsg::SyncBandolierItems {
+                active_bandolier_slot,
+                bandolier_items,
+                ..
+            }) => {
+                assert_eq!(active_bandolier_slot, 2);
+                assert_eq!(bandolier_items.len(), 3);
+            }
+            Ok(_) => panic!("expected SyncBandolierItems, got a different cell-tx variant"),
+            Err(e) => panic!("expected SyncBandolierItems, channel error: {e}"),
+        }
+
+        cleanup(&pool, account_id, player_id).await;
+    }
+
+    /// Empty-bandolier path: no INV_BANDOLIER rows. The function must
+    /// NOT touch sgw_player.bandolier_slot (so it stays pointing at
+    /// whatever the caller left it at) and still emit
+    /// SyncBandolierItems with an empty list — otherwise the cell-side
+    /// cache holds stale weapon entries until the next non-empty change.
+    #[tokio::test]
+    async fn empty_bandolier_preserves_slot_and_emits_empty_sync() {
+        let pool = require_db_or_skip!();
+        let account_id = TEST_BASE + 200;
+        let player_id = TEST_BASE + 201;
+        cleanup(&pool, account_id, player_id).await;
+        // bandolier_slot CHECK constrains the column to 0..=3, so pick 3 —
+        // distinct from the other tests' values so the assertion isn't a
+        // coincidence with whatever the function might have written.
+        insert_account_and_player(&pool, account_id, player_id, 3).await;
+        // Deliberately no bandolier rows.
+
+        let (socket, e2a, conn) = make_state(0x7000_0E21);
+        let db_pool = Some(Arc::new(pool.clone()));
+        let (cell_tx, mut cell_rx) = mpsc::channel::<BaseToCellMsg>(4);
+
+        sync_bandolier_after_inventory_change(
+            0x7000_0E21,
+            player_id,
+            &db_pool,
+            &Some(cell_tx),
+            &socket,
+            &conn,
+            &e2a,
+        )
+        .await;
+
+        assert_eq!(
+            bandolier_slot_of(&pool, player_id).await,
+            3,
+            "empty bandolier must NOT scribble bandolier_slot — caller's value is preserved",
+        );
+
+        match cell_rx.try_recv() {
+            Ok(BaseToCellMsg::SyncBandolierItems {
+                active_bandolier_slot,
+                bandolier_items,
+                ..
+            }) => {
+                assert_eq!(active_bandolier_slot, 3);
+                assert!(
+                    bandolier_items.is_empty(),
+                    "empty bandolier must drive an empty SyncBandolierItems payload",
+                );
+            }
+            Ok(_) => panic!("expected SyncBandolierItems, got a different cell-tx variant"),
+            Err(e) => panic!("expected SyncBandolierItems, channel error: {e}"),
+        }
+
+        cleanup(&pool, account_id, player_id).await;
+    }
+}


### PR DESCRIPTION
## Summary

Closes another slice of #79 — three live-DB regression tests for the
active-slot reconciliation ladder in
\`vendor/helpers.rs::sync_bandolier_after_inventory_change\`. The
function is the load-bearing piece that runs after every inventory
mutation that could vacate the bandolier (sell, move, grant, equip
swap), so a regression here silently breaks the equipped-weapon
state on the cell side.

- **\`vacated_active_slot_falls_back_to_min_remaining_slot\`** —
  pins the fixup branch: persisted \`bandolier_slot=1\` with only
  slots 2, 3 occupied must result in \`bandolier_slot=2\` (min) being
  persisted and propagated via \`SyncBandolierItems\`. Bug shape: a
  regression to "leave bandolier_slot pointing at vacated slot"
  leaves the cell rendering no active weapon.
- **\`valid_active_slot_passes_through_unchanged\`** — pins the
  no-op branch: persisted \`bandolier_slot=2\` with slots 1, 2, 3
  occupied must leave \`bandolier_slot\` untouched while still
  emitting \`SyncBandolierItems\` for cell-side cache consistency.
- **\`empty_bandolier_preserves_slot_and_emits_empty_sync\`** — pins
  the empty-bandolier branch: no \`INV_BANDOLIER\` rows must NOT
  scribble \`bandolier_slot\` but must still emit \`SyncBandolierItems\`
  with empty items so the cell-side cache drops stale entries.

Sentinel ID base: \`0x7000_0E00\`.

## File size

\`helpers.rs\` grows from 195 to 474 lines — under the 500-line soft
cap from \`CLAUDE.md\`, so tests are kept inline (\`mod sync_bandolier_tests\`)
rather than splitting to a directory module.

No production-code change.

## Test plan

- [x] \`cargo test -p cimmeria-services --lib base::world_entry::methods::vendor::helpers -- --test-threads=1\` — 3/3 pass
- [x] \`cargo clippy -p cimmeria-services --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --all -- --check\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)