### PR TITLE
test(cell/cell_methods/player): combat + world dispatch (#123 Group A)

### DIFF
--- a/crates/services/src/cell/cell_methods/player/combat.rs
+++ b/crates/services/src/cell/cell_methods/player/combat.rs
@@ -325,11 +325,17 @@ mod tests {
     }
 
     /// USE_ABILITY with a too-short payload (< 8 bytes) must return
-    /// true (handler took the method) but not start any cooldown or
-    /// emit packets — the args are silently ignored.
+    /// true (handler took the method) but not start any cooldown,
+    /// not consume any state, and not emit packets — the args are
+    /// silently ignored. Pre-seed an ability + cooldown-free state so
+    /// a regression that decodes garbage args and starts a cooldown
+    /// gets caught.
     #[tokio::test]
     async fn use_ability_with_short_args_silently_drops() {
         let mut mgr = make_mgr_with_player("Castle_CellBlock");
+        if let Some(p) = mgr.get_entity_mut(1) {
+            p.abilities.add_ability(7);
+        }
         let engine = ChainEngine::new();
         let (tx, mut rx) = mpsc::channel(8);
 
@@ -339,17 +345,22 @@ mod tests {
             rx.try_recv().is_err(),
             "short USE_ABILITY must not emit packets"
         );
+        assert!(
+            !mgr.get_entity(1).unwrap().abilities.is_on_cooldown(7),
+            "short USE_ABILITY must not start a cooldown"
+        );
     }
 
     /// `handle_respawn` is the load-bearing piece of CALL_FOR_AID.
-    /// Must restore HEALTH/FOCUS to max, clear all state flags, fire
-    /// onEndAidWait + RespawnReload, and update entity position to
-    /// the resolved spawn point.
+    /// Must restore HEALTH/FOCUS to max, clear all state flags, clear
+    /// ability cooldowns, update entity position to the resolved
+    /// spawn point (Castle default for Castle_CellBlock), and fire
+    /// onEndAidWait + RespawnReload.
     #[tokio::test]
     async fn handle_respawn_restores_stats_clears_flags_and_sends_respawn_reload() {
         let mut mgr = make_mgr_with_player("Castle_CellBlock");
         if let Some(e) = mgr.get_entity_mut(1) {
-            // Damaged + flagged dead.
+            // Damaged + flagged dead + an ability on cooldown.
             if let Some(h) = e.stats.get_mut(HEALTH) {
                 h.update(0, 1, 100);
                 h.clear_dirty();
@@ -359,6 +370,8 @@ mod tests {
                 f.clear_dirty();
             }
             e.state_field = 0xFF;
+            e.abilities
+                .start_ability_cooldown(592, std::time::Duration::from_secs(60));
         }
         let (tx, mut rx) = mpsc::channel(16);
         handle_respawn(1, -1, &tx, &mut mgr).await;
@@ -375,6 +388,20 @@ mod tests {
             "FOCUS must be restored to max"
         );
         assert_eq!(e.state_field, 0, "state flags must be fully cleared");
+        assert!(
+            !e.abilities.is_on_cooldown(592),
+            "respawn must clear ability cooldowns"
+        );
+        // Player started at [42.0, 1.0, 17.0] in make_mgr_with_player.
+        // Castle_CellBlock has no respawner registered → fallback to
+        // CASTLE_DEFAULT_POS = [-334.231, 73.472, -228.026]. Pin so a
+        // regression that drops the update_entity_position call
+        // (leaving the player at their corpse) gets caught.
+        assert_eq!(
+            [e.position.x, e.position.y, e.position.z],
+            [-334.231, 73.472, -228.026],
+            "respawn must teleport player to Castle default position"
+        );
 
         // Drain rx and check for RespawnReload.
         let mut saw_respawn_reload = false;

--- a/crates/services/src/cell/cell_methods/player/combat.rs
+++ b/crates/services/src/cell/cell_methods/player/combat.rs
@@ -287,3 +287,184 @@ fn resolve_respawn_position(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cell::spawner::RespawnerDef;
+    use cimmeria_entity::stats::{FOCUS, HEALTH};
+
+    /// Build a SpaceManager with one player at id=1 in the
+    /// Castle_CellBlock instanced space (every dispatch test sees a
+    /// fresh world). Caller can override is_player and stats.
+    fn make_mgr_with_player(world: &str) -> SpaceManager {
+        let mut mgr = SpaceManager::new(1);
+        let xml = format!(
+            r#"<?xml version="1.0"?><Spaces><Space WorldName="{world}" Instanced="true" MinX="-800" MaxX="800" MinY="-800" MaxY="800" /></Spaces>"#,
+        );
+        mgr.parse_spaces_xml(&xml).unwrap();
+        mgr.create_startup_spaces(r#"<?xml version="1.0"?><Spaces></Spaces>"#)
+            .unwrap();
+        mgr.create_entity(1, world, [42.0, 1.0, 17.0], [0.0; 3])
+            .unwrap();
+        if let Some(p) = mgr.get_entity_mut(1) {
+            p.is_player = true;
+            p.player_id = Some(100);
+        }
+        mgr.connect_entity(1);
+        mgr
+    }
+
+    #[tokio::test]
+    async fn dispatch_returns_false_for_unknown_method() {
+        let mut mgr = make_mgr_with_player("Castle_CellBlock");
+        let engine = ChainEngine::new();
+        let (tx, _rx) = mpsc::channel(8);
+        let handled = dispatch(1, 9999, &[], &tx, &mut mgr, &engine).await;
+        assert!(!handled);
+    }
+
+    /// USE_ABILITY with a too-short payload (< 8 bytes) must return
+    /// true (handler took the method) but not start any cooldown or
+    /// emit packets — the args are silently ignored.
+    #[tokio::test]
+    async fn use_ability_with_short_args_silently_drops() {
+        let mut mgr = make_mgr_with_player("Castle_CellBlock");
+        let engine = ChainEngine::new();
+        let (tx, mut rx) = mpsc::channel(8);
+
+        let handled = dispatch(1, USE_ABILITY, &[1u8, 2, 3], &tx, &mut mgr, &engine).await;
+        assert!(handled);
+        assert!(
+            rx.try_recv().is_err(),
+            "short USE_ABILITY must not emit packets"
+        );
+    }
+
+    /// `handle_respawn` is the load-bearing piece of CALL_FOR_AID.
+    /// Must restore HEALTH/FOCUS to max, clear all state flags, fire
+    /// onEndAidWait + RespawnReload, and update entity position to
+    /// the resolved spawn point.
+    #[tokio::test]
+    async fn handle_respawn_restores_stats_clears_flags_and_sends_respawn_reload() {
+        let mut mgr = make_mgr_with_player("Castle_CellBlock");
+        if let Some(e) = mgr.get_entity_mut(1) {
+            // Damaged + flagged dead.
+            if let Some(h) = e.stats.get_mut(HEALTH) {
+                h.update(0, 1, 100);
+                h.clear_dirty();
+            }
+            if let Some(f) = e.stats.get_mut(FOCUS) {
+                f.update(0, 0, 50);
+                f.clear_dirty();
+            }
+            e.state_field = 0xFF;
+        }
+        let (tx, mut rx) = mpsc::channel(16);
+        handle_respawn(1, -1, &tx, &mut mgr).await;
+
+        let e = mgr.get_entity(1).unwrap();
+        assert_eq!(
+            e.stats.get(HEALTH).unwrap().cur,
+            100,
+            "HEALTH must be restored to max"
+        );
+        assert_eq!(
+            e.stats.get(FOCUS).unwrap().cur,
+            50,
+            "FOCUS must be restored to max"
+        );
+        assert_eq!(e.state_field, 0, "state flags must be fully cleared");
+
+        // Drain rx and check for RespawnReload.
+        let mut saw_respawn_reload = false;
+        let mut saw_end_aid_wait = false;
+        while let Ok(m) = rx.try_recv() {
+            match m {
+                CellToBaseMsg::RespawnReload {
+                    entity_id,
+                    world_name,
+                    ..
+                } => {
+                    assert_eq!(entity_id, 1);
+                    assert_eq!(world_name, "Castle_CellBlock");
+                    saw_respawn_reload = true;
+                }
+                CellToBaseMsg::EntityMethodCall {
+                    entity_id,
+                    method_index,
+                    ..
+                } if entity_id == 1
+                    && method_index == crate::mercury::method_idx::ON_END_AID_WAIT =>
+                {
+                    saw_end_aid_wait = true;
+                }
+                _ => {}
+            }
+        }
+        assert!(saw_end_aid_wait, "respawn must emit onEndAidWait");
+        assert!(saw_respawn_reload, "respawn must emit RespawnReload");
+    }
+
+    /// `resolve_respawn_position` matches a respawner_id to its
+    /// stored position. The id-match path is the primary one — pin
+    /// it so a refactor that drops the iter().find() doesn't fall
+    /// back silently.
+    #[test]
+    fn resolve_respawn_position_uses_matching_respawner_id() {
+        let mut mgr = make_mgr_with_player("Castle_CellBlock");
+        mgr.respawners.push(RespawnerDef {
+            respawner_id: 42,
+            world_name: "Castle_CellBlock".to_string(),
+            name: "Hub".to_string(),
+            pos: [10.0, 20.0, 30.0],
+        });
+        let pos = resolve_respawn_position(42, 1, &mgr);
+        assert_eq!(pos, [10.0, 20.0, 30.0]);
+    }
+
+    /// `resolve_respawn_position` falls back to the world's first
+    /// respawner when the requested id isn't found. Pin so the
+    /// fallback path can't silently degrade to the Castle default
+    /// when the player's world has its own respawner registered.
+    #[test]
+    fn resolve_respawn_position_falls_back_to_world_respawner_on_id_miss() {
+        let mut mgr = make_mgr_with_player("Agnos_test");
+        mgr.respawners.push(RespawnerDef {
+            respawner_id: 7,
+            world_name: "Agnos_test".to_string(),
+            name: "Outpost".to_string(),
+            pos: [-5.0, 5.0, -5.0],
+        });
+        // respawner_id 999 doesn't exist.
+        let pos = resolve_respawn_position(999, 1, &mgr);
+        assert_eq!(pos, [-5.0, 5.0, -5.0]);
+    }
+
+    /// `resolve_respawn_position` returns CASTLE_DEFAULT_POS for
+    /// Castle_CellBlock when no respawners exist (ship-config
+    /// fallback). Pin the canonical fallback so a regression that
+    /// uses the in-place path inside Castle can't silently strand
+    /// players at their corpse.
+    #[test]
+    fn resolve_respawn_position_returns_castle_default_when_no_respawners() {
+        let mgr = make_mgr_with_player("Castle_CellBlock");
+        let pos = resolve_respawn_position(-1, 1, &mgr);
+        assert_eq!(pos, [-334.231, 73.472, -228.026]);
+    }
+
+    /// `resolve_respawn_position` for non-Castle worlds with no
+    /// respawner falls back to in-place (the player's current
+    /// position), NOT the Castle default. Pin the cross-world
+    /// teleport-prevention shape.
+    #[test]
+    fn resolve_respawn_position_uses_in_place_for_other_worlds_without_respawners() {
+        let mgr = make_mgr_with_player("Agnos_test");
+        let pos = resolve_respawn_position(-1, 1, &mgr);
+        assert_eq!(
+            pos,
+            [42.0, 1.0, 17.0],
+            "must respawn in place, not at Castle default"
+        );
+    }
+}

--- a/crates/services/src/cell/cell_methods/player/combat.rs
+++ b/crates/services/src/cell/cell_methods/player/combat.rs
@@ -358,9 +358,17 @@ mod tests {
     /// onEndAidWait + RespawnReload.
     #[tokio::test]
     async fn handle_respawn_restores_stats_clears_flags_and_sends_respawn_reload() {
+        use crate::cell::combat::{BSF_DEAD, BSF_MOVEMENT_LOCK};
         let mut mgr = make_mgr_with_player("Castle_CellBlock");
         if let Some(e) = mgr.get_entity_mut(1) {
-            // Damaged + flagged dead + an ability on cooldown.
+            // Damaged + flagged dead + an ability on cooldown. Use the
+            // refcounting set_state_flag helpers so the
+            // state_flag_counts map gets populated; that way the
+            // respawn assertion can distinguish `clear_all_state_flags`
+            // (which empties both `state_field` AND
+            // `state_flag_counts`) from a raw `state_field = 0` (which
+            // would leave stale counter entries — the regression shape
+            // this test guards against).
             if let Some(h) = e.stats.get_mut(HEALTH) {
                 h.update(0, 1, 100);
                 h.clear_dirty();
@@ -369,7 +377,12 @@ mod tests {
                 f.update(0, 0, 50);
                 f.clear_dirty();
             }
-            e.state_field = 0xFF;
+            e.set_state_flag(BSF_DEAD);
+            e.set_state_flag(BSF_MOVEMENT_LOCK);
+            assert!(
+                !e.state_flag_counts.is_empty(),
+                "fixture sanity: counters should be populated before respawn"
+            );
             e.abilities
                 .start_ability_cooldown(592, std::time::Duration::from_secs(60));
         }
@@ -387,7 +400,13 @@ mod tests {
             50,
             "FOCUS must be restored to max"
         );
-        assert_eq!(e.state_field, 0, "state flags must be fully cleared");
+        assert_eq!(e.state_field, 0, "state_field must be cleared");
+        assert!(
+            e.state_flag_counts.is_empty(),
+            "respawn must clear the per-flag refcount map too — \
+             a raw state_field=0 would leave stale counters and the \
+             next ref-counted unset would underflow back to a stuck bit"
+        );
         assert!(
             !e.abilities.is_on_cooldown(592),
             "respawn must clear ability cooldowns"

--- a/crates/services/src/cell/cell_methods/player/world.rs
+++ b/crates/services/src/cell/cell_methods/player/world.rs
@@ -284,3 +284,193 @@ async fn handle_reload(
         })
         .await;
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cimmeria_entity::abilities::AbilityDef;
+    use cimmeria_entity::cell_entity::BandolierItem;
+
+    fn make_mgr_with_player() -> SpaceManager {
+        let mut mgr = SpaceManager::new(1);
+        let xml = r#"<?xml version="1.0"?><Spaces><Space WorldName="Castle_CellBlock" Instanced="true" MinX="-800" MaxX="800" MinY="-800" MaxY="800" /></Spaces>"#;
+        mgr.parse_spaces_xml(xml).unwrap();
+        mgr.create_startup_spaces(r#"<?xml version="1.0"?><Spaces></Spaces>"#)
+            .unwrap();
+        mgr.create_entity(1, "Castle_CellBlock", [0.0; 3], [0.0; 3])
+            .unwrap();
+        if let Some(p) = mgr.get_entity_mut(1) {
+            p.is_player = true;
+            p.player_id = Some(100);
+        }
+        mgr.connect_entity(1);
+        mgr
+    }
+
+    #[tokio::test]
+    async fn dispatch_returns_false_for_unknown_method() {
+        let mut mgr = make_mgr_with_player();
+        let engine = ChainEngine::new();
+        let (tx, _rx) = mpsc::channel(8);
+        let handled = dispatch(1, 9999, &[], &tx, &mut mgr, &engine).await;
+        assert!(!handled);
+    }
+
+    /// SET_AUTO_CYCLE flips entity.abilities.auto_cycle. When
+    /// disabled, must clear auto_cycle_ability_id too — otherwise a
+    /// stale ability id would re-trigger on the next enable cycle.
+    #[tokio::test]
+    async fn set_auto_cycle_disable_clears_ability_id() {
+        let mut mgr = make_mgr_with_player();
+        if let Some(e) = mgr.get_entity_mut(1) {
+            e.abilities.auto_cycle = true;
+            e.abilities.auto_cycle_ability_id = Some(597);
+        }
+        let engine = ChainEngine::new();
+        let (tx, _rx) = mpsc::channel(8);
+
+        // args = [0] → enabled = false
+        let handled = dispatch(1, SET_AUTO_CYCLE, &[0], &tx, &mut mgr, &engine).await;
+        assert!(handled);
+
+        let e = mgr.get_entity(1).unwrap();
+        assert!(!e.abilities.auto_cycle);
+        assert!(
+            e.abilities.auto_cycle_ability_id.is_none(),
+            "disable must also clear auto_cycle_ability_id"
+        );
+    }
+
+    /// SET_AUTO_CYCLE enable doesn't touch auto_cycle_ability_id —
+    /// that's set elsewhere. Pin so a refactor that conflates the
+    /// two doesn't leak.
+    #[tokio::test]
+    async fn set_auto_cycle_enable_only_sets_flag() {
+        let mut mgr = make_mgr_with_player();
+        let engine = ChainEngine::new();
+        let (tx, _rx) = mpsc::channel(8);
+
+        let handled = dispatch(1, SET_AUTO_CYCLE, &[1], &tx, &mut mgr, &engine).await;
+        assert!(handled);
+        let e = mgr.get_entity(1).unwrap();
+        assert!(e.abilities.auto_cycle);
+        // auto_cycle_ability_id stays None (was never set)
+        assert!(e.abilities.auto_cycle_ability_id.is_none());
+    }
+
+    /// TRIGGER_REGION with a negative region_id must be rejected
+    /// without crashing — historical regression where i32 → u32
+    /// cast sign-extended into a high u32 that no real region
+    /// matched, but the warn log was the only signal.
+    #[tokio::test]
+    async fn trigger_region_with_negative_id_rejects_cleanly() {
+        let mut mgr = make_mgr_with_player();
+        let engine = ChainEngine::new();
+        let (tx, mut rx) = mpsc::channel(8);
+
+        // Layout: i32 region_id + u8 b_entering + 3 × f32 position.
+        let mut args = Vec::with_capacity(17);
+        args.extend_from_slice(&(-5i32).to_le_bytes());
+        args.push(1);
+        args.extend_from_slice(&0.0f32.to_le_bytes());
+        args.extend_from_slice(&0.0f32.to_le_bytes());
+        args.extend_from_slice(&0.0f32.to_le_bytes());
+
+        let handled = dispatch(1, TRIGGER_REGION, &args, &tx, &mut mgr, &engine).await;
+        assert!(
+            handled,
+            "TRIGGER_REGION must claim the method even when region_id is bogus"
+        );
+        // No region match → no fire_*_region cascades, no ring_transport.
+        assert!(
+            rx.try_recv().is_err(),
+            "negative region_id must not emit packets"
+        );
+    }
+
+    /// `handle_reload` is a no-op when the active slot is at full
+    /// clip and no reload is in flight. Pin so a refactor that
+    /// always starts a reload (and therefore wastes ammo on every
+    /// keypress) gets caught.
+    #[tokio::test]
+    async fn handle_reload_no_op_when_already_full() {
+        let mut mgr = make_mgr_with_player();
+        if let Some(e) = mgr.get_entity_mut(1) {
+            e.bandolier_items.insert(
+                0,
+                BandolierItem {
+                    item_id: 1,
+                    clip_size: 30,
+                    default_ammo_type: 2,
+                    current_ammo: 30, // full
+                    cur_ammo_type: 2,
+                },
+            );
+            e.active_bandolier_slot = 0;
+        }
+        let (tx, mut rx) = mpsc::channel(8);
+        handle_reload(1, &tx, &mut mgr).await;
+
+        let e = mgr.get_entity(1).unwrap();
+        assert!(
+            e.reload_complete_at.is_none(),
+            "no reload should be queued when full"
+        );
+        assert!(rx.try_recv().is_err(), "no packets should be emitted");
+    }
+
+    /// `handle_reload` from an empty magazine pins the slot id at
+    /// the time of issue. If the player swaps mid-reload, the
+    /// completion tick must refill THIS slot, not whatever slot is
+    /// active when the deadline elapses.
+    #[tokio::test]
+    async fn handle_reload_pins_reload_slot_id_to_current_active_slot() {
+        let mut mgr = make_mgr_with_player();
+        if let Some(e) = mgr.get_entity_mut(1) {
+            e.bandolier_items.insert(
+                2,
+                BandolierItem {
+                    item_id: 1,
+                    clip_size: 30,
+                    default_ammo_type: 2,
+                    current_ammo: 0,
+                    cur_ammo_type: 2,
+                },
+            );
+            e.active_bandolier_slot = 2;
+        }
+        // Seed the reload AbilityDef so warmup/cooldown/event_set are read.
+        mgr.ability_defs.insert(
+            596,
+            AbilityDef {
+                ability_id: 596,
+                name: "reload".to_string(),
+                cooldown: 1.0,
+                warmup: 0.5,
+                flags: 0,
+                is_ranged: false,
+                min_range: 0,
+                max_range: 0,
+                target_type_id: 0,
+                effect_ids: vec![],
+                moniker_ids: vec![],
+                required_ammo: 0,
+                event_set_id: None,
+                velocity: 0.0,
+            },
+        );
+        let (tx, _rx) = mpsc::channel(16);
+        handle_reload(1, &tx, &mut mgr).await;
+
+        let e = mgr.get_entity(1).unwrap();
+        assert!(
+            e.reload_complete_at.is_some(),
+            "reload must arm the deadline"
+        );
+        assert_eq!(
+            e.reload_slot_id,
+            Some(2),
+            "reload_slot_id must capture the active slot at issue time, not be re-read at completion"
+        );
+    }
+}

--- a/crates/services/src/cell/cell_methods/player/world.rs
+++ b/crates/services/src/cell/cell_methods/player/world.rs
@@ -358,13 +358,36 @@ mod tests {
         assert!(e.abilities.auto_cycle_ability_id.is_none());
     }
 
-    /// TRIGGER_REGION with a negative region_id must be rejected
-    /// without crashing — historical regression where i32 → u32
-    /// cast sign-extended into a high u32 that no real region
-    /// matched, but the warn log was the only signal.
+    /// TRIGGER_REGION with a negative region_id must be rejected by
+    /// the explicit `u32::try_from` guard, NOT by accidentally
+    /// missing a sign-extended u32 lookup. Pre-seed a real region at
+    /// the sign-extended id (`-5i32 as u32 == 0xFFFFFFFB`); if the
+    /// regression resurfaces (the cast slips through), the lookup
+    /// would match the planted region and fire content events.
+    /// With the negative-id guard in place the planted region must
+    /// stay invisible.
     #[tokio::test]
-    async fn trigger_region_with_negative_id_rejects_cleanly() {
+    async fn trigger_region_with_negative_id_rejects_via_explicit_guard() {
+        use crate::cell::space_manager::RegionData;
         let mut mgr = make_mgr_with_player();
+        // Plant a region at the sign-extended id of -5. If a regression
+        // reintroduces the `region_id as u32` cast, get_region(0xFFFFFFFB)
+        // would match this row and fire ring_transport / fire_enter_region.
+        let trap_id: u32 = (-5i32) as u32;
+        mgr.regions.insert(
+            trap_id,
+            RegionData {
+                runtime_id: trap_id,
+                db_set_id: 9999,
+                tag: "trap".to_string(),
+                world_name: "Castle_CellBlock".to_string(),
+                height: 0.0,
+                radius: 0.0,
+                flags: 0,
+                points: vec![],
+            },
+        );
+
         let engine = ChainEngine::new();
         let (tx, mut rx) = mpsc::channel(8);
 
@@ -381,10 +404,12 @@ mod tests {
             handled,
             "TRIGGER_REGION must claim the method even when region_id is bogus"
         );
-        // No region match → no fire_*_region cascades, no ring_transport.
+        // The planted trap region MUST NOT match. No fire_*_region
+        // cascade, no ring_transport message.
         assert!(
             rx.try_recv().is_err(),
-            "negative region_id must not emit packets"
+            "negative region_id must be rejected by u32::try_from before lookup, \
+             so the trap region at 0xFFFFFFFB can't fire"
         );
     }
 


### PR DESCRIPTION
## Summary

Closes the cell/cell_methods/player/combat + player/world bullets on #123 Group A. \`combat.rs\` (289 lines) and \`world.rs\` (286 lines) had zero coverage; 12 new tests pin the dispatch return shape, the respawn pipeline, and the reload state machine.

| File | Pinned invariants |
|---|---|
| \`combat.rs\` | dispatch unknown→false; USE_ABILITY short-args silently drops; \`handle_respawn\` restores HEALTH/FOCUS, clears state, emits onEndAidWait + RespawnReload; \`resolve_respawn_position\` uses respawner_id match → world fallback → Castle default → in-place. |
| \`world.rs\` | dispatch unknown→false; SET_AUTO_CYCLE disable clears auto_cycle_ability_id (canary for stale-id re-trigger); TRIGGER_REGION negative id rejects cleanly (sign-extend regression guard); \`handle_reload\` no-op when full + reload_slot_id pins to active-at-issue (swap-mid-reload guard). |

## Closes

- cell/cell_methods/player bullets (combat + world) on #123 Group A.

## Test plan

- [ ] CI passes all six existing jobs.
- [ ] Reverting the \`reload_slot_id = active_bandolier_slot\` capture or the negative-region-id check makes the corresponding test fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)