### PR TITLE
test(vendor/purchase): outbox cleanup by entity_id, not silent placeholder (#166)

### DIFF
--- a/crates/services/src/base/world_entry/methods/vendor/purchase/tests.rs
+++ b/crates/services/src/base/world_entry/methods/vendor/purchase/tests.rs
@@ -35,6 +35,8 @@ const ITEM_COST_DESIGN_ID: i32 = 5192;
 const ITEM_COST_PREREQ_DESIGN_ID: i32 = 55;
 
 async fn cleanup(pool: &PgPool, entity_id: i32, account_id: i32, player_id: i32) {
+    // Delete the outbox rows the test enqueues so a shared live DB
+    // doesn't accumulate stale entries from successful runs.
     let _ = sqlx::query("DELETE FROM cell_event_outbox WHERE entity_id = $1")
         .bind(entity_id)
         .execute(pool)
@@ -176,11 +178,11 @@ async fn pure_cash_purchase_debits_balance_and_grants_inventory_row() {
     // the exact delta rather than just "lower than before".
     insert_account_and_player(&pool, account_id, player_id, 5_000).await;
 
-    let (socket, e2a, conn) = make_state(0x7000_0A01);
+    let (socket, e2a, conn) = make_state(entity_id as u32);
     let db_pool = Some(Arc::new(pool.clone()));
 
     handle_purchase_vendor_items(
-        0x7000_0A01,
+        entity_id as u32,
         player_id,
         99,
         SEEDED_BUY_VENDOR_TEMPLATE_ID,
@@ -230,11 +232,11 @@ async fn item_prereq_purchase_consumes_prereq_and_skips_cash_update() {
     let prereq_item =
         insert_item(&pool, player_id, ITEM_COST_PREREQ_DESIGN_ID, INV_MAIN, 5, 3).await;
 
-    let (socket, e2a, conn) = make_state(0x7000_0A11);
+    let (socket, e2a, conn) = make_state(entity_id as u32);
     let db_pool = Some(Arc::new(pool.clone()));
 
     handle_purchase_vendor_items(
-        0x7000_0A11,
+        entity_id as u32,
         player_id,
         99,
         SEEDED_BUY_VENDOR_TEMPLATE_ID,
@@ -287,11 +289,11 @@ async fn purchase_rejected_when_player_cannot_afford() {
     // Less than PURE_CASH_PRICE — purchase must fail.
     insert_account_and_player(&pool, account_id, player_id, PURE_CASH_PRICE - 1).await;
 
-    let (socket, e2a, conn) = make_state(0x7000_0A21);
+    let (socket, e2a, conn) = make_state(entity_id as u32);
     let db_pool = Some(Arc::new(pool.clone()));
 
     handle_purchase_vendor_items(
-        0x7000_0A21,
+        entity_id as u32,
         player_id,
         99,
         SEEDED_BUY_VENDOR_TEMPLATE_ID,
@@ -318,6 +320,53 @@ async fn purchase_rejected_when_player_cannot_afford() {
     cleanup(&pool, entity_id, account_id, player_id).await;
 }
 
+/// Regression guard for the cleanup helper itself. The pre-fix WHERE
+/// clause was `entity_id < 0`, which matched zero rows because the
+/// test sentinels are positive — so successful runs leaked outbox
+/// rows into the shared live DB. Insert one outbox row at the test
+/// sentinel, run cleanup, assert the row is gone. Reverting cleanup
+/// to `entity_id < 0` leaves count == 1 and fails this guard.
+#[tokio::test]
+async fn cleanup_deletes_outbox_rows_for_test_entity() {
+    let pool = require_db_or_skip!();
+    let account_id = TEST_BASE + 400;
+    let player_id = TEST_BASE + 401;
+    let entity_id: i32 = 0x7000_0A41;
+    cleanup(&pool, entity_id, account_id, player_id).await;
+
+    sqlx::query(
+        "INSERT INTO cell_event_outbox (entity_id, event_type, payload) \
+         VALUES ($1, 'TestEvent', '{}'::jsonb)",
+    )
+    .bind(entity_id)
+    .execute(&pool)
+    .await
+    .expect("seed outbox row");
+
+    let pre: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM cell_event_outbox WHERE entity_id = $1")
+            .bind(entity_id)
+            .fetch_one(&pool)
+            .await
+            .expect("pre-cleanup count");
+    assert_eq!(pre, 1, "fixture must have inserted one outbox row");
+
+    cleanup(&pool, entity_id, account_id, player_id).await;
+
+    let post: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM cell_event_outbox WHERE entity_id = $1")
+            .bind(entity_id)
+            .fetch_one(&pool)
+            .await
+            .expect("post-cleanup count");
+    assert_eq!(
+        post, 0,
+        "cleanup must delete outbox rows for the test sentinel; \
+         reverting the WHERE clause to `entity_id < 0` would leave the \
+         row in place and fail this guard",
+    );
+}
+
 /// A store_index outside the buy list (here: 99, well past the 3 seeded
 /// rows) is rejected before any state mutates. Asserts via the
 /// no-DB-changes invariant: balance unchanged, no INV_MAIN rows of any
@@ -331,11 +380,11 @@ async fn purchase_rejected_for_index_not_in_buy_list() {
     cleanup(&pool, entity_id, account_id, player_id).await;
     insert_account_and_player(&pool, account_id, player_id, 5_000).await;
 
-    let (socket, e2a, conn) = make_state(0x7000_0A31);
+    let (socket, e2a, conn) = make_state(entity_id as u32);
     let db_pool = Some(Arc::new(pool.clone()));
 
     handle_purchase_vendor_items(
-        0x7000_0A31,
+        entity_id as u32,
         player_id,
         99,
         SEEDED_BUY_VENDOR_TEMPLATE_ID,

--- a/crates/services/src/base/world_entry/methods/vendor/purchase/tests.rs
+++ b/crates/services/src/base/world_entry/methods/vendor/purchase/tests.rs
@@ -34,10 +34,11 @@ const ITEM_COST_STORE_INDEX: i32 = 1;
 const ITEM_COST_DESIGN_ID: i32 = 5192;
 const ITEM_COST_PREREQ_DESIGN_ID: i32 = 55;
 
-async fn cleanup(pool: &PgPool, account_id: i32, player_id: i32) {
-    let _ = sqlx::query("DELETE FROM cell_event_outbox WHERE entity_id < 0")
+async fn cleanup(pool: &PgPool, entity_id: i32, account_id: i32, player_id: i32) {
+    let _ = sqlx::query("DELETE FROM cell_event_outbox WHERE entity_id = $1")
+        .bind(entity_id)
         .execute(pool)
-        .await; // no-op safety net
+        .await;
     let _ = sqlx::query("DELETE FROM sgw_inventory WHERE character_id = $1")
         .bind(player_id)
         .execute(pool)
@@ -169,7 +170,8 @@ async fn pure_cash_purchase_debits_balance_and_grants_inventory_row() {
     let pool = require_db_or_skip!();
     let account_id = TEST_BASE;
     let player_id = TEST_BASE + 1;
-    cleanup(&pool, account_id, player_id).await;
+    let entity_id: i32 = 0x7000_0A01;
+    cleanup(&pool, entity_id, account_id, player_id).await;
     // Start with a known balance well above the price so we can assert
     // the exact delta rather than just "lower than before".
     insert_account_and_player(&pool, account_id, player_id, 5_000).await;
@@ -207,7 +209,7 @@ async fn pure_cash_purchase_debits_balance_and_grants_inventory_row() {
         "balance must drop by exactly per-line cash_cost",
     );
 
-    cleanup(&pool, account_id, player_id).await;
+    cleanup(&pool, entity_id, account_id, player_id).await;
 }
 
 /// Item-prerequisite path: the seeded line at store_index 1 costs no
@@ -220,7 +222,8 @@ async fn item_prereq_purchase_consumes_prereq_and_skips_cash_update() {
     let pool = require_db_or_skip!();
     let account_id = TEST_BASE + 100;
     let player_id = TEST_BASE + 101;
-    cleanup(&pool, account_id, player_id).await;
+    let entity_id: i32 = 0x7000_0A11;
+    cleanup(&pool, entity_id, account_id, player_id).await;
     insert_account_and_player(&pool, account_id, player_id, 5_000).await;
     // Provide a 3-stack of the prereq so we can assert the post-purchase
     // stack drops by exactly 1, not "missing" or "zero".
@@ -267,7 +270,7 @@ async fn item_prereq_purchase_consumes_prereq_and_skips_cash_update() {
         "naquadah must be unchanged when cash_cost is 0",
     );
 
-    cleanup(&pool, account_id, player_id).await;
+    cleanup(&pool, entity_id, account_id, player_id).await;
 }
 
 /// Insufficient-cash rollback: a player below the line price gets the
@@ -279,7 +282,8 @@ async fn purchase_rejected_when_player_cannot_afford() {
     let pool = require_db_or_skip!();
     let account_id = TEST_BASE + 200;
     let player_id = TEST_BASE + 201;
-    cleanup(&pool, account_id, player_id).await;
+    let entity_id: i32 = 0x7000_0A21;
+    cleanup(&pool, entity_id, account_id, player_id).await;
     // Less than PURE_CASH_PRICE — purchase must fail.
     insert_account_and_player(&pool, account_id, player_id, PURE_CASH_PRICE - 1).await;
 
@@ -311,7 +315,7 @@ async fn purchase_rejected_when_player_cannot_afford() {
         "balance must not change when the purchase is rolled back",
     );
 
-    cleanup(&pool, account_id, player_id).await;
+    cleanup(&pool, entity_id, account_id, player_id).await;
 }
 
 /// A store_index outside the buy list (here: 99, well past the 3 seeded
@@ -323,7 +327,8 @@ async fn purchase_rejected_for_index_not_in_buy_list() {
     let pool = require_db_or_skip!();
     let account_id = TEST_BASE + 300;
     let player_id = TEST_BASE + 301;
-    cleanup(&pool, account_id, player_id).await;
+    let entity_id: i32 = 0x7000_0A31;
+    cleanup(&pool, entity_id, account_id, player_id).await;
     insert_account_and_player(&pool, account_id, player_id, 5_000).await;
 
     let (socket, e2a, conn) = make_state(0x7000_0A31);
@@ -360,5 +365,5 @@ async fn purchase_rejected_for_index_not_in_buy_list() {
         "balance must not change when the index is invalid",
     );
 
-    cleanup(&pool, account_id, player_id).await;
+    cleanup(&pool, entity_id, account_id, player_id).await;
 }


### PR DESCRIPTION
## Summary

Closes the \`vendor/purchase/tests.rs\` bullet from #166.

The cleanup helper used the no-op safety net pattern that issue #166 calls out:

\`\`\`rust
DELETE FROM cell_event_outbox WHERE entity_id < 0
\`\`\`

This deletes nothing — the \`entity_id\`s in scope are all positive sentinels. Successful runs left outbox rows behind, which can pollute a shared live DB and surface as flaky failures elsewhere (the recharge-bundle outbox round-trip test was the canonical victim — it expected 1 row, saw N).

PR #154 fixed the same shape in \`vendor/sell/tests.rs\`. This PR applies that fix to \`vendor/purchase/tests.rs\`:

- Take an \`entity_id\` parameter on \`cleanup\`
- \`DELETE FROM cell_event_outbox WHERE entity_id = \$1\`
- Each of the four purchase tests already had its own sentinel; thread it through

## Why this PR (not bundled)

#166 also lists \`buyback/tests.rs\`, \`paid_repair/tests.rs\`, \`data/tests.rs\`, and \`repair.rs\` for the same sweep. Those are the *hard-coded resource ids* pattern, which is a different fix shape (replace constants with runtime SELECTs) and #166's recommendation is "fold into the next PR that already touches each file." The outbox-cleanup pattern in purchase is the one fix that's a drop-in copy from PR #154 and worth landing on its own.

## Test plan

- [ ] \`DATABASE_URL=postgres://w-testing:w-testing@localhost:5433/sgw cargo test -p cimmeria-services --lib -- --test-threads=1\` — all four purchase tests still pass
- [ ] \`cell_event_outbox\` is empty after the test run (visual check via \`SELECT COUNT(*) FROM cell_event_outbox WHERE entity_id IN (...)\`)

## Related

- #166 — outbox + hard-coded-id sweep
- #154 — the vendor/sell PR this fix copies
- #207 — codecov ratchet (lands first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)