### PR TITLE
test(minigame/livewire): construction + seeded layout coverage (#123 Group A)

### DIFF
--- a/crates/services/src/minigame/games/livewire.rs
+++ b/crates/services/src/minigame/games/livewire.rs
@@ -215,6 +215,26 @@ impl LivewireGame {
         }
     }
 
+    #[cfg(test)]
+    pub(crate) fn difficulty_for_test(&self) -> u32 {
+        self.difficulty
+    }
+
+    #[cfg(test)]
+    pub(crate) fn goal_total_for_test(&self) -> u32 {
+        self.goal_total
+    }
+
+    #[cfg(test)]
+    pub(crate) fn read_out_for_test(&self) -> &str {
+        &self.read_out
+    }
+
+    #[cfg(test)]
+    pub(crate) fn wire_count_for_test(&self) -> usize {
+        self.wires.len()
+    }
+
     fn update_difficulty(&mut self) {
         let idx = (self.difficulty as usize - 1).min(3);
         let level = &DIFFICULTY_LEVELS[idx];
@@ -496,6 +516,11 @@ impl LivewireGame {
         self.update_difficulty();
         self.setup_wires();
     }
+
+    #[cfg(test)]
+    pub(crate) fn init_game_for_test(&mut self) {
+        self.init_game();
+    }
 }
 
 impl MinigameInstance for LivewireGame {
@@ -703,5 +728,128 @@ impl MinigameInstance for LivewireGame {
 
     fn needs_tick(&self) -> bool {
         true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_session(difficulty: u32, tech: u32, level: u32) -> MinigameSession {
+        MinigameSession {
+            entity_id: 1,
+            player_id: 100,
+            game_name: "livewire".to_string(),
+            difficulty,
+            tech_competency: tech,
+            seed: 0xDEADBEEF,
+            abilities_mask: 0,
+            intelligence: 0,
+            player_level: level,
+            ticket: String::new(),
+            on_victory_chains: vec![],
+            created_at: std::time::Instant::now(),
+        }
+    }
+
+    /// `LivewireGame::new` clamps difficulty to [1, 4]. Pin so a
+    /// future server bug (or malicious client) sending difficulty=0
+    /// or difficulty=99 can't index out-of-bounds in
+    /// DIFFICULTY_LEVELS during update_difficulty().
+    #[test]
+    fn new_clamps_difficulty_below_one() {
+        let g = LivewireGame::new(&make_session(0, 50, 5));
+        assert_eq!(g.difficulty_for_test(), 1);
+    }
+
+    #[test]
+    fn new_clamps_difficulty_above_four() {
+        let g = LivewireGame::new(&make_session(99, 50, 5));
+        assert_eq!(g.difficulty_for_test(), 4);
+    }
+
+    #[test]
+    fn new_preserves_difficulty_within_range() {
+        let g = LivewireGame::new(&make_session(3, 50, 5));
+        assert_eq!(g.difficulty_for_test(), 3);
+    }
+
+    /// `init_game` populates the wire grid via setup_wires. After
+    /// init the goal_total must equal the difficulty's seeded count
+    /// (2 / 4 / 4 / 6 for difficulties 1..4) and the wire HashMap
+    /// must be non-empty.
+    #[test]
+    fn init_game_populates_wires_and_goals_per_difficulty() {
+        for (difficulty, expected_goals) in [(1u32, 2u32), (2, 4), (3, 4), (4, 6)] {
+            let mut g = LivewireGame::new(&make_session(difficulty, 30, 5));
+            g.init_game_for_test();
+            assert_eq!(
+                g.goal_total_for_test(),
+                expected_goals,
+                "difficulty {difficulty} should seed goal_total {expected_goals}"
+            );
+            assert!(
+                g.wire_count_for_test() > 0,
+                "init_game must populate the wire grid"
+            );
+        }
+    }
+
+    /// `init_game` sets read_out to "<level_prefix><tech_competency>".
+    /// Pin the prefix so a refactor that drops the per-difficulty
+    /// label can't silently change what the player sees on the HUD.
+    #[test]
+    fn init_game_sets_read_out_prefix_per_difficulty() {
+        for (difficulty, prefix) in [(1u32, "I-"), (2, "S-"), (3, "C-"), (4, "E-")] {
+            let mut g = LivewireGame::new(&make_session(difficulty, 42, 5));
+            g.init_game_for_test();
+            assert_eq!(
+                g.read_out_for_test(),
+                &format!("{prefix}42"),
+                "difficulty {difficulty} prefix must be {prefix}"
+            );
+        }
+    }
+
+    /// Distinct seeds must produce distinct wire layouts. Pin so a
+    /// regression that always seeds StdRng from a constant (or
+    /// forgets to thread `session.seed` through) can't strip
+    /// per-room replay variability.
+    #[test]
+    fn different_seeds_produce_different_wire_layouts() {
+        let mut s1 = make_session(2, 30, 5);
+        s1.seed = 1;
+        let mut s2 = make_session(2, 30, 5);
+        s2.seed = 2;
+
+        let mut g1 = LivewireGame::new(&s1);
+        let mut g2 = LivewireGame::new(&s2);
+        g1.init_game_for_test();
+        g2.init_game_for_test();
+
+        // Compare the depth -> wire-name maps. Both games seed the
+        // same number of wires (same difficulty + tech_competency),
+        // but the depth assignment + wire-library picks vary by
+        // RNG seed.
+        let names1: std::collections::BTreeMap<u32, String> =
+            g1.wires.iter().map(|(&d, w)| (d, w.lib.clone())).collect();
+        let names2: std::collections::BTreeMap<u32, String> =
+            g2.wires.iter().map(|(&d, w)| (d, w.lib.clone())).collect();
+        assert_ne!(
+            names1, names2,
+            "different seeds must yield different layouts"
+        );
+    }
+
+    /// `started()` runs init_game and returns one Send output. Pin
+    /// the return-shape so a refactor that batches sends or routes
+    /// the initial state via a separate channel can't break the
+    /// MinigameInstance contract.
+    #[test]
+    fn started_returns_exactly_one_send_with_full_game_state() {
+        let mut g = LivewireGame::new(&make_session(2, 30, 5));
+        let outputs = g.started();
+        assert_eq!(outputs.len(), 1);
+        assert!(matches!(outputs[0], GameOutput::Send(_)));
     }
 }

--- a/crates/services/src/minigame/games/livewire/mod.rs
+++ b/crates/services/src/minigame/games/livewire/mod.rs
@@ -215,26 +215,6 @@ impl LivewireGame {
         }
     }
 
-    #[cfg(test)]
-    pub(crate) fn difficulty_for_test(&self) -> u32 {
-        self.difficulty
-    }
-
-    #[cfg(test)]
-    pub(crate) fn goal_total_for_test(&self) -> u32 {
-        self.goal_total
-    }
-
-    #[cfg(test)]
-    pub(crate) fn read_out_for_test(&self) -> &str {
-        &self.read_out
-    }
-
-    #[cfg(test)]
-    pub(crate) fn wire_count_for_test(&self) -> usize {
-        self.wires.len()
-    }
-
     fn update_difficulty(&mut self) {
         let idx = (self.difficulty as usize - 1).min(3);
         let level = &DIFFICULTY_LEVELS[idx];
@@ -516,11 +496,6 @@ impl LivewireGame {
         self.update_difficulty();
         self.setup_wires();
     }
-
-    #[cfg(test)]
-    pub(crate) fn init_game_for_test(&mut self) {
-        self.init_game();
-    }
 }
 
 impl MinigameInstance for LivewireGame {
@@ -732,124 +707,4 @@ impl MinigameInstance for LivewireGame {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn make_session(difficulty: u32, tech: u32, level: u32) -> MinigameSession {
-        MinigameSession {
-            entity_id: 1,
-            player_id: 100,
-            game_name: "livewire".to_string(),
-            difficulty,
-            tech_competency: tech,
-            seed: 0xDEADBEEF,
-            abilities_mask: 0,
-            intelligence: 0,
-            player_level: level,
-            ticket: String::new(),
-            on_victory_chains: vec![],
-            created_at: std::time::Instant::now(),
-        }
-    }
-
-    /// `LivewireGame::new` clamps difficulty to [1, 4]. Pin so a
-    /// future server bug (or malicious client) sending difficulty=0
-    /// or difficulty=99 can't index out-of-bounds in
-    /// DIFFICULTY_LEVELS during update_difficulty().
-    #[test]
-    fn new_clamps_difficulty_below_one() {
-        let g = LivewireGame::new(&make_session(0, 50, 5));
-        assert_eq!(g.difficulty_for_test(), 1);
-    }
-
-    #[test]
-    fn new_clamps_difficulty_above_four() {
-        let g = LivewireGame::new(&make_session(99, 50, 5));
-        assert_eq!(g.difficulty_for_test(), 4);
-    }
-
-    #[test]
-    fn new_preserves_difficulty_within_range() {
-        let g = LivewireGame::new(&make_session(3, 50, 5));
-        assert_eq!(g.difficulty_for_test(), 3);
-    }
-
-    /// `init_game` populates the wire grid via setup_wires. After
-    /// init the goal_total must equal the difficulty's seeded count
-    /// (2 / 4 / 4 / 6 for difficulties 1..4) and the wire HashMap
-    /// must be non-empty.
-    #[test]
-    fn init_game_populates_wires_and_goals_per_difficulty() {
-        for (difficulty, expected_goals) in [(1u32, 2u32), (2, 4), (3, 4), (4, 6)] {
-            let mut g = LivewireGame::new(&make_session(difficulty, 30, 5));
-            g.init_game_for_test();
-            assert_eq!(
-                g.goal_total_for_test(),
-                expected_goals,
-                "difficulty {difficulty} should seed goal_total {expected_goals}"
-            );
-            assert!(
-                g.wire_count_for_test() > 0,
-                "init_game must populate the wire grid"
-            );
-        }
-    }
-
-    /// `init_game` sets read_out to "<level_prefix><tech_competency>".
-    /// Pin the prefix so a refactor that drops the per-difficulty
-    /// label can't silently change what the player sees on the HUD.
-    #[test]
-    fn init_game_sets_read_out_prefix_per_difficulty() {
-        for (difficulty, prefix) in [(1u32, "I-"), (2, "S-"), (3, "C-"), (4, "E-")] {
-            let mut g = LivewireGame::new(&make_session(difficulty, 42, 5));
-            g.init_game_for_test();
-            assert_eq!(
-                g.read_out_for_test(),
-                &format!("{prefix}42"),
-                "difficulty {difficulty} prefix must be {prefix}"
-            );
-        }
-    }
-
-    /// Distinct seeds must produce distinct wire layouts. Pin so a
-    /// regression that always seeds StdRng from a constant (or
-    /// forgets to thread `session.seed` through) can't strip
-    /// per-room replay variability.
-    #[test]
-    fn different_seeds_produce_different_wire_layouts() {
-        let mut s1 = make_session(2, 30, 5);
-        s1.seed = 1;
-        let mut s2 = make_session(2, 30, 5);
-        s2.seed = 2;
-
-        let mut g1 = LivewireGame::new(&s1);
-        let mut g2 = LivewireGame::new(&s2);
-        g1.init_game_for_test();
-        g2.init_game_for_test();
-
-        // Compare the depth -> wire-name maps. Both games seed the
-        // same number of wires (same difficulty + tech_competency),
-        // but the depth assignment + wire-library picks vary by
-        // RNG seed.
-        let names1: std::collections::BTreeMap<u32, String> =
-            g1.wires.iter().map(|(&d, w)| (d, w.lib.clone())).collect();
-        let names2: std::collections::BTreeMap<u32, String> =
-            g2.wires.iter().map(|(&d, w)| (d, w.lib.clone())).collect();
-        assert_ne!(
-            names1, names2,
-            "different seeds must yield different layouts"
-        );
-    }
-
-    /// `started()` runs init_game and returns one Send output. Pin
-    /// the return-shape so a refactor that batches sends or routes
-    /// the initial state via a separate channel can't break the
-    /// MinigameInstance contract.
-    #[test]
-    fn started_returns_exactly_one_send_with_full_game_state() {
-        let mut g = LivewireGame::new(&make_session(2, 30, 5));
-        let outputs = g.started();
-        assert_eq!(outputs.len(), 1);
-        assert!(matches!(outputs[0], GameOutput::Send(_)));
-    }
-}
+mod tests;

--- a/crates/services/src/minigame/games/livewire/tests.rs
+++ b/crates/services/src/minigame/games/livewire/tests.rs
@@ -1,9 +1,14 @@
 //! Tests for `LivewireGame` — extracted to a sibling file to keep
-//! `livewire/mod.rs` under the 700-line hard cap. The test module
-//! is a child of `livewire` so private fields (`difficulty`,
-//! `goal_total`, `wires`, etc.) are reachable directly without
-//! per-field `#[cfg(test)]` accessors leaking into the production
-//! file.
+//! the production module separate from the tests. (The production
+//! `livewire/mod.rs` is still marginally over the 700-line hard cap
+//! because the Python port itself runs ~595 lines plus Rust
+//! boilerplate; bringing it fully under is a separate refactor PR.
+//! Splitting tests out is a strict improvement either way.)
+//!
+//! The test module is a child of `livewire` so private fields
+//! (`difficulty`, `goal_total`, `wires`, etc.) are reachable
+//! directly without per-field `#[cfg(test)]` accessors leaking into
+//! the production file.
 
 use super::*;
 
@@ -79,49 +84,51 @@ fn init_game_sets_read_out_prefix_per_difficulty() {
     }
 }
 
-/// Distinct seeds must produce distinct wire layouts. Pin so a
-/// regression that always seeds StdRng from a constant (or forgets
-/// to thread `session.seed` through) can't strip per-room replay
-/// variability.
+/// `session.seed` must thread through into the `StdRng` instance
+/// used by the layout generator. Pin via two complementary checks
+/// that are BOTH deterministic (no flakiness):
 ///
-/// The test compares wire COUNTS-per-library (a derivable property)
-/// rather than the full depth→lib map, so it doesn't tightly couple
-/// to the private `wires` HashMap layout. With ~10 distinct library
-/// strings drawn from the seeded random pools, two distinct seeds
-/// produce different counts with overwhelming probability — and the
-/// test fails deterministically (not flakily) if the seed isn't
-/// being used at all.
+/// 1. Same seed → identical layout. If this fails, the RNG isn't
+///    deterministic at all.
+/// 2. The two specific seeds 1 and 2 produce distinguishable
+///    layouts when init_game is run. If a regression always seeds
+///    `StdRng` from a constant (ignoring `session.seed`), both
+///    layouts collapse to identical and assertion #2 fails. The
+///    seeds are hand-picked so the layouts ARE distinct under the
+///    current implementation — re-pick if RNG semantics change.
 #[test]
-fn different_seeds_produce_different_wire_layouts() {
-    let mut s1 = make_session(4, 50, 5);
-    s1.seed = 1;
-    let mut s2 = make_session(4, 50, 5);
-    s2.seed = 2;
-
-    let mut g1 = LivewireGame::new(&s1);
-    let mut g2 = LivewireGame::new(&s2);
-    g1.init_game();
-    g2.init_game();
-
+fn session_seed_threads_through_into_layout_generator() {
     use std::collections::BTreeMap;
-    let counts1: BTreeMap<&str, usize> = g1.wires.values().fold(BTreeMap::new(), |mut acc, w| {
-        *acc.entry(w.lib.as_str()).or_insert(0) += 1;
-        acc
-    });
-    let counts2: BTreeMap<&str, usize> = g2.wires.values().fold(BTreeMap::new(), |mut acc, w| {
-        *acc.entry(w.lib.as_str()).or_insert(0) += 1;
-        acc
-    });
+
+    fn layout_for(seed: u32) -> BTreeMap<u32, String> {
+        let mut s = make_session(4, 50, 5);
+        s.seed = seed;
+        let mut g = LivewireGame::new(&s);
+        g.init_game();
+        g.wires.iter().map(|(&d, w)| (d, w.lib.clone())).collect()
+    }
+
+    // (1) Determinism: identical seed → identical layout.
+    assert_eq!(
+        layout_for(1),
+        layout_for(1),
+        "same seed must produce identical layout"
+    );
+
+    // (2) Seed actually drives layout: two hand-picked seeds whose
+    //     layouts are known to differ under the current RNG.
     assert_ne!(
-        counts1, counts2,
-        "different seeds must yield different per-library wire counts"
+        layout_for(1),
+        layout_for(2),
+        "seeds 1 and 2 must produce distinguishable layouts — \
+         a regression that ignores session.seed would collapse them"
     );
 }
 
 /// `started()` runs init_game and returns one Send carrying the
 /// full game-state SfsObject (timer/playfield/wire fields visible
 /// to the client). Pin both the return shape AND that the payload
-/// has the headline `_cmd=fullupdate` field — without that, the
+/// has the headline `_cmd=fullgamestate` field — without that, the
 /// test would only verify a Send variant, not that it's the
 /// initial-state payload.
 #[test]

--- a/crates/services/src/minigame/games/livewire/tests.rs
+++ b/crates/services/src/minigame/games/livewire/tests.rs
@@ -1,0 +1,143 @@
+//! Tests for `LivewireGame` — extracted to a sibling file to keep
+//! `livewire/mod.rs` under the 700-line hard cap. The test module
+//! is a child of `livewire` so private fields (`difficulty`,
+//! `goal_total`, `wires`, etc.) are reachable directly without
+//! per-field `#[cfg(test)]` accessors leaking into the production
+//! file.
+
+use super::*;
+
+fn make_session(difficulty: u32, tech: u32, level: u32) -> MinigameSession {
+    MinigameSession {
+        entity_id: 1,
+        player_id: 100,
+        game_name: "livewire".to_string(),
+        difficulty,
+        tech_competency: tech,
+        seed: 0xDEADBEEF,
+        abilities_mask: 0,
+        intelligence: 0,
+        player_level: level,
+        ticket: String::new(),
+        on_victory_chains: vec![],
+        created_at: std::time::Instant::now(),
+    }
+}
+
+/// `LivewireGame::new` clamps difficulty to [1, 4]. Pin so a
+/// future server bug (or malicious client) sending difficulty=0
+/// or difficulty=99 can't index out-of-bounds in
+/// DIFFICULTY_LEVELS during update_difficulty().
+#[test]
+fn new_clamps_difficulty_below_one() {
+    let g = LivewireGame::new(&make_session(0, 50, 5));
+    assert_eq!(g.difficulty, 1);
+}
+
+#[test]
+fn new_clamps_difficulty_above_four() {
+    let g = LivewireGame::new(&make_session(99, 50, 5));
+    assert_eq!(g.difficulty, 4);
+}
+
+#[test]
+fn new_preserves_difficulty_within_range() {
+    let g = LivewireGame::new(&make_session(3, 50, 5));
+    assert_eq!(g.difficulty, 3);
+}
+
+/// `init_game` populates the wire grid via setup_wires. After
+/// init the goal_total must equal the difficulty's seeded count
+/// (2 / 4 / 4 / 6 for difficulties 1..4) and the wire HashMap
+/// must be non-empty.
+#[test]
+fn init_game_populates_wires_and_goals_per_difficulty() {
+    for (difficulty, expected_goals) in [(1u32, 2u32), (2, 4), (3, 4), (4, 6)] {
+        let mut g = LivewireGame::new(&make_session(difficulty, 30, 5));
+        g.init_game();
+        assert_eq!(
+            g.goal_total, expected_goals,
+            "difficulty {difficulty} should seed goal_total {expected_goals}"
+        );
+        assert!(!g.wires.is_empty(), "init_game must populate the wire grid");
+    }
+}
+
+/// `init_game` sets read_out to "<level_prefix><tech_competency>".
+/// Pin the prefix so a refactor that drops the per-difficulty
+/// label can't silently change what the player sees on the HUD.
+#[test]
+fn init_game_sets_read_out_prefix_per_difficulty() {
+    for (difficulty, prefix) in [(1u32, "I-"), (2, "S-"), (3, "C-"), (4, "E-")] {
+        let mut g = LivewireGame::new(&make_session(difficulty, 42, 5));
+        g.init_game();
+        assert_eq!(
+            g.read_out,
+            format!("{prefix}42"),
+            "difficulty {difficulty} prefix must be {prefix}"
+        );
+    }
+}
+
+/// Distinct seeds must produce distinct wire layouts. Pin so a
+/// regression that always seeds StdRng from a constant (or forgets
+/// to thread `session.seed` through) can't strip per-room replay
+/// variability.
+///
+/// The test compares wire COUNTS-per-library (a derivable property)
+/// rather than the full depth→lib map, so it doesn't tightly couple
+/// to the private `wires` HashMap layout. With ~10 distinct library
+/// strings drawn from the seeded random pools, two distinct seeds
+/// produce different counts with overwhelming probability — and the
+/// test fails deterministically (not flakily) if the seed isn't
+/// being used at all.
+#[test]
+fn different_seeds_produce_different_wire_layouts() {
+    let mut s1 = make_session(4, 50, 5);
+    s1.seed = 1;
+    let mut s2 = make_session(4, 50, 5);
+    s2.seed = 2;
+
+    let mut g1 = LivewireGame::new(&s1);
+    let mut g2 = LivewireGame::new(&s2);
+    g1.init_game();
+    g2.init_game();
+
+    use std::collections::BTreeMap;
+    let counts1: BTreeMap<&str, usize> = g1.wires.values().fold(BTreeMap::new(), |mut acc, w| {
+        *acc.entry(w.lib.as_str()).or_insert(0) += 1;
+        acc
+    });
+    let counts2: BTreeMap<&str, usize> = g2.wires.values().fold(BTreeMap::new(), |mut acc, w| {
+        *acc.entry(w.lib.as_str()).or_insert(0) += 1;
+        acc
+    });
+    assert_ne!(
+        counts1, counts2,
+        "different seeds must yield different per-library wire counts"
+    );
+}
+
+/// `started()` runs init_game and returns one Send carrying the
+/// full game-state SfsObject (timer/playfield/wire fields visible
+/// to the client). Pin both the return shape AND that the payload
+/// has the headline `_cmd=fullupdate` field — without that, the
+/// test would only verify a Send variant, not that it's the
+/// initial-state payload.
+#[test]
+fn started_returns_exactly_one_send_with_full_game_state() {
+    let mut g = LivewireGame::new(&make_session(2, 30, 5));
+    let outputs = g.started();
+    assert_eq!(outputs.len(), 1);
+    let GameOutput::Send(payload) = &outputs[0] else {
+        panic!("expected GameOutput::Send, got {:?}", outputs[0]);
+    };
+    let cmd = payload
+        .get("_cmd")
+        .and_then(|v| v.as_str())
+        .expect("started() payload must carry the _cmd field");
+    assert_eq!(
+        cmd, "fullgamestate",
+        "started() must emit the fullgamestate cmd carrying the initial state"
+    );
+}


### PR DESCRIPTION
## Summary

Closes the minigame games/livewire bullet on #123 Group A. The 707-line file had zero coverage; 6 new tests pin construction shape, difficulty clamping, init-populated state, and per-seed layout variability.

| Pinned invariant | Why it matters |
|---|---|
| \`LivewireGame::new\` clamps difficulty to [1, 4] | Canary against out-of-bounds \`DIFFICULTY_LEVELS\` index when a malicious client or buggy server passes 0 / 99. |
| \`init_game\` populates wires + goal_total per difficulty table (2/4/4/6) | Regression guard if the table layout shifts. |
| \`init_game\` sets the read_out HUD prefix (I- / S- / C- / E-) per difficulty | Pin what the player sees on the HUD. |
| Distinct seeds → distinct wire layouts | Canary against a regression that drops \`session.seed\` and seeds StdRng from a constant. |
| \`started()\` returns exactly one Send GameOutput | MinigameInstance contract. |

Tests access private \`LivewireGame\` fields via a small set of \`#[cfg(test)]\` \`pub(crate)\` accessors so they don't mirror the struct layout.

\`server.rs\` is intentionally **not covered in this PR** — heavy TCP/SfsMessage plumbing whose testable surface needs a fixture stack (TcpListener, registry, result channel) bigger than the value. Filing a follow-up if needed.

## Closes

- minigame games/livewire bullet on #123 Group A.

## Test plan

- [ ] CI passes all six existing jobs.
- [ ] Reverting the difficulty clamp, the seed-threading, or the read_out prefix makes the corresponding test fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)