### PR TITLE
test(mercury): adversarial inputs for unpacker / encryption / packet flags (#123 Group A)

### DIFF
--- a/crates/mercury/src/encryption.rs
+++ b/crates/mercury/src/encryption.rs
@@ -357,4 +357,77 @@ mod tests {
         assert!(debug.contains("REDACTED"));
         assert!(!debug.contains("42")); // Should not leak key bytes.
     }
+
+    /// Decrypting with a wrong key fails at HMAC verification (the
+    /// HMAC key is the same as the AES key, so a wrong AES key always
+    /// produces a wrong HMAC tag). Surface this as an Encryption error
+    /// rather than letting it slip through to a garbage plaintext —
+    /// the encrypt-then-MAC ordering guarantees we reject before the
+    /// AES decrypt step runs.
+    #[test]
+    fn decrypt_with_wrong_key_fails_hmac_verification() {
+        let plaintext = b"secret payload";
+        let ct = test_keys().encrypt(plaintext).unwrap();
+
+        // A different 32-byte key — same shape, different bytes.
+        let wrong = MercuryEncryption::from_session_key([0xAAu8; 32]);
+        let err = wrong.decrypt(&ct).unwrap_err();
+        assert!(matches!(err, CimmeriaError::Encryption(_)));
+    }
+
+    /// Buffer exactly `HMAC_TAG_LEN` bytes (16) has an empty ciphertext
+    /// portion. The "ciphertext too short" branch must reject before
+    /// the AES init runs — otherwise a mock plaintext could be coaxed
+    /// out of a degenerate empty-block decrypt.
+    #[test]
+    fn decrypt_buffer_exactly_hmac_tag_len_rejects_empty_ciphertext() {
+        let enc = test_keys();
+        // 16 bytes = exactly the HMAC tag; ciphertext portion is empty.
+        let err = enc.decrypt(&[0u8; 16]).unwrap_err();
+        assert!(matches!(err, CimmeriaError::Encryption(_)));
+    }
+
+    /// Buffer with a ciphertext portion that's not a multiple of the
+    /// AES block size must reject with the block-size error — never
+    /// fall through to the AES decrypt call (which would produce a
+    /// garbage / partial-block error harder to interpret).
+    #[test]
+    fn decrypt_non_block_aligned_ciphertext_rejects_before_aes() {
+        let enc = test_keys();
+        // 17 ciphertext bytes (not divisible by 16) + 16 HMAC = 33 bytes.
+        let buf = vec![0u8; 17 + HMAC_TAG_LEN];
+        let err = enc.decrypt(&buf).unwrap_err();
+        match err {
+            CimmeriaError::Encryption(msg) => assert!(
+                msg.contains("multiple of AES block size"),
+                "expected block-size error, got: {msg}"
+            ),
+            other => panic!("expected Encryption error, got {other:?}"),
+        }
+    }
+
+    /// PKCS7 unpadding must reject any pad byte > AES_BLOCK_SIZE. A
+    /// crafted ciphertext that decrypts to a tail byte of, say, 0xFF
+    /// would otherwise be interpreted as "strip 255 bytes" and panic
+    /// or return wrong-length output.
+    #[test]
+    fn pkcs7_unpad_rejects_pad_byte_above_block_size() {
+        // Build raw bytes ending in 0xFF, which is an invalid PKCS7 pad.
+        let mut buf = vec![0u8; 16];
+        buf[15] = 0xFF;
+        let err = pkcs7_unpad(&buf).unwrap_err();
+        assert!(matches!(err, CimmeriaError::Encryption(_)));
+    }
+
+    /// PKCS7 unpadding must reject a pad byte of 0 — the spec requires
+    /// every padding byte to equal the pad length, and 0 indicates
+    /// no padding was applied (which can't happen because the encoder
+    /// always pads to a full block, including a full block of pad when
+    /// the plaintext length is already block-aligned).
+    #[test]
+    fn pkcs7_unpad_rejects_zero_pad_byte() {
+        let buf = vec![0u8; 16]; // last byte is 0x00
+        let err = pkcs7_unpad(&buf).unwrap_err();
+        assert!(matches!(err, CimmeriaError::Encryption(_)));
+    }
 }

--- a/crates/mercury/src/encryption.rs
+++ b/crates/mercury/src/encryption.rs
@@ -364,15 +364,31 @@ mod tests {
     /// rather than letting it slip through to a garbage plaintext —
     /// the encrypt-then-MAC ordering guarantees we reject before the
     /// AES decrypt step runs.
+    ///
+    /// Pin via `from_session_key` on both sides so the only thing that
+    /// differs is the 32-byte key (zero IV, HMAC key == AES key on both).
+    /// `test_keys()`-derived ciphertext would also have a different IV
+    /// and HMAC key, which would mask whether HMAC truly catches the
+    /// AES-key mismatch alone.
     #[test]
     fn decrypt_with_wrong_key_fails_hmac_verification() {
         let plaintext = b"secret payload";
-        let ct = test_keys().encrypt(plaintext).unwrap();
+        let ct = MercuryEncryption::from_session_key([0x55u8; 32])
+            .encrypt(plaintext)
+            .unwrap();
 
-        // A different 32-byte key — same shape, different bytes.
+        // Same `from_session_key` shape so IV and HMAC-key derivation
+        // are identical to the encrypt side — only the AES/HMAC key
+        // bytes differ.
         let wrong = MercuryEncryption::from_session_key([0xAAu8; 32]);
         let err = wrong.decrypt(&ct).unwrap_err();
-        assert!(matches!(err, CimmeriaError::Encryption(_)));
+        let CimmeriaError::Encryption(msg) = err else {
+            panic!("expected Encryption error");
+        };
+        assert!(
+            msg.contains("HMAC-MD5 verification failed"),
+            "wrong-key decrypt must be caught by HMAC verify branch (encrypt-then-MAC), got: {msg}"
+        );
     }
 
     /// Buffer exactly `HMAC_TAG_LEN` bytes (16) has an empty ciphertext
@@ -384,7 +400,13 @@ mod tests {
         let enc = test_keys();
         // 16 bytes = exactly the HMAC tag; ciphertext portion is empty.
         let err = enc.decrypt(&[0u8; 16]).unwrap_err();
-        assert!(matches!(err, CimmeriaError::Encryption(_)));
+        let CimmeriaError::Encryption(msg) = err else {
+            panic!("expected Encryption error");
+        };
+        assert!(
+            msg.contains("ciphertext portion is empty"),
+            "empty-ciphertext input must hit the dedicated guard, not slip into HMAC verify; got: {msg}"
+        );
     }
 
     /// Buffer with a ciphertext portion that's not a multiple of the

--- a/crates/mercury/src/encryption.rs
+++ b/crates/mercury/src/encryption.rs
@@ -428,15 +428,20 @@ mod tests {
         }
     }
 
-    /// PKCS7 unpadding must reject any pad byte > AES_BLOCK_SIZE. A
-    /// crafted ciphertext that decrypts to a tail byte of, say, 0xFF
-    /// would otherwise be interpreted as "strip 255 bytes" and panic
-    /// or return wrong-length output.
+    /// PKCS7 unpadding must reject any pad byte > AES_BLOCK_SIZE.
+    /// Use a buffer LARGER than the would-be pad_len so the
+    /// `pad_len > data.len()` guard does NOT also fire — that way
+    /// the test isolates the > AES_BLOCK_SIZE branch specifically.
+    /// With pad_len = AES_BLOCK_SIZE + 1 = 17 in an 18-byte buffer:
+    /// `pad_len > AES_BLOCK_SIZE` (17 > 16) rejects (the branch
+    /// under test); `pad_len > data.len()` (17 > 18) is false, so
+    /// that guard would NOT catch it. If a regression drops the
+    /// `> AES_BLOCK_SIZE` check, the function would happily strip 17
+    /// bytes from the 18-byte buffer and produce a 1-byte plaintext.
     #[test]
     fn pkcs7_unpad_rejects_pad_byte_above_block_size() {
-        // Build raw bytes ending in 0xFF, which is an invalid PKCS7 pad.
-        let mut buf = vec![0u8; 16];
-        buf[15] = 0xFF;
+        let mut buf = vec![0u8; 18];
+        buf[17] = (AES_BLOCK_SIZE + 1) as u8; // 17, just above the cap
         let err = pkcs7_unpad(&buf).unwrap_err();
         assert!(matches!(err, CimmeriaError::Encryption(_)));
     }

--- a/crates/mercury/src/packet.rs
+++ b/crates/mercury/src/packet.rs
@@ -584,6 +584,10 @@ mod tests {
     /// (innermost-to-outermost: first_req_offset → seq_id → acks → ack_count)
     /// because the existing tests cover each footer in isolation but never
     /// the full stack at once.
+    ///
+    /// Asserts the EXACT raw byte sequence build_outgoing emits before
+    /// re-parsing, so a serializer/parser pair that both agree on a
+    /// wrong layout can't slip through.
     #[test]
     fn round_trip_reliable_with_seq_and_acks() {
         let flags = FLAG_RELIABLE | FLAG_HAS_SEQUENCE | FLAG_HAS_ACKS | FLAG_ON_CHANNEL;
@@ -591,8 +595,24 @@ mod tests {
         let acks = [101u32, 102, 103];
 
         let raw = build_outgoing(flags, body, Some(7), &acks, None);
-        let pkt = parse_incoming(&raw).unwrap();
+        // Hand-computed wire layout:
+        //   [flags:u8] [body:5] [seq_id:u32 LE = 7]
+        //   [ack[0]:u32 LE = 101] [ack[1]:u32 LE = 102] [ack[2]:u32 LE = 103]
+        //   [ack_count:u8 = 3]
+        // No first_req_offset (FLAG_HAS_REQUESTS not set), no fragment ids.
+        // Total: 1 + 5 + 4 + 4*3 + 1 = 23 bytes.
+        let expected: &[u8] = &[
+            flags, // flags byte
+            0xAB, 0xCD, 0xEF, 0x12, 0x34, // body
+            7, 0, 0, 0, // seq_id = 7
+            101, 0, 0, 0, // ack[0]
+            102, 0, 0, 0, // ack[1]
+            103, 0, 0, 0, // ack[2]
+            3, // ack_count
+        ];
+        assert_eq!(raw.as_ref(), expected, "byte-exact wire layout");
 
+        let pkt = parse_incoming(&raw).unwrap();
         assert_eq!(pkt.flags, flags);
         assert_eq!(pkt.seq_id, Some(7));
         assert_eq!(pkt.acks, vec![101u32, 102, 103]);
@@ -607,6 +627,9 @@ mod tests {
     /// responsible for setting FLAG_HAS_ACKS in the base flags;
     /// build_outgoing_fragmented OR-merges FLAG_FRAGMENTED |
     /// FLAG_HAS_SEQUENCE on top.
+    ///
+    /// Asserts byte-exact output before re-parsing so a co-broken
+    /// builder/parser pair can't pass.
     #[test]
     fn round_trip_fragmented_with_reliable_and_acks() {
         let acks = [201u32, 202];
@@ -618,8 +641,24 @@ mod tests {
             502,
             &acks,
         );
-        let pkt = parse_incoming(&raw).unwrap();
+        // Hand-computed wire layout:
+        //   [flags:u8] [body:16] [frag_begin:u32 LE = 500]
+        //   [frag_end:u32 LE = 502] [seq_id:u32 LE = 500]
+        //   [ack[0]:u32 LE = 201] [ack[1]:u32 LE = 202] [ack_count:u8 = 2]
+        // Total: 1 + 16 + 4 + 4 + 4 + 4*2 + 1 = 38 bytes.
+        let expected_flags =
+            FLAG_RELIABLE | FLAG_ON_CHANNEL | FLAG_HAS_ACKS | FLAG_FRAGMENTED | FLAG_HAS_SEQUENCE;
+        let mut expected = vec![expected_flags];
+        expected.extend_from_slice(b"fragment-payload");
+        expected.extend_from_slice(&500u32.to_le_bytes()); // frag_begin
+        expected.extend_from_slice(&502u32.to_le_bytes()); // frag_end
+        expected.extend_from_slice(&500u32.to_le_bytes()); // seq_id
+        expected.extend_from_slice(&201u32.to_le_bytes()); // ack[0]
+        expected.extend_from_slice(&202u32.to_le_bytes()); // ack[1]
+        expected.push(2); // ack_count
+        assert_eq!(raw.as_ref(), expected.as_slice(), "byte-exact wire layout");
 
+        let pkt = parse_incoming(&raw).unwrap();
         assert!(pkt.flags & FLAG_FRAGMENTED != 0);
         assert!(pkt.flags & FLAG_HAS_SEQUENCE != 0);
         assert!(pkt.flags & FLAG_RELIABLE != 0);

--- a/crates/mercury/src/packet.rs
+++ b/crates/mercury/src/packet.rs
@@ -578,4 +578,74 @@ mod tests {
         assert!(!f2.is_reliable());
         assert!(f2.has_sequence());
     }
+
+    /// All-flags-on packet: FLAG_RELIABLE | FLAG_HAS_ACKS | FLAG_HAS_SEQUENCE
+    /// with a non-empty acks vector. Pins the footer-order invariant
+    /// (innermost-to-outermost: first_req_offset → seq_id → acks → ack_count)
+    /// because the existing tests cover each footer in isolation but never
+    /// the full stack at once.
+    #[test]
+    fn round_trip_reliable_with_seq_and_acks() {
+        let flags = FLAG_RELIABLE | FLAG_HAS_SEQUENCE | FLAG_HAS_ACKS | FLAG_ON_CHANNEL;
+        let body = b"\xAB\xCD\xEF\x12\x34";
+        let acks = [101u32, 102, 103];
+
+        let raw = build_outgoing(flags, body, Some(7), &acks, None);
+        let pkt = parse_incoming(&raw).unwrap();
+
+        assert_eq!(pkt.flags, flags);
+        assert_eq!(pkt.seq_id, Some(7));
+        assert_eq!(pkt.acks, vec![101u32, 102, 103]);
+        assert_eq!(pkt.body.as_ref(), body);
+        assert!(pkt.first_req_offset.is_none());
+    }
+
+    /// Fragmented + reliable + acks together: a real bundle for a large
+    /// reliable-channel message that piggybacks acks. Pin the layout
+    /// because the existing fragmentation tests don't exercise the
+    /// `acks` slice on `build_outgoing_fragmented`. The caller is
+    /// responsible for setting FLAG_HAS_ACKS in the base flags;
+    /// build_outgoing_fragmented OR-merges FLAG_FRAGMENTED |
+    /// FLAG_HAS_SEQUENCE on top.
+    #[test]
+    fn round_trip_fragmented_with_reliable_and_acks() {
+        let acks = [201u32, 202];
+        let raw = build_outgoing_fragmented(
+            FLAG_RELIABLE | FLAG_ON_CHANNEL | FLAG_HAS_ACKS,
+            b"fragment-payload",
+            500,
+            500,
+            502,
+            &acks,
+        );
+        let pkt = parse_incoming(&raw).unwrap();
+
+        assert!(pkt.flags & FLAG_FRAGMENTED != 0);
+        assert!(pkt.flags & FLAG_HAS_SEQUENCE != 0);
+        assert!(pkt.flags & FLAG_RELIABLE != 0);
+        assert!(pkt.flags & FLAG_HAS_ACKS != 0);
+        assert_eq!(pkt.seq_id, Some(500));
+        assert_eq!(pkt.frag_begin, Some(500));
+        assert_eq!(pkt.frag_end, Some(502));
+        assert_eq!(pkt.acks, vec![201u32, 202]);
+        assert_eq!(pkt.body.as_ref(), b"fragment-payload");
+    }
+
+    /// Empty body with acks-only footer. The body slice must be empty
+    /// even though the packet has substantive footer content; previous
+    /// versions of the parser bled the ack-count byte into `body` when
+    /// the body length was 0.
+    #[test]
+    fn parse_empty_body_with_acks_only() {
+        let flags = FLAG_HAS_ACKS;
+        let raw = build_outgoing(flags, b"", None, &[42u32, 43], None);
+        let pkt = parse_incoming(&raw).unwrap();
+
+        assert_eq!(pkt.flags, flags);
+        assert_eq!(pkt.acks, vec![42u32, 43]);
+        assert!(
+            pkt.body.is_empty(),
+            "body must be empty when only acks are present"
+        );
+    }
 }

--- a/crates/mercury/src/packet.rs
+++ b/crates/mercury/src/packet.rs
@@ -687,4 +687,39 @@ mod tests {
             "body must be empty when only acks are present"
         );
     }
+
+    /// Full matrix: FLAG_PIGGYBACK | FLAG_HAS_ACKS | FLAG_FRAGMENTED |
+    /// FLAG_RELIABLE | FLAG_HAS_SEQUENCE all set together. The #123
+    /// "flag combination matrix" item names piggyback explicitly;
+    /// this round-trips the bit through build/parse so a regression
+    /// that strips or relocates the piggyback bit gets caught.
+    /// Cimmeria doesn't actually parse piggyback sub-packets (see
+    /// the FLAG_PIGGYBACK doc-comment in this file), so the body is
+    /// just the same opaque payload the other tests use; the only
+    /// thing this test pins beyond the existing matrix is the flag
+    /// bit's preservation.
+    #[test]
+    fn round_trip_with_piggyback_in_full_matrix() {
+        let acks = [301u32];
+        let raw = build_outgoing_fragmented(
+            FLAG_RELIABLE | FLAG_ON_CHANNEL | FLAG_HAS_ACKS | FLAG_PIGGYBACK,
+            b"piggy-payload",
+            700,
+            700,
+            701,
+            &acks,
+        );
+        let pkt = parse_incoming(&raw).unwrap();
+        assert!(
+            pkt.flags & FLAG_PIGGYBACK != 0,
+            "piggyback bit must round-trip through build/parse"
+        );
+        assert!(pkt.flags & FLAG_FRAGMENTED != 0);
+        assert!(pkt.flags & FLAG_HAS_SEQUENCE != 0);
+        assert!(pkt.flags & FLAG_RELIABLE != 0);
+        assert!(pkt.flags & FLAG_HAS_ACKS != 0);
+        assert_eq!(pkt.seq_id, Some(700));
+        assert_eq!(pkt.acks, vec![301u32]);
+        assert_eq!(pkt.body.as_ref(), b"piggy-payload");
+    }
 }

--- a/crates/mercury/src/unpacker.rs
+++ b/crates/mercury/src/unpacker.rs
@@ -528,22 +528,49 @@ mod tests {
         assert_eq!(asm.pending_count(), 1);
     }
 
-    /// `cleanup_stale` removes only entries older than `max_age` —
-    /// fresh entries from the same call to `add_fragment` must
-    /// survive. Pin the per-entry age check so a regression that
-    /// drops the `started_at` comparison and clears the whole map
-    /// can't slip through.
+    /// `cleanup_stale` removes ONLY entries older than `max_age`,
+    /// not the whole map. Pin the per-entry age check by mixing a
+    /// stale entry (added pre-sleep) with a fresh entry (added
+    /// post-sleep), then choosing a `max_age` that's between the
+    /// two. A regression that drops the per-entry `started_at`
+    /// comparison and clears the whole map would also delete the
+    /// fresh entry.
     #[test]
-    fn cleanup_stale_leaves_fresh_entries_alone() {
+    fn cleanup_stale_reaps_only_old_entries_keeps_fresh_ones() {
         let mut asm = FragmentAssembler::new();
+        // Stale entry: added now, will be older than max_age below
+        // after the sleep.
         asm.add_fragment(10, 0, 3, Bytes::from_static(b"a"))
             .unwrap();
+        // Sleep so the next add_fragment has a noticeably-younger
+        // `started_at`. 50ms is well above any reasonable scheduler
+        // jitter while still keeping the test fast.
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        // Fresh entry.
         asm.add_fragment(20, 0, 3, Bytes::from_static(b"b"))
             .unwrap();
         assert_eq!(asm.pending_count(), 2);
-        // 1-hour max_age — both entries are fresh, neither should be
-        // reaped.
-        asm.cleanup_stale(std::time::Duration::from_secs(3600));
-        assert_eq!(asm.pending_count(), 2);
+
+        // 25ms cap: stale entry (>=50ms old) gets reaped, fresh
+        // entry (~0ms old) survives.
+        asm.cleanup_stale(std::time::Duration::from_millis(25));
+
+        assert_eq!(
+            asm.pending_count(),
+            1,
+            "stale entry should be reaped, fresh entry should remain"
+        );
+        // The fresh entry's first_seq is 20; sanity-check it's the
+        // survivor by completing it and observing the assembled
+        // payload.
+        let _ = asm.add_fragment(20, 1, 3, Bytes::from_static(b"b"));
+        let result = asm
+            .add_fragment(20, 2, 3, Bytes::from_static(b"b"))
+            .unwrap();
+        assert_eq!(
+            result.expect("fresh entry must complete").as_ref(),
+            b"bbb",
+            "the surviving entry must be the fresh one (first_seq=20)"
+        );
     }
 }

--- a/crates/mercury/src/unpacker.rs
+++ b/crates/mercury/src/unpacker.rs
@@ -505,4 +505,45 @@ mod tests {
         asm.cleanup_stale(std::time::Duration::ZERO);
         assert_eq!(asm.pending_count(), 0);
     }
+
+    /// Two fragments arriving for the same `first_seq` must agree on
+    /// `total_frags`. A peer (or attacker) sending a second fragment
+    /// with a different declared count is a protocol violation; the
+    /// assembler must reject rather than silently re-shape the
+    /// pending message.
+    #[test]
+    fn add_fragment_rejects_conflicting_total_fragments() {
+        let mut asm = FragmentAssembler::new();
+        // First fragment: declares 3 total.
+        asm.add_fragment(50, 0, 3, Bytes::from_static(b"aaa"))
+            .unwrap();
+        // Second fragment for the SAME first_seq but declares 5 total.
+        let err = asm
+            .add_fragment(50, 1, 5, Bytes::from_static(b"bbb"))
+            .unwrap_err();
+        assert!(matches!(err, CimmeriaError::FragmentReassembly(_)));
+        // Pending entry must remain (rejecting the new fragment must
+        // not wipe the in-progress reassembly that a well-behaved peer
+        // is still completing).
+        assert_eq!(asm.pending_count(), 1);
+    }
+
+    /// `cleanup_stale` removes only entries older than `max_age` —
+    /// fresh entries from the same call to `add_fragment` must
+    /// survive. Pin the per-entry age check so a regression that
+    /// drops the `started_at` comparison and clears the whole map
+    /// can't slip through.
+    #[test]
+    fn cleanup_stale_leaves_fresh_entries_alone() {
+        let mut asm = FragmentAssembler::new();
+        asm.add_fragment(10, 0, 3, Bytes::from_static(b"a"))
+            .unwrap();
+        asm.add_fragment(20, 0, 3, Bytes::from_static(b"b"))
+            .unwrap();
+        assert_eq!(asm.pending_count(), 2);
+        // 1-hour max_age — both entries are fresh, neither should be
+        // reaped.
+        asm.cleanup_stale(std::time::Duration::from_secs(3600));
+        assert_eq!(asm.pending_count(), 2);
+    }
 }


### PR DESCRIPTION
## Summary

Closes the four mercury items in #123 Group A that the existing tests didn't cover. 11 new tests across the three files; all 88 \`cimmeria-mercury\` tests pass locally with clippy + fmt clean.

| File | Coverage gain |
|---|---|
| \`unpacker.rs\` | Conflicting \`total_frags\` rejection (protocol violation guard); \`cleanup_stale\` per-entry age check (pin against "wipe-the-whole-map" regression). |
| \`encryption.rs\` | Wrong-key decrypt fails HMAC; buffer == \`HMAC_TAG_LEN\` rejects empty ciphertext before AES init; non-block-aligned ciphertext rejects with the block-size error; pkcs7_unpad rejects pad-byte > AES_BLOCK_SIZE; pkcs7_unpad rejects pad-byte == 0. |
| \`packet.rs\` | All-flags round-trip (FLAG_RELIABLE \| FLAG_HAS_SEQUENCE \| FLAG_HAS_ACKS) pins the full footer-stack ordering; fragmented + reliable + acks together pins build_outgoing_fragmented's acks slice; empty-body + acks-only pins body.is_empty() (regression guard for the historical bleed bug). |

## Closes

- mercury items 1, 2, 3, 4 under cell/mercury Group A on #123.

## Test plan

- [ ] CI passes all six existing jobs.
- [ ] Reverting any single fix hooked to a regression guard makes the corresponding test fail (manual sanity for: total_frags conflict, HMAC key mismatch detection, ciphertext block-alignment check, padding-byte validation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for encryption validation, packet parsing with combined flag scenarios, and fragment reassembly edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->