### PR TITLE
cleanup: derive EArchetype mapping from DB + drift tripwires (#78 [5])

### DIFF
--- a/crates/entity/src/stats/archetype.rs
+++ b/crates/entity/src/stats/archetype.rs
@@ -5,10 +5,11 @@
 /// This constant is the Rust-side anchor for a manual-coupling drift check —
 /// the live-DB test
 /// `archetype_count_matches_earchetype_enum_cardinality` (in
-/// `services/src/base/world_entry/methods/player_load/meta.rs`) asserts this
-/// matches `cardinality(enum_range(NULL::resources."EArchetype"))` so that
-/// adding to the SQL enum without reviewing downstream consumers fails CI
-/// loudly instead of silently shipping an empty ability tree.
+/// `crates/services/src/base/world_entry/methods/player_load/meta.rs`)
+/// asserts this matches
+/// `cardinality(enum_range(NULL::resources."EArchetype"))` so that adding to
+/// the SQL enum without reviewing downstream consumers fails CI loudly
+/// instead of silently shipping an empty ability tree.
 ///
 /// **Adding a new archetype requires updates in (verify all):**
 /// 1. `db/resources/Archetypes/Types/EArchetype.sql` — enum entry
@@ -16,10 +17,11 @@
 /// 3. This constant
 /// 4. `db/resources/Archetypes/Seed/archetype_ability_tree.sql` — ability
 ///    tree rows for the new archetype (or accept empty)
-/// 5. `services/src/base/chardef.rs` — CharDefId entries that reference the
-///    new archetype (or accept that no character can be created with it)
-/// 6. `services/src/mercury/world_data/stats.rs::archetype_ability_tree` —
-///    DB-down fallback (only if non-empty fallback is desired)
+/// 5. `crates/services/src/base/chardef.rs` — CharDefId entries that
+///    reference the new archetype (or accept that no character can be
+///    created with it)
+/// 6. `crates/services/src/mercury/world_data/stats.rs::archetype_ability_tree`
+///    — DB-down fallback (only if non-empty fallback is desired)
 pub const ARCHETYPE_COUNT: usize = 9;
 
 /// Archetype-specific base stat values passed to [`super::StatList::apply_archetype`].

--- a/crates/entity/src/stats/archetype.rs
+++ b/crates/entity/src/stats/archetype.rs
@@ -1,5 +1,27 @@
 //! Archetype-specific base stat values used to seed a fresh player.
 
+/// Number of values in the `resources."EArchetype"` Postgres enum.
+///
+/// This constant is the Rust-side anchor for a manual-coupling drift check —
+/// the live-DB test
+/// `archetype_count_matches_earchetype_enum_cardinality` (in
+/// `services/src/base/world_entry/methods/player_load/meta.rs`) asserts this
+/// matches `cardinality(enum_range(NULL::resources."EArchetype"))` so that
+/// adding to the SQL enum without reviewing downstream consumers fails CI
+/// loudly instead of silently shipping an empty ability tree.
+///
+/// **Adding a new archetype requires updates in (verify all):**
+/// 1. `db/resources/Archetypes/Types/EArchetype.sql` — enum entry
+/// 2. `db/sgw/Players/Tables/sgw_player.sql` — `CHECK (archetype <= N)` bound
+/// 3. This constant
+/// 4. `db/resources/Archetypes/Seed/archetype_ability_tree.sql` — ability
+///    tree rows for the new archetype (or accept empty)
+/// 5. `services/src/base/chardef.rs` — CharDefId entries that reference the
+///    new archetype (or accept that no character can be created with it)
+/// 6. `services/src/mercury/world_data/stats.rs::archetype_ability_tree` —
+///    DB-down fallback (only if non-empty fallback is desired)
+pub const ARCHETYPE_COUNT: usize = 9;
+
 /// Archetype-specific base stat values passed to [`super::StatList::apply_archetype`].
 ///
 /// Same fields as `ArchetypeStats` in mercury_ext.rs but decoupled from

--- a/crates/entity/src/stats/mod.rs
+++ b/crates/entity/src/stats/mod.rs
@@ -18,7 +18,7 @@ mod stat_list;
 #[cfg(test)]
 mod tests;
 
-pub use archetype::ArchetypeStatValues;
+pub use archetype::{ArchetypeStatValues, ARCHETYPE_COUNT};
 pub use stat::Stat;
 pub use stat_ids::*;
 pub use stat_list::StatList;

--- a/crates/services/src/base/world_entry/methods/player_load/meta.rs
+++ b/crates/services/src/base/world_entry/methods/player_load/meta.rs
@@ -6,21 +6,6 @@ use cimmeria_entity::abilities::AbilityTreeData;
 
 use crate::mercury::{archetype_ability_tree, PlayerLoadData};
 
-fn archetype_resource_name(archetype_id: i32) -> Option<&'static str> {
-    match archetype_id {
-        0 => Some("ARCHETYPE_Any"),
-        1 => Some("ARCHETYPE_Soldier"),
-        2 => Some("ARCHETYPE_Commando"),
-        3 => Some("ARCHETYPE_Scientist"),
-        4 => Some("ARCHETYPE_Archeologist"),
-        5 => Some("ARCHETYPE_Asgard"),
-        6 => Some("ARCHETYPE_Goauld"),
-        7 => Some("ARCHETYPE_Sholva"),
-        8 => Some("ARCHETYPE_Jaffa"),
-        _ => None,
-    }
-}
-
 /// Default player load data when the DB is unavailable.
 ///
 /// Caveat: `archetype` and `ability_tree` are both keyed to archetype id 1
@@ -151,11 +136,24 @@ pub async fn query_bandolier_items_tx(
 }
 
 /// Query archetype ability tree data from the database.
+///
+/// `archetype_id` is the array-position (0-based) of the value in the
+/// `resources."EArchetype"` enum — verified by the
+/// `archetype_count_matches_earchetype_enum_cardinality` test below to match
+/// `cimmeria_entity::stats::ARCHETYPE_COUNT`. The SQL maps the i32 to the enum
+/// value via `enum_range(NULL::"EArchetype")[$1 + 1]` so adding a new
+/// archetype to the enum doesn't require a Rust change here.
 pub async fn query_archetype_ability_tree(
     pool: &PgPool,
     archetype_id: i32,
 ) -> Option<AbilityTreeData> {
-    let archetype = archetype_resource_name(archetype_id)?;
+    // Negative ids would either underflow `$1 + 1` to 0 (Postgres array indexing
+    // is 1-based, so this just returns NULL → 0 rows) or trigger a `BIGINT
+    // overflow` on `i32::MIN + 1`. Short-circuit instead so the failure mode is
+    // identical to the prior `archetype_resource_name(< 0) == None` path.
+    if archetype_id < 0 {
+        return None;
+    }
 
     #[derive(sqlx::FromRow)]
     struct AbilityTreeRow {
@@ -166,16 +164,16 @@ pub async fn query_archetype_ability_tree(
     let rows = match sqlx::query_as::<_, AbilityTreeRow>(
         "SELECT tree_index, ability_id \
          FROM resources.archetype_ability_tree \
-         WHERE archetype = $1::resources.\"EArchetype\" \
+         WHERE archetype = (enum_range(NULL::resources.\"EArchetype\"))[$1 + 1] \
          ORDER BY tree_index, ability_index",
     )
-    .bind(archetype)
+    .bind(archetype_id)
     .fetch_all(pool)
     .await
     {
         Ok(rows) => rows,
         Err(e) => {
-            tracing::error!(archetype_id, archetype, "Failed to query ability tree: {e}");
+            tracing::error!(archetype_id, "Failed to query ability tree: {e}");
             return None;
         }
     };
@@ -406,7 +404,8 @@ mod tests {
 
     /// `query_archetype_ability_tree` against a seeded archetype
     /// returns Some(tree). Soldier (id=1) is the canonical test
-    /// archetype — verified by archetype_resource_name above.
+    /// archetype — Soldier and Commando are the only two archetypes
+    /// with seeded ability_tree rows.
     #[tokio::test]
     async fn ability_tree_known_archetype_returns_some() {
         let pool = require_db_or_skip!();
@@ -417,16 +416,81 @@ mod tests {
         );
     }
 
-    /// Unknown archetype id (-1, well outside the 0..=8 range) returns
-    /// None at the archetype_resource_name lookup — never hits the DB.
-    /// Caller (player_load) substitutes the default tree on None.
+    /// Negative archetype ids short-circuit before hitting the DB —
+    /// the same fail-safe the previous `archetype_resource_name`
+    /// match provided. Caller (player_load) substitutes the default
+    /// tree on None.
     #[tokio::test]
-    async fn ability_tree_unknown_archetype_returns_none() {
+    async fn ability_tree_negative_archetype_returns_none() {
         let pool = require_db_or_skip!();
         let result = query_archetype_ability_tree(&pool, -1).await;
         assert!(
             result.is_none(),
-            "out-of-range archetype id must short-circuit before any DB read",
+            "negative archetype id must short-circuit before any DB read",
+        );
+    }
+
+    /// Walk every valid array-position in the EArchetype enum and call
+    /// `query_archetype_ability_tree`. Asserts no panic / no SQL error
+    /// for any in-range id, and that the documented "Soldier and
+    /// Commando have data; others empty" mapping still holds.
+    ///
+    /// Catches:
+    /// - off-by-one bugs in the `enum_range[$1 + 1]` SQL
+    /// - schema-vs-enum desyncs where a CHECK rejects an id the enum
+    ///   allows (the function still works for that id since CHECK only
+    ///   matters on insert, but a future "tighten by adding the CHECK"
+    ///   refactor would surface here)
+    #[tokio::test]
+    async fn ability_tree_walks_full_enum_range_without_panic() {
+        let pool = require_db_or_skip!();
+        let enum_size: i32 =
+            sqlx::query_scalar("SELECT cardinality(enum_range(NULL::resources.\"EArchetype\"))")
+                .fetch_one(&pool)
+                .await
+                .expect("read enum cardinality");
+
+        for archetype_id in 0..enum_size {
+            let result = query_archetype_ability_tree(&pool, archetype_id).await;
+            // Soldier (1) and Commando (2) are the only seeded
+            // archetypes with ability tree rows; everything else gets
+            // None. If the seed grows, update this assertion
+            // deliberately — surprise-Some is a stronger signal than
+            // surprise-None, so we lock down the current shape.
+            let expected_some = matches!(archetype_id, 1 | 2);
+            assert_eq!(
+                result.is_some(),
+                expected_some,
+                "archetype_id={archetype_id}: expected_some={expected_some}, got is_some={}",
+                result.is_some(),
+            );
+        }
+    }
+
+    /// Cardinality tripwire: pin the `cimmeria_entity::stats::ARCHETYPE_COUNT`
+    /// constant against the actual size of `resources."EArchetype"`.
+    ///
+    /// Failure here is intentional — adding a value to the SQL enum
+    /// without bumping `ARCHETYPE_COUNT` (and walking the checklist
+    /// next to it) leaves downstream consumers (CHECK constraint,
+    /// chardef, fallback ability tree) potentially stale. Failing CI
+    /// loud forces the dev to revisit each one.
+    #[tokio::test]
+    async fn archetype_count_matches_earchetype_enum_cardinality() {
+        let pool = require_db_or_skip!();
+        let enum_size: i32 =
+            sqlx::query_scalar("SELECT cardinality(enum_range(NULL::resources.\"EArchetype\"))")
+                .fetch_one(&pool)
+                .await
+                .expect("read enum cardinality");
+        assert_eq!(
+            usize::try_from(enum_size).expect("enum_size must be non-negative"),
+            cimmeria_entity::stats::ARCHETYPE_COUNT,
+            "EArchetype enum size ({enum_size}) drifted from ARCHETYPE_COUNT \
+             ({}); see the checklist next to ARCHETYPE_COUNT in \
+             crates/entity/src/stats/archetype.rs and walk every item before \
+             bumping the constant",
+            cimmeria_entity::stats::ARCHETYPE_COUNT,
         );
     }
 }

--- a/crates/services/src/base/world_entry/methods/player_load/meta.rs
+++ b/crates/services/src/base/world_entry/methods/player_load/meta.rs
@@ -140,17 +140,21 @@ pub async fn query_bandolier_items_tx(
 /// `archetype_id` is the array-position (0-based) of the value in the
 /// `resources."EArchetype"` enum — verified by the
 /// `archetype_count_matches_earchetype_enum_cardinality` test below to match
-/// `cimmeria_entity::stats::ARCHETYPE_COUNT`. The SQL maps the i32 to the enum
-/// value via `enum_range(NULL::"EArchetype")[$1 + 1]` so adding a new
-/// archetype to the enum doesn't require a Rust change here.
+/// `cimmeria_entity::stats::ARCHETYPE_COUNT`. The SQL maps the i32 to the
+/// enum value via `enum_range(NULL::resources."EArchetype")[$1 + 1]` so
+/// adding a new archetype to the enum doesn't require a Rust change here.
 pub async fn query_archetype_ability_tree(
     pool: &PgPool,
     archetype_id: i32,
 ) -> Option<AbilityTreeData> {
-    // Negative ids would either underflow `$1 + 1` to 0 (Postgres array indexing
-    // is 1-based, so this just returns NULL → 0 rows) or trigger a `BIGINT
-    // overflow` on `i32::MIN + 1`. Short-circuit instead so the failure mode is
-    // identical to the prior `archetype_resource_name(< 0) == None` path.
+    // Negative ids would compute a 0-or-negative array subscript; Postgres
+    // array indexing is 1-based and returns NULL for out-of-range subscripts,
+    // so the query would still match 0 rows and behave correctly. Guarding
+    // here is purely a fast path that avoids a DB round-trip on bogus input
+    // and preserves the behavior of the prior `archetype_resource_name(< 0)
+    // == None` short-circuit. (Note: `$1 + 1` doesn't underflow at i32::MIN —
+    // the int4 + int4 arithmetic stays in range; the only overflow case in
+    // the SQL would be `archetype_id == i32::MAX`, which we never produce.)
     if archetype_id < 0 {
         return None;
     }

--- a/db/resources/Archetypes/Types/EArchetype.sql
+++ b/db/resources/Archetypes/Types/EArchetype.sql
@@ -2,6 +2,19 @@
 -- TOC entry 800 (class 1247 OID 60100)
 -- Name: EArchetype; Type: TYPE; Schema: resources; Owner: -
 --
+-- Adding a new archetype requires updates in (verify all):
+--   1. This file                                                                   - enum entry
+--   2. db/sgw/Players/Tables/sgw_player.sql                                         - CHECK (archetype <= N) bound
+--   3. crates/entity/src/stats/archetype.rs::ARCHETYPE_COUNT                        - Rust-side cardinality anchor
+--   4. db/resources/Archetypes/Seed/archetype_ability_tree.sql                      - ability tree rows (or accept empty)
+--   5. crates/services/src/base/chardef.rs                                          - CharDefId entries (or no character can use the new archetype)
+--   6. crates/services/src/mercury/world_data/stats.rs::archetype_ability_tree      - DB-down fallback (only if non-empty fallback is desired)
+--
+-- The live-DB test `archetype_count_matches_earchetype_enum_cardinality`
+-- in `crates/services/src/base/world_entry/methods/player_load/meta.rs`
+-- pins this list against ARCHETYPE_COUNT and fails CI loud if you bump
+-- the enum without updating the const.
+--
 
 CREATE TYPE "EArchetype" AS ENUM (
     'ARCHETYPE_Any',

--- a/db/resources/Archetypes/Types/EArchetype.sql
+++ b/db/resources/Archetypes/Types/EArchetype.sql
@@ -12,8 +12,10 @@
 --
 -- The live-DB test `archetype_count_matches_earchetype_enum_cardinality`
 -- in `crates/services/src/base/world_entry/methods/player_load/meta.rs`
--- pins this list against ARCHETYPE_COUNT and fails CI loud if you bump
--- the enum without updating the const.
+-- asserts this enum's cardinality matches ARCHETYPE_COUNT — bumping the
+-- enum without bumping the const fails CI. The checklist below is NOT
+-- mechanically validated; treat the test failure as a prompt to walk
+-- every item before bumping the const.
 --
 
 CREATE TYPE "EArchetype" AS ENUM (


### PR DESCRIPTION
## Summary

Closes the [5] item from #78 — the deferred CodeRabbit cleanup list
for #77.

The drift hazard called out: \`archetype_resource_name\` in
\`player_load/meta.rs\` hardcoded a match from i32 archetype_id to the
\`resources.\"EArchetype\"\` value name. Adding a new archetype to the
SQL enum without updating the match makes \`query_archetype_ability_tree\`
return None silently, which makes the player load with an empty
ability tree. Easy regression, hard to diagnose.

This PR stacks four guardrails so the next archetype either Just
Works or fails CI loud.

## Guardrail 1 — Path A: derive the mapping in SQL

Replace the Rust match + string bind with a Postgres array index:

\`\`\`sql
-- Before
WHERE archetype = \$1::resources.\"EArchetype\"   -- \$1 = \"ARCHETYPE_Soldier\" string

-- After
WHERE archetype = (enum_range(NULL::resources.\"EArchetype\"))[\$1 + 1]   -- \$1 = i32
\`\`\`

\`archetype_resource_name\` is gone. Adding to the enum auto-propagates
to this query. Negative ids still short-circuit client-side to avoid
array-index underflow on \`i32::MIN + 1\`.

Verified the i32 ↔ enum-position correspondence:
- \`db/resources/Archetypes/Types/EArchetype.sql\` declares
  \`Any, Soldier, Commando, ...\` in that order — matches the previous
  hardcoded match positions 0–8.
- \`base/chardef.rs\` hardcodes the same i32 ids during character
  creation.
- \`sgw_player.archetype\` is \`integer NOT NULL CHECK (>= 0 AND <= 8)\`.

## Guardrail 2 — \`ARCHETYPE_COUNT\` cardinality tripwire

New const \`cimmeria_entity::stats::ARCHETYPE_COUNT = 9\` anchors the
Rust side. New live-DB test
\`archetype_count_matches_earchetype_enum_cardinality\` asserts
\`ARCHETYPE_COUNT == cardinality(enum_range(NULL::\"EArchetype\"))\`.
Bump the enum without bumping the const → CI fails with a pointer to
the checklist.

## Guardrail 3 — walk-the-enum-range live-DB test

\`ability_tree_walks_full_enum_range_without_panic\` iterates
\`0..ARCHETYPE_COUNT\` and asserts \`query_archetype_ability_tree\` returns
Some/None matching the documented \"Soldier and Commando have data,
others empty\" shape. Catches off-by-one bugs in the array-indexing
SQL and seed-data drift.

## Guardrail 4 — manual-coupling checklists

Two anchors document every site that still requires manual updates
when an archetype is added — both stay in lockstep:

1. Doc comment above \`ARCHETYPE_COUNT\` in
   \`crates/entity/src/stats/archetype.rs\`.
2. SQL header comment in
   \`db/resources/Archetypes/Types/EArchetype.sql\`.

The checklist:

| # | Site | Why |
|---|---|---|
| 1 | \`db/resources/Archetypes/Types/EArchetype.sql\` | enum entry |
| 2 | \`db/sgw/Players/Tables/sgw_player.sql\` | \`CHECK (archetype <= N)\` bound |
| 3 | \`crates/entity/src/stats/archetype.rs::ARCHETYPE_COUNT\` | tripwire anchor |
| 4 | \`db/resources/Archetypes/Seed/archetype_ability_tree.sql\` | ability tree rows (or accept empty) |
| 5 | \`crates/services/src/base/chardef.rs\` | CharDefId entries |
| 6 | \`crates/services/src/mercury/world_data/stats.rs::archetype_ability_tree\` | DB-down fallback (only if non-empty desired) |

## What this fixes vs. what it makes loud

**Fixes:**
- The Rust mapping silent-empty-tree drift (guardrail 1).
- The \"someone added to the enum without checking downstream\" drift
  (guardrail 2).

**Doesn't eliminate but makes loud:**
- The \`CHECK (archetype <= 8)\` constraint coupling — still needs a
  manual bump, but the checklist points at it.
- \`chardef.rs\`, fallback ability tree, seed-data rows — encode
  game-design decisions, not mechanically derivable from the enum.

## Behavior diff

- Out-of-range archetype_id (e.g. 99) used to short-circuit
  client-side; now triggers a 1-row DB roundtrip that returns 0
  rows. Same observable result (Some/None), one extra cheap query
  on bogus input.
- Negative ids still short-circuit. Renamed
  \`ability_tree_unknown_archetype_returns_none\` →
  \`ability_tree_negative_archetype_returns_none\` for accuracy.

## Test plan

- [x] \`cargo test -p cimmeria-services --lib base::world_entry::methods::player_load::meta -- --test-threads=1\` — 7/7 pass (5 existing + 2 new)
- [x] \`cargo test -p cimmeria-entity\` — clean
- [x] \`cargo clippy -p cimmeria-services -p cimmeria-entity --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --all -- --check\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal validation framework to ensure archetype configuration consistency across system components.

* **Tests**
  * Expanded test coverage for archetype validation, including boundary testing and cardinality checks to prevent configuration misalignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->