### PR TITLE
docs: TESTING.md + bake test/doc updates into PR process

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -33,6 +33,24 @@ Default to **none**. Add a comment only when the **why** is non-obvious: a hidde
 
 When adding a client method call, confirm the index against `docs/protocol/client-method-dispatch-table.md` and byte layout against `entities/defs/*.def`. Notable trap: `onPlayerTeleport` (method 116) is a streaming-load hint, not an authoritative move — use `BASEMSG_FORCED_POSITION` (`build_forced_position` in `mercury/aoi.rs`) for actual avatar snaps.
 
+## Required tests on every PR
+
+A PR that changes runtime behaviour must add or update a test. **Read [TESTING.md](../TESTING.md) before writing one** — it has the picker for the seven test types we use (unit / wire-format / live-DB / smoke / concurrency / chain-replay / legacy reference) and the gotchas mined from review comments since PR #131. Reviewer non-negotiables:
+
+- The test must fail when the fix is reverted (regression-guard shape, not happy-path).
+- Tighten assertions: composite keys, exact final positions, `== 1` not `>= 1`, exact byte strings for serializers.
+- Don't hard-code seed ids — re-fetch baselines or assert by relationship (`slot.cur_ammo_type == slot.default_ammo_type`).
+- Sentinel ids fit in `i32`; cleanup deletes by exact sentinel, not by range.
+- Live-DB tests use `require_db_or_skip!` and run with `--test-threads=1`.
+- Test names match the assertion. If the assertion changes, rename.
+- No PR or issue numbers in source comments — provenance lives in the PR body.
+
+If a single feature touches several layers (handler logic + serializer + SQL + cross-handler invariant), expect to add several test types — see TESTING.md "When one feature needs more than one test".
+
+## Required docs on every PR
+
+A PR that changes user-visible behaviour, public surface, file layout, build steps, or test policy must update the corresponding doc(s). For non-trivial doc work, prefer the **Documentation Writer** agent over freehand edits — it follows the Diátaxis framework (tutorials / how-to / reference / explanations) and keeps voice consistent with the rest of `docs/`. The mapping of "what changed → what to update" is in [CLAUDE.md](../CLAUDE.md) under "Required documentation for every PR". Index entries in `docs/readme.md` and per-section `README.md` files must stay in sync with the documents they list — adding or renaming a doc means updating the index in the same PR.
+
 ## Where to find more
 
-Full conventions: `CLAUDE.md`. Architecture: `docs/architecture/`. Content engine: `docs/architecture/data-driven-content-engine.md`. Migration roadmap: `docs/architecture/migration-roadmap.md`.
+Full conventions: `CLAUDE.md`. Testing: `TESTING.md`. Architecture: `docs/architecture/`. Content engine: `docs/architecture/data-driven-content-engine.md`. Migration roadmap: `docs/architecture/migration-roadmap.md`. Live-DB infra: `docs/architecture/integration-test-infra.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,3 +23,10 @@ This applies especially to:
 
 - REPL-style logic UAT supplements browser/manual UAT; it does not replace visual verification.
 - If a feature cannot be meaningfully exercised in the JS REPL, state that clearly and explain why.
+
+## PR process — tests and docs
+
+Every PR that changes runtime behaviour must add or update a test, and every PR that changes user-visible behaviour, public surface, file layout, build steps, or test policy must update the corresponding documentation in the same PR.
+
+- **Tests**: read [TESTING.md](TESTING.md) before authoring. It covers the seven test types (unit / wire-format / live-DB / smoke / concurrency / chain-replay / legacy reference), the picker for which type fits which bug shape, and the review gotchas mined from PRs #131 onwards.
+- **Docs**: see the "Required documentation for every PR" mapping in [CLAUDE.md](CLAUDE.md). For non-trivial doc work, use the **Documentation Writer** agent — Diátaxis-aware (tutorials / how-to / reference / explanation) and keeps voice consistent with the rest of `docs/`. Index entries in `docs/readme.md` and per-section README files stay in sync with the documents they list.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,7 +116,7 @@ The map of "what changed → what to update":
 | Test conventions, types, or gotchas | [TESTING.md](TESTING.md) (and re-link from README if a new section is added) |
 | Live-DB infra or local setup | [docs/architecture/integration-test-infra.md](docs/architecture/integration-test-infra.md) |
 | Crate layout, dependency graph, or new crate | [crates/README.md](crates/README.md) and the crate diagram in [README.md](README.md) |
-| Wire format, method indices, or message catalog | [docs/protocol/](docs/protocol/) and `crates/services/src/mercury/method_idx.rs` constants |
+| Wire format, method indices, or message catalog | [docs/protocol/client-method-dispatch-table.md](docs/protocol/client-method-dispatch-table.md), [docs/protocol/message-catalog.md](docs/protocol/message-catalog.md), the rest of [docs/protocol/](docs/protocol/), the canonical entity definitions under [entities/defs/](entities/defs/), and `crates/services/src/mercury/method_idx.rs` constants |
 | Architecture decisions (cell/base split, outbox, state-flag conventions, etc.) | New or amended doc under [docs/architecture/](docs/architecture/) |
 | Game systems, content chains, or content-engine actions | [docs/game-systems.md](docs/game-systems.md) and/or [docs/content/](docs/content/), plus [.github/instructions/content-chains.instructions.md](.github/instructions/content-chains.instructions.md) if review rules shift |
 | Project status, gap analysis, or roadmap | [docs/project-status.md](docs/project-status.md), [docs/gap-analysis.md](docs/gap-analysis.md), [docs/architecture/migration-roadmap.md](docs/architecture/migration-roadmap.md) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,37 @@ DATABASE_URL=postgres://w-testing:w-testing@localhost:5433/sgw \
 - **test fails (no DB)** → unit + non-DB integration tests. Live-DB tests in `crates/services` self-skip via `require_db_or_skip!` when `DATABASE_URL` is unset, so this run can be green even with broken DB code.
 - **test-live-db fails** → CI runs `cargo test -p cimmeria-services --lib -- --test-threads=1` against a fresh `postgres:17.9` service container loaded from `db/database.sql`. `--test-threads=1` is required: some live-DB tests share sentinel id ranges and would collide under parallel execution against a single shared DB. To repro locally, start the bundled Postgres on `:5433` and run the command in the snippet above.
 
+## Required testing for every PR
+
+A PR that changes runtime behavior without adding or updating a test will be sent back. **Before writing a test, read [TESTING.md](TESTING.md)** — it covers the seven test types we use (unit / wire-format / live-DB / smoke / concurrency / chain-replay / legacy reference), the picker for which type fits which bug shape, and the gotchas mined from PR reviews #131 onwards.
+
+The non-negotiables:
+
+- **Pick the right type.** If you change a `WHERE` clause or `rows_affected` invariant, you need a live-DB regression guard, not a unit test. If you change a serializer, you need a byte-exact wire-format test. The picker table is in TESTING.md.
+- **Reproduce the bug shape.** A regression guard must fail when the fix is reverted; if it doesn't, it's a happy-path test, not a guard. PR reviewers will check.
+- **One feature can need multiple tests.** Vendor stack changes typically need unit + wire-format + live-DB + smoke. Don't skip a layer because "the next layer up will catch it" — that's the bug shape TESTING.md exists to prevent.
+- **Live-DB tests use `require_db_or_skip!`** and run with `--test-threads=1`. Sentinels fit in `i32`. Cleanup deletes by exact sentinel, not by range. See `crates/services/src/test_support.rs`.
+
+## Required documentation for every PR
+
+A PR that changes user-visible behavior, public surface, file layout, build steps, or test policy must include the corresponding doc update. **CI does not gate this; reviewers do.** When updating, prefer to use the **Documentation Writer agent** (Diátaxis-aware: tutorials / how-to / reference / explanation) rather than freehand edits — it keeps voice and structure consistent with the rest of `docs/`.
+
+The map of "what changed → what to update":
+
+| If you change… | Update… |
+|---|---|
+| The README's listed feature set, status, or structure | [README.md](README.md) |
+| The pre-PR checklist, build commands, or repo invariants | [CLAUDE.md](CLAUDE.md) and [.github/copilot-instructions.md](.github/copilot-instructions.md) |
+| Test conventions, types, or gotchas | [TESTING.md](TESTING.md) (and re-link from README if a new section is added) |
+| Live-DB infra or local setup | [docs/architecture/integration-test-infra.md](docs/architecture/integration-test-infra.md) |
+| Crate layout, dependency graph, or new crate | [crates/README.md](crates/README.md) and the crate diagram in [README.md](README.md) |
+| Wire format, method indices, or message catalog | [docs/protocol/](docs/protocol/) and `crates/services/src/mercury/method_idx.rs` constants |
+| Architecture decisions (cell/base split, outbox, state-flag conventions, etc.) | New or amended doc under [docs/architecture/](docs/architecture/) |
+| Game systems, content chains, or content-engine actions | [docs/game-systems.md](docs/game-systems.md) and/or [docs/content/](docs/content/), plus [.github/instructions/content-chains.instructions.md](.github/instructions/content-chains.instructions.md) if review rules shift |
+| Project status, gap analysis, or roadmap | [docs/project-status.md](docs/project-status.md), [docs/gap-analysis.md](docs/gap-analysis.md), [docs/architecture/migration-roadmap.md](docs/architecture/migration-roadmap.md) |
+
+Index entries in [docs/readme.md](docs/readme.md) and the per-section `README.md` files (`docs/content/README.md`, `docs/protocol/README.md`, etc.) must stay in sync with the documents they list — adding or renaming a doc means updating the index in the same PR.
+
 ## File organization
 
 Files should "do what it says on the tin" — a reader (human or LLM) should predict a file's contents from its name. Split large files along natural seams to keep both LLM context and human review tractable.

--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@ The project tracks **369 features** across 38 systems. **47% have code** (175 of
 
 **Tested end-to-end with the game client:**
 - Login and authentication (HTTP SOAP → shard select → Mercury UDP)
-- Mercury reliable UDP transport with AES-256 encryption
+- Mercury reliable UDP transport with AES-256 encryption, per-channel fragment reassembly
 - Game data pipeline (22 resource categories, 112,626 DB rows)
 - World entry, entity spawning, grid-based Area of Interest
+- Durable Base→Cell content event delivery via persistent outbox
 - One-command build and setup
 
 **Code exists, needs verification:**
@@ -22,6 +23,12 @@ Character creation (8 archetypes, 23 defs) | Inventory | Vendors | Chat | Crafti
 Combat & abilities | Effects | Missions | NPC AI | Stats & leveling | Stargate travel
 
 See [docs/project-status.md](docs/project-status.md) for the detailed breakdown.
+
+## Tests & CI
+
+The Rust workspace currently carries **878 `#[test]` / `#[tokio::test]` cases** across **136 files**, of which **84 are live-DB regression guards** (gated by `require_db_or_skip!`) and **3 are end-to-end PL/pgSQL smoke scripts** (vendor stack, inventory move, progression). GitHub Actions runs five gating jobs on every PR — `cargo fmt --check`, `cargo clippy -D warnings`, `cargo build`, `cargo test` (workspace, no DB), and `cargo test -p cimmeria-services --lib -- --test-threads=1` against a `postgres:17.9` service container loaded from `db/database.sql`.
+
+For the test-type taxonomy (unit / wire-format / live-DB / smoke / concurrency / chain-replay), when each is appropriate, common gotchas, and the patterns reviewers expect to see, read **[TESTING.md](TESTING.md)**.
 
 ## Why Rust
 
@@ -155,7 +162,7 @@ Cimmeria/
 │   ├── resources/          Resource data (abilities, effects, archetypes — 18 game systems)
 │   └── deprecated/         Old monolithic schema files (reference only)
 ├── docs/                   152 documents
-├── tools/                  Editor tools (ServerEd, ContentEditor, SceneEditor, RE utilities)
+├── tools/                  Editor tools, RE utilities, and live-DB smoke SQL scripts (vendor_store_smoke.sql, inventory_move_smoke.sql, progression_smoke.sql)
 ├── bootstrap/              C++ dependency automation
 └── W-NG.sln                Visual Studio solution (C++ legacy build)
 ```
@@ -214,6 +221,8 @@ Test account: **test** / **test** (SHA1 hashed).
 - [Connection Flow](docs/connection-flow.md) — End-to-end login and world entry
 - [Project Status](docs/project-status.md) — What works and what's left
 - [Gap Analysis](docs/gap-analysis.md) — Per-feature completion tracking
+- [Testing Guide](TESTING.md) — Test types, when to use which, common gotchas
+- [Integration Test Infra](docs/architecture/integration-test-infra.md) — Live-DB test setup and rationale
 
 For reverse engineering: [docs/reverse-engineering/](docs/reverse-engineering/PLAN.md)
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,268 @@
+# Testing Guide
+
+> **Audience**: Engineers writing or reviewing tests in the Cimmeria workspace.
+> **Type**: Reference + how-to.
+> **Companion docs**: [docs/architecture/integration-test-infra.md](docs/architecture/integration-test-infra.md) (live-DB infra rationale and local setup), [CLAUDE.md](CLAUDE.md) (pre-PR checklist), [.github/copilot-instructions.md](.github/copilot-instructions.md) (review checklist).
+
+The Rust workspace currently has **878 `#[test]` / `#[tokio::test]` cases across 136 files**: 84 are live-DB regression guards (`require_db_or_skip!`) and 3 are end-to-end PL/pgSQL smoke scripts. CI gates every PR on five jobs — `cargo fmt --check`, `cargo clippy -D warnings`, `cargo build`, `cargo test` (workspace, no DB), and `cargo test -p cimmeria-services --lib -- --test-threads=1` against a live `postgres:17.9` service container.
+
+This guide is the playbook for writing tests that survive review and catch real regressions. **Read it before opening a PR that adds tests.**
+
+---
+
+## TL;DR
+
+1. **Pick the right test type** for the bug shape. The taxonomy is below; the picker is in [Choosing a test type](#choosing-a-test-type).
+2. **Pin the bug shape, not the happy path.** A regression guard must reproduce the bug if the fix is reverted. If the test still passes after `git revert`-ing the fix, it isn't a regression guard.
+3. **Tighten assertions.** `== 1` beats `>= 1`; `(player_id, mission_id)` lookup beats filtering by `player_id` alone; exact final positions beat "two distinct positions".
+4. **Don't trust seed data.** Re-fetch baseline values inside the test, or assert by relationship (`slot.cur_ammo_type == slot.default_ammo_type`) rather than by hard-coded id.
+5. **Name tests by what they assert,** not by what the code under test happens to do today. Rename if the assertion changes.
+6. **One feature can need multiple test types.** A new vendor handler typically needs a unit test (logic) + a wire-format test (serializer) + a live-DB regression guard (SQL) + a slot in the smoke script (cross-handler invariants).
+
+---
+
+## Test types we use
+
+### 1. Unit tests (`#[test]` / `#[tokio::test]` inline)
+
+**Where**: `#[cfg(test)] mod tests` in the same file as the code under test, or in a sibling `tests.rs` / `tests/` submodule when the host file approaches the 700-line cap.
+
+**For**: Pure functions, normalizers, parsers, state machines, anything you can exercise without a network socket or a database. ~700 of the 878 tests are this kind.
+
+**Patterns to follow:**
+- One assertion focus per test. Multi-assertion tests are fine when they pin one invariant from several angles, but if the test name doesn't predict the assertion, split it.
+- Reuse a small `make_state()` / `make_ctx()` helper rather than copying setup. When PR #150 split concurrency tests off, reviewers required reuse of the existing helper, not a parallel one.
+- Cover the negative path: if the code returns early on `connected: empty`, write the test that constructs that empty map and asserts the early-return shape.
+
+**Examples**: `crates/mercury/src/unpacker.rs` (14 tests, byte-level cursor edge cases); `crates/common/src/math.rs` (14 tests, vector/quaternion math); `crates/services/src/cell/combat/threat.rs` (24 tests, threat list state machine).
+
+### 2. Wire-format tests
+
+**Where**: Same module as the serializer; conventionally `crates/mercury/src/**/*.rs` and `crates/services/src/mercury/protocol/tests.rs`.
+
+**For**: Anything that produces bytes the BigWorld client must accept. This is the single most "byte-exact" surface in the codebase — the client is unforgiving, and we have no way to renegotiate the protocol.
+
+**Patterns to follow:**
+- Assert the **exact byte string** the function emits, hand-written in the test as a `&[u8]` literal or a hex string. Don't assert "length is at least N" — that's trivially true.
+- For frame builders, assert the offset of structurally meaningful footer fields (e.g., the `seq_id` footer position), not just the total frame length. PR #142 review caught a "length tautology" of exactly this shape.
+- Round-trip both directions when the codec is symmetric (`build_x` then `parse_x` then assert equality of the input).
+- Confirm method indices against `docs/protocol/client-method-dispatch-table.md` and byte layout against `entities/defs/*.def` before writing the test, not after.
+
+**Examples**: `crates/mercury/src/packet.rs`, `crates/services/src/base/world_entry/methods/vendor/serializers.rs` (12 byte-exact tests for the store payload), `crates/services/src/mercury/aoi.rs` (5 wire-layout tests for the four AoI builders from PR #142).
+
+### 3. Live-DB regression guards
+
+**Where**: Same module as the handler being guarded, gated by `let pool = require_db_or_skip!();`.
+
+**For**: SQL invariants that pure unit tests can't reach — `WHERE` clauses, `rows_affected` shapes, advisory locks, `ON CONFLICT` semantics, the `flags` column's role in vendor buyback, multi-character isolation. **Every Group A regression guard in PRs #143–#175 is this kind.**
+
+**Patterns to follow:**
+- Pick a **negative sentinel `entity_id`** (e.g., `-1_000_007`) and use it for both inserts and cleanup. Document the per-module sentinel range in a module-doc comment.
+- Sentinels must fit in `i32` if the column type is `INTEGER`. `0xDEAD_0000` is a `u32` that wraps to a negative i32 and can step on another module's range — bind as `i64` or pick a smaller sentinel.
+- Run with `--test-threads=1`. Some guards share sentinel ranges and collide under parallel execution. CI enforces this; local repro must match.
+- Cleanup must `DELETE WHERE entity_id = $sentinel`, not `WHERE entity_id < 0`. The latter reaches into other modules.
+- For shared rows (resources.items inserts), use `ON CONFLICT DO NOTHING` so test B's insert doesn't conflict with test A's leftover, and **don't `DELETE` shared rows in cleanup** — let them leak for the next run.
+- **Reproduce the bug shape.** A `handle_grant_cash` regression guard must seed two characters on the same account, grant to one, and assert the other's balance is unchanged. That's the shape the bug took (PR #143). A test that just grants and asserts the credit went through is a happy-path test, not a regression guard.
+
+**Examples**: `crates/services/src/base/world_entry/methods/progression/tests.rs` (PR #143), `crates/services/src/base/world_entry/methods/vendor/sell/tests.rs` (PR #154 — pin the `flags` column's role as buyback unit price), `crates/services/src/base/character.rs` (3 guards on `query_character_list`).
+
+### 4. End-to-end PL/pgSQL smoke tests
+
+**Where**: SQL script in `tools/<feature>_smoke.sql`, embedded into a `#[tokio::test]` in `crates/services/src/base/smoke_tests.rs` via `include_str!`.
+
+**For**: Whole-stack invariants that span multiple handlers and would still pass each handler's own per-handler tests. Today's three:
+- `vendor_store_smoke.sql` — sell → buyback → grant → purchase round-trip; catches drift between `handle_sell_vendor_items` and `handle_buyback_vendor_items` on the meaning of the `flags` column.
+- `inventory_move_smoke.sql` — split → simple-move → three-step swap; pins the parking-at-sentinel procedure that dodges the `(character_id, container_id, slot_id)` unique index mid-swap.
+- `progression_smoke.sql` — multi-character isolation for `handle_grant_cash` and `handle_grant_xp`.
+
+**Patterns to follow:**
+- Wrap the whole script in `BEGIN ... ROLLBACK` so seed data is byte-identical after a passing run.
+- Assert via PL/pgSQL `RAISE EXCEPTION` — sqlx surfaces it as `Err`, the harness panics, and on failure the connection-release `ROLLBACK` still cleans up.
+- The Rust harness is intentionally tiny: `include_str!` the SQL, strip `\set` psql-only directives, run via `sqlx::raw_sql(...).execute(&pool)`, assert `is_ok()`.
+- Seed-data drift hardens the script: before asserting "naquadah == X", read X from the row first.
+
+**When to add a smoke test (vs another live-DB unit test):** when at least two handlers share an invariant whose violation wouldn't fail either handler's own tests. The vendor smoke caught exactly that — both handlers internally consistent, round-trip price wrong.
+
+### 5. Concurrency regression guards
+
+**Where**: Sibling `concurrency_tests.rs` next to the per-handler `tests.rs` (the split is required by file caps; see PR #150).
+
+**For**: Race conditions, TOCTOU between `SELECT` and `UPDATE`, advisory-lock correctness, multi-task `join!` behavior, outbox drainer-vs-caller interleaving.
+
+**Patterns to follow:**
+- A naked `tokio::join!` of two handler futures often serializes via the scheduler or DB and produces "the right answer" by accident. Add a barrier-coordinated start, or run the race in a small loop, so a no-lock regression actually fails.
+- Wrap each `JoinHandle::await` in `tokio::time::timeout(...)` so a deadlock fails the test instead of wedging the suite.
+- Capture and assert each spawned task's `Result`. Dropping the result lets an `Err` that left the DB in a state still satisfying the post-conditions become a false positive.
+- For TOCTOU guards on `update_X WHERE type_id = $1`, the racing replacement row must use the **same `type_id`** as the original. A different-`type_id` race doesn't exercise the predicate the bug lives in.
+- Validate `rows_affected() == 1` on staged setup `UPDATE`s. A fixture drift fails loudly at the staging step rather than as a confusing assertion mismatch.
+
+**Examples**: `crates/services/src/base/world_entry/methods/inventory/move_/concurrency_tests.rs` (PR #150, PR #175), `crates/services/src/base/world_entry/methods/inventory/grant.rs` concurrency tests (PR #145).
+
+### 6. Chain-replay tests
+
+**Where**: `crates/services/src/cell/content/chain_replay_tests.rs`.
+
+**For**: Content chains in `db/resources/Content/Seed/space_*_chains.sql` — guarding against converter bugs (auto-generated `accept_mission` where `complete_mission` was meant), shadow conditions, missing `interact_tag`/`set_interaction_type` pairings.
+
+**Patterns to follow:**
+- Phrase the `expect` so the failure points at the right component: "chain X must exist *and* successfully load" (covers both the seed and the loader). PR #173 review insisted on this.
+- When the loader rejects a chain for an unknown trigger/action, the replay test must distinguish "row missing" from "row present but skipped" — those have different fixes.
+
+### 7. C++ legacy + Python script tests
+
+The `src/` (C++) and `python/` (game scripts) trees are reference-only for active development. They have their own (smaller) test surface that is not part of the CI gate. **Don't write new tests there** unless you are specifically validating the reference behavior we're trying to match in Rust; in that case, document why in the test header and link the corresponding Rust test.
+
+---
+
+## Choosing a test type
+
+| If you are testing… | Use… |
+|---|---|
+| A pure function or a state machine | Unit test |
+| A byte producer/consumer (Mercury, vendor serializer, AoI builder) | Wire-format test |
+| A `WHERE` clause, `rows_affected`, advisory lock, `ON CONFLICT` | Live-DB regression guard |
+| An invariant that spans two or more handlers | PL/pgSQL smoke + Rust harness |
+| A race condition or `join!`-of-futures correctness | Concurrency regression guard |
+| Content seed correctness (chains, triggers, action wiring) | Chain-replay test |
+
+### When one feature needs more than one test
+
+The **vendor sell/purchase** stack is the canonical example, and it carries every type:
+
+- **Unit test**: `normalize_item_quantities` and `normalize_item_ids` (pure transforms — PR #137).
+- **Wire-format test**: `vendor::serializers` byte-exact tests — PR #136.
+- **Live-DB regression guard**: per-handler tests in `vendor/{sell,buyback,purchase,paid_repair,paid_recharge,recharge,repair,data}/tests.rs` — PRs #154–#161, #156–#157.
+- **Smoke**: `vendor_store_smoke.sql` round-trips the entire stack — PR #172.
+- **Concurrency guard**: separate from the per-handler test, in `concurrency_tests.rs` — PR #150, PR #175.
+
+Each layer catches a different class of bug. **Skipping a layer because "the next layer up will catch it" is the bug shape this list exists to prevent.** PR #172's review explicitly argued the smoke test catches whole-stack regressions the per-handler tests can't.
+
+---
+
+## Common gotchas (from PRs #131–#175)
+
+This section is mined from review comments since the test push began. Each item is a real reviewer correction; the parenthetical citation is where it came from.
+
+### Tightness
+
+- **Scope DB lookups by composite key**, not by `player_id` alone. Use `fetch_one` on `(player_id, mission_id)` instead of `fetch_optional` on `player_id` (PR #146).
+- **Assert "exactly one row"** with `SELECT COUNT(*)` or by fetching all rows. `fetch_optional` without `ORDER BY` or count check passes when the single-insert invariant is violated (PR #145).
+- **Assert exact final positions** after a deterministic swap (`item A at (1,5)`, `item B at (1,0)`), not "two distinct non-sentinel positions" — the loose form passes when both moves rolled back (PR #150).
+- **Use `== 1` not `>= 1`** for counts you control. Reviewers will flag the loose form (PR #111).
+- **Validate `rows_affected() == 1`** on staged UPDATEs in setup so fixture drift fails at the UPDATE, not later (PR #175).
+- **Assert the seq_id footer offset** in wire-format tests, not a slice length that's trivially satisfied (PR #142).
+
+### Naming
+
+- **Test names must match the assertion.** A test named `bails_silently_*` that asserts a `tracing::warn!` was logged is lying — rename it (PRs #139, #143).
+- **A test that returns `Some(VendorSession { server_template_id: None, .. })`** must not be named as if it returned `None` (PR #141).
+- **A test pinning JSON-tag stability** must serialize and inspect the JSON `kind` field. Asserting `event_type()` defeats the persistence contract the name promises (PR #133).
+
+### Don't trust seed data
+
+- **Re-fetch baseline values inside the test.** Hard-coded constants like `WEAPON_TYPE_ID = 3241` or specific clip-size enums break when seeds change (PRs #160, #158, #162).
+- **Mirror the handler's predicate** when the picker query selects a fixture row. If the handler filters on a sellable-flag bitmask, the picker must too — otherwise the test passes for the wrong reason (PR #154).
+- **Assert by relationship**, not by id: `slot.cur_ammo_type == slot.default_ammo_type` survives seed churn; `slot.cur_ammo_type == 3241` does not.
+- **Never use a "definitely nonexistent" id like `99_999_999`.** The sequence may have advanced past it. Use a negative sentinel (if the column allows) or `MAX(id) + 1` computed at runtime (PR #144).
+- **Assert fixture cardinality up front.** If `pick_main_bag_type_ids(2)` can return one row, assert `types.len() == 2` so the failure points at missing fixture data, not a cryptic out-of-bounds panic (PR #144).
+
+### Sentinel id discipline
+
+- **Sentinels for `INTEGER` columns must fit in `i32` range.** `0xDEAD_0000` as `u32` wraps to negative when bound `as i32` and can step on another module's cleanup (PRs #134, #150).
+- **Document and partition sentinel ranges per module.** Cleanup `DELETE WHERE entity_id = $sentinel` (precise) beats `DELETE WHERE entity_id < 0` (reaches into other modules) (PRs #154, #163).
+- **Don't share-row `DELETE` in cleanup.** For rows you `INSERT INTO resources.items` to set up the fixture, use `ON CONFLICT DO NOTHING` and let the row leak — otherwise test B's cleanup yanks a row out from under test A (PR #164).
+
+### Concurrency
+
+- **Two `join!`ed handler futures often serialize by accident.** Use a barrier-coordinated start or a small loop so a no-lock regression actually fails (PR #145).
+- **Wrap each `JoinHandle::await` in `tokio::time::timeout(...)`.** A deadlock regression should fail the test, not wedge the suite (PR #150).
+- **Capture and assert each spawned task's `Result`.** Dropping it lets an `Err` that left the DB in a satisfying state become a false positive (PR #150).
+- **Run live-DB tests with `--test-threads=1`.** Sentinel ranges are shared and parallel runs collide (PRs #153, #164). CI enforces this in the `test-live-db` job.
+
+### Regression-guard shape
+
+- **The bug shape must reproduce if the fix is reverted.** A `update_bandolier_ammo` TOCTOU guard needs a **same-`type_id`** racing replacement row — different `type_id` doesn't exercise the predicate (PR #158).
+- **Negative-path tests must assert what's actually missing.** "No wire packet was sent" is unprovable when the test set up an empty `connected` map; either set up a real receiver or narrow the doc-comment to the DB invariant you actually checked (PR #143).
+- **A loop that filters on `method == 16`** doesn't prove "no combat-side messages emitted." Either tighten the doc-comment to "no `onTargetUpdate`" or extend the loop to fail on `onTimerUpdate`/`onSequence`/`onStateFieldUpdate` (PR #138).
+
+### Failure messages
+
+- **Word the assertion message to match the failure mode you're protecting against.** "world::dispatch handled it instead" misleads when the regression actually returns `false` from `world::dispatch` (PR #140).
+- **Distinguish "row missing" from "row present but skipped".** "chain 3026 must exist in seeded content_chains" hides the case where the loader rejected the row for an unknown trigger; phrase as "must exist *and* successfully load/convert" (PR #173).
+
+### Test-DB hygiene
+
+- **Live-DB tests run against `sgw` loaded from `db/database.sql` in CI**, and against a developer-supplied `DATABASE_URL` locally. The bundled local Postgres binds to **port 5433** (not 5432) — see [docs/architecture/integration-test-infra.md](docs/architecture/integration-test-infra.md) for setup.
+- **The skip message must distinguish unset vs unreachable.** `test_pool()` returns a `SkipReason` enum so the developer sees "DATABASE_URL not set" vs "DATABASE_URL set but connect failed: …" (PR #134, see [crates/services/src/test_support.rs](crates/services/src/test_support.rs)).
+
+### File and module hygiene
+
+- **When a test module pushes the host file past 700 lines**, extract concurrency helpers and multi-threaded tests into a sibling `concurrency_tests.rs` or `tests/` submodule. **Reuse the existing `make_state()` / `make_ctx()` helper** — don't clone setup (PRs #143, #150).
+- **De-duplicate setup** across routing tests. PR #140 review required a `make_ctx()` helper so each test focuses on its routing assertion.
+
+### Comment hygiene
+
+- **No PR or issue numbers in source comments.** Describe the invariant directly. Numbers rot, the rationale should be self-contained (PRs #139, #150, #164, #172, #173). Provenance lives in the PR body.
+- **No line-numbered citations of the system under test.** Reference the function name only (PR #172).
+
+### CI gotchas
+
+- **Run `cargo test --workspace`**, not just `-p cimmeria-services`. A workspace test job that only runs one crate lets failures in `cimmeria-mercury` and `cimmeria-content-engine` merge green (PR #151).
+- **Pass `--locked` in CI** so a stale `Cargo.lock` fails the job rather than silently re-resolving (PR #151).
+- **Install `clang` and `mold` explicitly in CI.** A `.cargo/config.toml` that selects them as the linker means the runner image's preinstalls aren't enough — the suite must be self-contained (PR #151).
+
+---
+
+## Running the test suite
+
+### Locally (no DB — covers ~794 tests)
+
+```bash
+cargo test --workspace \
+  --exclude cimmeria-app --exclude cimmeria-content-editor \
+  --exclude cimmeria-scene-editor --exclude sgw-launcher
+```
+
+### Locally (live DB — adds the 84 `require_db_or_skip!` guards + 3 smokes)
+
+Start the bundled Postgres on port 5433 (via `setup.ps1`'s bootstrap), then:
+
+```bash
+DATABASE_URL=postgres://w-testing:w-testing@localhost:5433/sgw \
+  cargo test -p cimmeria-services --lib -- --test-threads=1
+```
+
+Without `DATABASE_URL`, those 84 tests self-skip with `module_path!: skipping live-DB test (DATABASE_URL not set)`. **Self-skipped tests are not failures** — but a green "no DB" run does not prove the live-DB suite passes. Always run both before declaring a PR ready.
+
+### CI (every PR)
+
+`.github/workflows/test.yml` runs five jobs: `fmt`, `clippy`, `build`, `test` (workspace, no DB), `test-live-db` (postgres:17.9 service container). All must pass before merge.
+
+---
+
+## Adding a new test — checklist
+
+Before opening a PR that adds tests:
+
+- [ ] Test type matches the bug shape (see [Choosing a test type](#choosing-a-test-type)).
+- [ ] Test name matches the assertion.
+- [ ] Assertions are tight (`==` not `>=`, composite keys not single-column filters, exact positions not "distinct").
+- [ ] No hard-coded resource ids; baseline values re-fetched at runtime.
+- [ ] Sentinels fit in `i32`; cleanup deletes by sentinel, not by range.
+- [ ] Live-DB tests use `require_db_or_skip!`.
+- [ ] Concurrency tests use `tokio::time::timeout` and capture `Result`s.
+- [ ] No PR/issue numbers in source comments.
+- [ ] Setup helper reused, not cloned.
+- [ ] Reverting the fix makes the test fail (regression-guard test).
+- [ ] Test runs locally with `--test-threads=1` against a live DB if applicable.
+
+---
+
+## See also
+
+- [docs/architecture/integration-test-infra.md](docs/architecture/integration-test-infra.md) — the "no testcontainers, no `sqlx::test`" decision and local setup.
+- [.github/workflows/test.yml](.github/workflows/test.yml) — the canonical CI definition.
+- [crates/services/src/test_support.rs](crates/services/src/test_support.rs) — `require_db_or_skip!` and `test_pool`.
+- [crates/services/src/base/smoke_tests.rs](crates/services/src/base/smoke_tests.rs) — the three end-to-end smokes and their rationale.
+- [tools/vendor_store_smoke.sql](tools/vendor_store_smoke.sql), [tools/inventory_move_smoke.sql](tools/inventory_move_smoke.sql), [tools/progression_smoke.sql](tools/progression_smoke.sql) — the smoke scripts themselves.
+- [.github/copilot-instructions.md](.github/copilot-instructions.md) — review checklist; the testing checklist in this file feeds into it.

--- a/TESTING.md
+++ b/TESTING.md
@@ -57,10 +57,10 @@ This guide is the playbook for writing tests that survive review and catch real 
 **For**: SQL invariants that pure unit tests can't reach — `WHERE` clauses, `rows_affected` shapes, advisory locks, `ON CONFLICT` semantics, the `flags` column's role in vendor buyback, multi-character isolation. **Every Group A regression guard in PRs #143–#175 is this kind.**
 
 **Patterns to follow:**
-- Pick a **negative sentinel `entity_id`** (e.g., `-1_000_007`) and use it for both inserts and cleanup. Document the per-module sentinel range in a module-doc comment.
-- Sentinels must fit in `i32` if the column type is `INTEGER`. `0xDEAD_0000` is a `u32` that wraps to a negative i32 and can step on another module's range — bind as `i64` or pick a smaller sentinel.
-- Run with `--test-threads=1`. Some guards share sentinel ranges and collide under parallel execution. CI enforces this; local repro must match.
-- Cleanup must `DELETE WHERE entity_id = $sentinel`, not `WHERE entity_id < 0`. The latter reaches into other modules.
+- Pick a **positive `0x7000_xxxx` sentinel base** for the module's test ids (e.g., `const TEST_BASE: i32 = 0x7000_0400;` for missions, `0x7000_1000` for character-list, `0x7000_0800` for vendor sell). Each module reserves its own slot in this range; the existing modules document neighbours in a doc-comment so the next contributor can step past them. See `crates/services/src/base/character.rs:281` and `crates/services/src/base/world_entry/methods/missions.rs:146-148` for the canonical comment shape.
+- The base must fit in `i32` because the `entity_id`/`account_id`/`player_id` columns are `INTEGER`. `0x7000_xxxx` does (it's well below `i32::MAX`); a `u32` like `0xDEAD_0000` wraps to a negative when bound `as i32` and lands in another module's territory — don't reach for high-bit constants.
+- Run with `--test-threads=1`. Even within the partitioned-range scheme, some guards share rows in `resources.*` and collide under parallel execution. CI enforces this; local repro must match.
+- Cleanup must `DELETE WHERE <id> = $sentinel` (or `IN (...)` over the exact ids the test inserted), not a range predicate like `WHERE entity_id < 0` or `WHERE account_id BETWEEN base AND base+0xFF`. Range deletes can reach into a sibling module's slot if the partitioning ever drifts.
 - For shared rows (resources.items inserts), use `ON CONFLICT DO NOTHING` so test B's insert doesn't conflict with test A's leftover, and **don't `DELETE` shared rows in cleanup** — let them leak for the next run.
 - **Reproduce the bug shape.** A `handle_grant_cash` regression guard must seed two characters on the same account, grant to one, and assert the other's balance is unchanged. That's the shape the bug took (PR #143). A test that just grants and asserts the credit went through is a happy-path test, not a regression guard.
 
@@ -163,13 +163,14 @@ This section is mined from review comments since the test push began. Each item 
 - **Re-fetch baseline values inside the test.** Hard-coded constants like `WEAPON_TYPE_ID = 3241` or specific clip-size enums break when seeds change (PRs #160, #158, #162).
 - **Mirror the handler's predicate** when the picker query selects a fixture row. If the handler filters on a sellable-flag bitmask, the picker must too — otherwise the test passes for the wrong reason (PR #154).
 - **Assert by relationship**, not by id: `slot.cur_ammo_type == slot.default_ammo_type` survives seed churn; `slot.cur_ammo_type == 3241` does not.
-- **Never use a "definitely nonexistent" id like `99_999_999`.** The sequence may have advanced past it. Use a negative sentinel (if the column allows) or `MAX(id) + 1` computed at runtime (PR #144).
+- **Never use a "definitely nonexistent" id like `99_999_999`.** The sequence may have advanced past it. Use a sentinel from your module's reserved `0x7000_xxxx` slot (see "Sentinel id discipline") or `MAX(id) + 1` computed at runtime (PR #144).
 - **Assert fixture cardinality up front.** If `pick_main_bag_type_ids(2)` can return one row, assert `types.len() == 2` so the failure points at missing fixture data, not a cryptic out-of-bounds panic (PR #144).
 
 ### Sentinel id discipline
 
-- **Sentinels for `INTEGER` columns must fit in `i32` range.** `0xDEAD_0000` as `u32` wraps to negative when bound `as i32` and can step on another module's cleanup (PRs #134, #150).
-- **Document and partition sentinel ranges per module.** Cleanup `DELETE WHERE entity_id = $sentinel` (precise) beats `DELETE WHERE entity_id < 0` (reaches into other modules) (PRs #154, #163).
+- **Reserve a positive `0x7000_xxxx` base per module** and partition the low byte (or low two bytes) for individual tests. Existing reservations include `0x7000_0100` (grant_cash), `0x7000_0200` (move_inventory), `0x7000_0300` (grant_item), `0x7000_0400` (missions), `0x7000_0600` (vendor repair), `0x7000_0800` (vendor sell), `0x7000_0B00` (inventory ammo), `0x7000_1000` (character-list), `0x7000_1200` (purchase_helpers), `0x7000_1300` (vendor recharge). Document the neighbours in a module-doc comment so the next contributor can step past them (`crates/services/src/base/character.rs:276-281` is the canonical shape).
+- **Sentinels for `INTEGER` columns must fit in `i32` range.** `0x7000_xxxx` does. `0xDEAD_0000` as `u32` wraps to negative when bound `as i32` and lands in another module's territory — don't reach for high-bit constants (PRs #134, #150).
+- **Cleanup must delete by exact id**, not by range. `DELETE WHERE entity_id = $sentinel` (or `IN (...)` over the exact ids the test inserted) beats `DELETE WHERE entity_id BETWEEN base AND base+0xFF` — range deletes can reach into a sibling module's slot if partitioning ever drifts (PRs #154, #163).
 - **Don't share-row `DELETE` in cleanup.** For rows you `INSERT INTO resources.items` to set up the fixture, use `ON CONFLICT DO NOTHING` and let the row leak — otherwise test B's cleanup yanks a row out from under test A (PR #164).
 
 ### Concurrency
@@ -248,7 +249,7 @@ Before opening a PR that adds tests:
 - [ ] Test name matches the assertion.
 - [ ] Assertions are tight (`==` not `>=`, composite keys not single-column filters, exact positions not "distinct").
 - [ ] No hard-coded resource ids; baseline values re-fetched at runtime.
-- [ ] Sentinels fit in `i32`; cleanup deletes by sentinel, not by range.
+- [ ] Sentinels are positive `0x7000_xxxx` ids in your module's reserved slot; cleanup deletes by exact id, not by range.
 - [ ] Live-DB tests use `require_db_or_skip!`.
 - [ ] Concurrency tests use `tokio::time::timeout` and capture `Result`s.
 - [ ] No PR/issue numbers in source comments.

--- a/crates/README.md
+++ b/crates/README.md
@@ -2,6 +2,8 @@
 
 This directory is the primary codebase. All active server development happens here. The C++ code in `src/` is the legacy reference implementation.
 
+For testing conventions across these crates — test types, when to use which, common gotchas — see **[../TESTING.md](../TESTING.md)**.
+
 ## Crate Overview
 
 ```
@@ -47,6 +49,22 @@ cargo check --workspace --exclude cimmeria-app --exclude cimmeria-content-editor
 ```
 
 See the root [CLAUDE.md](../CLAUDE.md) for WSL memory management rules.
+
+## Testing
+
+The workspace currently carries **878 `#[test]` / `#[tokio::test]` cases across 136 files**, of which 84 are live-DB regression guards and 3 are end-to-end PL/pgSQL smokes. Run the full suite:
+
+```bash
+# Unit + non-DB integration (covers ~794 tests):
+cargo test --workspace --exclude cimmeria-app --exclude cimmeria-content-editor \
+  --exclude cimmeria-scene-editor --exclude sgw-launcher
+
+# Live-DB tests (start the bundled Postgres on :5433 first, then):
+DATABASE_URL=postgres://w-testing:w-testing@localhost:5433/sgw \
+  cargo test -p cimmeria-services --lib -- --test-threads=1
+```
+
+`--test-threads=1` is required for the live-DB run — some guards share sentinel id ranges and would collide under parallel execution. See [../TESTING.md](../TESTING.md) for the full picker, gotchas, and review checklist.
 
 ## Key Source Files
 

--- a/docs/architecture/integration-test-infra.md
+++ b/docs/architecture/integration-test-infra.md
@@ -53,32 +53,40 @@ crate's `pub` API, which would force us to make implementation
 modules `pub` purely for testing — leaking surface for no
 production gain.
 
-Each live-DB test gates on `DATABASE_URL` at runtime:
+Each live-DB test gates on `DATABASE_URL` at runtime via the
+`require_db_or_skip!` macro, which wraps the pool open and the
+skip-with-reason branch:
 
 ```rust
+use crate::test_support::require_db_or_skip;
+
 #[tokio::test]
 async fn outbox_round_trip_against_real_db() {
-    let pool = match crate::test_support::test_pool().await {
-        Some(p) => p,
-        None => {
-            eprintln!("DATABASE_URL not set; skipping");
-            return;
-        }
-    };
+    let pool = require_db_or_skip!();
     // ... real-DB assertions ...
 }
 ```
 
-`test_support::test_pool()` reads `DATABASE_URL`, opens a `PgPool`,
-and returns `None` (so the test skips) when the variable is unset
-or the connection fails. The unit-test suite stays green on a fresh
-checkout — only `DATABASE_URL=postgres://… cargo test` exercises the
-integration path.
+`test_support::test_pool()` returns
+`Result<PgPool, SkipReason>`, where `SkipReason` distinguishes
+`NotConfigured` (DATABASE_URL unset or empty — silent skip) from
+`ConnectFailed(String)` (variable set but `connect()` failed —
+surfaces sqlx's underlying error so the developer can fix it). The
+macro logs the reason via `eprintln!("{module_path}: skipping
+live-DB test ({reason})")` and returns from the test on either
+shape. The unit-test suite stays green on a fresh checkout — only
+`DATABASE_URL=postgres://… cargo test` exercises the integration
+path.
 
 Each test is responsible for its own data isolation: either work
 inside a transaction it rolls back at the end (works for tests that
-don't need to span their own commit boundary), or pick a unique
-sentinel and delete its own rows on cleanup.
+don't need to span their own commit boundary), or pick a sentinel
+from the module's reserved `0x7000_xxxx` slot and delete its own
+rows on cleanup. The reserved-slot scheme is documented per-module
+(see `crates/services/src/base/character.rs:276-281` and
+`crates/services/src/base/world_entry/methods/missions.rs:146-148`
+for the canonical doc-comment shape) and is also summarised in the
+"Sentinel id discipline" section of [TESTING.md](../../TESTING.md).
 
 ## Setup for local dev
 

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -21,6 +21,9 @@ The emulator is **playable today**: players can log in, enter the world, interac
 | Database rows (game data) | 112,626 |
 | Abilities / Items / Missions / Effects | 1,887 / 6,060 / 1,041 / 3,217 |
 | Documentation files | 152 |
+| Rust tests (`#[test]` / `#[tokio::test]`) | 878 across 136 files |
+| Live-DB regression guards | 84 |
+| End-to-end PL/pgSQL smoke scripts | 3 |
 
 
 ## Document Map
@@ -32,6 +35,7 @@ The emulator is **playable today**: players can log in, enter the world, interac
 | [How SGW Works](how-sgw-works.md) | Technology overview -- BigWorld, CME, and how the pieces fit together |
 | [Client Tools](client-tools.md) | Launcher, editor mode, debug tools available in the client |
 | [Building the Server](building.md) | How to build and run the Cimmeria server emulator |
+| [Testing Guide](../TESTING.md) | Test types, picker for which to use when, gotchas mined from PR reviews |
 | [Game Systems](game-systems.md) | Survey of every game feature: combat, abilities, stargates, missions, crafting |
 | [Game Data](game-data.md) | What game content exists (items, abilities, missions) and what is missing |
 | [Commands Reference](commands.md) | Player commands, chat, GM tools, and debug commands |
@@ -135,7 +139,7 @@ See also: [technical/bigworld-version-analysis.md](technical/bigworld-version-an
 
 ### `architecture/` -- Cimmeria Server Architecture
 
-How the Cimmeria emulator itself is structured. 7 documents.
+How the Cimmeria emulator itself is structured. 10 documents.
 
 | Document | Description | Status |
 |----------|-------------|--------|
@@ -146,8 +150,11 @@ How the Cimmeria emulator itself is structured. 7 documents.
 | [tech-stack-replacement.md](architecture/tech-stack-replacement.md) | Tech stack replacement analysis: 5 options (incremental upgrade through full C# rewrite), codebase audit, protocol feasibility, phased recommendation | Complete |
 | [data-driven-content-engine.md](architecture/data-driven-content-engine.md) | Data-driven content engine: replace per-script Python with DB-driven trigger/condition/action chains, full schema, worked examples, runtime implementation, migration path | Complete |
 | [tauri-rewrite.md](architecture/tauri-rewrite.md) | Tauri desktop app rewrite analysis: replacing Qt ServerEd with a modern Rust+TypeScript stack | Complete |
+| [migration-roadmap.md](architecture/migration-roadmap.md) | Dependency migration roadmap (PostgreSQL ✅, MSVC ✅, OpenSSL pending) and per-migration agent definitions | Complete |
+| [state-flag-conventions.md](architecture/state-flag-conventions.md) | Reference for state-flag write conventions: refcounted vs raw, who can clear, auth flow | Complete |
+| [integration-test-infra.md](architecture/integration-test-infra.md) | Live-DB test infrastructure: why no testcontainers, why no `sqlx::test`, local setup, isolation patterns | Complete |
 
-See also: [building.md](building.md), [connection-flow.md](connection-flow.md)
+See also: [building.md](building.md), [connection-flow.md](connection-flow.md), [../TESTING.md](../TESTING.md)
 
 ---
 


### PR DESCRIPTION
## Summary

- **New `TESTING.md`** — project-wide testing guide. Seven-type taxonomy (unit / wire-format / live-DB / smoke / concurrency / chain-replay / legacy-reference), picker for which type fits which bug shape, the vendor-stack worked example for features that need several types, and ~30 gotchas mined from review comments since PR #131 (tightness, naming, seed-trust, sentinel discipline, concurrency, regression-guard shape, failure messages, test-DB hygiene, CI gotchas). Closes with run commands and a pre-PR checklist.
- **PR process now requires tests and docs.** `CLAUDE.md`, `AGENTS.md`, and `.github/copilot-instructions.md` each gained a "Required tests" and "Required documentation" section. The doc section is a "what changed → what to update" mapping table. Both call out the **Documentation Writer** agent for non-trivial doc work.
- **Forward-facing doc refresh.** Reflects the last 72 hours: outbox + per-channel fragment reassembly in the README's tested-end-to-end list, integration-test-infra and state-flag-conventions added to the architecture index, verified test counts (878 tests / 136 files / 84 live-DB guards / 3 PL/pgSQL smokes) in `README.md`, `crates/README.md`, and `docs/readme.md` Quick Stats.

Counts come from `rg '^\s*(#\[test\]|#\[tokio::test\]|#\[async_std::test\])' crates/` and `rg 'require_db_or_skip!' crates/` — not estimates.

## Test plan

- [ ] Markdown renders cleanly on github.com (relative links, tables, fenced blocks)
- [ ] All cross-references resolve: `TESTING.md` ↔ `CLAUDE.md` ↔ `.github/copilot-instructions.md` ↔ `AGENTS.md` ↔ `docs/readme.md` ↔ `crates/README.md`
- [ ] Files referenced in TESTING.md exist (`tools/*_smoke.sql`, `crates/services/src/test_support.rs`, `crates/services/src/base/smoke_tests.rs`, `.github/workflows/test.yml`, `docs/architecture/integration-test-infra.md`)
- [ ] No PR/issue numbers left in source code from this change (numbers in TESTING.md and PR descriptions are fine; TESTING.md cites them as provenance for the gotchas list)
- [ ] Doc-only PR — no code paths touched, so CI is expected to be green by virtue of running the same suite as `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive testing guide (`TESTING.md`) covering test types, execution patterns, and CI landscape.
  * Updated README with clarified status updates, new Tests & CI section, and enhanced project structure overview.
  * Expanded documentation index with testing guide and additional architecture references.
  * Refined contribution guidelines with explicit PR requirements for testing and documentation updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->