### PR TITLE
test(base): wire-format coverage for appearance + helpers (#123 Group A)

### DIFF
--- a/crates/services/src/base/helpers.rs
+++ b/crates/services/src/base/helpers.rs
@@ -157,3 +157,31 @@ pub(crate) async fn send_to_witness<F>(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `to_hex` formats each byte as two uppercase hex digits, separated
+    /// by single spaces. Pin the format so a refactor that swaps to
+    /// lowercase or drops the separator doesn't silently change every
+    /// trace log.
+    #[test]
+    fn to_hex_formats_bytes_as_uppercase_with_space_separator() {
+        assert_eq!(to_hex(&[]), "");
+        assert_eq!(to_hex(&[0x00]), "00");
+        assert_eq!(to_hex(&[0xAB, 0xCD]), "AB CD");
+        assert_eq!(
+            to_hex(&[0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0]),
+            "12 34 56 78 9A BC DE F0"
+        );
+    }
+
+    /// `to_hex` zero-pads single-digit byte values. A regression that
+    /// drops the `:02X` width specifier would emit "1 2" for [0x01, 0x02]
+    /// instead of "01 02", breaking deterministic log diffs.
+    #[test]
+    fn to_hex_zero_pads_single_digit_bytes() {
+        assert_eq!(to_hex(&[0x01, 0x02, 0x0F]), "01 02 0F");
+    }
+}

--- a/crates/services/src/base/world_entry_appearance.rs
+++ b/crates/services/src/base/world_entry_appearance.rs
@@ -284,39 +284,52 @@ mod tests {
         assert_eq!(buf, expected, "byte-exact wire layout");
     }
 
-    /// Non-ASCII regression guard: write_wstring must emit
-    /// UTF-16-LE code units (with a UTF-16 char_count), not a
-    /// UTF-8 byte sequence (with a UTF-8 byte length). A drift to
-    /// UTF-8 would produce identical bytes for ASCII but corrupt
-    /// the wire payload for any character above 0x7F.
+    /// Non-BMP regression guard: write_wstring must use the
+    /// UTF-16 code-unit count, NOT `chars().count()`, for the
+    /// length prefix. Pick "🌟" (U+1F31F) — a single Unicode
+    /// scalar that requires a UTF-16 surrogate PAIR (D83C DF1F),
+    /// so:
+    ///   - `chars().count()`           = 1
+    ///   - `encode_utf16().count()`    = 2
+    ///   - UTF-8 byte length           = 4
     ///
-    /// "café" in UTF-16: c (0x0063), a (0x0061), f (0x0066),
-    /// é (0x00E9) → char_count = 4, byte_count = 8.
-    /// In UTF-8 the same string would be 5 bytes (é is two bytes).
-    /// Pinning byte-exact UTF-16-LE catches the drift.
+    /// All three values are distinct, so the byte-exact assertion
+    /// catches both the "drifted to UTF-8" regression and the
+    /// "used chars().count() instead of encode_utf16().count()"
+    /// regression. (A simpler character like é wouldn't distinguish
+    /// the second case because its chars and UTF-16 counts agree.)
     #[test]
-    fn build_appearance_args_emits_utf16_for_non_ascii_components() {
-        let buf = build_appearance_args("Body", &["café".to_string()]);
+    fn build_appearance_args_emits_utf16_for_non_bmp_components() {
+        let buf = build_appearance_args("Body", &["🌟".to_string()]);
         let expected: &[u8] = &[
             // bodyset wstring: "Body"
             4, 0, 0, 0, b'B', 0, b'o', 0, b'd', 0, b'y', 0, // component_count = 1
-            1, 0, 0, 0, // component "café": char_count=4, then UTF-16-LE code units
-            4, 0, 0, 0, // c (0x0063), a (0x0061), f (0x0066), é (0x00E9)
-            0x63, 0x00, 0x61, 0x00, 0x66, 0x00, 0xE9, 0x00,
+            1, 0, 0, 0,
+            // component "🌟": char_count = 2 (UTF-16 code units),
+            // then surrogate pair D83C DF1F as little-endian u16s.
+            2, 0, 0, 0, 0x3C, 0xD8, 0x1F, 0xDF,
         ];
         assert_eq!(
             buf, expected,
-            "non-ASCII string must serialize as UTF-16-LE, not UTF-8"
+            "non-BMP string must serialize as UTF-16-LE surrogate pair with code-unit count"
         );
     }
 
+    /// Empty-components case must emit the EXACT bodyset wstring
+    /// followed by a u32 zero count, with no trailing bytes. Pin
+    /// the full byte sequence (not just a length + count slice)
+    /// so a regression that drifts the bodyset payload bytes —
+    /// e.g. flipping endianness or emitting UTF-8 in the bodyset
+    /// while leaving the count zero — still fails this test.
     #[test]
     fn build_appearance_args_with_no_components_emits_zero_count() {
         let buf = build_appearance_args("X", &[]);
-        // bodyset "X": 4 + 2 = 6 bytes; then count=0 (4 bytes).
-        assert_eq!(buf.len(), 6 + 4);
-        assert_eq!(buf[0..4], [1, 0, 0, 0]);
-        assert_eq!(buf[6..10], [0, 0, 0, 0]);
+        let expected: &[u8] = &[
+            // bodyset "X": char_count = 1, then 'X' 0x00
+            1, 0, 0, 0, b'X', 0, // component_count = 0
+            0, 0, 0, 0,
+        ];
+        assert_eq!(buf, expected);
     }
 
     /// `build_tint_args` wire layout: `[u32 0][u32 0][u32 LE skin_tint]`.

--- a/crates/services/src/base/world_entry_appearance.rs
+++ b/crates/services/src/base/world_entry_appearance.rs
@@ -267,27 +267,47 @@ mod tests {
     /// `build_appearance_args` wire layout:
     /// `[wstring bodyset] [u32 LE component_count] [wstring component]*`
     /// where each wstring is `[u32 LE char_count] [UTF-16LE chars]`.
+    /// Asserts the COMPLETE byte vector against a hand-computed
+    /// expected slice — partial spot-checks would let a broken
+    /// implementation that emits the right first byte but wrong
+    /// subsequent ones still pass.
     #[test]
     fn build_appearance_args_emits_bodyset_count_components_layout() {
         let buf = build_appearance_args("Body", &["A".to_string(), "BB".to_string()]);
-        // bodyset: 4 (count) + 8 (4 chars × 2 bytes)
-        assert_eq!(buf[0..4], [4, 0, 0, 0]);
-        assert_eq!(buf[4], b'B');
-        assert_eq!(buf[5], 0);
-        // 12 bytes of bodyset wstring done.
-        // count=2 little-endian
-        assert_eq!(buf[12..16], [2, 0, 0, 0]);
-        // component "A": [1,0,0,0]['A',0]
-        assert_eq!(buf[16..20], [1, 0, 0, 0]);
-        assert_eq!(buf[20], b'A');
-        assert_eq!(buf[21], 0);
-        // component "BB": [2,0,0,0]['B',0,'B',0]
-        assert_eq!(buf[22..26], [2, 0, 0, 0]);
-        assert_eq!(buf[26], b'B');
-        assert_eq!(buf[27], 0);
-        assert_eq!(buf[28], b'B');
-        assert_eq!(buf[29], 0);
-        assert_eq!(buf.len(), 30);
+        let expected: &[u8] = &[
+            // bodyset wstring: count=4, then 'B' 0 'o' 0 'd' 0 'y' 0
+            4, 0, 0, 0, b'B', 0, b'o', 0, b'd', 0, b'y', 0, // component_count = 2
+            2, 0, 0, 0, // component "A": count=1, 'A' 0
+            1, 0, 0, 0, b'A', 0, // component "BB": count=2, 'B' 0 'B' 0
+            2, 0, 0, 0, b'B', 0, b'B', 0,
+        ];
+        assert_eq!(buf, expected, "byte-exact wire layout");
+    }
+
+    /// Non-ASCII regression guard: write_wstring must emit
+    /// UTF-16-LE code units (with a UTF-16 char_count), not a
+    /// UTF-8 byte sequence (with a UTF-8 byte length). A drift to
+    /// UTF-8 would produce identical bytes for ASCII but corrupt
+    /// the wire payload for any character above 0x7F.
+    ///
+    /// "café" in UTF-16: c (0x0063), a (0x0061), f (0x0066),
+    /// é (0x00E9) → char_count = 4, byte_count = 8.
+    /// In UTF-8 the same string would be 5 bytes (é is two bytes).
+    /// Pinning byte-exact UTF-16-LE catches the drift.
+    #[test]
+    fn build_appearance_args_emits_utf16_for_non_ascii_components() {
+        let buf = build_appearance_args("Body", &["café".to_string()]);
+        let expected: &[u8] = &[
+            // bodyset wstring: "Body"
+            4, 0, 0, 0, b'B', 0, b'o', 0, b'd', 0, b'y', 0, // component_count = 1
+            1, 0, 0, 0, // component "café": char_count=4, then UTF-16-LE code units
+            4, 0, 0, 0, // c (0x0063), a (0x0061), f (0x0066), é (0x00E9)
+            0x63, 0x00, 0x61, 0x00, 0x66, 0x00, 0xE9, 0x00,
+        ];
+        assert_eq!(
+            buf, expected,
+            "non-ASCII string must serialize as UTF-16-LE, not UTF-8"
+        );
     }
 
     #[test]

--- a/crates/services/src/base/world_entry_appearance.rs
+++ b/crates/services/src/base/world_entry_appearance.rs
@@ -258,3 +258,77 @@ pub(crate) async fn handle_cancel_movie(
 
     tracing::info!(%addr, entity_id, "cancelMovie: BeingAppearance + onEntityTint resent after cinematic");
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mercury::SKIN_TINTS;
+
+    /// `build_appearance_args` wire layout:
+    /// `[wstring bodyset] [u32 LE component_count] [wstring component]*`
+    /// where each wstring is `[u32 LE char_count] [UTF-16LE chars]`.
+    #[test]
+    fn build_appearance_args_emits_bodyset_count_components_layout() {
+        let buf = build_appearance_args("Body", &["A".to_string(), "BB".to_string()]);
+        // bodyset: 4 (count) + 8 (4 chars × 2 bytes)
+        assert_eq!(buf[0..4], [4, 0, 0, 0]);
+        assert_eq!(buf[4], b'B');
+        assert_eq!(buf[5], 0);
+        // 12 bytes of bodyset wstring done.
+        // count=2 little-endian
+        assert_eq!(buf[12..16], [2, 0, 0, 0]);
+        // component "A": [1,0,0,0]['A',0]
+        assert_eq!(buf[16..20], [1, 0, 0, 0]);
+        assert_eq!(buf[20], b'A');
+        assert_eq!(buf[21], 0);
+        // component "BB": [2,0,0,0]['B',0,'B',0]
+        assert_eq!(buf[22..26], [2, 0, 0, 0]);
+        assert_eq!(buf[26], b'B');
+        assert_eq!(buf[27], 0);
+        assert_eq!(buf[28], b'B');
+        assert_eq!(buf[29], 0);
+        assert_eq!(buf.len(), 30);
+    }
+
+    #[test]
+    fn build_appearance_args_with_no_components_emits_zero_count() {
+        let buf = build_appearance_args("X", &[]);
+        // bodyset "X": 4 + 2 = 6 bytes; then count=0 (4 bytes).
+        assert_eq!(buf.len(), 6 + 4);
+        assert_eq!(buf[0..4], [1, 0, 0, 0]);
+        assert_eq!(buf[6..10], [0, 0, 0, 0]);
+    }
+
+    /// `build_tint_args` wire layout: `[u32 0][u32 0][u32 LE skin_tint]`.
+    /// The first two slots are reserved for primary/secondary tints and
+    /// must always be zero.
+    #[test]
+    fn build_tint_args_layout_with_valid_skin_color_id() {
+        let buf = build_tint_args(3);
+        assert_eq!(buf.len(), 12);
+        assert_eq!(buf[0..4], [0, 0, 0, 0], "primary tint must be 0");
+        assert_eq!(buf[4..8], [0, 0, 0, 0], "secondary tint must be 0");
+        let tint = u32::from_le_bytes([buf[8], buf[9], buf[10], buf[11]]);
+        assert_eq!(tint, SKIN_TINTS[3]);
+    }
+
+    /// Out-of-range skin_color_id falls back to SKIN_TINTS[0]. Pin so a
+    /// future regression that panics on the index path can't crash the
+    /// world-entry flow.
+    #[test]
+    fn build_tint_args_clamps_oob_skin_color_id_to_zero() {
+        let buf = build_tint_args(999);
+        let tint = u32::from_le_bytes([buf[8], buf[9], buf[10], buf[11]]);
+        assert_eq!(tint, SKIN_TINTS[0]);
+    }
+
+    /// Negative skin_color_id casts to a huge usize and falls into the
+    /// fallback branch. Pin so the cast doesn't accidentally succeed
+    /// after a refactor (which would index into garbage).
+    #[test]
+    fn build_tint_args_negative_id_falls_back() {
+        let buf = build_tint_args(-1);
+        let tint = u32::from_le_bytes([buf[8], buf[9], buf[10], buf[11]]);
+        assert_eq!(tint, SKIN_TINTS[0]);
+    }
+}


### PR DESCRIPTION
## Summary

Closes the base bullet on #123 Group A with focused regression guards for the two highest-leverage helper files.

| File | Pinned invariants |
|---|---|
| \`world_entry_appearance.rs\` | \`build_appearance_args\` byte layout: \`[wstring bodyset] [u32 LE count] [wstring component]*\` (exact bytes for "Body" + ["A","BB"] and empty-components case). \`build_tint_args\` layout: \`[u32 0] [u32 0] [u32 LE skin_tint]\` — first two slots reserved must be zero. OOB / negative skin_color_id falls back to \`SKIN_TINTS[0]\` (cast-into-garbage-index canary). |
| \`helpers.rs\` | \`to_hex\` uppercase + space separator + \`:02X\` zero-padding — pin so refactors don't silently change every trace log. |

\`cooked_data.rs\`, \`dispatch.rs\`, \`service.rs\` are intentionally **not covered in this PR** — heavy socket/state plumbing whose testable surface needs a fixture stack (UdpSocket, ConnectedClientState, EntityManager) bigger than the value. Filing a follow-up if they become hot spots.

## Closes

- base bullet on #123 Group A.

## Test plan

- [ ] CI passes all six existing jobs.
- [ ] Reverting the SKIN_TINTS bounds-check, the wstring char-count emission, or the \`:02X\` padding makes the corresponding test fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)