### PR TITLE
test(cell): extract make_space_manager helper for cell test fixtures (#149)

### DIFF
--- a/crates/services/src/cell/cell_methods/player/dispatch.rs
+++ b/crates/services/src/cell/cell_methods/player/dispatch.rs
@@ -48,7 +48,7 @@ pub async fn dispatch(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_support::make_space_manager;
+    use crate::test_support::make_space_manager_with_player;
 
     /// Pin the SGWPlayer cell-method constant values. The dispatch routing in
     /// `dispatch` above uses `..=` ranges over these constants — if a future
@@ -86,9 +86,7 @@ mod tests {
     /// 88..=90) returns false, and so does the outer dispatch.
     #[tokio::test]
     async fn pet_methods_route_to_social_not_world() {
-        let mut mgr = make_space_manager();
-        mgr.create_entity(1, "Agnos", [0.0, 0.0, 0.0], [0.0; 3])
-            .unwrap();
+        let mut mgr = make_space_manager_with_player(1);
 
         let (tx, _rx) = mpsc::channel(8);
         let engine = ChainEngine::new();
@@ -111,9 +109,7 @@ mod tests {
     /// as `dispatch` returning false for one of these.
     #[tokio::test]
     async fn each_outer_range_routes_to_a_handler() {
-        let mut mgr = make_space_manager();
-        mgr.create_entity(1, "Agnos", [0.0, 0.0, 0.0], [0.0; 3])
-            .unwrap();
+        let mut mgr = make_space_manager_with_player(1);
 
         let (tx, _rx) = mpsc::channel(64);
         let engine = ChainEngine::new();
@@ -140,9 +136,7 @@ mod tests {
 
     #[tokio::test]
     async fn out_of_range_methods_return_false() {
-        let mut mgr = make_space_manager();
-        mgr.create_entity(1, "Agnos", [0.0, 0.0, 0.0], [0.0; 3])
-            .unwrap();
+        let mut mgr = make_space_manager_with_player(1);
 
         let (tx, _rx) = mpsc::channel(8);
         let engine = ChainEngine::new();

--- a/crates/services/src/cell/cell_methods/player/dispatch.rs
+++ b/crates/services/src/cell/cell_methods/player/dispatch.rs
@@ -48,6 +48,7 @@ pub async fn dispatch(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::make_space_manager;
 
     /// Pin the SGWPlayer cell-method constant values. The dispatch routing in
     /// `dispatch` above uses `..=` ranges over these constants — if a future
@@ -85,13 +86,7 @@ mod tests {
     /// 88..=90) returns false, and so does the outer dispatch.
     #[tokio::test]
     async fn pet_methods_route_to_social_not_world() {
-        let mut mgr = SpaceManager::new(1);
-        let spaces_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
-<Spaces><Space WorldName="Agnos" Instanced="false" MinX="-2400" MaxX="2200" MinY="-3200" MaxY="2800" /></Spaces>"#;
-        let cell_spaces_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
-<Spaces><Space WorldName="Agnos" /></Spaces>"#;
-        mgr.parse_spaces_xml(spaces_xml).unwrap();
-        mgr.create_startup_spaces(cell_spaces_xml).unwrap();
+        let mut mgr = make_space_manager();
         mgr.create_entity(1, "Agnos", [0.0, 0.0, 0.0], [0.0; 3])
             .unwrap();
 
@@ -116,13 +111,7 @@ mod tests {
     /// as `dispatch` returning false for one of these.
     #[tokio::test]
     async fn each_outer_range_routes_to_a_handler() {
-        let mut mgr = SpaceManager::new(1);
-        let spaces_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
-<Spaces><Space WorldName="Agnos" Instanced="false" MinX="-2400" MaxX="2200" MinY="-3200" MaxY="2800" /></Spaces>"#;
-        let cell_spaces_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
-<Spaces><Space WorldName="Agnos" /></Spaces>"#;
-        mgr.parse_spaces_xml(spaces_xml).unwrap();
-        mgr.create_startup_spaces(cell_spaces_xml).unwrap();
+        let mut mgr = make_space_manager();
         mgr.create_entity(1, "Agnos", [0.0, 0.0, 0.0], [0.0; 3])
             .unwrap();
 
@@ -151,13 +140,7 @@ mod tests {
 
     #[tokio::test]
     async fn out_of_range_methods_return_false() {
-        let mut mgr = SpaceManager::new(1);
-        let spaces_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
-<Spaces><Space WorldName="Agnos" Instanced="false" MinX="-2400" MaxX="2200" MinY="-3200" MaxY="2800" /></Spaces>"#;
-        let cell_spaces_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
-<Spaces><Space WorldName="Agnos" /></Spaces>"#;
-        mgr.parse_spaces_xml(spaces_xml).unwrap();
-        mgr.create_startup_spaces(cell_spaces_xml).unwrap();
+        let mut mgr = make_space_manager();
         mgr.create_entity(1, "Agnos", [0.0, 0.0, 0.0], [0.0; 3])
             .unwrap();
 

--- a/crates/services/src/cell/cell_methods/player/interaction.rs
+++ b/crates/services/src/cell/cell_methods/player/interaction.rs
@@ -243,19 +243,8 @@ pub async fn dispatch(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::make_space_manager;
     use cimmeria_entity::cell_entity::NpcInteractionType;
-
-    /// Standard test space setup: SpaceManager with a single Agnos space.
-    fn make_space_manager() -> SpaceManager {
-        let mut mgr = SpaceManager::new(1);
-        let spaces_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
-<Spaces><Space WorldName="Agnos" Instanced="false" MinX="-2400" MaxX="2200" MinY="-3200" MaxY="2800" /></Spaces>"#;
-        let cell_spaces_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
-<Spaces><Space WorldName="Agnos" /></Spaces>"#;
-        mgr.parse_spaces_xml(spaces_xml).unwrap();
-        mgr.create_startup_spaces(cell_spaces_xml).unwrap();
-        mgr
-    }
 
     /// Right-clicking an ALIVE hostile NPC reroutes interact → useAbility.
     /// Baseline for the dead-corpse regression test below.

--- a/crates/services/src/cell/cell_methods/player/vendor.rs
+++ b/crates/services/src/cell/cell_methods/player/vendor.rs
@@ -356,18 +356,7 @@ mod read_i32_array_tests {
 #[cfg(test)]
 mod vendor_context_tests {
     use super::{vendor_context, VendorSession};
-    use crate::cell::space_manager::SpaceManager;
-
-    fn make_space_manager() -> SpaceManager {
-        let mut mgr = SpaceManager::new(1);
-        let spaces_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
-<Spaces><Space WorldName="Agnos" Instanced="false" MinX="-2400" MaxX="2200" MinY="-3200" MaxY="2800" /></Spaces>"#;
-        let cell_spaces_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
-<Spaces><Space WorldName="Agnos" /></Spaces>"#;
-        mgr.parse_spaces_xml(spaces_xml).unwrap();
-        mgr.create_startup_spaces(cell_spaces_xml).unwrap();
-        mgr
-    }
+    use crate::test_support::make_space_manager;
 
     fn assert_session(
         session: Option<VendorSession>,

--- a/crates/services/src/cell/interactions/vendor.rs
+++ b/crates/services/src/cell/interactions/vendor.rs
@@ -69,17 +69,7 @@ pub(super) async fn send_store_open(
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    fn make_space_manager() -> SpaceManager {
-        let mut mgr = SpaceManager::new(1);
-        let spaces_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
-<Spaces><Space WorldName="Agnos" Instanced="false" MinX="-2400" MaxX="2200" MinY="-3200" MaxY="2800" /></Spaces>"#;
-        let cell_spaces_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
-<Spaces><Space WorldName="Agnos" /></Spaces>"#;
-        mgr.parse_spaces_xml(spaces_xml).unwrap();
-        mgr.create_startup_spaces(cell_spaces_xml).unwrap();
-        mgr
-    }
+    use crate::test_support::make_space_manager;
 
     fn collect_open_vendor_messages(
         rx: &mut mpsc::Receiver<CellToBaseMsg>,

--- a/crates/services/src/test_support.rs
+++ b/crates/services/src/test_support.rs
@@ -78,7 +78,7 @@ macro_rules! require_db_or_skip {
 
 pub(crate) use require_db_or_skip;
 
-// ── SpaceManager test fixtures (issue #149) ───────────────────────────
+// ── SpaceManager test fixtures ────────────────────────────────────────
 
 use crate::cell::space_manager::SpaceManager;
 

--- a/crates/services/src/test_support.rs
+++ b/crates/services/src/test_support.rs
@@ -77,3 +77,33 @@ macro_rules! require_db_or_skip {
 }
 
 pub(crate) use require_db_or_skip;
+
+// ── SpaceManager test fixtures (issue #149) ───────────────────────────
+
+use crate::cell::space_manager::SpaceManager;
+
+/// Standard test space setup: SpaceManager with a single Agnos space.
+///
+/// The same ~5-line block was duplicated across dispatch, interaction,
+/// and vendor test modules. Extracted here so every cell test shares
+/// the same default world geometry.
+pub(crate) fn make_space_manager() -> SpaceManager {
+    let mut mgr = SpaceManager::new(1);
+    let spaces_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<Spaces><Space WorldName="Agnos" Instanced="false" MinX="-2400" MaxX="2200" MinY="-3200" MaxY="2800" /></Spaces>"#;
+    let cell_spaces_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<Spaces><Space WorldName="Agnos" /></Spaces>"#;
+    mgr.parse_spaces_xml(spaces_xml).unwrap();
+    mgr.create_startup_spaces(cell_spaces_xml).unwrap();
+    mgr
+}
+
+/// Same as [`make_space_manager`], but also creates a player entity at
+/// the origin so tests that need an avatar don't repeat the entity
+/// creation boilerplate.
+pub(crate) fn make_space_manager_with_player(entity_id: u32) -> SpaceManager {
+    let mut mgr = make_space_manager();
+    mgr.create_entity(entity_id, "Agnos", [0.0, 0.0, 0.0], [0.0; 3])
+        .unwrap();
+    mgr
+}


### PR DESCRIPTION
## Summary

Closes #149.

Four cell test modules duplicated the same ~5-line block to set up a SpaceManager with a single Agnos space:

- \`cell/cell_methods/player/dispatch.rs\` — 3 inline copies
- \`cell/cell_methods/player/interaction.rs\` — local \`make_space_manager()\`
- \`cell/cell_methods/player/vendor.rs\` — local \`make_space_manager()\`
- \`cell/interactions/vendor.rs\` — local \`make_space_manager()\`

Extract a public \`make_space_manager()\` (and a \`make_space_manager_with_player(entity_id)\` variant for tests that need an avatar at the origin) into \`crates/services/src/test_support.rs\`, gated on \`#[cfg(test)]\`. All four sites now share the same default world geometry — a future Agnos-bounds change becomes one edit.

## Scope

- Net: +37 / -56 (boilerplate down).
- Helper keeps Agnos hard-coded as the default per #149's "out of scope" note. Adding a world-override variant is a follow-up if/when a cross-world test needs it.

## Test plan

- [ ] \`cargo test -p cimmeria-services\` (the four migrated test modules)
- [ ] \`cargo clippy -p cimmeria-services --all-targets -- -D warnings\`

## Related

- #149 — original issue
- #207 — codecov ratchet (lands first; this PR's coverage neutral, just dedup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)