### PR TITLE
fix(content): unswap Prisoner 329 archetype-gated dialog routing (#216)

### DIFF
--- a/crates/services/src/cell/content/chain_replay_tests.rs
+++ b/crates/services/src/cell/content/chain_replay_tests.rs
@@ -325,3 +325,185 @@ async fn chain_1051_does_not_fire_when_mission_641_active() {
          {chain_1051_actions} actions.",
     );
 }
+
+// ────────────────────────────────────────────────────────────────────
+// Mission 638 (Speak to Prisoner 329) — archetype-gated dialog routing
+// ────────────────────────────────────────────────────────────────────
+//
+// Chains 1011 (non-Jaffa) and 1012 (Jaffa) had their `add_dialog_set`
+// IDs swapped relative to the archetype condition (issue #216), so a
+// Tau'ri / Human player saw the Jaffa "My symbiote will cure me"
+// dialog and vice versa.
+//
+// The shared helper [`assert_region_enter_resolves_dialog_set`] is the
+// reusable shape for any future archetype-gated dialog regression
+// guard: pass a chain id, an archetype value, and the dialog_set_map id
+// you expect the chain to add. Every other archetype-routed dialog
+// pair in the seed (1056/1057, future siblings) can be regression-
+// guarded by adding two calls.
+
+/// Load `chain_id`, fire a `RegionEnter('Castle_Cellblock.Region2')`
+/// event with the supplied `archetype` (and `mission_638_status =
+/// 'not_active'` so the mission-gate condition passes), and assert
+/// that the resolved actions contain exactly one `AddDialogSet` whose
+/// `dialog_set_id` matches `expected_dialog_set_map`.
+///
+/// `expected_dialog_set_map` is the `dialog_set_maps.dialog_set_map_id`
+/// (i.e., the `target_id` column on the `add_dialog_set` action row),
+/// not the `dialog_set_id` it groups under. The Rust field is named
+/// `dialog_set_id` for historical reasons; the value stored is the
+/// per-archetype map row.
+async fn assert_region_enter_resolves_dialog_set(
+    chain_id: i32,
+    archetype: i32,
+    expected_dialog_set_map: i32,
+) {
+    use cimmeria_content_engine::actions::Action;
+
+    let pool = require_db_or_skip!();
+    let chain = load_single_chain_for_test(&pool, chain_id)
+        .await
+        .unwrap_or_else(|e| panic!("DB query for chain {chain_id} must succeed: {e}"))
+        .unwrap_or_else(|| panic!("chain {chain_id} must exist in seeded content_chains"));
+
+    let mut engine = ChainEngine::new();
+    engine.register_chain(chain);
+
+    let mut ctx = ExecutionContext::new();
+    ctx.set_param(
+        "region_key".to_string(),
+        serde_json::json!("Castle_Cellblock.Region2"),
+    );
+    ctx.set_param(
+        "mission_638_status".to_string(),
+        serde_json::json!("not_active"),
+    );
+    ctx.set_param("archetype".to_string(), serde_json::json!(archetype));
+
+    let event = TriggerEvent {
+        trigger_type: TriggerType::RegionEnter,
+        source_entity: None,
+        target_entity: None,
+        params: ctx.params.clone(),
+    };
+
+    let resolved = engine.resolve_event(&event, &ctx);
+
+    let actual: Vec<i32> = resolved
+        .actions
+        .iter()
+        .filter_map(|(_, action)| match action {
+            Action::AddDialogSet { dialog_set_id, .. } => Some(*dialog_set_id),
+            _ => None,
+        })
+        .collect();
+
+    assert_eq!(
+        actual,
+        vec![expected_dialog_set_map],
+        "chain {chain_id} with archetype={archetype} must add exactly \
+         dialog_set_map {expected_dialog_set_map}; got {actual:?}"
+    );
+}
+
+/// Load `chain_id` and fire `RegionEnter('Castle_Cellblock.Region2')`
+/// with the supplied archetype. Assert that NO `AddDialogSet` actions
+/// resolve — used as the negative pin (the wrong archetype must not
+/// match the chain's gate).
+async fn assert_region_enter_does_not_resolve(chain_id: i32, archetype: i32) {
+    use cimmeria_content_engine::actions::Action;
+
+    let pool = require_db_or_skip!();
+    let chain = load_single_chain_for_test(&pool, chain_id)
+        .await
+        .unwrap_or_else(|e| panic!("DB query for chain {chain_id} must succeed: {e}"))
+        .unwrap_or_else(|| panic!("chain {chain_id} must exist in seeded content_chains"));
+
+    let mut engine = ChainEngine::new();
+    engine.register_chain(chain);
+
+    let mut ctx = ExecutionContext::new();
+    ctx.set_param(
+        "region_key".to_string(),
+        serde_json::json!("Castle_Cellblock.Region2"),
+    );
+    ctx.set_param(
+        "mission_638_status".to_string(),
+        serde_json::json!("not_active"),
+    );
+    ctx.set_param("archetype".to_string(), serde_json::json!(archetype));
+
+    let event = TriggerEvent {
+        trigger_type: TriggerType::RegionEnter,
+        source_entity: None,
+        target_entity: None,
+        params: ctx.params.clone(),
+    };
+
+    let resolved = engine.resolve_event(&event, &ctx);
+    let dialog_set_actions: Vec<i32> = resolved
+        .actions
+        .iter()
+        .filter_map(|(_, action)| match action {
+            Action::AddDialogSet { dialog_set_id, .. } => Some(*dialog_set_id),
+            _ => None,
+        })
+        .collect();
+
+    assert!(
+        dialog_set_actions.is_empty(),
+        "chain {chain_id} must NOT match for archetype={archetype} — \
+         the archetype condition is what gates branch selection. \
+         Got AddDialogSet ids: {dialog_set_actions:?}"
+    );
+}
+
+/// Tau'ri / Human player (archetype Soldier=1) entering Region2 must get
+/// the Human "Free Prisoner 329" dialog set (dialog_set_map 2794 →
+/// dialog 2300), not the Jaffa one. Pinned shape: chain 1011's
+/// archetype-neq-8 condition routes here.
+#[tokio::test]
+async fn chain_1011_routes_non_jaffa_to_human_dialog_set() {
+    const ARCHETYPE_SOLDIER: i32 = 1;
+    const HUMAN_FREE_PRISONER_DIALOG_SET_MAP: i32 = 2794;
+    assert_region_enter_resolves_dialog_set(
+        1011,
+        ARCHETYPE_SOLDIER,
+        HUMAN_FREE_PRISONER_DIALOG_SET_MAP,
+    )
+    .await;
+}
+
+/// Jaffa player (archetype 8) entering Region2 must get the Jaffa
+/// "Free Prisoner 329" dialog set (dialog_set_map 5866 → dialog 5021,
+/// the symbiote dialog), not the Human one. Pinned shape: chain 1012's
+/// archetype-eq-8 condition routes here.
+#[tokio::test]
+async fn chain_1012_routes_jaffa_to_jaffa_dialog_set() {
+    const ARCHETYPE_JAFFA: i32 = 8;
+    const JAFFA_FREE_PRISONER_DIALOG_SET_MAP: i32 = 5866;
+    assert_region_enter_resolves_dialog_set(
+        1012,
+        ARCHETYPE_JAFFA,
+        JAFFA_FREE_PRISONER_DIALOG_SET_MAP,
+    )
+    .await;
+}
+
+/// Negative pin: chain 1011 (non-Jaffa branch) must NOT match when the
+/// player is Jaffa. Without the archetype condition both chains would
+/// fire and the prisoner would offer both dialog sets at once.
+#[tokio::test]
+async fn chain_1011_does_not_match_jaffa_archetype() {
+    const ARCHETYPE_JAFFA: i32 = 8;
+    assert_region_enter_does_not_resolve(1011, ARCHETYPE_JAFFA).await;
+}
+
+/// Negative pin: chain 1012 (Jaffa branch) must NOT match when the
+/// player is non-Jaffa. Mirror of the above, on the other side of the
+/// archetype gate.
+#[tokio::test]
+async fn chain_1012_does_not_match_non_jaffa_archetype() {
+    const ARCHETYPE_SOLDIER: i32 = 1;
+    assert_region_enter_does_not_resolve(1012, ARCHETYPE_SOLDIER).await;
+}

--- a/db/resources/Content/Seed/castle_cellblock_chains.sql
+++ b/db/resources/Content/Seed/castle_cellblock_chains.sql
@@ -70,9 +70,34 @@ VALUES
 -- ============================================================
 -- MISSION 638 — Speak to Prisoner 329
 -- ============================================================
+--
+-- Dialog ID convention used throughout Mission 638 (and the rest of
+-- this seed):
+--   2xxx / 3xxx prefix → Tau'ri / Human dialogs.
+--   5xxx prefix        → Jaffa dialogs.
+--
+-- For Mission 638 specifically, the per-archetype mapping is:
+--
+--   Topic / step                        Human         Jaffa
+--   "Free Prisoner 329" topic dialog    2300          5021
+--   "Agree to escape" follow-up dialog  2299          5020
+--   dialog_set_map row (set_id 603)     2794          5866
+--
+-- Chains 1011/1012 add the *correct* dialog_set_map row to slot 17 so
+-- the prisoner only offers the topic dialog matching the player's
+-- archetype. Chains 1018/1019 remove the same marker after the player
+-- commits to the escape, so re-talking to the prisoner doesn't re-offer
+-- the topic.
+--
+-- A swap here is a user-visible bug (a Tau'ri player gets the
+-- "My symbiote will cure me" Jaffa dialog and vice versa) — issue #216.
+-- The chain-replay tests in
+-- `crates/services/src/cell/content/chain_replay_tests.rs`
+-- (`mission_638_*` group) regression-guard the resolved-action shape
+-- for both archetype branches.
 
--- Chain 1011: enter Region2 when 638 not active + non-Jaffa → accept + human dialog set
--- dialog_set 5866 maps to dialog 5021 (Human version of "Free Prisoner 329")
+-- Chain 1011: enter Region2 when 638 not active + non-Jaffa → accept + Human dialog set
+-- dialog_set_map 2794 (set_id 603) → dialog 2300 (Human "Free Prisoner 329")
 INSERT INTO content_chains (chain_id, description, scope_type, scope_id, enabled, priority)
 VALUES (1011, '638 - Region2 entry: accept (non-Jaffa)', 'mission', 638, true, 0);
 
@@ -87,10 +112,10 @@ VALUES
 INSERT INTO content_actions (chain_id, action_type, target_id, target_key, params, delay_ms, sort_order)
 VALUES
   (1011, 'accept_mission', 638, NULL, '{}', 0, 0),
-  (1011, 'add_dialog_set', 5866, NULL, '{"slot": 17}', 0, 1);
+  (1011, 'add_dialog_set', 2794, NULL, '{"slot": 17}', 0, 1);
 
 -- Chain 1012: enter Region2 when 638 not active + Jaffa → accept + Jaffa dialog set
--- dialog_set 2794 maps to dialog 2300 (Jaffa version — mentions symbiote)
+-- dialog_set_map 5866 (set_id 603) → dialog 5021 (Jaffa "Free Prisoner 329", mentions symbiote)
 INSERT INTO content_chains (chain_id, description, scope_type, scope_id, enabled, priority)
 VALUES (1012, '638 - Region2 entry: accept (Jaffa)', 'mission', 638, true, 0);
 
@@ -105,7 +130,7 @@ VALUES
 INSERT INTO content_actions (chain_id, action_type, target_id, target_key, params, delay_ms, sort_order)
 VALUES
   (1012, 'accept_mission', 638, NULL, '{}', 0, 0),
-  (1012, 'add_dialog_set', 2794, NULL, '{"slot": 17}', 0, 1);
+  (1012, 'add_dialog_set', 5866, NULL, '{"slot": 17}', 0, 1);
 
 -- Chain 1013: enter Region2 always → system message 5040
 INSERT INTO content_chains (chain_id, description, scope_type, scope_id, enabled, priority)
@@ -117,9 +142,9 @@ VALUES (1013, 'enter_region', 'Castle_Cellblock.Region2', 'player', false, 0);
 INSERT INTO content_actions (chain_id, action_type, target_id, target_key, params, delay_ms, sort_order)
 VALUES (1013, 'system_message', 5040, NULL, '{}', 0, 0);
 
--- Chain 1014: dialog choice 5021 (non-sci talk to 329) while step 2114 active → advance to 2115 + enable door
+-- Chain 1014: dialog choice 5021 (Jaffa talk to 329) while step 2114 active → advance to 2115 + enable door
 INSERT INTO content_chains (chain_id, description, scope_type, scope_id, enabled, priority)
-VALUES (1014, '638 - Talk to Prisoner (non-sci): advance step to 2115', 'mission', 638, true, 0);
+VALUES (1014, '638 - Talk to Prisoner (Jaffa): advance step to 2115', 'mission', 638, true, 0);
 
 INSERT INTO content_triggers (chain_id, event_type, event_key, scope, once, sort_order)
 VALUES (1014, 'dialog_choice', '5021', 'player', false, 0);
@@ -132,9 +157,9 @@ VALUES
   (1014, 'advance_step', 638, '2115', '{}', 0, 0),
   (1014, 'set_interaction_type', NULL, '329_CellDoorButton', '{"op": "|", "mask": 256}', 0, 1);
 
--- Chain 1015: dialog choice 2300 (sci talk to 329) while step 2114 active → advance to 2115 + enable door
+-- Chain 1015: dialog choice 2300 (Human talk to 329) while step 2114 active → advance to 2115 + enable door
 INSERT INTO content_chains (chain_id, description, scope_type, scope_id, enabled, priority)
-VALUES (1015, '638 - Talk to Prisoner (sci): advance step to 2115', 'mission', 638, true, 0);
+VALUES (1015, '638 - Talk to Prisoner (Human): advance step to 2115', 'mission', 638, true, 0);
 
 INSERT INTO content_triggers (chain_id, event_type, event_key, scope, once, sort_order)
 VALUES (1015, 'dialog_choice', '2300', 'player', false, 0);
@@ -174,9 +199,9 @@ VALUES
   (1017, 'play_sequence', 1749, NULL, '{}', 0, 1),
   (1017, 'set_interaction_type', NULL, '329_CellDoorButton', '{"op": "~", "mask": 256}', 0, 2);
 
--- Chain 1020: dialog choice 5021 (human) while step 2116 active → show follow-up dialog 5020
+-- Chain 1020: dialog choice 5021 (Jaffa) while step 2116 active → show follow-up dialog 5020
 INSERT INTO content_chains (chain_id, description, scope_type, scope_id, enabled, priority)
-VALUES (1020, '638 - Post-minigame (human): show escape dialog', 'mission', 638, true, 0);
+VALUES (1020, '638 - Post-minigame (Jaffa): show escape dialog', 'mission', 638, true, 0);
 
 INSERT INTO content_triggers (chain_id, event_type, event_key, scope, once, sort_order)
 VALUES (1020, 'dialog_choice', '5021', 'player', false, 0);
@@ -187,9 +212,9 @@ VALUES (1020, 'step_status', 638, '2116', 'eq', 'active', 0);
 INSERT INTO content_actions (chain_id, action_type, target_id, target_key, params, delay_ms, sort_order)
 VALUES (1020, 'display_dialog', 5020, NULL, '{}', 0, 0);
 
--- Chain 1021: dialog choice 2300 (Jaffa) while step 2116 active → show follow-up dialog 5020
+-- Chain 1021: dialog choice 2300 (Human) while step 2116 active → show follow-up dialog 5020
 INSERT INTO content_chains (chain_id, description, scope_type, scope_id, enabled, priority)
-VALUES (1021, '638 - Post-minigame (Jaffa): show escape dialog', 'mission', 638, true, 0);
+VALUES (1021, '638 - Post-minigame (Human): show escape dialog', 'mission', 638, true, 0);
 
 INSERT INTO content_triggers (chain_id, event_type, event_key, scope, once, sort_order)
 VALUES (1021, 'dialog_choice', '2300', 'player', false, 0);
@@ -200,9 +225,9 @@ VALUES (1021, 'step_status', 638, '2116', 'eq', 'active', 0);
 INSERT INTO content_actions (chain_id, action_type, target_id, target_key, params, delay_ms, sort_order)
 VALUES (1021, 'display_dialog', 5020, NULL, '{}', 0, 0);
 
--- Chain 1018: dialog choice 5020 (non-sci agree escape) while step 2116 active → finish 638, accept 639
+-- Chain 1018: dialog choice 5020 (Jaffa agree escape) while step 2116 active → finish 638, accept 639
 INSERT INTO content_chains (chain_id, description, scope_type, scope_id, enabled, priority)
-VALUES (1018, '638 - Agree to help (non-sci): complete 638, accept 639', 'mission', 638, true, 0);
+VALUES (1018, '638 - Agree to help (Jaffa): complete 638, accept 639', 'mission', 638, true, 0);
 
 INSERT INTO content_triggers (chain_id, event_type, event_key, scope, once, sort_order)
 VALUES (1018, 'dialog_choice', '5020', 'player', false, 0);
@@ -217,9 +242,9 @@ VALUES
   (1018, 'complete_mission', 638, NULL, '{}', 0, 2),
   (1018, 'remove_dialog_set', 5866, NULL, '{"slot": 17}', 0, 3);
 
--- Chain 1019: dialog choice 2299 (sci agree escape) while step 2116 active → finish 638, accept 639
+-- Chain 1019: dialog choice 2299 (Human agree escape) while step 2116 active → finish 638, accept 639
 INSERT INTO content_chains (chain_id, description, scope_type, scope_id, enabled, priority)
-VALUES (1019, '638 - Agree to help (sci): complete 638, accept 639', 'mission', 638, true, 0);
+VALUES (1019, '638 - Agree to help (Human): complete 638, accept 639', 'mission', 638, true, 0);
 
 INSERT INTO content_triggers (chain_id, event_type, event_key, scope, once, sort_order)
 VALUES (1019, 'dialog_choice', '2299', 'player', false, 0);

--- a/db/scripts/fix_prisoner_329_dialog_archetype_swap.sql
+++ b/db/scripts/fix_prisoner_329_dialog_archetype_swap.sql
@@ -1,0 +1,33 @@
+-- Migration: fix swapped dialog_set_map IDs in Mission 638's archetype
+-- gating chains (Prisoner 329 dialog).
+--
+-- Chains 1011 (non-Jaffa) and 1012 (Jaffa) had their `add_dialog_set`
+-- target_id values swapped relative to the archetype condition, so a
+-- Tau'ri / Human player would see the Jaffa "My symbiote will cure me"
+-- dialog (5021 via dialog_set_map 5866) and a Jaffa player would see
+-- the Human "stasis sickness" dialog (2300 via dialog_set_map 2794).
+--
+-- Correct mapping for Mission 638 / dialog_set_id 603:
+--   dialog_set_map 2794 → dialog 2300 (Human "Free Prisoner 329")
+--   dialog_set_map 5866 → dialog 5021 (Jaffa "Free Prisoner 329")
+--
+-- The chain_id pinpoints the exact action row via (chain_id,
+-- action_type='add_dialog_set'); the existing seed has exactly one
+-- such action per chain so the WHERE clause matches a single row.
+--
+-- Idempotent: if the seed already has the correct values (e.g. from a
+-- fresh load post-fix), the UPDATE is a no-op.
+
+\set ON_ERROR_STOP on
+
+-- Chain 1011 (non-Jaffa archetype) must add the Human dialog set (2794).
+UPDATE resources.content_actions
+SET    target_id = 2794
+WHERE  chain_id = 1011
+  AND  action_type = 'add_dialog_set';
+
+-- Chain 1012 (Jaffa archetype) must add the Jaffa dialog set (5866).
+UPDATE resources.content_actions
+SET    target_id = 5866
+WHERE  chain_id = 1012
+  AND  action_type = 'add_dialog_set';

--- a/docs/testing/inventory/README.md
+++ b/docs/testing/inventory/README.md
@@ -3,7 +3,7 @@
 > **Type**: reference  
 > **Audience**: engineers  
 > **Last updated**: 2026-05-05  
-> **Total tests catalogued**: 1097  
+> **Total tests catalogued**: 1101  
 > **Companion docs**: [TESTING.md](../../../TESTING.md) (the playbook for *how to write* tests), [maintenance.md](maintenance.md), [review-report.md](review-report.md) (audit findings — owned by the testing-validation-engineer agent)
 
 Catalogue of every test in the workspace. The playbook for *how to write* tests is [TESTING.md](../../../TESTING.md); this directory is the reference complement — what tests already exist, where they live, and what each one asserts.
@@ -14,7 +14,7 @@ Catalogue of every test in the workspace. The playbook for *how to write* tests 
 
 | Crate | Tests | File |
 |---|---:|---|
-| `services` | 575 | [services.md](services.md) |
+| `services` | 579 | [services.md](services.md) |
 | `entity` | 151 | [entity.md](entity.md) |
 | `mercury` | 97 | [mercury.md](mercury.md) |
 | `game` | 70 | [game.md](game.md) |
@@ -28,7 +28,7 @@ Catalogue of every test in the workspace. The playbook for *how to write* tests 
 | `tauri-app` | 6 | [tauri-app.md](tauri-app.md) |
 | `defs` | 5 | [defs.md](defs.md) |
 | `server` | 2 | [server.md](server.md) |
-| **Total** | **1097** | |
+| **Total** | **1101** | |
 
 ### By kind
 
@@ -36,7 +36,7 @@ Catalogue of every test in the workspace. The playbook for *how to write* tests 
 |---|---:|
 | unit | 925 |
 | wire-format | 46 |
-| live-DB | 108 |
+| live-DB | 112 |
 | chain-replay | 6 |
 | smoke | 6 |
 | proptest | 4 |
@@ -46,7 +46,7 @@ Catalogue of every test in the workspace. The playbook for *how to write* tests 
 
 | Year | Tests |
 |---|---:|
-| 2026 | 1097 |
+| 2026 | 1101 |
 
 ## Reading guide
 

--- a/docs/testing/inventory/services.md
+++ b/docs/testing/inventory/services.md
@@ -3,7 +3,7 @@
 > **Type**: reference  
 > **Audience**: engineers  
 > **Last updated**: 2026-05-05  
-> **Total tests**: 575  
+> **Total tests**: 579  
 > **CI-gated**: yes  
 > **Index**: [README](README.md) | **Playbook**: [TESTING.md](../../../TESTING.md)
 
@@ -334,6 +334,10 @@ Auth, Base, and Cell service implementations — the bulk of server logic. House
 | [chain_3026_fires_dialog_5365_when_mission_1562_is_not_active](../../../crates/services/src/cell/content/chain_replay_tests.rs#L32) | live-DB | Cell / Content | 2026-05-03 | Chain 3026 (`db/resources/Content/Seed/sgc_w1_chains.sql`): `dialog_choice('5365')` accepts mission 1562, gated by `mission_status(1562) = 'not_active'` |  |
 | [chain_3026_does_not_fire_when_mission_1562_is_active](../../../crates/services/src/cell/content/chain_replay_tests.rs#L84) | live-DB | Cell / Content | 2026-05-03 | Test 2: with `mission_1562_status = 'active'`, the chain's `mission_status` condition fails and the engine does NOT resolve any actions for chain 3026 |  |
 | [chain_3026_does_not_fire_when_mission_1562_is_completed](../../../crates/services/src/cell/content/chain_replay_tests.rs#L128) | live-DB | Cell / Content | 2026-05-03 | Test 3: `mission_1562_status = 'completed'` also blocks chain 3026 |  |
+| [chain_1011_routes_non_jaffa_to_human_dialog_set](../../../crates/services/src/cell/content/chain_replay_tests.rs#L466) | live-DB | Cell / Content | 2026-05-05 | Chain 1011 (Mission 638 / Region2 entry / non-Jaffa) must add the Human dialog_set_map 2794 (→ dialog 2300, "Free Prisoner 329") to slot 17. Regression guard for the issue #216 ID swap that gave Tau'ri players the Jaffa "My symbiote will cure me" dialog |  |
+| [chain_1012_routes_jaffa_to_jaffa_dialog_set](../../../crates/services/src/cell/content/chain_replay_tests.rs#L482) | live-DB | Cell / Content | 2026-05-05 | Chain 1012 (Mission 638 / Region2 entry / Jaffa) must add the Jaffa dialog_set_map 5866 (→ dialog 5021, the symbiote dialog) to slot 17. Mirror of chain 1011's guard on the Jaffa side |  |
+| [chain_1011_does_not_match_jaffa_archetype](../../../crates/services/src/cell/content/chain_replay_tests.rs#L497) | live-DB | Cell / Content | 2026-05-05 | Negative pin: chain 1011 must NOT resolve when the player is Jaffa. Without the archetype condition both chains would fire and the prisoner would offer both dialog sets |  |
+| [chain_1012_does_not_match_non_jaffa_archetype](../../../crates/services/src/cell/content/chain_replay_tests.rs#L506) | live-DB | Cell / Content | 2026-05-05 | Negative pin: chain 1012 must NOT resolve when the player is non-Jaffa. Mirror of `chain_1011_does_not_match_jaffa_archetype` |  |
 | [build_engine_with_none_returns_empty_engine](../../../crates/services/src/cell/content/engine_loader.rs#L245) | unit | Cell / Content / Engine Loader | 2026-05-04 | `build_engine(None)` returns an empty engine — the codepath the server takes when started without a DB pool |  |
 | [build_engine_with_db_pool_loads_seeded_chains](../../../crates/services/src/cell/content/engine_loader.rs#L255) | live-DB | Cell / Content / Engine Loader | 2026-05-04 | Live-DB sanity: against the seeded `resources.content_*` tables, `build_engine` returns a non-empty engine |  |
 | [load_single_chain_returns_none_for_missing_id](../../../crates/services/src/cell/content/engine_loader.rs#L275) | live-DB | Cell / Content / Engine Loader | 2026-05-04 | `load_single_chain_for_test` returns `Ok(None)` for a chain id that doesn't exist in the seed |  |


### PR DESCRIPTION
## Summary

Closes #216. A Tau'ri / Human player talking to Prisoner 329 in Castle CellBlock got the Jaffa dialog (\"My symbiote will cure me. I will not trust a Goa'uld.\") and a Jaffa player got the Human dialog (\"You feel uncomfortable, don't you? Nauseous? … stasis sickness.\"). Chains 1011 (non-Jaffa) and 1012 (Jaffa) had their `add_dialog_set` target_ids swapped relative to the archetype condition.

## Verified mapping

`dialog_set_maps` rows for `dialog_set_id = 603` (\"Free Prisoner 329\" topic):

| `dialog_set_map_id` | `dialog_id` | First-screen text |
|---|---|---|
| **2794** | 2300 | \"You feel uncomfortable, don't you? Nauseous? … stasis sickness.\" — **Human** |
| **5866** | 5021 | \"My symbiote will cure me. I will not trust a Goa'uld.\" — **Jaffa** |

Pre-fix: chain 1011 (non-Jaffa) added 5866 (Jaffa); chain 1012 (Jaffa) added 2794 (Human). Inverted.

Post-fix: chain 1011 → 2794, chain 1012 → 5866. Plus the existing `remove_dialog_set` calls in chains 1018 (`remove 5866`) and 1019 (`remove 2794`) now match their respective archetype branches.

## Changes

- **[`db/resources/Content/Seed/castle_cellblock_chains.sql`](https://github.com/SandboxServers/Cimmeria/blob/fix/prisoner-329-dialog-216/db/resources/Content/Seed/castle_cellblock_chains.sql)** — swap the two `add_dialog_set` target_ids on chains 1011/1012 + fix all the misleading race tags in chain descriptions and comments for chains 1014/1015/1018/1019/1020/1021 (drive-by since I'm in there; only comments, no behavior change). Added a header doc block at the Mission 638 section documenting the seed-wide dialog ID convention (5xxx=Jaffa, 2xxx/3xxx=Human) so the next author sees the rule before they swap anything.

- **[`db/scripts/fix_prisoner_329_dialog_archetype_swap.sql`](https://github.com/SandboxServers/Cimmeria/blob/fix/prisoner-329-dialog-216/db/scripts/fix_prisoner_329_dialog_archetype_swap.sql)** — idempotent migration for live DBs that already have the swapped seed loaded. Two `UPDATE … WHERE chain_id = N AND action_type = 'add_dialog_set'` statements; the existing seed has exactly one such row per chain so each statement matches a single row.

- **[`crates/services/src/cell/content/chain_replay_tests.rs`](https://github.com/SandboxServers/Cimmeria/blob/fix/prisoner-329-dialog-216/crates/services/src/cell/content/chain_replay_tests.rs)** — 4 new live-DB chain-replay guards under a Mission-638 section. Two reusable helpers (`assert_region_enter_resolves_dialog_set`, `assert_region_enter_does_not_resolve`) handle the boilerplate so future archetype-gated dialog regression guards land as two helper calls, not 50-line copies of the resolve-event scaffolding.

  - `chain_1011_routes_non_jaffa_to_human_dialog_set` — archetype Soldier (1) → 2794.
  - `chain_1012_routes_jaffa_to_jaffa_dialog_set` — archetype Jaffa (8) → 5866.
  - `chain_1011_does_not_match_jaffa_archetype` — negative pin: chain 1011 must NOT match for archetype 8.
  - `chain_1012_does_not_match_non_jaffa_archetype` — negative pin, mirror.

- **Test inventory** — services.md: 4 new entries for the chain-replay guards. README.md: services 575→579, total 1097→1101, live-DB 108→112.

## Reusability angle

Per #216's design discussion, the chain pattern itself (`condition_type='archetype'` + `action_type='add_dialog_set'`) is the reusable abstraction — it's already used correctly in chains 1056/1057 elsewhere in the same seed. This bug was data-entry, not architecture. The reusable improvement is on the regression-guard side: the helper pair makes \"two more `assert_*` calls\" all that's needed for the next swap-style bug.

## Out of scope

- The `display_dialog 5020` action in chain 1021 (Human post-minigame branch) shows the Jaffa follow-up dialog to Human players. May be intentional (the legacy script has the same shape) or a separate bug; either way, not the user-visible bug from #216 and not in this PR's scope. Filing a follow-up if I confirm it's wrong.
- The `5865/2793` ↔ `5866/2794` add/remove pair pattern from the legacy Python (where 5865/2793 are added, 5866/2794 are removed). Our chain action `add_dialog_set` works directly with whatever target_id we give it, so 2794/5866 are the right values to add (they're the per-archetype rows under set_id 603). The 5865/2793 IDs in the legacy reference are for a different mission's dialog topic (Find Ambernol, set_id 602) and not relevant here.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p cimmeria-services --all-targets -- -D warnings` clean
- [x] `cargo test -p cimmeria-services --lib` — 579 passed (was 575, +4)
- [ ] Manual in-game (post-merge): log in as Soldier, enter Region2, verify the prisoner offers \"You feel uncomfortable, don't you?\" (dialog 2300), not the symbiote line.
- [ ] Manual in-game: log in as Jaffa, verify the inverse.
- [ ] Live-DB CI: confirm the 4 new chain-replay tests pass against the seeded `postgres:17.9` container.

## Related

- #213 (canonical enum source) — surfaces the same kind of cross-reference data drift this bug came from. Adding a single source of truth would have caught the inverted comments mechanically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)