### PR TITLE
test(content): chain-replay regression guard for chain 3026 (#79 group E)

### DIFF
--- a/crates/services/src/cell/content/chain_replay_tests.rs
+++ b/crates/services/src/cell/content/chain_replay_tests.rs
@@ -130,7 +130,7 @@ async fn chain_3026_does_not_fire_when_mission_1562_is_completed() {
     let chain = load_single_chain_for_test(&pool, 3026)
         .await
         .expect("DB query for chain 3026 must succeed")
-        .expect("chain 3026 must exist in seeded content_chains");
+        .expect("chain 3026 must exist in seeded content_chains and successfully load/convert");
 
     let mut engine = ChainEngine::new();
     engine.register_chain(chain);

--- a/crates/services/src/cell/content/chain_replay_tests.rs
+++ b/crates/services/src/cell/content/chain_replay_tests.rs
@@ -1,0 +1,163 @@
+//! Live-DB chain-replay regression guards.
+//!
+//! Each test loads a specific seeded `content_*` chain from the database
+//! through the same `build_chains_from_rows` pipeline that the cell service
+//! uses at startup, registers it in a fresh `ChainEngine`, and fires
+//! synthetic events through `resolve_event` to assert the chain matches
+//! (or doesn't) under specific `ExecutionContext` shapes.
+//!
+//! Loading from DB rather than hand-constructing the chain in Rust is
+//! deliberate: the whole point is to catch silent drift in the SQL seed
+//! (e.g. someone removes a `mission_status` condition that was added to fix
+//! a bug). A pure-Rust replica would let that drift pass.
+//!
+//! Skip cleanly when DATABASE_URL is unset.
+
+use cimmeria_content_engine::chain::ChainEngine;
+use cimmeria_content_engine::context::ExecutionContext;
+use cimmeria_content_engine::triggers::{TriggerEvent, TriggerType};
+
+use super::engine_loader::load_single_chain_for_test;
+use crate::test_support::require_db_or_skip;
+
+/// Chain 3026 (`db/resources/Content/Seed/sgc_w1_chains.sql`):
+/// `dialog_choice('5365')` accepts mission 1562, gated by
+/// `mission_status(1562) = 'not_active'`. The condition is the
+/// regression guard added in #77 — without it, every dialog re-display
+/// re-accepts the mission and resets progress.
+///
+/// Test 1: with `mission_1562_status = 'not_active'`, the chain matches
+/// and the engine resolves its actions. Pins the happy-path acceptance.
+#[tokio::test]
+async fn chain_3026_fires_dialog_5365_when_mission_1562_is_not_active() {
+    let pool = require_db_or_skip!();
+    let chain = load_single_chain_for_test(&pool, 3026)
+        .await
+        .expect("DB query for chain 3026 must succeed")
+        .expect("chain 3026 must exist in seeded content_chains");
+
+    let mut engine = ChainEngine::new();
+    engine.register_chain(chain);
+
+    let mut ctx = ExecutionContext::new();
+    // The dialog_id key matches the trigger's filter. The mission
+    // status param is what the chain's MissionStatus condition reads
+    // (key shape is `mission_{id}_status` per
+    // `crates/content-engine/src/conditions.rs`).
+    ctx.set_param("dialog_id".to_string(), serde_json::json!(5365));
+    ctx.set_param(
+        "mission_1562_status".to_string(),
+        serde_json::json!("not_active"),
+    );
+
+    let event = TriggerEvent {
+        trigger_type: TriggerType::DialogChoice,
+        source_entity: None,
+        target_entity: None,
+        params: ctx.params.clone(),
+    };
+
+    let resolved = engine.resolve_event(&event, &ctx);
+    let chain_3026_actions = resolved
+        .actions
+        .iter()
+        .filter(|(id, _)| *id == 3026)
+        .count();
+    assert!(
+        chain_3026_actions > 0,
+        "chain 3026 must resolve at least one action when \
+         mission_1562_status = 'not_active'; resolver returned {} actions \
+         total ({chain_3026_actions} from chain 3026)",
+        resolved.actions.len(),
+    );
+}
+
+/// Test 2: with `mission_1562_status = 'active'`, the chain's
+/// `mission_status` condition fails and the engine does NOT resolve any
+/// actions for chain 3026. This is the regression guard proper: if the
+/// condition is removed from the seed, this test fails.
+///
+/// We don't assert that the resolver returns *zero* actions overall —
+/// other chains may match `dialog_id=5365`, and the goal is specifically
+/// to pin chain 3026's behavior, not the whole content pipeline.
+#[tokio::test]
+async fn chain_3026_does_not_fire_when_mission_1562_is_active() {
+    let pool = require_db_or_skip!();
+    let chain = load_single_chain_for_test(&pool, 3026)
+        .await
+        .expect("DB query for chain 3026 must succeed")
+        .expect("chain 3026 must exist in seeded content_chains");
+
+    let mut engine = ChainEngine::new();
+    engine.register_chain(chain);
+
+    let mut ctx = ExecutionContext::new();
+    ctx.set_param("dialog_id".to_string(), serde_json::json!(5365));
+    ctx.set_param(
+        "mission_1562_status".to_string(),
+        serde_json::json!("active"),
+    );
+
+    let event = TriggerEvent {
+        trigger_type: TriggerType::DialogChoice,
+        source_entity: None,
+        target_entity: None,
+        params: ctx.params.clone(),
+    };
+
+    let resolved = engine.resolve_event(&event, &ctx);
+    let chain_3026_actions = resolved
+        .actions
+        .iter()
+        .filter(|(id, _)| *id == 3026)
+        .count();
+    assert_eq!(
+        chain_3026_actions, 0,
+        "chain 3026 must NOT resolve any actions when \
+         mission_1562_status = 'active' (the not_active condition is \
+         the regression guard against re-accepting on dialog re-display); \
+         got {chain_3026_actions} actions from chain 3026",
+    );
+}
+
+/// Test 3: `mission_1562_status = 'completed'` also blocks chain 3026.
+/// Same shape as the active-state test but pins the third leaf of the
+/// MissionStatusValue enum so a future "operator changed from eq to !="
+/// regression on the seed surfaces here.
+#[tokio::test]
+async fn chain_3026_does_not_fire_when_mission_1562_is_completed() {
+    let pool = require_db_or_skip!();
+    let chain = load_single_chain_for_test(&pool, 3026)
+        .await
+        .expect("DB query for chain 3026 must succeed")
+        .expect("chain 3026 must exist in seeded content_chains");
+
+    let mut engine = ChainEngine::new();
+    engine.register_chain(chain);
+
+    let mut ctx = ExecutionContext::new();
+    ctx.set_param("dialog_id".to_string(), serde_json::json!(5365));
+    ctx.set_param(
+        "mission_1562_status".to_string(),
+        serde_json::json!("completed"),
+    );
+
+    let event = TriggerEvent {
+        trigger_type: TriggerType::DialogChoice,
+        source_entity: None,
+        target_entity: None,
+        params: ctx.params.clone(),
+    };
+
+    let resolved = engine.resolve_event(&event, &ctx);
+    let chain_3026_actions = resolved
+        .actions
+        .iter()
+        .filter(|(id, _)| *id == 3026)
+        .count();
+    assert_eq!(
+        chain_3026_actions, 0,
+        "chain 3026 must NOT resolve any actions when \
+         mission_1562_status = 'completed'; got {chain_3026_actions}",
+    );
+}

--- a/crates/services/src/cell/content/chain_replay_tests.rs
+++ b/crates/services/src/cell/content/chain_replay_tests.rs
@@ -34,7 +34,7 @@ async fn chain_3026_fires_dialog_5365_when_mission_1562_is_not_active() {
     let chain = load_single_chain_for_test(&pool, 3026)
         .await
         .expect("DB query for chain 3026 must succeed")
-        .expect("chain 3026 must exist in seeded content_chains");
+        .expect("chain 3026 must exist in seeded content_chains and assemble successfully");
 
     let mut engine = ChainEngine::new();
     engine.register_chain(chain);

--- a/crates/services/src/cell/content/chain_replay_tests.rs
+++ b/crates/services/src/cell/content/chain_replay_tests.rs
@@ -22,9 +22,9 @@ use crate::test_support::require_db_or_skip;
 
 /// Chain 3026 (`db/resources/Content/Seed/sgc_w1_chains.sql`):
 /// `dialog_choice('5365')` accepts mission 1562, gated by
-/// `mission_status(1562) = 'not_active'`. The condition is the
-/// regression guard added in #77 — without it, every dialog re-display
-/// re-accepts the mission and resets progress.
+/// `mission_status(1562) = 'not_active'`. That condition is the
+/// regression guard: without it, every dialog re-display re-accepts
+/// the mission and resets progress.
 ///
 /// Test 1: with `mission_1562_status = 'not_active'`, the chain matches
 /// and the engine resolves its actions. Pins the happy-path acceptance.

--- a/crates/services/src/cell/content/engine_loader.rs
+++ b/crates/services/src/cell/content/engine_loader.rs
@@ -132,3 +132,103 @@ async fn load_chains_from_db(pool: &PgPool) -> Result<Vec<Chain>, sqlx::Error> {
         action_rows,
     ))
 }
+
+/// Load a single content chain by id, fully assembled (rows from all four
+/// `content_*` tables joined into a `Chain`). Returns `None` if no row exists
+/// in `content_chains` for the id.
+///
+/// Used by the chain-replay tests in `chain_replay_tests` to exercise a
+/// specific seeded chain through the engine without loading the entire content
+/// surface. Mirrors `load_chains_from_db` but scopes every query by
+/// `chain_id = $1` so the test runs in milliseconds even on the full seed.
+#[cfg(test)]
+pub(super) async fn load_single_chain_for_test(
+    pool: &PgPool,
+    chain_id: i32,
+) -> Result<Option<Chain>, sqlx::Error> {
+    use sqlx::Row;
+
+    let chain_rows: Vec<DbChainRow> = sqlx::query(
+        "SELECT chain_id, description, scope_type, scope_id, enabled, priority \
+         FROM resources.content_chains WHERE chain_id = $1",
+    )
+    .bind(chain_id)
+    .fetch_all(pool)
+    .await?
+    .into_iter()
+    .map(|r| DbChainRow {
+        chain_id: r.get("chain_id"),
+        description: r.get("description"),
+        scope_type: r.get("scope_type"),
+        scope_id: r.get("scope_id"),
+        enabled: r.get("enabled"),
+        priority: r.get("priority"),
+    })
+    .collect();
+
+    if chain_rows.is_empty() {
+        return Ok(None);
+    }
+
+    let trigger_rows: Vec<DbTriggerRow> = sqlx::query(
+        "SELECT chain_id, event_type, event_key, scope, once, sort_order \
+         FROM resources.content_triggers WHERE chain_id = $1 ORDER BY sort_order",
+    )
+    .bind(chain_id)
+    .fetch_all(pool)
+    .await?
+    .into_iter()
+    .map(|r| DbTriggerRow {
+        chain_id: r.get("chain_id"),
+        event_type: r.get("event_type"),
+        event_key: r.get("event_key"),
+        scope: r.get("scope"),
+        once: r.get("once"),
+        sort_order: r.get("sort_order"),
+    })
+    .collect();
+
+    let condition_rows: Vec<DbConditionRow> = sqlx::query(
+        "SELECT chain_id, condition_type, target_id, target_key, operator, value, sort_order \
+         FROM resources.content_conditions WHERE chain_id = $1 ORDER BY sort_order",
+    )
+    .bind(chain_id)
+    .fetch_all(pool)
+    .await?
+    .into_iter()
+    .map(|r| DbConditionRow {
+        chain_id: r.get("chain_id"),
+        condition_type: r.get("condition_type"),
+        target_id: r.get("target_id"),
+        target_key: r.get("target_key"),
+        operator: r.get("operator"),
+        value: r.get("value"),
+        sort_order: r.get("sort_order"),
+    })
+    .collect();
+
+    let action_rows: Vec<DbActionRow> = sqlx::query(
+        "SELECT chain_id, action_type, target_id, target_key, params, delay_ms, sort_order \
+         FROM resources.content_actions WHERE chain_id = $1 ORDER BY sort_order",
+    )
+    .bind(chain_id)
+    .fetch_all(pool)
+    .await?
+    .into_iter()
+    .map(|r| DbActionRow {
+        chain_id: r.get("chain_id"),
+        action_type: r.get("action_type"),
+        target_id: r.get("target_id"),
+        target_key: r.get("target_key"),
+        params: r.get("params"),
+        delay_ms: r.get("delay_ms"),
+        sort_order: r.get("sort_order"),
+    })
+    .collect();
+
+    Ok(
+        build_chains_from_rows(chain_rows, trigger_rows, condition_rows, action_rows)
+            .into_iter()
+            .next(),
+    )
+}

--- a/crates/services/src/cell/content/mod.rs
+++ b/crates/services/src/cell/content/mod.rs
@@ -10,6 +10,9 @@ mod event_dispatch;
 mod executor;
 mod mission_context;
 
+#[cfg(test)]
+mod chain_replay_tests;
+
 // Public surface — preserve the flat `crate::cell::content::<fn>` paths that
 // callers across the cell service already use.
 pub use engine_loader::build_engine;


### PR DESCRIPTION
## Summary

Closes group E from the test-coverage burndown. Three live-DB tests that load chain 3026 from the seeded `content_*` tables, register it in a fresh `ChainEngine`, and fire `dialog_choice(5365)` events under varying mission states.

The regression guard proper (`...does_not_fire_when_mission_1562_is_active`) catches the bug fixed in #77: without the `mission_status='not_active'` condition on chain 3026, every dialog re-display re-accepts mission 1562 and resets progress.

## What it tests

| Test | Setup | Asserts |
|---|---|---|
| `chain_3026_fires_dialog_5365_when_mission_1562_is_not_active` | `mission_1562_status='not_active'` | engine resolves ≥1 action from chain 3026 |
| `chain_3026_does_not_fire_when_mission_1562_is_active` | `mission_1562_status='active'` | engine resolves 0 actions from chain 3026 |
| `chain_3026_does_not_fire_when_mission_1562_is_completed` | `mission_1562_status='completed'` | engine resolves 0 actions from chain 3026 |

## Why load from DB instead of hand-constructing the chain

The entire point of the regression guard is to catch silent drift between the SQL seed and the documented behavior. A pure-Rust replica would let that drift pass — someone could remove the `mission_status` condition from the seed and the in-Rust copy would still gate correctly.

Loading the actual seeded chain ties the test to the production data path. If the seed changes, the test sees the change.

## What was needed (and what wasn't)

The "framework" the issue body called for didn't really exist as a gap — `ChainEngine`, `ExecutionContext`, the `MissionStatus` condition, `build_chains_from_rows`, and the loader infrastructure were all already in place. The only missing piece was a test-scoped single-chain loader: `engine_loader::load_single_chain_for_test(pool, chain_id)`, ~50 lines, mirrors `load_chains_from_db` but scopes every query by `chain_id` so the round-trip is milliseconds against the full content seed.

This generalises naturally: any future "regression-guard chain N" test is now a 10-line addition. Group E expansion beyond 3026 gets cheap from here.

## Test plan

- [x] `cargo test -p cimmeria-services --lib cell::content::chain_replay_tests -- --test-threads=1` — 3/3 pass against bundled local Postgres
- [x] `cargo clippy -p cimmeria-services --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

## Group E status after this

- ✅ chain 3026 (mission 1562 re-accept guard)

The "chain-replay test harness" called out in #79's group E now exists as the `load_single_chain_for_test` + `ChainEngine` pattern, ready for any future content-side drift to be guarded the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
