### PR TITLE
test(mercury): cargo-fuzz scaffolding + stable-Rust never-panic proptest (issue #123 Group E)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,6 +200,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -572,6 +587,7 @@ dependencies = [
  "digest",
  "hmac",
  "md-5",
+ "proptest",
  "rand 0.9.2",
  "thiserror 2.0.18",
  "tokio",
@@ -3471,10 +3487,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.11.0",
+ "num-traits",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "pxfm"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
@@ -3633,6 +3674,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3993,6 +4043,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -5773,6 +5835,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unic-char-property"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5996,6 +6064,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb067e4cbd1ff067d1df46c9194b5de0e98efd2810bbc95c5d5e5f25a3231150"
 dependencies = [
  "cc",
+ "libc",
+]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
  "libc",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,10 @@
 resolver = "2"
 exclude = [
     "tools/SGWLauncher/src-tauri",
+    # cargo-fuzz target — depends on libfuzzer-sys which requires
+    # nightly Rust. Run manually via `cargo +nightly fuzz run <target>`
+    # from inside `fuzz/`. See fuzz/README.md for invocation.
+    "fuzz",
 ]
 members = [
     "crates/common",
@@ -94,6 +98,9 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 
 # Auth
 jsonwebtoken = "9"
+
+# Property-based testing (used as dev-dependency in mercury)
+proptest = "1"
 
 # Logging
 tracing = "0.1"

--- a/crates/mercury/Cargo.toml
+++ b/crates/mercury/Cargo.toml
@@ -28,5 +28,5 @@ digest = "0.10"
 [dev-dependencies]
 # Property-based "never panics on arbitrary bytes" coverage for
 # parse_incoming. Stable-Rust complement to the cargo-fuzz target
-# in /fuzz/parse_incoming.rs (which needs nightly).
+# at /fuzz/fuzz_targets/parse_incoming.rs (which needs nightly).
 proptest = { workspace = true }

--- a/crates/mercury/Cargo.toml
+++ b/crates/mercury/Cargo.toml
@@ -24,3 +24,9 @@ md-5 = { workspace = true }
 tokio-util = { version = "0.7", features = ["codec"] }
 cipher = "0.4"
 digest = "0.10"
+
+[dev-dependencies]
+# Property-based "never panics on arbitrary bytes" coverage for
+# parse_incoming. Stable-Rust complement to the cargo-fuzz target
+# in /fuzz/parse_incoming.rs (which needs nightly).
+proptest = { workspace = true }

--- a/crates/mercury/src/packet.rs
+++ b/crates/mercury/src/packet.rs
@@ -24,6 +24,9 @@ use bytes::{BufMut, Bytes, BytesMut};
 use cimmeria_common::{CimmeriaError, Result};
 
 #[cfg(test)]
+mod parse_proptest;
+
+#[cfg(test)]
 mod replay_smoke;
 
 // ── Flag byte constants (C++ packet.hpp) ────────────────────────────────────

--- a/crates/mercury/src/packet/parse_proptest.rs
+++ b/crates/mercury/src/packet/parse_proptest.rs
@@ -1,0 +1,62 @@
+//! Property test: `parse_incoming` must never panic, regardless of
+//! input length or contents.
+//!
+//! The stable-Rust complement to the cargo-fuzz target in
+//! [`fuzz/fuzz_targets/parse_incoming.rs`](../../../../../fuzz/fuzz_targets/parse_incoming.rs).
+//! Fuzzing requires nightly Rust (libfuzzer-sys); this proptest runs
+//! in every per-PR CI invocation under stable. It catches the
+//! obvious panic sources (unchecked indexing, integer overflow,
+//! pathological allocations driven by user-supplied counts) without
+//! the coverage-guided exploration cargo-fuzz brings.
+//!
+//! Contract: for ANY byte slice, `parse_incoming` returns either
+//! `Ok(ParsedPacket)` or `Err(CimmeriaError)`. A panic is a bug.
+
+use super::parse_incoming;
+use proptest::prelude::*;
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        // 4096 random byte sequences per run. Much higher than the
+        // 256-case round-trip property because the input space here
+        // is wider (all u8 sequences in 0..=512 bytes long) and the
+        // assertion is just "didn't panic" — fast to evaluate.
+        cases: 4096,
+        ..ProptestConfig::default()
+    })]
+
+    /// Arbitrary byte input must never crash the parser. Length range
+    /// 0..=512 covers: empty buffer (BufferUnderflow path), realistic
+    /// UDP datagrams (≤ MTU ~ 1500), and over-long inputs that exercise
+    /// the bound-strip arithmetic in `pop_u32_le!` etc.
+    #[test]
+    fn parse_incoming_never_panics_on_arbitrary_bytes(
+        raw in proptest::collection::vec(any::<u8>(), 0..=512),
+    ) {
+        // The result is intentionally discarded — we only care that
+        // the call returns rather than panicking. Wrapping in
+        // catch_unwind would convert a panic into a test failure,
+        // but the test runner already does that for us — a panic in
+        // this body fails the property and proptest shrinks the
+        // input to a minimal repro.
+        let _ = parse_incoming(&raw);
+    }
+
+    /// Specifically exercise the FLAG_HAS_REQUESTS / FLAG_HAS_ACKS /
+    /// FLAG_HAS_SEQUENCE / FLAG_FRAGMENTED bits in the leading flags
+    /// byte. The general property above also hits these by chance,
+    /// but seeding the first byte with a flag combination
+    /// systematically makes the footer-strip paths get exercised
+    /// even when the body is too short to hold them — the failure
+    /// mode that triggers BufferUnderflow.
+    #[test]
+    fn parse_incoming_handles_truncated_footer_input_without_panic(
+        flags in any::<u8>(),
+        body in proptest::collection::vec(any::<u8>(), 0..=64),
+    ) {
+        let mut raw = Vec::with_capacity(1 + body.len());
+        raw.push(flags);
+        raw.extend_from_slice(&body);
+        let _ = parse_incoming(&raw);
+    }
+}

--- a/crates/mercury/src/packet/parse_proptest.rs
+++ b/crates/mercury/src/packet/parse_proptest.rs
@@ -1,8 +1,9 @@
 //! Property test: `parse_incoming` must never panic, regardless of
 //! input length or contents.
 //!
-//! The stable-Rust complement to the cargo-fuzz target in
-//! [`fuzz/fuzz_targets/parse_incoming.rs`](../../../../../fuzz/fuzz_targets/parse_incoming.rs).
+//! The stable-Rust complement to the cargo-fuzz target at
+//! `fuzz/fuzz_targets/parse_incoming.rs` (run via
+//! `cargo +nightly fuzz run parse_incoming` from `fuzz/`).
 //! Fuzzing requires nightly Rust (libfuzzer-sys); this proptest runs
 //! in every per-PR CI invocation under stable. It catches the
 //! obvious panic sources (unchecked indexing, integer overflow,
@@ -19,19 +20,24 @@ proptest! {
     #![proptest_config(ProptestConfig {
         // 4096 random byte sequences per run. Much higher than the
         // 256-case round-trip property because the input space here
-        // is wider (all u8 sequences in 0..=512 bytes long) and the
+        // is wider (all u8 sequences in 0..=1500 bytes long) and the
         // assertion is just "didn't panic" — fast to evaluate.
         cases: 4096,
         ..ProptestConfig::default()
     })]
 
     /// Arbitrary byte input must never crash the parser. Length range
-    /// 0..=512 covers: empty buffer (BufferUnderflow path), realistic
-    /// UDP datagrams (≤ MTU ~ 1500), and over-long inputs that exercise
-    /// the bound-strip arithmetic in `pop_u32_le!` etc.
+    /// 0..=1500 covers: empty buffer (BufferUnderflow path), every
+    /// length up through Ethernet MTU-sized UDP datagrams (Mercury's
+    /// PACKET_MAX_SIZE is 1472), and inputs longer than any valid
+    /// frame so the bound-strip arithmetic in `pop_u32_le!` etc.
+    /// gets exercised on payloads where every footer would still
+    /// have room. parse_incoming has no upper-length cap of its own,
+    /// so any byte budget here is fine — capping at 1500 keeps the
+    /// proptest runtime bounded.
     #[test]
     fn parse_incoming_never_panics_on_arbitrary_bytes(
-        raw in proptest::collection::vec(any::<u8>(), 0..=512),
+        raw in proptest::collection::vec(any::<u8>(), 0..=1500),
     ) {
         // The result is intentionally discarded — we only care that
         // the call returns rather than panicking. Wrapping in

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -14,7 +14,6 @@ cargo-fuzz = true
 [dependencies]
 libfuzzer-sys = "0.4"
 cimmeria-mercury = { path = "../crates/mercury" }
-cimmeria-common = { path = "../crates/common" }
 
 [[bin]]
 name = "parse_incoming"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "cimmeria-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+# This crate is excluded from the workspace because libfuzzer-sys
+# requires nightly Rust. Run manually from this directory under a
+# nightly toolchain — see README.md.
+
+[dependencies]
+libfuzzer-sys = "0.4"
+cimmeria-mercury = { path = "../crates/mercury" }
+cimmeria-common = { path = "../crates/common" }
+
+[[bin]]
+name = "parse_incoming"
+path = "fuzz_targets/parse_incoming.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "add_fragment"
+path = "fuzz_targets/add_fragment.rs"
+test = false
+doc = false

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -8,10 +8,13 @@ most corruption-exposed surface in the codebase.
 - **`parse_incoming`** — drives `cimmeria_mercury::packet::parse_incoming`
   with arbitrary bytes. Must never panic on any input.
 - **`add_fragment`** — chains `parse_incoming` → `FragmentAssembler::process_parsed`.
-  Drives the fragment header parser + reassembly state machine with
-  arbitrary input. Must never panic regardless of how malicious the
-  fragment headers are (impossible total counts, conflicting first_seq
-  values across fragments, repeats, etc.).
+  Drives the reassembly state machine, which derives the reassembly
+  key / fragment index / total count from the parsed footer fields
+  (`seq_id`, `frag_begin`, `frag_end`) and treats the packet body as
+  fragment payload. Must never panic regardless of how malicious the
+  footer values are: inverted ranges (`frag_begin > frag_end`),
+  ranges exceeding `MAX_FRAGMENTS`, seq IDs outside
+  `[frag_begin, frag_end]`, etc.
 
 ## Why this crate is excluded from the workspace
 

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -1,0 +1,59 @@
+# cimmeria-fuzz
+
+Fuzz targets for the Mercury wire-level decode path — the
+most corruption-exposed surface in the codebase.
+
+## Targets
+
+- **`parse_incoming`** — drives `cimmeria_mercury::packet::parse_incoming`
+  with arbitrary bytes. Must never panic on any input.
+- **`add_fragment`** — chains `parse_incoming` → `FragmentAssembler::process_parsed`.
+  Drives the fragment header parser + reassembly state machine with
+  arbitrary input. Must never panic regardless of how malicious the
+  fragment headers are (impossible total counts, conflicting first_seq
+  values across fragments, repeats, etc.).
+
+## Why this crate is excluded from the workspace
+
+`libfuzzer-sys` requires nightly Rust (the `-Z sanitizer` flag).
+Including the crate as a regular workspace member would force the
+whole workspace onto a nightly toolchain even when only stable
+crates are being built. Excluded here so `cargo build --workspace`
+on stable continues to work.
+
+## Running
+
+```bash
+# One-time setup
+cargo install cargo-fuzz
+
+# From the repository root, change into this directory:
+cd fuzz
+
+# Run a single target indefinitely (Ctrl+C to stop)
+cargo +nightly fuzz run parse_incoming
+
+# Time-bound run (e.g. 60 seconds — useful for CI)
+cargo +nightly fuzz run parse_incoming -- -max_total_time=60
+cargo +nightly fuzz run add_fragment    -- -max_total_time=60
+
+# Reproduce a crash from a saved input
+cargo +nightly fuzz run parse_incoming -- artifacts/parse_incoming/crash-<hash>
+```
+
+## CI integration
+
+Not currently wired into the per-PR workflow because nightly Rust
+is not part of the default toolchain. Add a separate scheduled
+workflow (e.g. nightly cron) that runs each target for a few
+minutes and uploads any crash artefacts when it finds them.
+
+## Stable-Rust complement
+
+A stable-Rust property test in
+[`crates/mercury/src/packet/parse_proptest.rs`](../crates/mercury/src/packet/parse_proptest.rs)
+covers the same "never panics on arbitrary input" contract using
+proptest, which runs in every per-PR CI invocation. It's not as
+thorough as fuzzing — proptest has a shrinker but no coverage-
+guided exploration — but it catches the obvious panic sources
+without the nightly dependency.

--- a/fuzz/fuzz_targets/add_fragment.rs
+++ b/fuzz/fuzz_targets/add_fragment.rs
@@ -1,0 +1,32 @@
+//! Fuzz target for `FragmentAssembler::process_parsed`.
+//!
+//! Fragment reassembly is the second corruption-exposed surface:
+//! after `parse_incoming` succeeds, fragmented packets feed their
+//! body bytes through `process_parsed`, which reads a 6-byte header
+//! (fragment_index, total_fragments, first_seq) and dispatches to
+//! the assembler. A pathological header (claiming 255 fragments,
+//! claiming index ≥ total, varying first_seq across fragments,
+//! sending the same fragment twice) is the second class of input
+//! that must not panic / OOM.
+//!
+//! The harness chains parse_incoming → process_parsed so every
+//! input is exercised through the production decode path. We accept
+//! that some inputs will fail parse_incoming and skip — the goal is
+//! that NEITHER call panics on any input.
+
+#![no_main]
+
+use cimmeria_mercury::packet::parse_incoming;
+use cimmeria_mercury::unpacker::FragmentAssembler;
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    // Build a fresh assembler per input so state doesn't accumulate
+    // across cases — keeps the corpus minimisation work focused on
+    // the parser/assembler logic rather than on state-machine paths
+    // that depend on prior inputs.
+    let mut asm = FragmentAssembler::new();
+    if let Ok(pkt) = parse_incoming(data) {
+        let _ = asm.process_parsed(&pkt);
+    }
+});

--- a/fuzz/fuzz_targets/add_fragment.rs
+++ b/fuzz/fuzz_targets/add_fragment.rs
@@ -1,13 +1,15 @@
 //! Fuzz target for `FragmentAssembler::process_parsed`.
 //!
 //! Fragment reassembly is the second corruption-exposed surface:
-//! after `parse_incoming` succeeds, fragmented packets feed their
-//! body bytes through `process_parsed`, which reads a 6-byte header
-//! (fragment_index, total_fragments, first_seq) and dispatches to
-//! the assembler. A pathological header (claiming 255 fragments,
-//! claiming index ≥ total, varying first_seq across fragments,
-//! sending the same fragment twice) is the second class of input
-//! that must not panic / OOM.
+//! after `parse_incoming` succeeds on a `FLAG_FRAGMENTED` packet,
+//! `process_parsed` reads the parsed FOOTER fields (`seq_id`,
+//! `frag_begin`, `frag_end`) — NOT a body header — to derive the
+//! reassembly key, this fragment's index, and the total fragment
+//! count. The body bytes are the fragment's payload. Adversarial
+//! inputs (frag_begin > frag_end, range exceeding MAX_FRAGMENTS,
+//! seq outside [frag_begin, frag_end], repeated indices, conflicting
+//! frag_begin / frag_end across fragments) must not panic, OOM, or
+//! unboundedly allocate.
 //!
 //! The harness chains parse_incoming → process_parsed so every
 //! input is exercised through the production decode path. We accept

--- a/fuzz/fuzz_targets/parse_incoming.rs
+++ b/fuzz/fuzz_targets/parse_incoming.rs
@@ -1,0 +1,22 @@
+//! Fuzz target for `parse_incoming` — the wire-level UDP datagram parser.
+//!
+//! This is the most corruption-exposed surface in the codebase: every
+//! UDP packet that reaches the server is fed through it before any
+//! authentication or encryption check. A panic / OOM / pathological
+//! allocation triggered by adversarial input is a denial-of-service
+//! vector.
+//!
+//! Contract under test: `parse_incoming` must NEVER panic, regardless
+//! of input length / contents. It must EITHER return `Ok(ParsedPacket)`
+//! OR return `Err(CimmeriaError)`. Crashes here are bugs.
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    // Drop the result — we only care about not panicking. libfuzzer
+    // catches panics, OOMs, and timeouts; the harness's only job is
+    // to drive the function with arbitrary bytes.
+    let _ = cimmeria_mercury::packet::parse_incoming(data);
+});


### PR DESCRIPTION
## Summary

Two-track coverage for the wire-decode surface — the most corruption-exposed code path in the codebase.

### Track 1: cargo-fuzz scaffolding (`/fuzz/`)

New crate excluded from the workspace because `libfuzzer-sys` requires nightly Rust (workspace stays buildable on stable).

Two targets:

- **`parse_incoming`** — drives bytes through the wire-level UDP parser. Every UDP datagram passes through it before any auth/encrypt check, so a panic here is a DoS vector.
- **`add_fragment`** — chains `parse_incoming` → `FragmentAssembler::process_parsed`. Drives the fragment header parser + reassembly state machine with arbitrary input (impossible total counts, conflicting `first_seq` across fragments, repeated indices).

Run via:
```bash
cd fuzz
cargo +nightly fuzz run parse_incoming -- -max_total_time=60
cargo +nightly fuzz run add_fragment    -- -max_total_time=60
```

`fuzz/README.md` documents invocation, CI integration suggestion (separate scheduled nightly job), and points at the stable-Rust complement.

### Track 2: stable-Rust proptest (`crates/mercury/src/packet/parse_proptest.rs`)

Runs in every per-PR CI invocation under stable. Two properties:

- **`parse_incoming_never_panics_on_arbitrary_bytes`** — 4096 cases of random byte sequences (0..=512 bytes). Catches the obvious panic sources without nightly.
- **`parse_incoming_handles_truncated_footer_input_without_panic`** — seeds the leading flags byte systematically so footer-strip paths get exercised even when the body is too short to hold them. Exercises the `BufferUnderflow` path on every flag combination.

Not as thorough as fuzzing (proptest has a shrinker but no coverage-guided exploration), but catches the obvious panic sources and runs in every PR without the nightly toolchain dependency.

## Test plan

- [x] `cargo fmt --all -- --check` (clean)
- [x] `cargo clippy -p cimmeria-mercury --all-targets -- -D warnings` (clean)
- [x] `cargo test -p cimmeria-mercury --lib parse_proptest` (2 passing, 4096 + 4096 cases)
- [x] `cargo build --workspace ${CI_EXCLUDES}` (clean — fuzz crate excluded so this passes on stable)

`proptest` declared as a workspace dep + dev-dep in mercury. The `fuzz` crate has its own `Cargo.toml` and pulls `libfuzzer-sys` only when built directly under nightly.

Refs #123 (Group E item: cargo fuzz target on unpacker::unpack + packet::parse).

🤖 Generated with [Claude Code](https://claude.com/claude-code)