### PR TITLE
ci: bump checkout to v5 and upload-artifact to v6 for Node 24

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
     name: cargo fmt --check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
@@ -51,7 +51,7 @@ jobs:
     name: cargo clippy -D warnings
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
@@ -79,7 +79,7 @@ jobs:
     name: cargo build (workspace)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - name: install clang + mold
         run: sudo apt-get update && sudo apt-get install -y clang mold
@@ -107,7 +107,7 @@ jobs:
     name: cargo test (workspace, no DB)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - name: install clang + mold
         run: sudo apt-get update && sudo apt-get install -y clang mold
@@ -157,7 +157,7 @@ jobs:
     env:
       DATABASE_URL: postgres://w-testing:w-testing@localhost:5432/sgw
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - name: install clang + mold + psql
         run: sudo apt-get update && sudo apt-get install -y clang mold postgresql-client
@@ -213,7 +213,7 @@ jobs:
     env:
       DATABASE_URL: postgres://w-testing:w-testing@localhost:5432/sgw
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: llvm-tools-preview
@@ -264,7 +264,7 @@ jobs:
           cat target/coverage/summary.txt >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
       - name: upload coverage artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: coverage-report
           path: target/coverage/


### PR DESCRIPTION
## Summary
GitHub is forcing Node 24 on runners 2026-06-02 and removing Node 20 entirely 2026-09-16 ([blog post](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). The runner currently warns about \`actions/checkout@v4\` on every job in this workflow.

- \`actions/checkout@v4\` → \`@v5\` in all six jobs (fmt, clippy, build, test, test-live-db, coverage). v5 is the major that migrated to Node 24.
- \`actions/upload-artifact@v4\` → \`@v6\`. v6 is the Node 24 bump; skipped v7 deliberately because it ships behavioral changes (Direct Uploads) and we only want the runtime fix here.

## Actions left alone
- \`Swatinem/rust-cache@v2\` — v2.9 already migrated to Node 24, the v2 tag tracks that line.
- \`dtolnay/rust-toolchain@stable\` — composite action, no Node runtime.
- \`taiki-e/install-action@cargo-llvm-cov\` — composite action, no Node runtime.
- \`codecov/codecov-action@v5\` — already Node 24 (landing in #188).

## Test plan
- [ ] No more "Node.js 20 actions are deprecated" warnings in the CI run on this PR.
- [ ] All six jobs (fmt, clippy, build, test, test-live-db, coverage) still pass.
- [ ] The coverage artifact uploads + downloads cleanly under upload-artifact v6.
- [ ] Caches restore correctly post-checkout-v5 bump (sanity-check the rust-cache hit/miss line in each job log).

🤖 Generated with [Claude Code](https://claude.com/claude-code)