### PR TITLE
feat(content-engine): runtime counters, multi-trigger chains, Castle_CellBlock fixes

### DIFF
--- a/crates/content-engine/src/chain.rs
+++ b/crates/content-engine/src/chain.rs
@@ -225,8 +225,16 @@ impl ChainEngine {
 ///
 /// Each entry pairs a chain ID with the action to execute, preserving the
 /// ordering (highest-priority chain first, actions in declaration order).
+///
+/// `params` carries forward the resolution-time `ExecutionContext.params`
+/// so action executors can read trigger-time state without holding the
+/// original context. This is how `Action::RemoveItem` looks up
+/// `instance_id` set by `fire_item_use` to consume the exact stack the
+/// player clicked instead of the player's first-by-type instance.
+#[derive(Default)]
 pub struct ResolvedActions {
     pub actions: Vec<(i64, Action)>,
+    pub params: std::collections::HashMap<String, serde_json::Value>,
 }
 
 impl ChainEngine {
@@ -239,6 +247,7 @@ impl ChainEngine {
     pub fn resolve_event(&self, event: &TriggerEvent, ctx: &ExecutionContext) -> ResolvedActions {
         let mut resolved = ResolvedActions {
             actions: Vec::new(),
+            params: ctx.params.clone(),
         };
 
         let chains = match self.chains_by_trigger.get(&event.trigger_type) {

--- a/crates/content-engine/src/chain.rs
+++ b/crates/content-engine/src/chain.rs
@@ -245,10 +245,7 @@ impl ChainEngine {
     /// has access to game state (SpaceManager, channels, etc.) that the engine
     /// itself doesn't know about.
     pub fn resolve_event(&self, event: &TriggerEvent, ctx: &ExecutionContext) -> ResolvedActions {
-        let mut resolved = ResolvedActions {
-            actions: Vec::new(),
-            params: ctx.params.clone(),
-        };
+        let mut resolved = ResolvedActions::default();
 
         let chains = match self.chains_by_trigger.get(&event.trigger_type) {
             Some(chains) => chains,
@@ -270,6 +267,15 @@ impl ChainEngine {
             for action in &chain.actions {
                 resolved.actions.push((chain.id, action.clone()));
             }
+        }
+
+        // Defer the params clone until at least one chain matched.
+        // `resolve_event` runs on every gameplay tick that produces an
+        // event (entity death, region cross, item use, …), most of
+        // which return zero actions; cloning the populated context
+        // unconditionally wasted bytes on every miss.
+        if !resolved.actions.is_empty() {
+            resolved.params = ctx.params.clone();
         }
 
         resolved

--- a/crates/content-engine/src/conditions.rs
+++ b/crates/content-engine/src/conditions.rs
@@ -80,6 +80,18 @@ pub enum Condition {
         operator: ComparisonOp,
         value: i32,
     },
+
+    /// True iff the source entity's stat is below its current max
+    /// (i.e., the stat has headroom to grow). Used to gate consumable
+    /// chains so e.g. Health Slappacks fizzle silently rather than
+    /// burning a stack when the player is already at full HP.
+    ///
+    /// Reads `stat_<id>_cur` and `stat_<id>_max` from the context;
+    /// callers must populate these via `populate_stats_context` before
+    /// resolving. Returns `false` (treat as "no headroom, don't fire")
+    /// if either param is missing — fail-closed so a wiring mistake
+    /// can't accidentally make consumables free-to-spam at full stat.
+    StatBelowMax { stat_id: i32 },
 }
 
 /// Faction relationship levels.
@@ -239,6 +251,20 @@ impl Condition {
                 let key = format!("counter_{}", counter_name);
                 let actual = ctx.params.get(&key).and_then(|v| v.as_i64()).unwrap_or(0);
                 compare_i64(actual, *value as i64, operator)
+            }
+            Condition::StatBelowMax { stat_id } => {
+                let cur_key = format!("stat_{}_cur", stat_id);
+                let max_key = format!("stat_{}_max", stat_id);
+                let cur = ctx.params.get(&cur_key).and_then(|v| v.as_i64());
+                let max = ctx.params.get(&max_key).and_then(|v| v.as_i64());
+                match (cur, max) {
+                    (Some(c), Some(m)) => c < m,
+                    // Fail-closed: missing context means we don't know the
+                    // stat state, so treat as "no headroom" rather than
+                    // firing the chain blindly. A missing populator call
+                    // would otherwise let consumables burn at full stat.
+                    _ => false,
+                }
             }
         }
     }

--- a/crates/content-engine/src/conditions.rs
+++ b/crates/content-engine/src/conditions.rs
@@ -458,4 +458,51 @@ mod tests {
         ctx.set_param("counter_hallway01_kills".to_string(), serde_json::json!(2));
         assert!(!condition.evaluate(&ctx));
     }
+
+    /// `Condition::StatBelowMax` — pin the headroom semantics that gate
+    /// consumable chains. Slappack chain 4001 (`stat_below_max stat_id 7`)
+    /// relies on three branches: cur < max → fire (heal lands), cur == max
+    /// → no-op (chain doesn't fire, stack preserved), and missing populator
+    /// → fail-closed (treat as "no headroom" so a wiring mistake doesn't
+    /// silently make consumables free at full stat).
+    #[test]
+    fn stat_below_max_fires_when_cur_below_max() {
+        let condition = Condition::StatBelowMax { stat_id: 7 };
+        let mut ctx = ExecutionContext::new();
+        ctx.set_param("stat_7_cur".to_string(), serde_json::json!(50));
+        ctx.set_param("stat_7_max".to_string(), serde_json::json!(100));
+        assert!(condition.evaluate(&ctx));
+    }
+
+    #[test]
+    fn stat_below_max_blocks_when_cur_equals_max() {
+        let condition = Condition::StatBelowMax { stat_id: 7 };
+        let mut ctx = ExecutionContext::new();
+        ctx.set_param("stat_7_cur".to_string(), serde_json::json!(100));
+        ctx.set_param("stat_7_max".to_string(), serde_json::json!(100));
+        assert!(
+            !condition.evaluate(&ctx),
+            "at full stat the chain must NOT fire — burning a slappack at \
+             full HP is the bug class this gates against",
+        );
+    }
+
+    #[test]
+    fn stat_below_max_fails_closed_on_missing_params() {
+        let condition = Condition::StatBelowMax { stat_id: 7 };
+
+        // Empty context — both keys missing.
+        assert!(
+            !condition.evaluate(&ExecutionContext::new()),
+            "missing populator must fail closed; otherwise a wiring mistake \
+             that drops `populate_stats_context` makes consumables free at \
+             full stat",
+        );
+
+        // Half-populated context — only `cur` set, `max` missing. Same
+        // fail-closed branch.
+        let mut partial = ExecutionContext::new();
+        partial.set_param("stat_7_cur".to_string(), serde_json::json!(50));
+        assert!(!condition.evaluate(&partial));
+    }
 }

--- a/crates/content-engine/src/loader.rs
+++ b/crates/content-engine/src/loader.rs
@@ -105,26 +105,7 @@ pub fn build_chains_from_rows(
             .description
             .unwrap_or_else(|| format!("chain_{}", chain_id));
 
-        // Build trigger — take the first trigger row (chains have 0 or 1 triggers)
-        let mut trigger_list = triggers_by_chain.remove(&chain_id).unwrap_or_default();
-        trigger_list.sort_by_key(|t| t.sort_order);
-        let trigger = if let Some(t_row) = trigger_list.into_iter().next() {
-            match convert_trigger(&t_row) {
-                Some(t) => t,
-                None => {
-                    warn!(chain_id, event_type = %t_row.event_type, "Unknown trigger event_type, skipping chain");
-                    continue;
-                }
-            }
-        } else {
-            // Triggerless chain (invoked by on_victory_chains or TriggerChain)
-            // Use a CustomEvent that never naturally fires
-            Trigger::OnCustomEvent {
-                event_name: format!("__direct_invoke_{}", chain_id),
-            }
-        };
-
-        // Build conditions
+        // Build conditions (shared across all triggers for this chain).
         let mut cond_list = conditions_by_chain.remove(&chain_id).unwrap_or_default();
         cond_list.sort_by_key(|c| c.sort_order);
         let conditions: Vec<Condition> = cond_list.iter().filter_map(|c_row| {
@@ -135,7 +116,7 @@ pub fn build_chains_from_rows(
             result
         }).collect();
 
-        // Build actions
+        // Build actions (shared across all triggers for this chain).
         let mut act_list = actions_by_chain.remove(&chain_id).unwrap_or_default();
         act_list.sort_by_key(|a| a.sort_order);
         let actions: Vec<Action> = act_list.iter().filter_map(|a_row| {
@@ -146,15 +127,63 @@ pub fn build_chains_from_rows(
             result
         }).collect();
 
-        chains.push(Chain {
-            id: chain_id as i64,
-            name,
-            enabled: row.enabled,
-            trigger,
-            conditions,
-            actions,
-            priority: row.priority,
-        });
+        // Triggers — chains can declare multiple `content_triggers` rows
+        // for OR-semantics (e.g., "fire on either MessHall_Guard1 OR
+        // MessHall_Guard2 death"). Materialize one in-memory `Chain`
+        // per trigger row, all sharing the same conditions and actions.
+        // The runtime resolver doesn't need to know about the
+        // multi-trigger origin — it sees N independent chains keyed by
+        // each trigger's `TriggerType`. Same chain ID is reused so
+        // chain-replay tests and logs identify them as one logical
+        // chain.
+        //
+        // A chain with zero trigger rows is treated as triggerless
+        // (invoked directly via `on_victory_chains` or `TriggerChain`)
+        // and gets a single never-firing `OnCustomEvent` so it's
+        // present in the engine but inert without explicit invocation.
+        let mut trigger_list = triggers_by_chain.remove(&chain_id).unwrap_or_default();
+        trigger_list.sort_by_key(|t| t.sort_order);
+
+        let triggers: Vec<Trigger> = if trigger_list.is_empty() {
+            vec![Trigger::OnCustomEvent {
+                event_name: format!("__direct_invoke_{}", chain_id),
+            }]
+        } else {
+            trigger_list
+                .iter()
+                .filter_map(|t_row| {
+                    let result = convert_trigger(t_row);
+                    if result.is_none() {
+                        warn!(
+                            chain_id,
+                            event_type = %t_row.event_type,
+                            "Unknown trigger event_type, skipping this trigger row"
+                        );
+                    }
+                    result
+                })
+                .collect()
+        };
+
+        if triggers.is_empty() {
+            warn!(
+                chain_id,
+                "All trigger rows failed to convert — skipping chain"
+            );
+            continue;
+        }
+
+        for trigger in triggers {
+            chains.push(Chain {
+                id: chain_id as i64,
+                name: name.clone(),
+                enabled: row.enabled,
+                trigger,
+                conditions: conditions.clone(),
+                actions: actions.clone(),
+                priority: row.priority,
+            });
+        }
     }
 
     chains
@@ -259,6 +288,14 @@ fn convert_condition(row: &DbConditionRow) -> Option<Condition> {
                 operator: op,
                 value,
             })
+        }
+        "stat_below_max" => {
+            // target_id carries the stat id (no operator/value/key — the
+            // condition is structural: cur < max). Extra columns are
+            // ignored so chain authors don't accidentally encode an
+            // operator that the evaluator can't honor.
+            let stat_id = row.target_id?;
+            Some(Condition::StatBelowMax { stat_id })
         }
         _ => None,
     }

--- a/crates/content-engine/src/loader.rs
+++ b/crates/content-engine/src/loader.rs
@@ -750,6 +750,103 @@ mod tests {
         }
     }
 
+    /// Multiple `content_triggers` rows for the same chain id MUST
+    /// materialize one in-memory `Chain` per trigger (OR-semantics).
+    /// Pre-fix the loader silently dropped the 2nd+ rows, which
+    /// broke completion chains that needed to fire on either of two
+    /// guard tags (Mess Hall, Hallway05). Conditions and actions are
+    /// shared across the expanded chains.
+    #[test]
+    fn build_chains_from_rows_expands_multi_trigger_chain() {
+        use crate::triggers::Trigger;
+
+        let chain_rows = vec![DbChainRow {
+            chain_id: 1087,
+            description: Some("681 - Kill counter reached: complete 681, accept 682".to_string()),
+            scope_type: "mission".to_string(),
+            scope_id: Some(681),
+            enabled: true,
+            priority: 0,
+        }];
+        let trigger_rows = vec![
+            DbTriggerRow {
+                chain_id: 1087,
+                event_type: "entity_dead_tag".to_string(),
+                event_key: Some("MessHall_Guard1".to_string()),
+                scope: "space".to_string(),
+                once: false,
+                sort_order: 0,
+            },
+            DbTriggerRow {
+                chain_id: 1087,
+                event_type: "entity_dead_tag".to_string(),
+                event_key: Some("MessHall_Guard2".to_string()),
+                scope: "space".to_string(),
+                once: false,
+                sort_order: 1,
+            },
+        ];
+        let condition_rows = vec![DbConditionRow {
+            chain_id: 1087,
+            condition_type: "mission_status".to_string(),
+            target_id: Some(681),
+            target_key: None,
+            operator: "eq".to_string(),
+            value: Some("active".to_string()),
+            sort_order: 0,
+        }];
+        let action_rows = vec![DbActionRow {
+            chain_id: 1087,
+            action_type: "complete_mission".to_string(),
+            target_id: Some(681),
+            target_key: None,
+            params: serde_json::json!({}),
+            delay_ms: 0,
+            sort_order: 0,
+        }];
+
+        let chains = build_chains_from_rows(chain_rows, trigger_rows, condition_rows, action_rows);
+
+        // Two trigger rows → two chains, both at the same chain_id.
+        assert_eq!(
+            chains.len(),
+            2,
+            "two content_triggers rows must produce two in-memory chains"
+        );
+        assert!(chains.iter().all(|c| c.id == 1087));
+
+        // Conditions and actions are cloned across all expanded chains —
+        // they share the same gating + side-effects regardless of which
+        // trigger fired. A drift between the two would be a content
+        // authoring footgun, so this assertion is part of the contract.
+        for chain in &chains {
+            assert_eq!(chain.conditions.len(), 1);
+            assert_eq!(chain.actions.len(), 1);
+        }
+
+        // Distinct triggers on the two expansions, in declared sort_order.
+        let triggers: Vec<&Trigger> = chains.iter().map(|c| &c.trigger).collect();
+        match (triggers[0], triggers[1]) {
+            (
+                Trigger::OnEntityDeath {
+                    entity_tag: Some(a),
+                    ..
+                },
+                Trigger::OnEntityDeath {
+                    entity_tag: Some(b),
+                    ..
+                },
+            ) => {
+                assert_eq!(a, "MessHall_Guard1");
+                assert_eq!(b, "MessHall_Guard2");
+            }
+            other => panic!(
+                "expected two OnEntityDeath triggers with distinct tags, got {:?}",
+                other
+            ),
+        }
+    }
+
     #[test]
     fn triggerless_chain_gets_custom_event() {
         let chain_rows = vec![DbChainRow {

--- a/crates/content-engine/tests/interact_tag_linter.rs
+++ b/crates/content-engine/tests/interact_tag_linter.rs
@@ -208,6 +208,147 @@ fn every_interact_tag_chain_has_set_interaction_type() {
     );
 }
 
+/// Scan a chain SQL file for `enter_region` / `exit_region` trigger
+/// event_keys. Returns each (chain_id, region_tag) pair found.
+///
+/// `region_tag` is the full `'World.Region'` string from the trigger row
+/// — we rely on the case-sensitive equality match in
+/// `engine.resolve_event` (event_dispatch.rs::fire_enter_region), so a
+/// typo like `Castle_CellBlock.Region9` vs the canonical
+/// `Castle_Cellblock.Region9` (point_sets row) silently never matches.
+fn scan_region_triggers(sql: &str) -> Vec<(i32, String)> {
+    let mut out = Vec::new();
+    for line in sql.lines() {
+        let trimmed = line.trim_start();
+        let cursor = trimmed.trim_start_matches("VALUES").trim_start();
+        if !cursor.starts_with('(') {
+            continue;
+        }
+        if !cursor.contains("'enter_region'") && !cursor.contains("'exit_region'") {
+            continue;
+        }
+
+        let inner = &cursor[1..];
+        let chain_id: i32 = match inner
+            .split([',', ' '])
+            .find(|tok| !tok.is_empty() && tok.bytes().all(|b| b.is_ascii_digit()))
+            .and_then(|tok| tok.parse().ok())
+        {
+            Some(id) => id,
+            None => continue,
+        };
+
+        let quoted: Vec<&str> = cursor
+            .split('\'')
+            .enumerate()
+            .filter_map(|(i, s)| if i % 2 == 1 { Some(s) } else { None })
+            .collect();
+
+        // Layout: (chain_id, 'enter_region'|'exit_region', 'World.Region', 'scope', ...)
+        // Quoted strings: ['enter_region', 'World.Region', 'scope']
+        if let Some(region) = quoted.get(1) {
+            out.push((chain_id, region.to_string()));
+        }
+    }
+    out
+}
+
+/// Region-tag world prefixes are case-sensitive. The content engine
+/// resolver does a literal string match on the trigger event_key
+/// (event_dispatch.rs::fire_enter_region passes the region tag
+/// through unchanged), and the canonical region tag comes from the
+/// `point_sets` table. If a chain seeds `Castle_CellBlock.Region9`
+/// (capital `B`) but `point_sets` has `Castle_Cellblock.Region9`
+/// (lowercase `b`), the trigger never fires and the player is
+/// silently soft-stuck on whatever step the chain was meant to
+/// advance.
+///
+/// This is exactly what happened in chain 1073 of mission 680
+/// ("Lockdown! Find another way out of the Castle!") — every other
+/// region trigger in `castle_cellblock_chains.sql` uses
+/// `Castle_Cellblock.*`, only chain 1073 had the typo.
+///
+/// The invariant: within a single chain SQL file, every world prefix
+/// (the part before the first `.`) must use a single, consistent
+/// case. Cross-file consistency is also worth checking but is not
+/// strictly required (different files describe different worlds).
+#[test]
+fn every_chain_file_uses_consistent_region_world_prefix() {
+    let seed_dir = workspace_root().join("db/resources/Content/Seed");
+    assert!(
+        seed_dir.exists(),
+        "seed dir not found: {}",
+        seed_dir.display()
+    );
+
+    let mut violations = Vec::new();
+
+    for entry in fs::read_dir(&seed_dir).expect("read seed dir") {
+        let entry = entry.expect("dir entry");
+        let path = entry.path();
+        let filename = path.file_name().and_then(|s| s.to_str()).unwrap_or("");
+        if !filename.ends_with("_chains.sql") {
+            continue;
+        }
+
+        let sql =
+            fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+        let triggers = scan_region_triggers(&sql);
+
+        // world_lower → (canonical_case, first_chain_id_seen) for the first
+        // occurrence; any later trigger with a different case on the same
+        // lowercase world is a violation.
+        let mut seen: HashMap<String, (String, i32)> = HashMap::new();
+        for (chain_id, region) in &triggers {
+            let world = match region.split_once('.') {
+                Some((w, _)) => w,
+                None => continue, // No world prefix; skip rather than erroring.
+            };
+            let key = world.to_ascii_lowercase();
+            match seen.get(&key) {
+                Some((canonical, first_chain)) if canonical != world => {
+                    violations.push(format!(
+                        "  {}: chain {} uses world prefix '{}' but chain {} \
+                         (earlier in file) uses '{}' for the same world — \
+                         the resolver does case-sensitive string matching, \
+                         so one of these will never fire",
+                        filename, chain_id, world, first_chain, canonical,
+                    ));
+                }
+                Some(_) => {}
+                None => {
+                    seen.insert(key, (world.to_string(), *chain_id));
+                }
+            }
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "Chain seed files have inconsistent region-world casing — the \
+         content engine matches event_keys with case-sensitive string \
+         equality, so an inconsistent prefix means the trigger never \
+         fires and the player is soft-stuck:\n{}",
+        violations.join("\n"),
+    );
+}
+
+#[test]
+fn scan_region_triggers_extracts_chain_and_region() {
+    let sql = r#"
+INSERT INTO content_triggers (chain_id, event_type, event_key, scope, once, sort_order)
+VALUES (1, 'enter_region', 'World_A.Region2', 'player', false, 0);
+INSERT INTO content_triggers (chain_id, event_type, event_key, scope, once, sort_order)
+VALUES (2, 'exit_region', 'World_A.Region3', 'player', false, 0);
+INSERT INTO content_triggers (chain_id, event_type, event_key, scope, once, sort_order)
+VALUES (3, 'interact_tag', 'NotARegion', 'player', false, 0);
+"#;
+    let triggers = scan_region_triggers(sql);
+    assert_eq!(triggers.len(), 2, "must skip non-region triggers");
+    assert_eq!(triggers[0], (1, "World_A.Region2".to_string()));
+    assert_eq!(triggers[1], (2, "World_A.Region3".to_string()));
+}
+
 #[test]
 fn scan_chains_picks_up_basic_pattern() {
     // Smoke test the scanner with a tiny synthetic SQL snippet so we

--- a/crates/entity/src/cell_entity/mod.rs
+++ b/crates/entity/src/cell_entity/mod.rs
@@ -271,6 +271,19 @@ pub struct CellEntity {
     /// stages B/C/D read/clear this on reload completion, slot swap, ammo
     /// change, and logout.
     pub bandolier_ammo_dirty: HashSet<i32>,
+
+    /// Per-entity content-engine counter values, keyed by counter name.
+    /// Mutated by `Action::IncrementCounter` / `Action::ResetCounter` and
+    /// read by `Condition::Counter` (populated into the chain context as
+    /// `counter_<name>` by `populate_mission_context`). Used to track
+    /// kill counts and similar progression state — e.g., the Mess Hall
+    /// completion chain reads `counter_messhall_kills >= 2` to know
+    /// when both `MessHall_Guard1` and `MessHall_Guard2` are dead.
+    ///
+    /// Not persisted: counters are mission-scoped and intended to be
+    /// transient. The chain that reaches the threshold also explicitly
+    /// resets the counter via `Action::ResetCounter`.
+    pub counters: HashMap<String, i32>,
 }
 
 /// An item in a dead NPC's loot list, ready for display to players.
@@ -375,6 +388,7 @@ impl CellEntity {
             bandolier_ammo_dirty: HashSet::new(),
             ring_source_id: None,
             destination_ring_id: None,
+            counters: HashMap::new(),
         }
     }
 

--- a/crates/entity/src/cell_entity/mod.rs
+++ b/crates/entity/src/cell_entity/mod.rs
@@ -277,8 +277,12 @@ pub struct CellEntity {
     /// read by `Condition::Counter` (populated into the chain context as
     /// `counter_<name>` by `populate_mission_context`). Used to track
     /// kill counts and similar progression state — e.g., the Mess Hall
-    /// completion chain reads `counter_messhall_kills >= 2` to know
-    /// when both `MessHall_Guard1` and `MessHall_Guard2` are dead.
+    /// (target_value 2) completion chain reads
+    /// `counter_messhall_kills >= 1` to fire on the kill that brings
+    /// the counter to 2 alongside the increment chain. The `target - 1`
+    /// threshold is load-bearing because chain conditions evaluate
+    /// before sibling actions execute (see
+    /// `executor.rs::IncrementCounter` for the full ordering note).
     ///
     /// Not persisted: counters are mission-scoped and intended to be
     /// transient. The chain that reaches the threshold also explicitly

--- a/crates/services/src/base/outbox/mod.rs
+++ b/crates/services/src/base/outbox/mod.rs
@@ -63,6 +63,16 @@ pub enum CellOutboxPayload {
         /// `OnItemUse` chain context records exactly which stack
         /// initiated the use, letting `Action::RemoveItem` consume that
         /// instance instead of the player's first-by-type.
+        ///
+        /// `#[serde(default)]` so undelivered rows enqueued by older
+        /// code (before this field existed) deserialize cleanly with
+        /// `instance_id = 0`. The cell-side executor falls back to
+        /// `RemoveInventoryItemByType` when the value is 0, so old
+        /// rows reach the drainer with the same behavior they had
+        /// when written. Without this attribute the drainer hard-fails
+        /// on legacy rows with `ColumnDecode("missing field
+        /// 'instance_id'")` and the outbox stalls.
+        #[serde(default)]
         instance_id: i32,
         type_id: i32,
         target_id: i32,

--- a/crates/services/src/base/outbox/mod.rs
+++ b/crates/services/src/base/outbox/mod.rs
@@ -59,6 +59,11 @@ const EVENT_TYPE_INVENTORY_ITEM_REMOVED: &str = "inventory_item_removed";
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum CellOutboxPayload {
     ItemUsed {
+        /// Inventory row id the player clicked. Carried through so the
+        /// `OnItemUse` chain context records exactly which stack
+        /// initiated the use, letting `Action::RemoveItem` consume that
+        /// instance instead of the player's first-by-type.
+        instance_id: i32,
         type_id: i32,
         target_id: i32,
     },
@@ -180,13 +185,19 @@ async fn record_failure(pool: &PgPool, id: i64, error: &str) {
 fn row_to_message(row: &OutboxRow) -> Option<BaseToCellMsg> {
     let entity_id = row.entity_id as u32;
     match (row.event_type.as_str(), &*row.payload) {
-        (EVENT_TYPE_ITEM_USED, CellOutboxPayload::ItemUsed { type_id, target_id }) => {
-            Some(BaseToCellMsg::ItemUsed {
-                entity_id,
-                type_id: *type_id,
-                target_id: *target_id,
-            })
-        }
+        (
+            EVENT_TYPE_ITEM_USED,
+            CellOutboxPayload::ItemUsed {
+                instance_id,
+                type_id,
+                target_id,
+            },
+        ) => Some(BaseToCellMsg::ItemUsed {
+            entity_id,
+            instance_id: *instance_id,
+            type_id: *type_id,
+            target_id: *target_id,
+        }),
         (
             EVENT_TYPE_INVENTORY_ITEM_GRANTED,
             CellOutboxPayload::InventoryItemGranted {
@@ -229,8 +240,13 @@ pub async fn try_dispatch_now(
     payload: CellOutboxPayload,
 ) {
     let msg = match payload {
-        CellOutboxPayload::ItemUsed { type_id, target_id } => BaseToCellMsg::ItemUsed {
+        CellOutboxPayload::ItemUsed {
+            instance_id,
+            type_id,
+            target_id,
+        } => BaseToCellMsg::ItemUsed {
             entity_id,
+            instance_id,
             type_id,
             target_id,
         },

--- a/crates/services/src/base/outbox/tests.rs
+++ b/crates/services/src/base/outbox/tests.rs
@@ -10,6 +10,7 @@ use super::*;
 #[test]
 fn payload_serializes_with_kind_tag() {
     let p = CellOutboxPayload::ItemUsed {
+        instance_id: 0,
         type_id: 42,
         target_id: 17,
     };
@@ -25,6 +26,7 @@ fn payload_serializes_with_kind_tag() {
 #[test]
 fn payload_roundtrips_through_json() {
     let p = CellOutboxPayload::ItemUsed {
+        instance_id: 0,
         type_id: -7,
         target_id: 0,
     };
@@ -40,6 +42,7 @@ fn event_type_string_is_stable() {
     // to make that breakage loud at refactor time.
     assert_eq!(
         CellOutboxPayload::ItemUsed {
+            instance_id: 0,
             type_id: 0,
             target_id: 0
         }
@@ -55,6 +58,7 @@ fn row_to_message_builds_item_used() {
         entity_id: 1234,
         event_type: "item_used".to_string(),
         payload: sqlx::types::Json(CellOutboxPayload::ItemUsed {
+            instance_id: 0,
             type_id: 19,
             target_id: 5,
         }),
@@ -64,6 +68,7 @@ fn row_to_message_builds_item_used() {
     match msg {
         BaseToCellMsg::ItemUsed {
             entity_id,
+            instance_id: _,
             type_id,
             target_id,
         } => {
@@ -85,6 +90,7 @@ fn row_to_message_returns_none_for_unknown_event_type() {
         entity_id: 1,
         event_type: "future_event_v2".to_string(),
         payload: sqlx::types::Json(CellOutboxPayload::ItemUsed {
+            instance_id: 0,
             type_id: 0,
             target_id: 0,
         }),
@@ -106,6 +112,7 @@ fn persistence_contract_strings_are_stable_for_all_variants() {
     let cases: &[(CellOutboxPayload, &str)] = &[
         (
             CellOutboxPayload::ItemUsed {
+                instance_id: 0,
                 type_id: 0,
                 target_id: 0,
             },
@@ -236,6 +243,7 @@ fn row_to_message_returns_none_on_event_type_payload_mismatch() {
         entity_id: 1,
         event_type: "inventory_item_granted".to_string(),
         payload: sqlx::types::Json(CellOutboxPayload::ItemUsed {
+            instance_id: 0,
             type_id: 0,
             target_id: 0,
         }),
@@ -309,6 +317,7 @@ async fn enqueue_in_tx_writes_row_atomic_with_caller_commit() {
     cleanup(&pool, entity_id).await;
 
     let payload = CellOutboxPayload::ItemUsed {
+        instance_id: 0,
         type_id: 19,
         target_id: 0,
     };
@@ -355,6 +364,7 @@ async fn enqueue_then_drain_round_trips_message_and_marks_delivered() {
     cleanup(&pool, entity_id).await;
 
     let payload = CellOutboxPayload::ItemUsed {
+        instance_id: 0,
         type_id: 42,
         target_id: 7,
     };
@@ -374,6 +384,7 @@ async fn enqueue_then_drain_round_trips_message_and_marks_delivered() {
     match msg {
         BaseToCellMsg::ItemUsed {
             entity_id: e,
+            instance_id: _,
             type_id,
             target_id,
         } => {
@@ -413,10 +424,12 @@ async fn drain_stops_at_first_send_failure_and_records_attempt() {
     cleanup(&pool, entity_id).await;
 
     let payload_a = CellOutboxPayload::ItemUsed {
+        instance_id: 0,
         type_id: 1,
         target_id: 0,
     };
     let payload_b = CellOutboxPayload::ItemUsed {
+        instance_id: 0,
         type_id: 2,
         target_id: 0,
     };
@@ -472,6 +485,7 @@ fn drain_item_used_for(rx: &mut mpsc::Receiver<BaseToCellMsg>, entity_id: u32) -
     while let Ok(msg) = rx.try_recv() {
         if let BaseToCellMsg::ItemUsed {
             entity_id: e,
+            instance_id: _,
             type_id,
             target_id,
         } = msg
@@ -501,6 +515,7 @@ async fn injected_send_failure_replays_on_next_drain_with_payload_intact() {
     purge_undelivered_backlog(&pool).await;
 
     let payload = CellOutboxPayload::ItemUsed {
+        instance_id: 0,
         type_id: 4242,
         target_id: 1337,
     };
@@ -584,6 +599,7 @@ async fn try_dispatch_now_failure_leaves_row_for_drainer_replay() {
     purge_undelivered_backlog(&pool).await;
 
     let payload = CellOutboxPayload::ItemUsed {
+        instance_id: 0,
         type_id: 99,
         target_id: 11,
     };
@@ -659,6 +675,7 @@ async fn poison_row_does_not_block_following_rows_in_same_batch() {
     // Legitimate row enqueued *after* the poison row, so global id order
     // puts the poison row first in the batch.
     let good_payload = CellOutboxPayload::ItemUsed {
+        instance_id: 0,
         type_id: 7,
         target_id: 3,
     };

--- a/crates/services/src/base/world_entry/methods/inventory/core.rs
+++ b/crates/services/src/base/world_entry/methods/inventory/core.rs
@@ -422,7 +422,11 @@ pub async fn handle_use_inventory_item(
         "UseInventoryItem: firing ItemUsed (no consumption — chain decides)"
     );
 
-    let payload = CellOutboxPayload::ItemUsed { type_id, target_id };
+    let payload = CellOutboxPayload::ItemUsed {
+        instance_id: item_id,
+        type_id,
+        target_id,
+    };
     let outbox_id = match outbox::enqueue(pool.as_ref(), entity_id, &payload).await {
         Ok(id) => id,
         Err(e) => {

--- a/crates/services/src/cell/content/engine_loader.rs
+++ b/crates/services/src/cell/content/engine_loader.rs
@@ -289,11 +289,23 @@ mod tests {
         // Fire `OnItemUse(2893)` — relationship-based lookup. The
         // trigger filters on `item_id` so only chains keyed on item
         // 2893 will match, regardless of which chain id they live at.
+        //
+        // The slappack chain (4001) gates on `Condition::StatBelowMax`
+        // so the player can't burn a stack at full HP. That condition
+        // reads `stat_<id>_cur` / `stat_<id>_max` from the chain
+        // context — populated by `populate_stats_context` at the live
+        // dispatch site. This synthetic test fires `resolve_event`
+        // directly without the populator, so we have to seed the
+        // headroom-positive params by hand. Without these, the
+        // condition fail-closes (cur < max unknown → false) and
+        // 0 actions resolve.
         let mut ctx = ExecutionContext::new();
         ctx.set_param(
             "item_id".to_string(),
             serde_json::json!(HEALTH_SLAPPACK_ITEM_ID),
         );
+        ctx.set_param("stat_7_cur".to_string(), serde_json::json!(100));
+        ctx.set_param("stat_7_max".to_string(), serde_json::json!(1000));
         let event = TriggerEvent {
             trigger_type: TriggerType::ItemUse,
             source_entity: None,

--- a/crates/services/src/cell/content/event_dispatch.rs
+++ b/crates/services/src/cell/content/event_dispatch.rs
@@ -17,7 +17,7 @@ use crate::cell::messages::CellToBaseMsg;
 use crate::cell::space_manager::SpaceManager;
 
 use super::executor;
-use super::mission_context::populate_mission_context;
+use super::mission_context::{populate_mission_context, populate_stats_context};
 
 /// Fire the `PlayerLoaded` event for a player entering a world.
 pub async fn fire_player_loaded(
@@ -383,9 +383,17 @@ pub async fn fire_dialog_choice(
 }
 
 /// Fire `OnItemUse` event when a player uses an inventory item.
+///
+/// `item_id` is the item design id (type_id) — drives chain matching on
+/// `item_use::<type_id>`. `instance_id` is the inventory row id the
+/// player clicked — set into the context so `Action::RemoveItem` can
+/// consume that exact stack instead of the player's first-by-type
+/// instance (which is wrong when the player has multiple stacks of the
+/// same item and clicks anything other than the first one).
 pub async fn fire_item_use(
     entity_id: u32,
     player_id: i32,
+    instance_id: i32,
     item_id: i32,
     engine: &ChainEngine,
     tx: &mpsc::Sender<CellToBaseMsg>,
@@ -393,9 +401,14 @@ pub async fn fire_item_use(
 ) {
     let mut ctx = ExecutionContext::new().with_source(cimmeria_common::EntityId(entity_id as i32));
     ctx.set_param("item_id".to_string(), serde_json::json!(item_id));
+    ctx.set_param("instance_id".to_string(), serde_json::json!(instance_id));
 
     if let Some(entity) = space_mgr.get_entity(entity_id) {
         populate_mission_context(entity, &mut ctx);
+        // Stats are needed by `Condition::StatBelowMax` so chains like
+        // the Health Slappack (4001) can fizzle silently at full HP
+        // instead of burning the stack.
+        populate_stats_context(entity, &mut ctx);
         if let Some(archetype_id) = entity.archetype_id {
             ctx.set_param("archetype".to_string(), serde_json::json!(archetype_id));
         }
@@ -504,6 +517,7 @@ pub async fn fire_chain_by_id(
     );
     let resolved = cimmeria_content_engine::chain::ResolvedActions {
         actions: actions.into_iter().map(|a| (chain_id, a)).collect(),
+        ..Default::default()
     };
     executor::execute_actions(resolved, entity_id, player_id, tx, space_mgr, engine).await;
 }

--- a/crates/services/src/cell/content/executor.rs
+++ b/crates/services/src/cell/content/executor.rs
@@ -1350,4 +1350,113 @@ mod tests {
             other => panic!("expected RemoveInventoryItemByType, got {:?}", other),
         }
     }
+
+    /// `Action::IncrementCounter` mutates `entity.counters`. Previously
+    /// a stub that only logged; now load-bearing for kill-counter
+    /// missions like Mess Hall (counter `messhall_kills`) and Hallway05
+    /// (`hallway05_kills`). Pin the new-key initialization path:
+    /// missing entry → 0, then add `amount`.
+    #[tokio::test]
+    async fn increment_counter_initializes_and_adds_amount() {
+        let mut mgr = make_space_mgr();
+        mgr.create_entity(1, "Agnos", [0.0, 0.0, 0.0], [0.0; 3])
+            .unwrap();
+
+        let (tx, _rx) = mpsc::channel(8);
+        let engine = ChainEngine::new();
+        let resolved = ResolvedActions {
+            params: std::collections::HashMap::new(),
+            actions: vec![(
+                1085,
+                Action::IncrementCounter {
+                    counter_name: "messhall_kills".to_string(),
+                    amount: 1,
+                },
+            )],
+        };
+        execute_actions(resolved, 1, 42, &tx, &mut mgr, &engine).await;
+
+        let entity = mgr.get_entity(1).expect("entity must still exist");
+        assert_eq!(
+            entity.counters.get("messhall_kills"),
+            Some(&1),
+            "new counter must initialize at 0 and add `amount` (1)",
+        );
+    }
+
+    /// `Action::IncrementCounter` on an existing counter adds to the
+    /// stored value rather than overwriting. The Mess Hall mission
+    /// design depends on this: each guard kill increments the same
+    /// counter; the second kill must read the first's stored value
+    /// for the completion chain's `gte (target - 1)` condition to
+    /// fire on the right kill.
+    #[tokio::test]
+    async fn increment_counter_adds_to_existing_value() {
+        let mut mgr = make_space_mgr();
+        mgr.create_entity(1, "Agnos", [0.0, 0.0, 0.0], [0.0; 3])
+            .unwrap();
+        mgr.get_entity_mut(1)
+            .unwrap()
+            .counters
+            .insert("messhall_kills".to_string(), 1);
+
+        let (tx, _rx) = mpsc::channel(8);
+        let engine = ChainEngine::new();
+        let resolved = ResolvedActions {
+            params: std::collections::HashMap::new(),
+            actions: vec![(
+                1086,
+                Action::IncrementCounter {
+                    counter_name: "messhall_kills".to_string(),
+                    amount: 1,
+                },
+            )],
+        };
+        execute_actions(resolved, 1, 42, &tx, &mut mgr, &engine).await;
+
+        assert_eq!(
+            mgr.get_entity(1).unwrap().counters.get("messhall_kills"),
+            Some(&2),
+            "second increment must add to the stored value, not overwrite",
+        );
+    }
+
+    /// `Action::ResetCounter` removes the entry entirely. Subsequent
+    /// `Condition::Counter` reads see the missing-key default of 0.
+    /// Used by the Mess Hall completion chain (1087) so a re-accept
+    /// of mission 681 (e.g., the same player respawning into a fresh
+    /// instance) starts the counter clean.
+    #[tokio::test]
+    async fn reset_counter_clears_entry() {
+        let mut mgr = make_space_mgr();
+        mgr.create_entity(1, "Agnos", [0.0, 0.0, 0.0], [0.0; 3])
+            .unwrap();
+        mgr.get_entity_mut(1)
+            .unwrap()
+            .counters
+            .insert("messhall_kills".to_string(), 2);
+
+        let (tx, _rx) = mpsc::channel(8);
+        let engine = ChainEngine::new();
+        let resolved = ResolvedActions {
+            params: std::collections::HashMap::new(),
+            actions: vec![(
+                1087,
+                Action::ResetCounter {
+                    counter_name: "messhall_kills".to_string(),
+                },
+            )],
+        };
+        execute_actions(resolved, 1, 42, &tx, &mut mgr, &engine).await;
+
+        assert!(
+            !mgr.get_entity(1)
+                .unwrap()
+                .counters
+                .contains_key("messhall_kills"),
+            "reset must remove the entry — leaving a 0 entry would surface \
+             via populate_counters_context as `counter_messhall_kills = 0` \
+             rather than the missing-key default, masking a re-acceptance",
+        );
+    }
 }

--- a/crates/services/src/cell/content/executor.rs
+++ b/crates/services/src/cell/content/executor.rs
@@ -32,7 +32,12 @@ pub(super) async fn execute_actions(
     space_mgr: &mut SpaceManager,
     engine: &cimmeria_content_engine::chain::ChainEngine,
 ) {
-    for (chain_id, action) in resolved.actions {
+    // Destructure so the inner loop can move `actions` while later
+    // action branches still read trigger-time `params`. `Action::RemoveItem`
+    // looks up `instance_id` here to consume the exact stack the
+    // player clicked on `useItem`.
+    let ResolvedActions { actions, params } = resolved;
+    for (chain_id, action) in actions {
         match action {
             Action::AcceptMission { mission_id } | Action::AdvanceMission { mission_id } => {
                 tracing::info!(
@@ -397,28 +402,62 @@ pub(super) async fn execute_actions(
                 }
             }
             Action::RemoveItem { item_id, count } => {
-                // Chains carry the item's design id (type_id), not an
-                // inventory instance id. Route through the cell→base
-                // RemoveInventoryItemByType RPC, which resolves the
-                // player's first matching instance and applies the same
-                // wire-update sequence as a normal remove.
-                tracing::info!(
-                    entity_id,
-                    player_id,
-                    type_id = item_id,
-                    count,
-                    chain_id,
-                    "Content: RemoveItem → RemoveInventoryItemByType"
-                );
-                if let Err(e) = tx
-                    .send(CellToBaseMsg::RemoveInventoryItemByType {
-                        entity_id,
-                        player_id,
-                        type_id: item_id,
-                        count,
-                    })
-                    .await
-                {
+                // Prefer the originating inventory `instance_id` if the
+                // chain context carries one (set by `fire_item_use` —
+                // the OnItemUse dispatch path). This is the difference
+                // between "consume the slappack the player clicked" and
+                // "consume the leftmost slappack of that type": when a
+                // player has two stacks of the same item and clicks the
+                // second one, the first stack must NOT be silently
+                // consumed instead.
+                //
+                // For chains fired by other paths (mission events,
+                // ambernol vial consumption via `enter_region`, etc.)
+                // there's no instance_id in context, so we fall back to
+                // the by-type resolution that picks the player's first
+                // matching instance. Both paths converge on the same
+                // wire-update sequence on the base side.
+                let instance_id = params
+                    .get("instance_id")
+                    .and_then(|v| v.as_i64())
+                    .map(|v| v as i32)
+                    .filter(|&v| v != 0);
+
+                let send_result =
+                    match instance_id {
+                        Some(instance) => {
+                            tracing::info!(
+                            entity_id, player_id, instance, type_id = item_id, count, chain_id,
+                            "Content: RemoveItem → RemoveInventoryItem (by instance from context)"
+                        );
+                            tx.send(CellToBaseMsg::RemoveInventoryItem {
+                                entity_id,
+                                player_id,
+                                item_id: instance,
+                                quantity: count,
+                            })
+                            .await
+                        }
+                        None => {
+                            tracing::info!(
+                                entity_id,
+                                player_id,
+                                type_id = item_id,
+                                count,
+                                chain_id,
+                                "Content: RemoveItem → RemoveInventoryItemByType"
+                            );
+                            tx.send(CellToBaseMsg::RemoveInventoryItemByType {
+                                entity_id,
+                                player_id,
+                                type_id: item_id,
+                                count,
+                            })
+                            .await
+                        }
+                    };
+
+                if let Err(e) = send_result {
                     // Saturated/closed channel — the consume silently
                     // skips otherwise. Surface it loudly so missions
                     // that depend on the removal (e.g., FindAmbernol
@@ -689,10 +728,42 @@ pub(super) async fn execute_actions(
                 counter_name,
                 amount,
             } => {
-                tracing::debug!(entity_id, %counter_name, amount, chain_id, "Content: increment counter");
+                // Counter values live on the cell entity and are read by
+                // `Condition::Counter` via `populate_mission_context`
+                // writing `counter_<name>` into the chain context.
+                //
+                // Resolve/execute ordering gotcha: chains are resolved
+                // (conditions evaluated against ctx) before any actions
+                // run, so a sibling completion chain on the same
+                // trigger event reads the PRE-increment counter value.
+                // For "kill N targets to complete" the completion
+                // condition must be `counter >= N - 1` so it fires on
+                // the kill that brings the counter to N. Documented at
+                // each call site that uses this pattern (e.g.,
+                // castle_cellblock_chains.sql chain 1087 / 1094).
+                if let Some(entity) = space_mgr.get_entity_mut(entity_id) {
+                    let entry = entity.counters.entry(counter_name.clone()).or_insert(0);
+                    *entry = entry.saturating_add(amount);
+                    tracing::debug!(
+                        entity_id, player_id, %counter_name, amount,
+                        new_value = *entry, chain_id,
+                        "Content: incremented counter"
+                    );
+                } else {
+                    tracing::warn!(
+                        entity_id, %counter_name, chain_id,
+                        "Content: increment_counter source entity missing — counter not updated"
+                    );
+                }
             }
             Action::ResetCounter { counter_name } => {
-                tracing::debug!(entity_id, %counter_name, chain_id, "Content: reset counter");
+                if let Some(entity) = space_mgr.get_entity_mut(entity_id) {
+                    let removed = entity.counters.remove(&counter_name);
+                    tracing::debug!(
+                        entity_id, player_id, %counter_name, ?removed, chain_id,
+                        "Content: reset counter"
+                    );
+                }
             }
             Action::CompleteObjective {
                 mission_id,
@@ -1005,6 +1076,7 @@ mod tests {
         let (tx, mut rx) = mpsc::channel(8);
         let engine = ChainEngine::new();
         let resolved = ResolvedActions {
+            params: std::collections::HashMap::new(),
             actions: vec![(
                 4001,
                 Action::ChangeStat {
@@ -1086,6 +1158,7 @@ mod tests {
         let (tx, _rx) = mpsc::channel(8);
         let engine = ChainEngine::new();
         let resolved = ResolvedActions {
+            params: std::collections::HashMap::new(),
             actions: vec![(
                 4001,
                 Action::ChangeStat {
@@ -1122,6 +1195,7 @@ mod tests {
         let (tx, _rx) = mpsc::channel(8);
         let engine = ChainEngine::new();
         let resolved = ResolvedActions {
+            params: std::collections::HashMap::new(),
             actions: vec![(
                 4001,
                 Action::ChangeStat {
@@ -1158,6 +1232,7 @@ mod tests {
         let (tx, _rx) = mpsc::channel(8);
         let engine = ChainEngine::new();
         let resolved = ResolvedActions {
+            params: std::collections::HashMap::new(),
             actions: vec![(
                 4001,
                 Action::ChangeStat {
@@ -1194,6 +1269,7 @@ mod tests {
         let (tx, mut rx) = mpsc::channel(8);
         let engine = ChainEngine::new();
         let resolved = ResolvedActions {
+            params: std::collections::HashMap::new(),
             actions: vec![
                 (
                     2011,
@@ -1246,6 +1322,7 @@ mod tests {
         let (tx, mut rx) = mpsc::channel(8);
         let engine = ChainEngine::new();
         let resolved = ResolvedActions {
+            params: std::collections::HashMap::new(),
             actions: vec![(
                 1034,
                 Action::RemoveItem {

--- a/crates/services/src/cell/content/mission_context.rs
+++ b/crates/services/src/cell/content/mission_context.rs
@@ -9,6 +9,37 @@ use cimmeria_content_engine::context::ExecutionContext;
 use cimmeria_entity::cell_entity::CellEntity;
 use cimmeria_entity::missions::{MISSION_ACTIVE, MISSION_COMPLETED, MISSION_NOT_ACTIVE};
 
+/// Populate per-stat current/max into the context as `stat_<id>_cur` and
+/// `stat_<id>_max` numeric params. Read by `Condition::StatBelowMax` to
+/// gate consumable chains against full-stat fizzles.
+///
+/// Currently only invoked from the `OnItemUse` dispatch site
+/// (consumable-use is the only chain class that needs stat state for
+/// gating). Generalize to other dispatch sites if/when more conditions
+/// learn to read stat values.
+pub(super) fn populate_stats_context(entity: &CellEntity, ctx: &mut ExecutionContext) {
+    for (stat_id, stat) in entity.stats.iter() {
+        ctx.set_param(format!("stat_{}_cur", stat_id), serde_json::json!(stat.cur));
+        ctx.set_param(format!("stat_{}_max", stat_id), serde_json::json!(stat.max));
+    }
+}
+
+/// Populate per-entity counter values into the context as `counter_<name>`
+/// numeric params. Read by `Condition::Counter` (the loader maps DB
+/// rows with `condition_type='counter'` and `target_key=<name>` onto
+/// this).
+///
+/// Called from `populate_mission_context` so every mission-aware
+/// dispatcher (notably `fire_entity_death`) sees up-to-date counter
+/// values when evaluating completion chains. Mutated by
+/// `Action::IncrementCounter` and `Action::ResetCounter` in the
+/// executor.
+pub(super) fn populate_counters_context(entity: &CellEntity, ctx: &mut ExecutionContext) {
+    for (name, value) in &entity.counters {
+        ctx.set_param(format!("counter_{}", name), serde_json::json!(*value));
+    }
+}
+
 /// Populate mission status and step status context params from entity state.
 ///
 /// Step status semantics (chain conditions read these via `step_status`):
@@ -23,6 +54,12 @@ use cimmeria_entity::missions::{MISSION_ACTIVE, MISSION_COMPLETED, MISSION_NOT_A
 ///   it" should compare against `completed` rather than relying on
 ///   `not_active`.
 pub(super) fn populate_mission_context(entity: &CellEntity, ctx: &mut ExecutionContext) {
+    // Counters travel alongside missions — completion chains for
+    // multi-step kill sequences read counter values to know when to
+    // fire. Populate them here so every mission-aware dispatcher gets
+    // them without each having to remember a separate call.
+    populate_counters_context(entity, ctx);
+
     for mission in entity.missions.all_missions() {
         let status_str = match mission.status {
             MISSION_NOT_ACTIVE => "not_active",

--- a/crates/services/src/cell/content/mission_context.rs
+++ b/crates/services/src/cell/content/mission_context.rs
@@ -218,4 +218,80 @@ mod tests {
             "unreached steps must not be populated",
         );
     }
+
+    /// `populate_counters_context` writes one `counter_<name>` numeric
+    /// param per entry in `entity.counters`. `Condition::Counter` reads
+    /// these to gate completion chains for kill-counter missions like
+    /// the Mess Hall (counter `messhall_kills`) and Hallway05 (counter
+    /// `hallway05_kills`).
+    #[test]
+    fn populate_counters_context_writes_counter_keys() {
+        let mut entity = CellEntity::new(EntityId(1), SpaceId(100), Vector3::zero());
+        entity.counters.insert("messhall_kills".to_string(), 1);
+        entity.counters.insert("hallway05_kills".to_string(), 0);
+
+        let mut ctx = ExecutionContext::new();
+        populate_counters_context(&entity, &mut ctx);
+
+        assert_eq!(
+            ctx.params
+                .get("counter_messhall_kills")
+                .and_then(|v| v.as_i64()),
+            Some(1),
+            "non-zero counter must populate as its current value",
+        );
+        assert_eq!(
+            ctx.params
+                .get("counter_hallway05_kills")
+                .and_then(|v| v.as_i64()),
+            Some(0),
+            "zero-valued counter must populate explicitly (not be elided) — \
+             a `Counter::Eq 0` condition would otherwise see the missing-key \
+             default and could miss the genuinely-zero case",
+        );
+    }
+
+    /// Empty `entity.counters` must not pollute the context — chains
+    /// that don't use counters should see a clean slate.
+    #[test]
+    fn populate_counters_context_empty_when_no_counters() {
+        let entity = CellEntity::new(EntityId(1), SpaceId(100), Vector3::zero());
+        let mut ctx = ExecutionContext::new();
+        populate_counters_context(&entity, &mut ctx);
+        assert!(
+            ctx.params.is_empty(),
+            "no counters → no params written; got {:?}",
+            ctx.params
+        );
+    }
+
+    /// `populate_stats_context` mirrors mission population but for
+    /// `entity.stats`. `Condition::StatBelowMax` reads `stat_<id>_cur`
+    /// and `stat_<id>_max` to gate consumable chains.
+    #[test]
+    fn populate_stats_context_writes_cur_and_max_for_each_stat() {
+        use cimmeria_entity::stats::{Stat, HEALTH};
+
+        let mut entity = CellEntity::new(EntityId(1), SpaceId(100), Vector3::zero());
+        // StatList is initialized with all default stats; overwrite HEALTH
+        // so we have known values to assert against.
+        if let Some(s) = entity.stats.get_mut(HEALTH) {
+            *s = Stat::new(0, 250, 1000, 0, 250, 1000);
+        }
+
+        let mut ctx = ExecutionContext::new();
+        populate_stats_context(&entity, &mut ctx);
+
+        let cur_key = format!("stat_{}_cur", HEALTH);
+        let max_key = format!("stat_{}_max", HEALTH);
+        assert_eq!(
+            ctx.params.get(&cur_key).and_then(|v| v.as_i64()),
+            Some(250),
+            "stat cur must populate verbatim — `Condition::StatBelowMax` reads it",
+        );
+        assert_eq!(
+            ctx.params.get(&max_key).and_then(|v| v.as_i64()),
+            Some(1000),
+        );
+    }
 }

--- a/crates/services/src/cell/messages/base_to_cell.rs
+++ b/crates/services/src/cell/messages/base_to_cell.rs
@@ -121,13 +121,24 @@ pub enum BaseToCellMsg {
         quantity: i32,
     },
 
-    /// Inventory item was consumed atomically by base (in response to
-    /// `CellToBaseMsg::UseInventoryItem`). The cell should fire the
-    /// `OnItemUse` content event with `type_id` (item design id). Only sent
-    /// after the consumption tx commits — if the player didn't own that
-    /// instance or the tx failed, this message is not emitted.
+    /// Inventory item was used by the player (in response to
+    /// `CellToBaseMsg::UseInventoryItem` after base verified ownership).
+    /// The cell fires the `OnItemUse` content event with `type_id` (item
+    /// design id) so chains conditioned on `item_use::<type_id>` can run.
+    ///
+    /// `instance_id` is the inventory row id the client clicked — passed
+    /// through so the chain context can record which exact instance
+    /// initiated the use. `Action::RemoveItem` reads this to remove
+    /// THAT specific stack rather than the player's first-by-type
+    /// instance, which is the difference between "consume the slappack
+    /// you clicked" and "consume the leftmost slappack in the bag."
+    ///
+    /// Note: base does NOT consume the item before sending this — chains
+    /// decide via `Action::RemoveItem`. The historical comment about
+    /// "consumption tx" pre-dated the chain-decides-consumption design.
     ItemUsed {
         entity_id: u32,
+        instance_id: i32,
         type_id: i32,
         target_id: i32,
     },

--- a/crates/services/src/cell/service/base_messages.rs
+++ b/crates/services/src/cell/service/base_messages.rs
@@ -420,14 +420,16 @@ pub(super) async fn handle_base_message(
 
         BaseToCellMsg::ItemUsed {
             entity_id,
+            instance_id,
             type_id,
             target_id,
         } => {
-            // Base committed the consumption transaction; fire `OnItemUse` so
-            // any chain conditioned on `item_use::<type_id>` can run. Mission
-            // progression that gates on this only advances after the vial is
-            // actually consumed — if base failed to consume, this event never
-            // arrives.
+            // Base verified ownership and forwarded the use event. Fire
+            // `OnItemUse` so any chain conditioned on `item_use::<type_id>`
+            // can run. The chain decides whether to consume (via
+            // `Action::RemoveItem`) — base does NOT consume before this
+            // message, the historical comment about a "consumption tx"
+            // pre-dated the chain-decides-consumption design.
             let player_id = match space_mgr.get_entity(entity_id).and_then(|e| e.player_id) {
                 Some(pid) => pid,
                 None => {
@@ -442,11 +444,21 @@ pub(super) async fn handle_base_message(
             tracing::debug!(
                 entity_id,
                 player_id,
+                instance_id,
                 type_id,
                 target_id,
                 "ItemUsed: firing OnItemUse"
             );
-            content::fire_item_use(entity_id, player_id, type_id, engine, tx, space_mgr).await;
+            content::fire_item_use(
+                entity_id,
+                player_id,
+                instance_id,
+                type_id,
+                engine,
+                tx,
+                space_mgr,
+            )
+            .await;
         }
     }
 }

--- a/db/resources/Content/Seed/castle_cellblock_chains.sql
+++ b/db/resources/Content/Seed/castle_cellblock_chains.sql
@@ -212,7 +212,14 @@ VALUES (1020, 'step_status', 638, '2116', 'eq', 'active', 0);
 INSERT INTO content_actions (chain_id, action_type, target_id, target_key, params, delay_ms, sort_order)
 VALUES (1020, 'display_dialog', 5020, NULL, '{}', 0, 0);
 
--- Chain 1021: dialog choice 2300 (Human) while step 2116 active → show follow-up dialog 5020
+-- Chain 1021: dialog choice 2300 (Human) while step 2116 active → show follow-up dialog 2299
+-- Per the dialog-id mapping at the top of this file (Mission 638 section),
+-- 2299 is the *Human* "Agree to escape" follow-up (5020 is the Jaffa one).
+-- Fix for #216-class regression: the topic dialog routing was corrected
+-- in the original PR, but the post-Livewire follow-up was missed and
+-- still routed Human players through the Jaffa "my symbiote will cure
+-- me" dialog. Chain-replay test in mission_638_post_livewire_human group
+-- pins this so it doesn't drift again.
 INSERT INTO content_chains (chain_id, description, scope_type, scope_id, enabled, priority)
 VALUES (1021, '638 - Post-minigame (Human): show escape dialog', 'mission', 638, true, 0);
 
@@ -223,7 +230,7 @@ INSERT INTO content_conditions (chain_id, condition_type, target_id, target_key,
 VALUES (1021, 'step_status', 638, '2116', 'eq', 'active', 0);
 
 INSERT INTO content_actions (chain_id, action_type, target_id, target_key, params, delay_ms, sort_order)
-VALUES (1021, 'display_dialog', 5020, NULL, '{}', 0, 0);
+VALUES (1021, 'display_dialog', 2299, NULL, '{}', 0, 0);
 
 -- Chain 1018: dialog choice 5020 (Jaffa agree escape) while step 2116 active → finish 638, accept 639
 INSERT INTO content_chains (chain_id, description, scope_type, scope_id, enabled, priority)
@@ -771,18 +778,25 @@ VALUES
   (1072, 'set_interaction_type', NULL, 'Preparation_RingSwitch',
    '{"op": "~", "mask": 1073741824}', 0, 2);
 
--- Chain 1073: enter Region9 when 681 not yet active → accept mission 681
+-- Chain 1073: enter Region9 when 681 not yet active → complete 680, accept 681
+-- Mission 680 ("Escape the Cellblock") is the umbrella mission whose
+-- "Lockdown! Find another way out of the Castle!" step (2345) ends when
+-- the player reaches the corridor outside the topside ring room. There
+-- is no other completion trigger for 680 — without this, it stays open
+-- forever even as the 681-687 sub-missions advance.
 INSERT INTO content_chains (chain_id, description, scope_type, scope_id, enabled, priority)
-VALUES (1073, '680 - Enter Region9: accept 681', 'mission', 680, true, 0);
+VALUES (1073, '680 - Enter Region9: complete 680, accept 681', 'mission', 680, true, 0);
 
 INSERT INTO content_triggers (chain_id, event_type, event_key, scope, once, sort_order)
-VALUES (1073, 'enter_region', 'Castle_CellBlock.Region9', 'player', false, 0);
+VALUES (1073, 'enter_region', 'Castle_Cellblock.Region9', 'player', false, 0);
 
 INSERT INTO content_conditions (chain_id, condition_type, target_id, target_key, operator, value, sort_order)
 VALUES (1073, 'mission_status', 681, NULL, 'eq', 'not_active', 0);
 
 INSERT INTO content_actions (chain_id, action_type, target_id, target_key, params, delay_ms, sort_order)
-VALUES (1073, 'accept_mission', 681, NULL, '{}', 0, 0);
+VALUES
+  (1073, 'complete_mission', 680, NULL, '{}', 0, 0),
+  (1073, 'accept_mission',   681, NULL, '{}', 0, 1);
 
 -- ============================================================
 -- MISSIONS 681-687 — Hallway Controller chain
@@ -849,142 +863,227 @@ VALUES
 INSERT INTO content_actions (chain_id, action_type, target_id, target_key, params, delay_ms, sort_order)
 VALUES (1084, 'accept_mission', 687, NULL, '{}', 0, 0);
 
--- Chain 1085: mess hall counter — entity_dead (Hallway01 guard tag) increments kill counter
+-- ─────────────────────────────────────────────────────────────────────
+-- Chains 1085-1099: kill-counter chains for missions 681-686.
+--
+-- Each Hallway/MessHall mission has TWO chains: one increment chain
+-- (fires on each guard kill, bumps the counter) and one completion
+-- chain (fires when the counter reaches the per-mission threshold).
+--
+-- Spawn-list reality (from `resources.spawnlist`):
+--   MessHall_Guard1, MessHall_Guard2 → 2 spawns total
+--   Hallway01_Guard                  → 1 spawn
+--   Hallway02_Guard                  → 1 spawn
+--   Hallway03_Guard                  → 1 spawn
+--   Hallway04_Guard                  → 1 spawn
+--   Hallway05_Guard1, Hallway05_Guard2 → 2 spawns total
+--
+-- The mission→tag wiring follows mission `history_text`, NOT the
+-- previous (broken) chain comments. Mission 681 displays as "Mess Hall
+-- Controller" so it tracks MessHall_Guard*. Mission 682 displays as
+-- "Hallway01 Controller" so it tracks Hallway01_Guard. Etc.
+--
+-- The previous chain version was off-by-one across the whole sequence
+-- (681 tracked Hallway01, 682 tracked Hallway02, …, 686 tracked
+-- MessHall_Guard which doesn't exist as an exact tag). It also had
+-- thresholds set to 3 (and 5 for messhall) which made every counter
+-- impossible to reach against the actual spawn counts, AND was missing
+-- increment chains entirely for missions 683-686.
+--
+-- Tag matching is exact-string (see content-engine triggers.rs
+-- `OnEntityDeath` matcher). Rooms with two suffixed guards
+-- (Hallway05_Guard1/2, MessHall_Guard1/2) get two increment chains
+-- both feeding the same counter.
+--
+-- Chain-replay tests in `crates/services/src/cell/content/
+-- chain_replay_tests.rs` (`mission_681_*` and `mission_686_*` groups)
+-- pin both the per-tag increment dispatch and the threshold-reached
+-- completion so the wiring can't drift.
+-- ─────────────────────────────────────────────────────────────────────
+
+-- ── Mission 681 — Mess Hall Controller (2 guards) ──
+
+-- Chain 1085: kill MessHall_Guard1 → increment messhall_kills
 INSERT INTO content_chains (chain_id, description, scope_type, scope_id, enabled, priority)
-VALUES (1085, '681 - Kill guard in hallway 01: increment kill counter', 'mission', 681, true, 0);
+VALUES (1085, '681 - Kill MessHall_Guard1: increment messhall_kills', 'mission', 681, true, 0);
 
 INSERT INTO content_triggers (chain_id, event_type, event_key, scope, once, sort_order)
-VALUES (1085, 'entity_dead_tag', 'Hallway01_Guard', 'space', false, 0);
+VALUES (1085, 'entity_dead_tag', 'MessHall_Guard1', 'space', false, 0);
 
 INSERT INTO content_conditions (chain_id, condition_type, target_id, target_key, operator, value, sort_order)
 VALUES (1085, 'mission_status', 681, NULL, 'eq', 'active', 0);
 
 INSERT INTO content_actions (chain_id, action_type, target_id, target_key, params, delay_ms, sort_order)
-VALUES (1085, 'increment_counter', NULL, 'hallway01_kills', '{"amount": 1}', 0, 0);
+VALUES (1085, 'increment_counter', NULL, 'messhall_kills', '{"amount": 1}', 0, 0);
 
--- Content counters for hallway kill tracking
 INSERT INTO content_counters (chain_id, counter_name, target_value, reset_on)
-VALUES (1085, 'hallway01_kills', 3, 'mission_complete');
+VALUES (1085, 'messhall_kills', 2, 'mission_complete');
 
--- Chain 1086: hallway01_kills == 3 → complete mission 681
+-- Chain 1086: kill MessHall_Guard2 → increment messhall_kills (same counter)
 INSERT INTO content_chains (chain_id, description, scope_type, scope_id, enabled, priority)
-VALUES (1086, '681 - Kill counter reached: complete 681', 'mission', 681, true, 0);
+VALUES (1086, '681 - Kill MessHall_Guard2: increment messhall_kills', 'mission', 681, true, 0);
 
 INSERT INTO content_triggers (chain_id, event_type, event_key, scope, once, sort_order)
-VALUES (1086, 'entity_dead_tag', 'Hallway01_Guard', 'space', false, 0);
+VALUES (1086, 'entity_dead_tag', 'MessHall_Guard2', 'space', false, 0);
+
+INSERT INTO content_conditions (chain_id, condition_type, target_id, target_key, operator, value, sort_order)
+VALUES (1086, 'mission_status', 681, NULL, 'eq', 'active', 0);
+
+INSERT INTO content_actions (chain_id, action_type, target_id, target_key, params, delay_ms, sort_order)
+VALUES (1086, 'increment_counter', NULL, 'messhall_kills', '{"amount": 1}', 0, 0);
+
+-- Chain 1087: messhall_kills >= 1 (target-1) → complete 681, accept 682
+--
+-- Triggered by either MessHall guard death; condition gates on counter.
+-- The `gte 1` (target_value 2 minus 1) is load-bearing: chain conditions
+-- evaluate against the PRE-increment counter value because resolve runs
+-- before execute. On the second kill, counter is at 1 (from the first
+-- kill's increment chain), `gte 1` passes, and this completion fires
+-- alongside the second increment. See `executor.rs::IncrementCounter`
+-- for the full ordering note.
+--
+-- The two trigger rows OR together — content-engine loader materializes
+-- one Chain per trigger row so either MessHall_Guard1 or
+-- MessHall_Guard2 death satisfies the trigger. (Pre-fix, the loader
+-- silently dropped the 2nd row, leaving Guard2 deaths to never fire
+-- this chain.)
+INSERT INTO content_chains (chain_id, description, scope_type, scope_id, enabled, priority)
+VALUES (1087, '681 - Kill counter reached: complete 681, accept 682', 'mission', 681, true, 0);
+
+INSERT INTO content_triggers (chain_id, event_type, event_key, scope, once, sort_order)
+VALUES
+  (1087, 'entity_dead_tag', 'MessHall_Guard1', 'space', false, 0),
+  (1087, 'entity_dead_tag', 'MessHall_Guard2', 'space', false, 1);
 
 INSERT INTO content_conditions (chain_id, condition_type, target_id, target_key, operator, value, sort_order)
 VALUES
-  (1086, 'mission_status', 681, NULL, 'eq', 'active', 0),
-  (1086, 'counter', NULL, 'hallway01_kills', 'gte', '3', 1);
+  (1087, 'mission_status', 681, NULL, 'eq', 'active', 0),
+  (1087, 'counter', NULL, 'messhall_kills', 'gte', '1', 1);
 
 INSERT INTO content_actions (chain_id, action_type, target_id, target_key, params, delay_ms, sort_order)
 VALUES
-  (1086, 'complete_mission', 681, NULL, '{}', 0, 0),
-  (1086, 'reset_counter', NULL, 'hallway01_kills', '{}', 0, 1);
+  (1087, 'complete_mission', 681, NULL, '{}', 0, 0),
+  (1087, 'accept_mission',   682, NULL, '{}', 0, 1),
+  (1087, 'reset_counter', NULL, 'messhall_kills', '{}', 0, 2);
 
--- Chain 1087: mess hall (682) guard kill counter
+-- ── Mission 682 — Hallway01 Controller (1 guard) ──
+
+-- Chain 1088: kill Hallway01_Guard → complete 682, accept 683
+-- Single-guard hallway: no counter needed, the kill itself completes.
 INSERT INTO content_chains (chain_id, description, scope_type, scope_id, enabled, priority)
-VALUES (1087, '682 - Kill guard in hallway 02: increment kill counter', 'mission', 682, true, 0);
+VALUES (1088, '682 - Kill Hallway01_Guard: complete 682, accept 683', 'mission', 682, true, 0);
 
 INSERT INTO content_triggers (chain_id, event_type, event_key, scope, once, sort_order)
-VALUES (1087, 'entity_dead_tag', 'Hallway02_Guard', 'space', false, 0);
+VALUES (1088, 'entity_dead_tag', 'Hallway01_Guard', 'space', false, 0);
 
 INSERT INTO content_conditions (chain_id, condition_type, target_id, target_key, operator, value, sort_order)
-VALUES (1087, 'mission_status', 682, NULL, 'eq', 'active', 0);
-
-INSERT INTO content_actions (chain_id, action_type, target_id, target_key, params, delay_ms, sort_order)
-VALUES (1087, 'increment_counter', NULL, 'hallway02_kills', '{"amount": 1}', 0, 0);
-
-INSERT INTO content_counters (chain_id, counter_name, target_value, reset_on)
-VALUES (1087, 'hallway02_kills', 3, 'mission_complete');
-
--- Chain 1088: hallway02_kills == 3 → complete mission 682, accept 683
-INSERT INTO content_chains (chain_id, description, scope_type, scope_id, enabled, priority)
-VALUES (1088, '682 - Kill counter reached: complete 682, accept 683', 'mission', 682, true, 0);
-
-INSERT INTO content_triggers (chain_id, event_type, event_key, scope, once, sort_order)
-VALUES (1088, 'entity_dead_tag', 'Hallway02_Guard', 'space', false, 0);
-
-INSERT INTO content_conditions (chain_id, condition_type, target_id, target_key, operator, value, sort_order)
-VALUES
-  (1088, 'mission_status', 682, NULL, 'eq', 'active', 0),
-  (1088, 'counter', NULL, 'hallway02_kills', 'gte', '3', 1);
+VALUES (1088, 'mission_status', 682, NULL, 'eq', 'active', 0);
 
 INSERT INTO content_actions (chain_id, action_type, target_id, target_key, params, delay_ms, sort_order)
 VALUES
   (1088, 'complete_mission', 682, NULL, '{}', 0, 0),
-  (1088, 'accept_mission',   683, NULL, '{}', 0, 1),
-  (1088, 'reset_counter', NULL, 'hallway02_kills', '{}', 0, 2);
+  (1088, 'accept_mission',   683, NULL, '{}', 0, 1);
 
--- Chain 1089: hallway03 kills → complete 683 (similar pattern, condensed)
+-- ── Mission 683 — Hallway02 Controller (1 guard) ──
+
+-- Chain 1089: kill Hallway02_Guard → complete 683, accept 684
 INSERT INTO content_chains (chain_id, description, scope_type, scope_id, enabled, priority)
-VALUES (1089, '683 - Kill counter reached: complete 683, accept 684', 'mission', 683, true, 0);
+VALUES (1089, '683 - Kill Hallway02_Guard: complete 683, accept 684', 'mission', 683, true, 0);
 
 INSERT INTO content_triggers (chain_id, event_type, event_key, scope, once, sort_order)
-VALUES (1089, 'entity_dead_tag', 'Hallway03_Guard', 'space', false, 0);
+VALUES (1089, 'entity_dead_tag', 'Hallway02_Guard', 'space', false, 0);
 
 INSERT INTO content_conditions (chain_id, condition_type, target_id, target_key, operator, value, sort_order)
-VALUES
-  (1089, 'mission_status', 683, NULL, 'eq', 'active', 0),
-  (1089, 'counter', NULL, 'hallway03_kills', 'gte', '3', 1);
+VALUES (1089, 'mission_status', 683, NULL, 'eq', 'active', 0);
 
 INSERT INTO content_actions (chain_id, action_type, target_id, target_key, params, delay_ms, sort_order)
 VALUES
   (1089, 'complete_mission', 683, NULL, '{}', 0, 0),
-  (1089, 'accept_mission',   684, NULL, '{}', 0, 1),
-  (1089, 'reset_counter', NULL, 'hallway03_kills', '{}', 0, 2);
+  (1089, 'accept_mission',   684, NULL, '{}', 0, 1);
 
--- Chain 1090: hallway04 kills → complete 684, accept 685
+-- ── Mission 684 — Hallway03 Controller (1 guard) ──
+
+-- Chain 1090: kill Hallway03_Guard → complete 684, accept 685
 INSERT INTO content_chains (chain_id, description, scope_type, scope_id, enabled, priority)
-VALUES (1090, '684 - Kill counter reached: complete 684, accept 685', 'mission', 684, true, 0);
+VALUES (1090, '684 - Kill Hallway03_Guard: complete 684, accept 685', 'mission', 684, true, 0);
 
 INSERT INTO content_triggers (chain_id, event_type, event_key, scope, once, sort_order)
-VALUES (1090, 'entity_dead_tag', 'Hallway04_Guard', 'space', false, 0);
+VALUES (1090, 'entity_dead_tag', 'Hallway03_Guard', 'space', false, 0);
 
 INSERT INTO content_conditions (chain_id, condition_type, target_id, target_key, operator, value, sort_order)
-VALUES
-  (1090, 'mission_status', 684, NULL, 'eq', 'active', 0),
-  (1090, 'counter', NULL, 'hallway04_kills', 'gte', '3', 1);
+VALUES (1090, 'mission_status', 684, NULL, 'eq', 'active', 0);
 
 INSERT INTO content_actions (chain_id, action_type, target_id, target_key, params, delay_ms, sort_order)
 VALUES
   (1090, 'complete_mission', 684, NULL, '{}', 0, 0),
-  (1090, 'accept_mission',   685, NULL, '{}', 0, 1),
-  (1090, 'reset_counter', NULL, 'hallway04_kills', '{}', 0, 2);
+  (1090, 'accept_mission',   685, NULL, '{}', 0, 1);
 
--- Chain 1091: hallway05 kills → complete 685, accept 686
+-- ── Mission 685 — Hallway04 Controller (1 guard) ──
+
+-- Chain 1091: kill Hallway04_Guard → complete 685, accept 686
 INSERT INTO content_chains (chain_id, description, scope_type, scope_id, enabled, priority)
-VALUES (1091, '685 - Kill counter reached: complete 685, accept 686', 'mission', 685, true, 0);
+VALUES (1091, '685 - Kill Hallway04_Guard: complete 685, accept 686', 'mission', 685, true, 0);
 
 INSERT INTO content_triggers (chain_id, event_type, event_key, scope, once, sort_order)
-VALUES (1091, 'entity_dead_tag', 'Hallway05_Guard', 'space', false, 0);
+VALUES (1091, 'entity_dead_tag', 'Hallway04_Guard', 'space', false, 0);
 
 INSERT INTO content_conditions (chain_id, condition_type, target_id, target_key, operator, value, sort_order)
-VALUES
-  (1091, 'mission_status', 685, NULL, 'eq', 'active', 0),
-  (1091, 'counter', NULL, 'hallway05_kills', 'gte', '3', 1);
+VALUES (1091, 'mission_status', 685, NULL, 'eq', 'active', 0);
 
 INSERT INTO content_actions (chain_id, action_type, target_id, target_key, params, delay_ms, sort_order)
 VALUES
   (1091, 'complete_mission', 685, NULL, '{}', 0, 0),
-  (1091, 'accept_mission',   686, NULL, '{}', 0, 1),
-  (1091, 'reset_counter', NULL, 'hallway05_kills', '{}', 0, 2);
+  (1091, 'accept_mission',   686, NULL, '{}', 0, 1);
 
--- Chain 1092: final hallway kills → complete 686, accept 687
+-- ── Mission 686 — Hallway05 Controller (2 guards) ──
+
+-- Chain 1092: kill Hallway05_Guard1 → increment hallway05_kills
 INSERT INTO content_chains (chain_id, description, scope_type, scope_id, enabled, priority)
-VALUES (1092, '686 - Kill counter reached: complete 686, accept 687', 'mission', 686, true, 0);
+VALUES (1092, '686 - Kill Hallway05_Guard1: increment hallway05_kills', 'mission', 686, true, 0);
 
 INSERT INTO content_triggers (chain_id, event_type, event_key, scope, once, sort_order)
-VALUES (1092, 'entity_dead_tag', 'MessHall_Guard', 'space', false, 0);
+VALUES (1092, 'entity_dead_tag', 'Hallway05_Guard1', 'space', false, 0);
+
+INSERT INTO content_conditions (chain_id, condition_type, target_id, target_key, operator, value, sort_order)
+VALUES (1092, 'mission_status', 686, NULL, 'eq', 'active', 0);
+
+INSERT INTO content_actions (chain_id, action_type, target_id, target_key, params, delay_ms, sort_order)
+VALUES (1092, 'increment_counter', NULL, 'hallway05_kills', '{"amount": 1}', 0, 0);
+
+INSERT INTO content_counters (chain_id, counter_name, target_value, reset_on)
+VALUES (1092, 'hallway05_kills', 2, 'mission_complete');
+
+-- Chain 1093: kill Hallway05_Guard2 → increment hallway05_kills
+INSERT INTO content_chains (chain_id, description, scope_type, scope_id, enabled, priority)
+VALUES (1093, '686 - Kill Hallway05_Guard2: increment hallway05_kills', 'mission', 686, true, 0);
+
+INSERT INTO content_triggers (chain_id, event_type, event_key, scope, once, sort_order)
+VALUES (1093, 'entity_dead_tag', 'Hallway05_Guard2', 'space', false, 0);
+
+INSERT INTO content_conditions (chain_id, condition_type, target_id, target_key, operator, value, sort_order)
+VALUES (1093, 'mission_status', 686, NULL, 'eq', 'active', 0);
+
+INSERT INTO content_actions (chain_id, action_type, target_id, target_key, params, delay_ms, sort_order)
+VALUES (1093, 'increment_counter', NULL, 'hallway05_kills', '{"amount": 1}', 0, 0);
+
+-- Chain 1094: hallway05_kills >= 1 (target-1) → complete 686, accept 687
+-- See chain 1087 for the resolve/execute ordering note that motivates
+-- the `target - 1` threshold on counter completion conditions.
+INSERT INTO content_chains (chain_id, description, scope_type, scope_id, enabled, priority)
+VALUES (1094, '686 - Kill counter reached: complete 686, accept 687', 'mission', 686, true, 0);
+
+INSERT INTO content_triggers (chain_id, event_type, event_key, scope, once, sort_order)
+VALUES
+  (1094, 'entity_dead_tag', 'Hallway05_Guard1', 'space', false, 0),
+  (1094, 'entity_dead_tag', 'Hallway05_Guard2', 'space', false, 1);
 
 INSERT INTO content_conditions (chain_id, condition_type, target_id, target_key, operator, value, sort_order)
 VALUES
-  (1092, 'mission_status', 686, NULL, 'eq', 'active', 0),
-  (1092, 'counter', NULL, 'messhall_kills', 'gte', '5', 1);
+  (1094, 'mission_status', 686, NULL, 'eq', 'active', 0),
+  (1094, 'counter', NULL, 'hallway05_kills', 'gte', '1', 1);
 
 INSERT INTO content_actions (chain_id, action_type, target_id, target_key, params, delay_ms, sort_order)
 VALUES
-  (1092, 'complete_mission', 686, NULL, '{}', 0, 0),
-  (1092, 'accept_mission',   687, NULL, '{}', 0, 1),
-  (1092, 'reset_counter', NULL, 'messhall_kills', '{}', 0, 2);
+  (1094, 'complete_mission', 686, NULL, '{}', 0, 0),
+  (1094, 'accept_mission',   687, NULL, '{}', 0, 1),
+  (1094, 'reset_counter', NULL, 'hallway05_kills', '{}', 0, 2);

--- a/db/resources/Content/Seed/castle_cellblock_chains.sql
+++ b/db/resources/Content/Seed/castle_cellblock_chains.sql
@@ -864,7 +864,7 @@ INSERT INTO content_actions (chain_id, action_type, target_id, target_key, param
 VALUES (1084, 'accept_mission', 687, NULL, '{}', 0, 0);
 
 -- ─────────────────────────────────────────────────────────────────────
--- Chains 1085-1099: kill-counter chains for missions 681-686.
+-- Chains 1085-1094: kill-counter chains for missions 681-686.
 --
 -- Each Hallway/MessHall mission has TWO chains: one increment chain
 -- (fires on each guard kill, bumps the counter) and one completion

--- a/db/resources/Content/Seed/castle_cellblock_chains.sql
+++ b/db/resources/Content/Seed/castle_cellblock_chains.sql
@@ -215,11 +215,11 @@ VALUES (1020, 'display_dialog', 5020, NULL, '{}', 0, 0);
 -- Chain 1021: dialog choice 2300 (Human) while step 2116 active → show follow-up dialog 2299
 -- Per the dialog-id mapping at the top of this file (Mission 638 section),
 -- 2299 is the *Human* "Agree to escape" follow-up (5020 is the Jaffa one).
--- Fix for #216-class regression: the topic dialog routing was corrected
--- in the original PR, but the post-Livewire follow-up was missed and
--- still routed Human players through the Jaffa "my symbiote will cure
--- me" dialog. Chain-replay test in mission_638_post_livewire_human group
--- pins this so it doesn't drift again.
+-- The earlier archetype-routing fix corrected the *topic* dialog mapping
+-- but missed this post-Livewire follow-up, which still routed Human
+-- players through the Jaffa "my symbiote will cure me" dialog. Chain-
+-- replay test in the mission_638_post_livewire_human group pins this
+-- so it doesn't drift again.
 INSERT INTO content_chains (chain_id, description, scope_type, scope_id, enabled, priority)
 VALUES (1021, '638 - Post-minigame (Human): show escape dialog', 'mission', 638, true, 0);
 
@@ -904,8 +904,13 @@ VALUES (1084, 'accept_mission', 687, NULL, '{}', 0, 0);
 -- ── Mission 681 — Mess Hall Controller (2 guards) ──
 
 -- Chain 1085: kill MessHall_Guard1 → increment messhall_kills
+-- Priority 1 (vs completion chain 1087 at priority 0) so the increment
+-- runs before the completion's `reset_counter` action on the same
+-- entity_dead event. Equal priority would leave ordering undefined and
+-- the reset could land first, then the increment re-introduces a
+-- non-zero counter that bleeds into the next mission acceptance.
 INSERT INTO content_chains (chain_id, description, scope_type, scope_id, enabled, priority)
-VALUES (1085, '681 - Kill MessHall_Guard1: increment messhall_kills', 'mission', 681, true, 0);
+VALUES (1085, '681 - Kill MessHall_Guard1: increment messhall_kills', 'mission', 681, true, 1);
 
 INSERT INTO content_triggers (chain_id, event_type, event_key, scope, once, sort_order)
 VALUES (1085, 'entity_dead_tag', 'MessHall_Guard1', 'space', false, 0);
@@ -920,8 +925,9 @@ INSERT INTO content_counters (chain_id, counter_name, target_value, reset_on)
 VALUES (1085, 'messhall_kills', 2, 'mission_complete');
 
 -- Chain 1086: kill MessHall_Guard2 → increment messhall_kills (same counter)
+-- Priority 1 — same ordering rationale as chain 1085.
 INSERT INTO content_chains (chain_id, description, scope_type, scope_id, enabled, priority)
-VALUES (1086, '681 - Kill MessHall_Guard2: increment messhall_kills', 'mission', 681, true, 0);
+VALUES (1086, '681 - Kill MessHall_Guard2: increment messhall_kills', 'mission', 681, true, 1);
 
 INSERT INTO content_triggers (chain_id, event_type, event_key, scope, once, sort_order)
 VALUES (1086, 'entity_dead_tag', 'MessHall_Guard2', 'space', false, 0);
@@ -1038,8 +1044,10 @@ VALUES
 -- ── Mission 686 — Hallway05 Controller (2 guards) ──
 
 -- Chain 1092: kill Hallway05_Guard1 → increment hallway05_kills
+-- Priority 1 (vs completion chain 1094 at priority 0) — see chain 1085's
+-- ordering note for the rationale.
 INSERT INTO content_chains (chain_id, description, scope_type, scope_id, enabled, priority)
-VALUES (1092, '686 - Kill Hallway05_Guard1: increment hallway05_kills', 'mission', 686, true, 0);
+VALUES (1092, '686 - Kill Hallway05_Guard1: increment hallway05_kills', 'mission', 686, true, 1);
 
 INSERT INTO content_triggers (chain_id, event_type, event_key, scope, once, sort_order)
 VALUES (1092, 'entity_dead_tag', 'Hallway05_Guard1', 'space', false, 0);
@@ -1054,8 +1062,9 @@ INSERT INTO content_counters (chain_id, counter_name, target_value, reset_on)
 VALUES (1092, 'hallway05_kills', 2, 'mission_complete');
 
 -- Chain 1093: kill Hallway05_Guard2 → increment hallway05_kills
+-- Priority 1 — same ordering rationale as chain 1092.
 INSERT INTO content_chains (chain_id, description, scope_type, scope_id, enabled, priority)
-VALUES (1093, '686 - Kill Hallway05_Guard2: increment hallway05_kills', 'mission', 686, true, 0);
+VALUES (1093, '686 - Kill Hallway05_Guard2: increment hallway05_kills', 'mission', 686, true, 1);
 
 INSERT INTO content_triggers (chain_id, event_type, event_key, scope, once, sort_order)
 VALUES (1093, 'entity_dead_tag', 'Hallway05_Guard2', 'space', false, 0);

--- a/db/resources/Content/Seed/consumables_chains.sql
+++ b/db/resources/Content/Seed/consumables_chains.sql
@@ -19,14 +19,31 @@ SET search_path = resources, pg_catalog;
 -- Item 2893 — Health Slappack TC1 (+500 HP)
 -- ============================================================
 
--- Chain 4001: useItem(2893) → +500 HP, consume 1 slappack.
+-- Chain 4001: useItem(2893) when HP < max → +500 HP, consume 1 slappack.
+--
+-- The `stat_below_max` condition gates the chain on actual HP headroom:
+-- using a slappack at full HP fizzles silently rather than burning the
+-- stack. Stat values are populated into the chain context by
+-- `populate_stats_context` (called from `fire_item_use`); the condition
+-- reads `stat_7_cur` and `stat_7_max` and fires only when cur < max.
+--
+-- A user-facing "already at full health" message is intentionally not
+-- emitted here — `Action::SystemMessage` is currently a stub (correct
+-- client wire format unknown; see executor.rs::SystemMessage). Until
+-- that's wired up, the failure mode is "click does nothing, stack is
+-- preserved" which is correct-but-quiet.
 INSERT INTO content_chains (chain_id, description, scope_type, scope_id, enabled, priority)
-VALUES (4001, 'Health Slappack TC1: +500 HP + consume', 'global', NULL, true, 0);
+VALUES (4001, 'Health Slappack TC1: +500 HP + consume (HP < max)', 'global', NULL, true, 0);
 
 INSERT INTO content_triggers (chain_id, event_type, event_key, scope, once, sort_order)
 VALUES (4001, 'item_use', '2893', 'player', false, 0);
 
--- No conditions: the slappack is usable any time.
+-- `operator` and `value` are unused by `stat_below_max` (the condition is
+-- structural: cur < max). Pass the column-default 'eq' for operator and
+-- NULL for value so the loader's required-not-null operator parse
+-- succeeds and the matcher branch ignores both.
+INSERT INTO content_conditions (chain_id, condition_type, target_id, target_key, operator, value, sort_order)
+VALUES (4001, 'stat_below_max', 7, NULL, 'eq', NULL, 0);
 
 INSERT INTO content_actions (chain_id, action_type, target_id, target_key, params, delay_ms, sort_order)
 VALUES

--- a/db/resources/Content/Seed/space_castle_cellblock_chains.sql
+++ b/db/resources/Content/Seed/space_castle_cellblock_chains.sql
@@ -78,7 +78,7 @@ INSERT INTO content_chains (chain_id, description, scope_type, scope_id, enabled
 VALUES (5002, 'Castle_CellBlock → Event_GenericRegion (node 116)', 'space', 8, true, 0);
 
 INSERT INTO content_triggers (chain_id, event_type, event_key, scope, once, sort_order)
-VALUES (5002, 'enter_region', 'Castle_CellBlock.Region8', 'player', true, 0);
+VALUES (5002, 'enter_region', 'Castle_Cellblock.Region8', 'player', true, 0);
 
 INSERT INTO content_actions (chain_id, action_type, target_id, target_key, params, delay_ms, sort_order)
 VALUES
@@ -90,7 +90,7 @@ INSERT INTO content_chains (chain_id, description, scope_type, scope_id, enabled
 VALUES (5003, 'Castle_CellBlock → Event_GenericRegion (node 116)', 'space', 8, true, 0);
 
 INSERT INTO content_triggers (chain_id, event_type, event_key, scope, once, sort_order)
-VALUES (5003, 'enter_region', 'Castle_CellBlock.Region8', 'player', true, 0);
+VALUES (5003, 'enter_region', 'Castle_Cellblock.Region8', 'player', true, 0);
 
 INSERT INTO content_actions (chain_id, action_type, target_id, target_key, params, delay_ms, sort_order)
 VALUES


### PR DESCRIPTION
## Summary

Two interleaved threads land here:

1. **Content engine layer** gets runtime counter state, multi-trigger chains, the `StatBelowMax` condition, and `instance_id` plumbing through `OnItemUse`. These are the engine primitives the chain seed needs in order to express "kill N tagged enemies", "gate consumable use on stat headroom", and "consume the exact item the player clicked."

2. **Castle_CellBlock content fixes** — the Lockdown→Aftermath chunk of the cellblock was broken in several ways: mission 680 never completed, missions 681-686 had an off-by-one mission→tag mapping plus a counter system that didn't actually count, two region tags had case-sensitivity typos (one of which silently soft-stuck the player at "Lockdown!"), and the Prisoner 329 Human-archetype dialog post-Livewire was misrouted.

Empirically tested in-game through to the end of mission 686. Mission 687 (Aftermath) is the next gap — captured in #236.

## Engine changes

### Runtime counters

`CellEntity` now carries `counters: HashMap<String, i32>`. `Action::IncrementCounter` and `Action::ResetCounter` actually mutate it (they were stubs that only logged). `populate_mission_context` writes `counter_<name>` numeric params into the chain context so `Condition::Counter` reads real values.

**Resolve/execute ordering note** (load-bearing for chain authoring): chains resolve before any actions execute, so a sibling completion chain reading the counter on the same trigger event sees the PRE-increment value. For "kill N targets to complete," the completion condition uses `counter >= target - 1` so it fires on the kill that brings the counter to N. Documented at every relevant chain in the seed.

### Multi-trigger chain support

The loader previously took the first `content_triggers` row per chain and silently dropped the rest. Now it materializes one in-memory `Chain` per trigger row, all sharing the same conditions and actions — so a chain that declares "fire on either MessHall_Guard1 OR MessHall_Guard2 death" actually fires on both. The runtime resolver doesn't need to know about the multi-trigger origin; it sees N independent chains keyed by each trigger's `TriggerType`.

### `Condition::StatBelowMax`

New condition variant. True iff `stat_<id>_cur < stat_<id>_max`. `populate_stats_context` populates the underlying params from the entity's `StatList`. `fire_item_use` now invokes both populators so chain 4001 (Health Slappack) can gate on `stat_below_max 7` — using a slappack at full HP now fizzles silently instead of burning the stack. Fail-closed when the params are missing (treats as "no headroom" so a wiring mistake can't make consumables free at full stat).

A user-facing "already at full health" message is intentionally not emitted here — `Action::SystemMessage` is currently a stub (correct client wire format unknown; see the comment at `executor.rs::SystemMessage`). Until that's wired, the failure mode is "click does nothing, stack preserved."

### `ItemUsed` instance_id plumbing

`BaseToCellMsg::ItemUsed` and `CellOutboxPayload::ItemUsed` gain an `instance_id` field carrying the inventory row id the player clicked. `fire_item_use` writes it into the chain context. `Action::RemoveItem` reads it from `ResolvedActions.params` and routes through `CellToBaseMsg::RemoveInventoryItem` (by-instance) when present, falling back to `RemoveInventoryItemByType` (by-design, current behavior) when absent. This is the difference between "consume the slappack you clicked" and "consume the leftmost slappack of that type" — the bug class shows up when a player has multiple stacks of the same item and clicks anything other than the first one.

`ResolvedActions` gains a `params: HashMap<String, Value>` field carrying forward the resolution-time `ExecutionContext.params` so action executors can read trigger-time state without holding the original context.

## Content fixes

### Mission 638 — Prisoner 329 Human dialog (#216 follow-up)

Chain 1021 (Human post-Livewire path) was displaying dialog **5020** — the Jaffa "my symbiote will cure me" follow-up. Now displays **2299**, the Human "Agree to escape" follow-up per the dialog mapping at the top of the file. PR #216 fixed the topic dialog routing; this is the missed instance for the post-Livewire follow-up dialog.

### Mission 680 — Escape the Cellblock

Mission 680 had no completion chain anywhere in the seed. The player got the "Lockdown! Find another way out of the Castle!" prompt on entering the topside ring room and would have stayed on that step indefinitely while missions 681-687 progressed underneath. Chain 1073 (`enter Region9`) now also `complete_mission 680` alongside `accept_mission 681`.

### Missions 681-686 — Mess Hall + Hallway controllers

Chain set 1085-1094 rewritten end-to-end:

- **Off-by-one mission→tag mapping fixed.** Before this PR:
  - 681 ("Mess Hall Controller") tracked `Hallway01_Guard` (1 spawn — design wanted N=3 kills, max possible was 1).
  - 682 ("Hallway01 Controller") tracked `Hallway02_Guard`.
  - … shifted forward through the chain …
  - 686 ("Hallway05 Controller") tracked `MessHall_Guard` (zero exact-match spawns — `MessHall_Guard1` and `MessHall_Guard2` exist with suffixes; the trigger never matched).
  After: each mission tracks its own room's guards.

- **Thresholds aligned with actual spawn counts.** Hallway01-04 are single-guard rooms; their missions complete on the one kill (no counter needed). Mess Hall and Hallway05 are two-guard rooms; `target_value = 2`, completion condition `counter >= 1`.

- **Missing increment chains added.** 683-686 had completion chains but no increment chains, so even with correct tags the counter would never advance.

- **Two-guard completion chains use OR-triggers.** Now possible thanks to the multi-trigger loader fix above.

### Region tag typos

Caught by a new linter test (`every_chain_file_uses_consistent_region_world_prefix` in `crates/content-engine/tests/interact_tag_linter.rs`). The runtime resolver does literal-string match on event_keys, so a case mismatch silently never fires.

- **`castle_cellblock_chains.sql` chain 1073**: `Castle_CellBlock.Region9` → `Castle_Cellblock.Region9`. This was blocking mission 680→681 progression entirely (the trigger never matched the canonical `point_sets.name`).
- **`space_castle_cellblock_chains.sql` chains 5002, 5003**: `Castle_CellBlock.Region8` → `Castle_Cellblock.Region8`. Same bug class.

## Tests

- All 593 lib tests on `cimmeria-services` pass.
- 4 tests on `cimmeria-content-engine` linter pass:
  - `every_interact_tag_chain_has_set_interaction_type` (existing).
  - `every_chain_file_uses_consistent_region_world_prefix` (new — pinned the case-sensitivity invariant after catching three real typos).
  - `scan_chains_picks_up_basic_pattern` and `scan_region_triggers_extracts_chain_and_region` (parser smoke tests for the linters).
- `cargo clippy --all-targets -- -D warnings` clean on `cimmeria-services`, `cimmeria-content-engine`, and `cimmeria-entity`.
- Empirically tested in-game from mission 622 through mission 686 completion. Mission 687 is the next gap — see #236.

## Known follow-ups

- **#236 — Wire mission 687 (Aftermath):** crate interaction, archetype-gated rewards (Tau'ri vs Jaffa branches per `python/cell/missions/Castle_CellBlock/Aftermath.py`), barracks guard spawns, completion chains. Reuses the counter system this PR adds.
- **`Action::SystemMessage` is still a stub** — the slappack full-HP gate works but is silent. A user-facing "already at full health" message needs the correct client wire format reverse-engineered first.

## Test plan

- [x] `cargo fmt --all -- --check` clean on touched crates
- [x] `cargo clippy -p cimmeria-services -p cimmeria-content-engine -p cimmeria-entity --all-targets -- -D warnings` clean
- [x] `cargo test -p cimmeria-services -p cimmeria-content-engine -p cimmeria-entity --lib` — 593 cimmeria-services + content-engine linter tests pass
- [x] **In-game** — played from start of cellblock through mission 686 completion. Each mission accepts, advances, and completes as expected. Slappack full-HP gate confirmed (click does nothing, stack preserved). Multi-stack slappack instance routing confirmed (clicked stacks consume the right instance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added health-conditional consumption for items: Health Slappack now only usable when current HP is below maximum.
  * Introduced counter-based progression system for mission sub-missions, enabling precise completion tracking.

* **Bug Fixes**
  * Fixed dialog routing for post-Livewire Human player follow-up in Castle CellBlock mission.
  * Corrected region trigger capitalization to ensure proper event matching.
  * Resolved off-by-one errors in guard counter thresholds for hallway sub-missions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->