### PR TITLE
ci: cargo-llvm-cov + Codecov upload as a non-blocking sixth job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -181,3 +181,102 @@ jobs:
       - name: cargo test (live DB)
         run: |
           cargo test -p cimmeria-services --lib -- --test-threads=1
+
+  # Coverage report. Same matrix as the test + test-live-db jobs combined,
+  # instrumented under cargo-llvm-cov. Two passes share counter data via
+  # `--no-report`: the workspace pass picks up unit + non-DB integration
+  # coverage, the second pass runs `-p cimmeria-services --lib` against a
+  # live Postgres so the require_db_or_skip! guards actually count.
+  # `cargo llvm-cov report` then merges them into one HTML/cobertura/summary.
+  #
+  # Non-blocking: continue-on-error so a coverage-tool flake doesn't gate
+  # merges. The artifact + summary log are advisory — the PR-gating signal
+  # is still test/test-live-db turning green.
+  coverage:
+    name: cargo llvm-cov (workspace + live DB)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    services:
+      postgres:
+        image: postgres:17.9
+        env:
+          POSTGRES_USER: w-testing
+          POSTGRES_PASSWORD: w-testing
+          POSTGRES_DB: sgw
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      DATABASE_URL: postgres://w-testing:w-testing@localhost:5432/sgw
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+      - name: install clang + mold + psql
+        run: sudo apt-get update && sudo apt-get install -y clang mold postgresql-client
+      - name: hydrate external/recast
+        run: |
+          mkdir -p external
+          curl -sL --retry 3 \
+            -o /tmp/recast.zip \
+            "https://github.com/recastnavigation/recastnavigation/archive/refs/tags/v${RECAST_VERSION}.zip"
+          unzip -q /tmp/recast.zip -d /tmp/recast_extract
+          mv "/tmp/recast_extract/recastnavigation-${RECAST_VERSION}" external/recast
+          test -f external/recast/Detour/Source/DetourAssert.cpp
+      - name: load schema + seeds
+        env:
+          PGPASSWORD: w-testing
+        run: |
+          psql -h localhost -U w-testing -d sgw -v ON_ERROR_STOP=1 -f db/database.sql
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: coverage
+      - name: install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+      - name: clean stale counter data
+        run: cargo llvm-cov clean --workspace
+      - name: workspace pass (no DB)
+        # DATABASE_URL is set on the job, but we deliberately unset it here so
+        # the live-DB tests skip in this pass — they're owned by the second
+        # pass below, which runs with --test-threads=1.
+        env:
+          DATABASE_URL: ""
+        run: |
+          cargo llvm-cov --workspace ${{ env.WORKSPACE_EXCLUDES }} --no-report
+      - name: services live-DB pass
+        run: |
+          cargo llvm-cov -p cimmeria-services --lib --no-report -- --test-threads=1
+      - name: render reports
+        run: |
+          mkdir -p target/coverage
+          cargo llvm-cov report --html --output-dir target/coverage/html
+          cargo llvm-cov report --cobertura --output-path target/coverage/cobertura.xml
+          cargo llvm-cov report --summary-only | tee target/coverage/summary.txt
+      - name: print summary to job log
+        run: |
+          echo "## Coverage summary" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          cat target/coverage/summary.txt >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+      - name: upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: target/coverage/
+          retention-days: 14
+      - name: upload to Codecov
+        # Public repo, so no token needed. Codecov ingests cobertura.xml,
+        # posts a sticky PR comment with delta vs main, and renders the
+        # per-file coverage overlay in GitHub's Files-Changed tab. Settings
+        # (advisory vs blocking, drop tolerance, path ignores) live in
+        # codecov.yml at the repo root.
+        uses: codecov/codecov-action@v4
+        with:
+          files: target/coverage/cobertura.xml
+          fail_ci_if_error: false
+          verbose: true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Cimmeria — Stargate Worlds Server Emulator
 
+[![ci](https://github.com/SandboxServers/Cimmeria/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/SandboxServers/Cimmeria/actions/workflows/test.yml)
+[![codecov](https://codecov.io/gh/SandboxServers/Cimmeria/branch/main/graph/badge.svg)](https://codecov.io/gh/SandboxServers/Cimmeria)
+
 A server emulator for [Stargate Worlds](https://en.wikipedia.org/wiki/Stargate_Worlds), the cancelled Stargate MMO developed by Cheyenne Mountain Entertainment. The game was built on [BigWorld Technology](https://en.wikipedia.org/wiki/BigWorld) (networking/server) and Unreal Engine 3 (rendering/client), and reached a playable beta before the studio shut down in 2010.
 
 Cimmeria reimplements the server infrastructure — authentication, world simulation, entity management, and game logic — allowing the original game client to connect and play.

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,92 @@
+# Codecov configuration. Reference: https://docs.codecov.com/docs/codecov-yaml
+#
+# Coverage is advisory in this repo — the test + test-live-db jobs are the
+# blocking gate. The Codecov status check exists to surface drift in PR
+# review, not to fail builds on small fluctuations.
+
+coverage:
+  status:
+    project:
+      default:
+        # The whole-project check posts a status against the PR. We allow
+        # small drops (1%) without flagging — random scheduler ordering on
+        # async tests can shift counters by a fraction of a percent run to
+        # run, and a strict zero-tolerance gate would just teach reviewers
+        # to ignore the check.
+        target: auto
+        threshold: 1%
+        informational: true
+    patch:
+      default:
+        # New code in the patch should be exercised. 70% is the floor for
+        # informational signal; reviewers can ask for more on a per-PR basis.
+        target: 70%
+        threshold: 0%
+        informational: true
+
+# PR comment shape. The defaults are noisy on a workspace this size, so we
+# scope the comment to a header + the per-component diff and trim file lists.
+comment:
+  layout: "header, diff, components, files, footer"
+  behavior: default
+  require_changes: true
+  require_base: false
+  require_head: true
+
+# Code that doesn't get instrumented or doesn't represent runtime behaviour.
+# Keep this list aligned with the cargo workspace's CI excludes
+# (cimmeria-app / cimmeria-content-editor / cimmeria-scene-editor /
+# sgw-launcher are Tauri/GUI surfaces excluded from CI, so their files
+# would show as 0% covered and skew the report).
+ignore:
+  - "crates/cimmeria-app/**"
+  - "crates/cimmeria-content-editor/**"
+  - "crates/cimmeria-scene-editor/**"
+  - "crates/sgw-launcher/**"
+  - "src/**"           # legacy C++ reference
+  - "python/**"        # legacy Python reference
+  - "tools/**"         # editor tools + smoke SQL scripts
+  - "bootstrap/**"
+  - "ghidra/**"
+  - "external/**"
+  - "**/build.rs"
+  - "**/tests/**"      # test code itself
+  - "**/*_tests.rs"
+
+# Components let the PR comment break coverage out by subsystem. Mirrors
+# the crate dependency graph in README.md so reviewers can see "the
+# mercury delta is +2.1%, the services delta is -0.4%" at a glance.
+component_management:
+  individual_components:
+    - component_id: mercury
+      name: mercury
+      paths:
+        - "crates/mercury/**"
+    - component_id: services
+      name: services
+      paths:
+        - "crates/services/**"
+    - component_id: content-engine
+      name: content-engine
+      paths:
+        - "crates/content-engine/**"
+    - component_id: entity
+      name: entity
+      paths:
+        - "crates/entity/**"
+    - component_id: game
+      name: game
+      paths:
+        - "crates/game/**"
+    - component_id: defs
+      name: defs
+      paths:
+        - "crates/defs/**"
+    - component_id: common
+      name: common
+      paths:
+        - "crates/common/**"
+    - component_id: commands
+      name: commands
+      paths:
+        - "crates/commands/**"

--- a/codecov.yml
+++ b/codecov.yml
@@ -39,10 +39,10 @@ comment:
 # sgw-launcher are Tauri/GUI surfaces excluded from CI, so their files
 # would show as 0% covered and skew the report).
 ignore:
-  - "crates/cimmeria-app/**"
+  - "src-tauri/**"
   - "crates/cimmeria-content-editor/**"
   - "crates/cimmeria-scene-editor/**"
-  - "crates/sgw-launcher/**"
+  - "crates/launcher/**"
   - "src/**"           # legacy C++ reference
   - "python/**"        # legacy Python reference
   - "tools/**"         # editor tools + smoke SQL scripts


### PR DESCRIPTION
## Summary

- New `coverage` job in `.github/workflows/test.yml` runs `cargo-llvm-cov` against the same matrix as `test` + `test-live-db` combined, then publishes results two ways:
  - **GitHub Actions artifact** (HTML + cobertura + summary, 14-day retention) for spelunking from the run page.
  - **Codecov upload** for the per-PR sticky comment, per-file overlay in GitHub's Files-Changed tab, and a README badge — the closest GitHub-ecosystem analog to ADO's first-class coverage tab.
- Two-pass instrumentation: workspace `cargo llvm-cov --no-report` picks up unit + non-DB integration coverage; second pass runs `-p cimmeria-services --lib` against the same `postgres:17.9` service container the `test-live-db` job uses, with `--test-threads=1`. A final `cargo llvm-cov report` merges them into one HTML/cobertura/summary.
- **Non-blocking by design.** The job has `continue-on-error: true`; the codecov action runs with `fail_ci_if_error: false`. `test` + `test-live-db` remain the gating signal — coverage is advisory until a real baseline is set.
- `codecov.yml` configures both project and patch status checks as `informational: true` with a 1% drift tolerance so a random scheduler shift on async tests doesn't flag the PR. Path-ignore list aligns with the existing CI excludes (Tauri/GUI crates, `src/` C++ reference, `python/`, `tools/`, etc.). Per-component slices (`mercury` / `services` / `content-engine` / `entity` / `game` / `defs` / `common` / `commands`) mirror the dependency graph in `README.md`.

## Why Codecov over the alternatives

| Option | What you get |
|---|---|
| **Codecov** (chosen) | Sticky PR comment with delta vs main, per-file line-coverage overlay in the Files-Changed view, `codecov/project` + `codecov/patch` status checks, README badge. Public repo → no token. |
| Coveralls | Similar, slightly less polished overlay. `GITHUB_TOKEN` only. |
| Self-rolled PR comment | Markdown table; no per-file overlay or history. |
| Step-summary only | Job's summary tab; nothing in PR conversation. |

## Closes

- Group F item on #123 — _"Coverage report (`cargo llvm-cov --workspace --html`) published as a CI artifact so we can see drift over time."_

## Test plan

- [ ] On this PR: the `coverage` job runs to completion (~10–15 min on top of existing jobs), uploads the artifact, and posts a Codecov comment showing the patch's coverage.
- [ ] The five existing CI jobs (`fmt`, `clippy`, `build`, `test`, `test-live-db`) stay green and remain the merge gate.
- [ ] `codecov/project` and `codecov/patch` status checks appear and are advisory (informational, not required).
- [ ] After merge to main, the README badge resolves (currently "unknown" until the first upload completes against `main`).
- [ ] The artifact contains `html/`, `cobertura.xml`, and `summary.txt`.
- [ ] No false positives on the `WORKSPACE_EXCLUDES` Tauri crates (they're absent from cobertura per `codecov.yml` `ignore`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)