### PR TITLE
test(aoi): differential property — diff-accumulated witness set ≡ actual set every tick (issue #123 Group E)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,6 +200,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -634,6 +649,7 @@ dependencies = [
  "cimmeria-entity",
  "cimmeria-game",
  "cimmeria-mercury",
+ "proptest",
  "quick-xml 0.37.5",
  "rand 0.9.2",
  "rand_chacha 0.9.0",
@@ -3471,10 +3487,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.11.0",
+ "num-traits",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "pxfm"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
@@ -3633,6 +3674,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3993,6 +4043,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -5773,6 +5835,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unic-char-property"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5996,6 +6064,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb067e4cbd1ff067d1df46c9194b5de0e98efd2810bbc95c5d5e5f25a3231150"
 dependencies = [
  "cc",
+ "libc",
+]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
  "libc",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # Auth
 jsonwebtoken = "9"
 
-# Property-based testing (used as dev-dependency in mercury + services)
+# Property-based testing (used as dev-dependency in services)
 proptest = "1"
 
 # Logging

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,9 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # Auth
 jsonwebtoken = "9"
 
+# Property-based testing (used as dev-dependency in mercury + services)
+proptest = "1"
+
 # Logging
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }

--- a/crates/services/Cargo.toml
+++ b/crates/services/Cargo.toml
@@ -31,3 +31,8 @@ anyhow = { workspace = true }
 # endpoints in-process). Already used elsewhere in the workspace, so
 # version comes from the workspace lock.
 reqwest = { workspace = true }
+
+# Property-based testing — used by the AoI differential test to drive
+# random entity walks across many ticks and verify that the per-event
+# diff-accumulated witness set always equals the actual witness set.
+proptest = { workspace = true }

--- a/crates/services/src/cell/space_manager/aoi_differential_test.rs
+++ b/crates/services/src/cell/space_manager/aoi_differential_test.rs
@@ -52,14 +52,16 @@ fn arb_initial_pos() -> impl Strategy<Value = [f32; 3]> {
     (r.clone(), r).prop_map(|(x, z)| [x, 0.0, z])
 }
 
-/// Per-tick displacement vector. Bounded so an entity can move at
-/// most ~50 units per tick — comparable to a sprint in real play —
-/// without teleporting across the entire world. Crucially, the
-/// magnitude can exceed the AoI radius (100), so a single tick can
+/// Per-tick displacement vector. Bounded at ±80 per axis so an entity
+/// can move up to ~113 units of euclidean distance in one tick —
+/// comfortably above the 100-unit AoI radius, so a single tick can
 /// move an entity from outside-AoI to inside or vice versa, exercising
-/// both transition arms of the diff.
+/// both transition arms of the diff. The previous ±50 cap maxed out
+/// at √(50²+50²) ≈ 70.7 which couldn't cross the radius in one tick;
+/// the comment claimed it could, and the sibling assertion needs
+/// outside↔inside crossings to actually exercise the fast-mover path.
 fn arb_step() -> impl Strategy<Value = [f32; 3]> {
-    let r = -50.0f32..=50.0f32;
+    let r = -80.0f32..=80.0f32;
     (r.clone(), r).prop_map(|(dx, dz)| [dx, 0.0, dz])
 }
 

--- a/crates/services/src/cell/space_manager/aoi_differential_test.rs
+++ b/crates/services/src/cell/space_manager/aoi_differential_test.rs
@@ -1,0 +1,199 @@
+//! Differential property test for the AoI diff machinery.
+//!
+//! For every player, every tick, the contract is:
+//!
+//!     after_witnesses == apply_diff(before_witnesses, events)
+//!
+//! where `events` is the slice of `EnteredAoI` / `LeftAoI` events
+//! emitted by `compute_aoi_changes` for that player on that tick.
+//! If a `LeftAoI` is dropped or an `EnteredAoI` is double-fired,
+//! the diff-accumulated set drifts from the actual one and this
+//! test fails — pointing the reviewer at the exact tick + entity
+//! pair where the divergence first surfaces.
+//!
+//! The walk uses proptest to drive random entity placement and
+//! per-tick movement vectors, so a regression that only triggers
+//! on a specific spatial pattern (e.g. an entity exiting AoI on the
+//! same tick it crosses a grid-cell boundary) gets shrunk to a
+//! minimal counterexample rather than buried in an opaque scripted
+//! scenario.
+
+use super::SpaceManager;
+use crate::cell::messages::CellToBaseMsg;
+use cimmeria_common::EntityId;
+use proptest::prelude::*;
+use std::collections::{HashMap, HashSet};
+
+const TEST_SPACES_XML: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<Spaces>
+    <Space WorldName="Agnos" Instanced="false" MinX="-2400" MaxX="2200" MinY="-3200" MaxY="2800" />
+</Spaces>"#;
+
+const TEST_CELL_SPACES_XML: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<Spaces>
+    <Space WorldName="Agnos" />
+</Spaces>"#;
+
+fn make_manager() -> SpaceManager {
+    let mut mgr = SpaceManager::new(1);
+    mgr.parse_spaces_xml(TEST_SPACES_XML).unwrap();
+    mgr.create_startup_spaces(TEST_CELL_SPACES_XML).unwrap();
+    mgr
+}
+
+const WORLD_HALF_WIDTH: f32 = 800.0;
+
+/// Initial entity placement: position drawn from a uniform square
+/// around the origin, well inside the Agnos world bounds. Strict
+/// f32 ranges keep proptest from picking NaN / infinity inputs that
+/// the AoI code isn't expected to handle.
+fn arb_initial_pos() -> impl Strategy<Value = [f32; 3]> {
+    let r = -WORLD_HALF_WIDTH..=WORLD_HALF_WIDTH;
+    (r.clone(), r).prop_map(|(x, z)| [x, 0.0, z])
+}
+
+/// Per-tick displacement vector. Bounded so an entity can move at
+/// most ~50 units per tick — comparable to a sprint in real play —
+/// without teleporting across the entire world. Crucially, the
+/// magnitude can exceed the AoI radius (100), so a single tick can
+/// move an entity from outside-AoI to inside or vice versa, exercising
+/// both transition arms of the diff.
+fn arb_step() -> impl Strategy<Value = [f32; 3]> {
+    let r = -50.0f32..=50.0f32;
+    (r.clone(), r).prop_map(|(dx, dz)| [dx, 0.0, dz])
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        // 16 cases each at 12 entities × 25 ticks = ~4800 ticks of
+        // simulation per run. That's enough to surface a missed-
+        // LeftAoI bug while keeping the workspace `cargo test`
+        // runtime well under one second for this property.
+        cases: 16,
+        ..ProptestConfig::default()
+    })]
+
+    /// For every player, on every tick, the diff-accumulated witness
+    /// set (prior + EnteredAoI - LeftAoI) must exactly equal the
+    /// post-tick witness set on the entity. A regression that drops
+    /// a LeftAoI when an entity exits AoI would surface here as a
+    /// stale entry in the diff-accumulated set; a phantom EnteredAoI
+    /// would surface as an extra entry.
+    #[test]
+    fn witness_set_equals_diff_accumulated_set_after_every_tick(
+        // 4 players, 8 NPCs — enough to get meaningful AoI churn
+        // without runaway runtime.
+        initial_positions in proptest::collection::vec(arb_initial_pos(), 12),
+        // 25 ticks × 12 entities of step vectors. Pre-generated so
+        // the proptest shrinker can shrink the *sequence* — when a
+        // failure happens, proptest minimises the trajectory until
+        // it finds the smallest one that still triggers the divergence.
+        per_tick_steps in proptest::collection::vec(
+            proptest::collection::vec(arb_step(), 12),
+            25,
+        ),
+    ) {
+        const PLAYER_COUNT: u32 = 4;
+        const ENTITY_COUNT: u32 = 12;
+        const ID_BASE: u32 = 100;
+
+        let mut mgr = make_manager();
+
+        // Seed all entities. The first PLAYER_COUNT are connected
+        // players (have witness sets and are observers); the rest are
+        // NPCs (observable but don't observe).
+        for i in 0..ENTITY_COUNT {
+            let id = ID_BASE + i;
+            let pos = initial_positions[i as usize];
+            if i < PLAYER_COUNT {
+                mgr.create_entity(id, "Agnos", pos, [0.0; 3]).unwrap();
+                mgr.connect_entity(id);
+            } else {
+                mgr.spawn_npc(id, "Agnos", pos, [0.0; 3]).unwrap();
+            }
+        }
+
+        // Initial tick to populate witness sets — without this, the
+        // first per-tick step would observe before/after sets that
+        // both equal "everything in range from the seed positions",
+        // which is fine but skips the EnteredAoI events from the
+        // initial population.
+        let _ = mgr.compute_aoi_changes();
+
+        // For each subsequent tick, capture per-player before/after
+        // witness sets + the events emitted, and verify the diff
+        // contract.
+        for (tick_idx, step_set) in per_tick_steps.iter().enumerate() {
+            // Snapshot every player's witness set BEFORE this tick.
+            let before: HashMap<u32, HashSet<u32>> = (0..PLAYER_COUNT)
+                .map(|p| {
+                    let id = ID_BASE + p;
+                    let wit: HashSet<u32> = mgr
+                        .get_entity(id)
+                        .map(|e| e.witnesses.iter().map(|EntityId(i)| *i as u32).collect())
+                        .unwrap_or_default();
+                    (id, wit)
+                })
+                .collect();
+
+            // Apply the step to every entity.
+            for i in 0..ENTITY_COUNT {
+                let id = ID_BASE + i;
+                let step = step_set[i as usize];
+                let cur_pos = mgr.get_entity(id).map(|e| e.position).unwrap();
+                let new_pos = [
+                    (cur_pos.x + step[0]).clamp(-WORLD_HALF_WIDTH, WORLD_HALF_WIDTH),
+                    0.0,
+                    (cur_pos.z + step[2]).clamp(-WORLD_HALF_WIDTH, WORLD_HALF_WIDTH),
+                ];
+                mgr.update_entity_position(id, new_pos, [0, 0, 0], [0.0; 3]);
+            }
+
+            let events = mgr.compute_aoi_changes();
+
+            // Apply the per-player events to the before-snapshots and
+            // compare to the actual after-tick witness sets.
+            for p in 0..PLAYER_COUNT {
+                let player_id = ID_BASE + p;
+                let mut diffed = before.get(&player_id).cloned().unwrap_or_default();
+                for ev in &events {
+                    match ev {
+                        CellToBaseMsg::EnteredAoI {
+                            witness_id,
+                            entity_id,
+                            ..
+                        } if *witness_id == player_id => {
+                            diffed.insert(*entity_id);
+                        }
+                        CellToBaseMsg::LeftAoI {
+                            witness_id,
+                            entity_id,
+                        } if *witness_id == player_id => {
+                            diffed.remove(entity_id);
+                        }
+                        _ => {}
+                    }
+                }
+
+                let actual: HashSet<u32> = mgr
+                    .get_entity(player_id)
+                    .map(|e| e.witnesses.iter().map(|EntityId(i)| *i as u32).collect())
+                    .unwrap_or_default();
+
+                prop_assert_eq!(
+                    &diffed,
+                    &actual,
+                    "tick {}, player {}: witness set must equal diff-accumulated set. \
+                     diff-accumulated had {:?}, actual had {:?}; \
+                     missing-from-actual = {:?}, extra-in-actual = {:?}",
+                    tick_idx,
+                    player_id,
+                    diffed,
+                    actual,
+                    diffed.difference(&actual).collect::<Vec<_>>(),
+                    actual.difference(&diffed).collect::<Vec<_>>()
+                );
+            }
+        }
+    }
+}

--- a/crates/services/src/cell/space_manager/mod.rs
+++ b/crates/services/src/cell/space_manager/mod.rs
@@ -24,6 +24,9 @@ mod tests;
 #[cfg(test)]
 mod aoi_churn_smoke;
 
+#[cfg(test)]
+mod aoi_differential_test;
+
 /// Grid cell size for spatial hashing (world units).
 pub(crate) const GRID_CELL_SIZE: f32 = 50.0;
 


### PR DESCRIPTION
## Summary

Adds a proptest under `cell/space_manager/aoi_differential_test.rs` that pins the load-bearing AoI invariant:

```
after_witnesses == apply_diff(before_witnesses, events)
```

For every player, every tick, the post-tick witness set on the entity must exactly equal `prior_set + EnteredAoI events - LeftAoI events`.

### What this catches

- **Dropped `LeftAoI`** — surfaces as a stale entry in the diff-accumulated set
- **Phantom `EnteredAoI`** — surfaces as an extra entry in the diff-accumulated set
- **Mis-attributed `witness_id`** — surfaces as an event that affects the wrong player's diff set
- **Spatial-hash bugs that only trigger on grid-cell boundary crossings** — proptest's random trajectory generation reaches these naturally

### Test shape

- 4 connected players + 8 NPCs (12 entities total)
- Random initial positions in a 1600×1600 square — far enough apart that not everyone starts in everyone else's AoI
- 25 ticks of random per-entity displacement vectors; step magnitudes can exceed the 100-unit AoI radius, so a single tick can trigger both enter and leave transitions
- 16 proptest cases × 25 ticks × 12 entities = **4800 tick-checks per run**

### Why proptest over a seeded deterministic walk

The shrinker. When the property fails, proptest minimises both the initial positions AND the per-tick step sequence until it finds the smallest trajectory that still triggers the divergence — pointing the reviewer at the exact tick where the witness set drifts rather than burying the failure in a 4800-tick log.

## Test plan

- [x] `cargo fmt --all -- --check` (clean)
- [x] `cargo clippy -p cimmeria-services --all-targets -- -D warnings` (clean)
- [x] `cargo test -p cimmeria-services --lib aoi_differential` (1 passing)

`proptest` added as a dev-dependency in cimmeria-services (workspace dep declared at root).

Refs #123 (Group E item: AoI differential test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)