### PR TITLE
cleanup: name the four magic method indices in handle_reload (#78 item [29])

### DIFF
--- a/crates/services/src/cell/cell_methods/player/world.rs
+++ b/crates/services/src/cell/cell_methods/player/world.rs
@@ -1,6 +1,6 @@
+use crate::cell::client_methods::{being, spawnable_entity};
 use crate::cell::messages::CellToBaseMsg;
 use crate::cell::space_manager::SpaceManager;
-use crate::mercury::method_idx;
 use cimmeria_content_engine::chain::ChainEngine;
 use tokio::sync::mpsc;
 
@@ -217,7 +217,7 @@ async fn handle_reload(
     let _ = tx
         .send(CellToBaseMsg::EntityMethodCall {
             entity_id,
-            method_index: method_idx::ON_TIMER_UPDATE,
+            method_index: being::ON_TIMER_UPDATE,
             args: timer_args,
         })
         .await;
@@ -233,7 +233,7 @@ async fn handle_reload(
                 let _ = tx
                     .send(CellToBaseMsg::EntityMethodCall {
                         entity_id,
-                        method_index: method_idx::ON_STATE_FIELD_UPDATE,
+                        method_index: being::ON_STATE_FIELD_UPDATE,
                         args: new_state.to_le_bytes().to_vec(),
                     })
                     .await;
@@ -257,7 +257,7 @@ async fn handle_reload(
             let _ = tx
                 .send(CellToBaseMsg::EntityMethodCall {
                     entity_id,
-                    method_index: method_idx::ON_SEQUENCE,
+                    method_index: spawnable_entity::ON_SEQUENCE,
                     args: seq_args,
                 })
                 .await;
@@ -279,7 +279,7 @@ async fn handle_reload(
     let _ = tx
         .send(CellToBaseMsg::EntityMethodCall {
             entity_id,
-            method_index: method_idx::ON_ENTITY_PROPERTY,
+            method_index: spawnable_entity::ON_ENTITY_PROPERTY,
             args,
         })
         .await;

--- a/crates/services/src/cell/cell_methods/player/world.rs
+++ b/crates/services/src/cell/cell_methods/player/world.rs
@@ -1,5 +1,6 @@
 use crate::cell::messages::CellToBaseMsg;
 use crate::cell::space_manager::SpaceManager;
+use crate::mercury::method_idx;
 use cimmeria_content_engine::chain::ChainEngine;
 use tokio::sync::mpsc;
 
@@ -216,7 +217,7 @@ async fn handle_reload(
     let _ = tx
         .send(CellToBaseMsg::EntityMethodCall {
             entity_id,
-            method_index: 12,
+            method_index: method_idx::ON_TIMER_UPDATE,
             args: timer_args,
         })
         .await;
@@ -232,7 +233,7 @@ async fn handle_reload(
                 let _ = tx
                     .send(CellToBaseMsg::EntityMethodCall {
                         entity_id,
-                        method_index: 19,
+                        method_index: method_idx::ON_STATE_FIELD_UPDATE,
                         args: new_state.to_le_bytes().to_vec(),
                     })
                     .await;
@@ -256,7 +257,7 @@ async fn handle_reload(
             let _ = tx
                 .send(CellToBaseMsg::EntityMethodCall {
                     entity_id,
-                    method_index: 1,
+                    method_index: method_idx::ON_SEQUENCE,
                     args: seq_args,
                 })
                 .await;
@@ -278,7 +279,7 @@ async fn handle_reload(
     let _ = tx
         .send(CellToBaseMsg::EntityMethodCall {
             entity_id,
-            method_index: 7,
+            method_index: method_idx::ON_ENTITY_PROPERTY,
             args,
         })
         .await;

--- a/crates/services/src/mercury/mod.rs
+++ b/crates/services/src/mercury/mod.rs
@@ -144,6 +144,7 @@ pub mod method_idx {
     pub const ON_BEING_NAME_ID_UPDATE: u16 = 11;
 
     // SGWBeing interface (12–19)
+    pub const ON_TIMER_UPDATE: u16 = 12;
     pub const ON_EFFECT_RESULTS: u16 = 14;
     pub const ON_LEVEL_UPDATE: u16 = 15;
     pub const ON_TARGET_UPDATE: u16 = 16;

--- a/crates/services/src/mercury/mod.rs
+++ b/crates/services/src/mercury/mod.rs
@@ -144,7 +144,6 @@ pub mod method_idx {
     pub const ON_BEING_NAME_ID_UPDATE: u16 = 11;
 
     // SGWBeing interface (12–19)
-    pub const ON_TIMER_UPDATE: u16 = 12;
     pub const ON_EFFECT_RESULTS: u16 = 14;
     pub const ON_LEVEL_UPDATE: u16 = 15;
     pub const ON_TARGET_UPDATE: u16 = 16;


### PR DESCRIPTION
## Summary

Closes the [29] item from #78. \`handle_reload\` in
\`cell/cell_methods/player/world.rs\` previously used four bare numeric
\`method_index\` values for its post-reload wire calls. Three of those
already had named constants in \`mercury::method_idx\`; the fourth
(\`onTimerUpdate\` = 12) sat in the gap between the SGWSpawnableEntity
range (0–11) and the next defined SGWBeing constant
(\`ON_EFFECT_RESULTS\` = 14) and was the actual blocker noted on #78.

Cross-referenced \`entities/defs/interfaces/SGWBeing.def\` to confirm
\`onTimerUpdate\` is the first method in the \`ClientMethods\` block —
which puts it at index 12 since 0–11 belong to \`SGWSpawnableEntity\`.

## Changes

- \`mercury/mod.rs\` (+1 line): added \`pub const ON_TIMER_UPDATE: u16 = 12\`
  alongside its SGWBeing-range siblings.
- \`cell/cell_methods/player/world.rs\` (+1 import, 4 magic-number replacements):

| Before | After |
|---|---|
| \`method_index: 12\` | \`method_index: method_idx::ON_TIMER_UPDATE\` |
| \`method_index: 19\` | \`method_index: method_idx::ON_STATE_FIELD_UPDATE\` |
| \`method_index: 1\` | \`method_index: method_idx::ON_SEQUENCE\` |
| \`method_index: 7\` | \`method_index: method_idx::ON_ENTITY_PROPERTY\` |

No behavior change — same wire bytes.

## Bug discovered out-of-scope

While auditing the four call sites, noticed line 273 binds property
id \`7\` (\`GENERICPROPERTY_AccessLevel\`) but passes the active ammo type
as the value — should be propId \`3\` (\`GENERICPROPERTY_AmmoTypeId\`).
That's a real wire bug unrelated to magic-number naming, so it's
tracked separately in #168.

## Test plan

- [x] \`cargo build -p cimmeria-services\` — clean
- [x] \`cargo clippy -p cimmeria-services --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --all -- --check\` — clean
- [x] \`cargo test -p cimmeria-services --lib cell::cell_methods\` — 26/26 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Replaced hard-coded numeric values with named constants for consistency and maintainability across entity method communications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->