### PR TITLE
test(cell/content): event_dispatch + engine_loader baseline (#123 Group A)

### DIFF
--- a/crates/services/src/cell/content/engine_loader.rs
+++ b/crates/services/src/cell/content/engine_loader.rs
@@ -263,12 +263,21 @@ mod tests {
 
     /// `load_single_chain_for_test` returns `Ok(None)` for a chain id
     /// that doesn't exist in the seed. Boundary used by the
-    /// chain-replay tests; pin so a regression that returns `Some(empty_chain)`
-    /// instead can't slip through.
+    /// chain-replay tests; pin so a regression that returns
+    /// `Some(empty_chain)` instead can't slip through.
+    ///
+    /// Sentinel uses the project's reserved 0x7000_xxxx range per
+    /// TESTING.md "Sentinel id discipline" rather than a raw negative
+    /// id. The seed's content_chains rows are positive low-thousands,
+    /// so 0x7000_2000 is guaranteed to miss without the loader needing
+    /// to special-case negatives.
     #[tokio::test]
     async fn load_single_chain_returns_none_for_missing_id() {
         let pool = crate::test_support::require_db_or_skip!();
-        let result = load_single_chain_for_test(&pool, -999_999).await.unwrap();
+        const TEST_MISSING_CHAIN_ID: i32 = 0x7000_2000;
+        let result = load_single_chain_for_test(&pool, TEST_MISSING_CHAIN_ID)
+            .await
+            .unwrap();
         assert!(result.is_none());
     }
 }

--- a/crates/services/src/cell/content/engine_loader.rs
+++ b/crates/services/src/cell/content/engine_loader.rs
@@ -232,3 +232,43 @@ pub(super) async fn load_single_chain_for_test(
             .next(),
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `build_engine(None)` returns an empty engine — the codepath
+    /// the server takes when started without a DB pool. Pin so a
+    /// regression that panics on the None branch (e.g. via unwrap)
+    /// gets caught.
+    #[tokio::test]
+    async fn build_engine_with_none_returns_empty_engine() {
+        let engine = build_engine(None).await;
+        assert_eq!(engine.chain_count(), 0);
+    }
+
+    /// Live-DB sanity: against the seeded `resources.content_*` tables,
+    /// `build_engine` returns a non-empty engine. Catches a JOIN
+    /// breakage, a column rename, or a content_chains schema drift
+    /// that the rest of the test suite wouldn't surface.
+    #[tokio::test]
+    async fn build_engine_with_db_pool_loads_seeded_chains() {
+        let pool = crate::test_support::require_db_or_skip!();
+        let engine = build_engine(Some(&pool)).await;
+        assert!(
+            engine.chain_count() > 0,
+            "seeded resources.content_chains has rows; engine must load them"
+        );
+    }
+
+    /// `load_single_chain_for_test` returns `Ok(None)` for a chain id
+    /// that doesn't exist in the seed. Boundary used by the
+    /// chain-replay tests; pin so a regression that returns `Some(empty_chain)`
+    /// instead can't slip through.
+    #[tokio::test]
+    async fn load_single_chain_returns_none_for_missing_id() {
+        let pool = crate::test_support::require_db_or_skip!();
+        let result = load_single_chain_for_test(&pool, -999_999).await.unwrap();
+        assert!(result.is_none());
+    }
+}

--- a/crates/services/src/cell/content/event_dispatch.rs
+++ b/crates/services/src/cell/content/event_dispatch.rs
@@ -511,7 +511,9 @@ pub async fn fire_chain_by_id(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cell::space_manager::SpaceManager;
+    // SpaceManager is re-exported through `super::*` because the parent
+    // module imports it; no separate `use crate::cell::space_manager::SpaceManager`
+    // needed here.
 
     /// Build the standard Castle-startup-space fixture used across the
     /// abilities/ event-dispatch tests. One player at id=1, one NPC at

--- a/crates/services/src/cell/content/event_dispatch.rs
+++ b/crates/services/src/cell/content/event_dispatch.rs
@@ -507,3 +507,92 @@ pub async fn fire_chain_by_id(
     };
     executor::execute_actions(resolved, entity_id, player_id, tx, space_mgr, engine).await;
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cell::space_manager::SpaceManager;
+
+    /// Build the standard Castle-startup-space fixture used across the
+    /// abilities/ event-dispatch tests. One player at id=1, one NPC at
+    /// id=2, both at the origin so any AoI-related assertion has both
+    /// in range.
+    fn make_mgr_with_player_and_npc() -> SpaceManager {
+        let mut mgr = SpaceManager::new(1);
+        let xml = r#"<?xml version="1.0"?><Spaces><Space WorldName="Castle" Instanced="false" MinX="-800" MaxX="800" MinY="-800" MaxY="800" /></Spaces>"#;
+        mgr.parse_spaces_xml(xml).unwrap();
+        mgr.create_startup_spaces(
+            r#"<?xml version="1.0"?><Spaces><Space WorldName="Castle" /></Spaces>"#,
+        )
+        .unwrap();
+        mgr.create_entity(1, "Castle", [0.0; 3], [0.0; 3]).unwrap();
+        mgr.create_entity(2, "Castle", [0.0; 3], [0.0; 3]).unwrap();
+        if let Some(p) = mgr.get_entity_mut(1) {
+            p.is_player = true;
+            p.player_id = Some(100);
+        }
+        mgr.connect_entity(1);
+        mgr
+    }
+
+    /// Empty engine: every fire_* function must complete without
+    /// panicking, emit no actions, and (for the bool-returning fns)
+    /// return false. Pin so a refactor that adds a `default chain`
+    /// fallback or panics on unmatched events gets caught.
+    #[tokio::test]
+    async fn fire_player_loaded_with_empty_engine_emits_nothing() {
+        let mut mgr = make_mgr_with_player_and_npc();
+        let engine = ChainEngine::new();
+        let (tx, mut rx) = mpsc::channel(8);
+
+        fire_player_loaded(1, 100, "Castle", &engine, &tx, &mut mgr).await;
+
+        assert!(
+            rx.try_recv().is_err(),
+            "empty engine must produce no wire messages"
+        );
+    }
+
+    /// `fire_interact_tag` returns false when the engine has no chain
+    /// matching the InteractTag trigger. This is the load-bearing
+    /// "should the caller fall through to default handling?" signal,
+    /// per the doc comment.
+    #[tokio::test]
+    async fn fire_interact_tag_returns_false_when_no_chain_matches() {
+        let mut mgr = make_mgr_with_player_and_npc();
+        let engine = ChainEngine::new();
+        let (tx, _rx) = mpsc::channel(8);
+
+        let matched = fire_interact_tag(1, 100, "SomeTag", 2, &engine, &tx, &mut mgr).await;
+        assert!(!matched);
+    }
+
+    /// `fire_interact_template` mirrors `fire_interact_tag` for
+    /// template-keyed interactions. Same return-shape contract.
+    #[tokio::test]
+    async fn fire_interact_template_returns_false_when_no_chain_matches() {
+        let mut mgr = make_mgr_with_player_and_npc();
+        let engine = ChainEngine::new();
+        let (tx, _rx) = mpsc::channel(8);
+
+        let matched =
+            fire_interact_template(1, 100, "TemplateName", 2, &engine, &tx, &mut mgr).await;
+        assert!(!matched);
+    }
+
+    /// Missing source entity in the SpaceManager: fire_* must not
+    /// panic, must complete cleanly, and must not emit messages. The
+    /// pre-mutation entity-vanish branch — common after a destroy —
+    /// is the regression shape this guards against.
+    #[tokio::test]
+    async fn fire_player_loaded_handles_missing_entity_gracefully() {
+        let mut mgr = make_mgr_with_player_and_npc();
+        // Destroy the player before firing.
+        mgr.destroy_entity(1);
+        let engine = ChainEngine::new();
+        let (tx, mut rx) = mpsc::channel(8);
+
+        fire_player_loaded(1, 100, "Castle", &engine, &tx, &mut mgr).await;
+        assert!(rx.try_recv().is_err());
+    }
+}


### PR DESCRIPTION
## Summary

Closes the cell/content bullets on #123 Group A. \`event_dispatch.rs\` (509 lines, 0 tests) and \`engine_loader.rs\` (234 lines, 0 tests) get focused regression guards.

| File | Pinned invariants |
|---|---|
| \`engine_loader.rs\` | \`build_engine(None)\` → empty engine (no-DB-pool branch). Live-DB: \`build_engine(Some(&pool))\` loads non-empty engine from seeded \`resources.content_chains\` (canary for JOIN/schema drift). Live-DB: \`load_single_chain_for_test\` returns \`Ok(None)\` for missing id (used by chain-replay tests). |
| \`event_dispatch.rs\` | \`fire_player_loaded\` with empty engine emits no wire messages. \`fire_interact_tag\` / \`fire_interact_template\` return \`false\` when no chain matches — the load-bearing "fall through to default" signal. \`fire_player_loaded\` with a destroyed source entity must not panic. |

## Closes

- cell/content bullets (event_dispatch + engine_loader) on #123 Group A.

## Test plan

- [ ] CI passes all six existing jobs.
- [ ] Live-DB job runs the two new \`require_db_or_skip!\` engine-loader tests against the seeded chain table.
- [ ] No-DB job self-skips them via the macro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)