### PR TITLE
ci: pass CODECOV_TOKEN and bump codecov-action to v5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -270,13 +270,19 @@ jobs:
           path: target/coverage/
           retention-days: 14
       - name: upload to Codecov
-        # Public repo, so no token needed. Codecov ingests cobertura.xml,
-        # posts a sticky PR comment with delta vs main, and renders the
-        # per-file coverage overlay in GitHub's Files-Changed tab. Settings
-        # (advisory vs blocking, drop tolerance, path ignores) live in
-        # codecov.yml at the repo root.
-        uses: codecov/codecov-action@v4
+        # Codecov ingests cobertura.xml, posts a sticky PR comment with delta
+        # vs main, and renders the per-file coverage overlay in GitHub's
+        # Files-Changed tab. Settings (advisory vs blocking, drop tolerance,
+        # path ignores) live in codecov.yml at the repo root.
+        #
+        # CODECOV_TOKEN is required even for public repos — Codecov disabled
+        # tokenless uploads. Fork PRs won't see the secret and will skip the
+        # upload (the action exits 0 when no token is present); coverage
+        # deltas for fork PRs come via Codecov's GitHub App on the merge
+        # commit instead.
+        uses: codecov/codecov-action@v5
         with:
           files: target/coverage/cobertura.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
           verbose: true


### PR DESCRIPTION
## Summary
- Codecov disabled tokenless uploads, so the `coverage` job was failing with `HTTP 400: Token required - not valid tokenless upload` after rendering cobertura.xml. Wires up the existing `CODECOV_TOKEN` repo secret.
- Bumps `codecov/codecov-action@v4` → `@v5` (v5 uses `codecov-cli` under the hood — matches what the v4 action was already invoking per the failing job log).
- Updates the comment block: drops the stale "Public repo, so no token needed" line and notes the fork-PR behavior (secret isn't exposed on `pull_request` from forks; the action exits 0 and Codecov's GitHub App picks up coverage on the merge commit instead).

Coverage report format is unchanged — still cobertura.xml from `cargo llvm-cov report --cobertura`, which is what Codecov's [supported-languages docs](https://docs.codecov.com/docs/supported-languages) list as the Rust ingestion format.

## Test plan
- [ ] CI's `coverage` job uploads successfully (no HTTP 400) and the Codecov sticky comment appears on this PR.
- [ ] Confirm the per-file coverage overlay renders in the Files-Changed tab.
- [ ] Spot-check that fork-PR runs (if any happen) skip the upload gracefully rather than failing the job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)