### PR TITLE
feat(content-engine): wire mission 687 Aftermath end-to-end

### DIFF
--- a/crates/content-engine/src/loader.rs
+++ b/crates/content-engine/src/loader.rs
@@ -852,9 +852,9 @@ mod tests {
 
     /// `event_type = "mission_accepted"` with the mission id in `event_key`
     /// must round-trip into a `Trigger::OnMissionAccepted`. This is the
-    /// load-bearing path for chains like Aftermath (#236) chain 1097 that
-    /// need to react to mission start without piggybacking on whichever
-    /// chain did the accepting.
+    /// load-bearing path for chains like Aftermath chain 1097 that need
+    /// to react to mission start without piggybacking on whichever chain
+    /// did the accepting.
     #[test]
     fn mission_accepted_event_type_loads_as_on_mission_accepted_trigger() {
         use crate::triggers::Trigger;

--- a/crates/content-engine/src/loader.rs
+++ b/crates/content-engine/src/loader.rs
@@ -234,6 +234,9 @@ fn convert_trigger(row: &DbTriggerRow) -> Option<Trigger> {
         "dialog_set_open" => Some(Trigger::OnDialogSetOpen {
             dialog_set_name: key?.to_string(),
         }),
+        "mission_accepted" => Some(Trigger::OnMissionAccepted {
+            mission_id: key?.parse().ok()?,
+        }),
         _ => None,
     }
 }
@@ -845,6 +848,46 @@ mod tests {
                 other
             ),
         }
+    }
+
+    /// `event_type = "mission_accepted"` with the mission id in `event_key`
+    /// must round-trip into a `Trigger::OnMissionAccepted`. This is the
+    /// load-bearing path for chains like Aftermath (#236) chain 1097 that
+    /// need to react to mission start without piggybacking on whichever
+    /// chain did the accepting.
+    #[test]
+    fn mission_accepted_event_type_loads_as_on_mission_accepted_trigger() {
+        use crate::triggers::Trigger;
+
+        let row = DbTriggerRow {
+            chain_id: 1097,
+            event_type: "mission_accepted".to_string(),
+            event_key: Some("687".to_string()),
+            scope: "player".to_string(),
+            once: false,
+            sort_order: 0,
+        };
+
+        match convert_trigger(&row) {
+            Some(Trigger::OnMissionAccepted { mission_id }) => assert_eq!(mission_id, 687),
+            other => panic!("expected OnMissionAccepted(687), got {:?}", other),
+        }
+    }
+
+    /// `mission_accepted` without an `event_key` cannot resolve a target
+    /// mission — must drop to None so the loader skips the row rather
+    /// than firing on every accept event.
+    #[test]
+    fn mission_accepted_without_key_returns_none() {
+        let row = DbTriggerRow {
+            chain_id: 1097,
+            event_type: "mission_accepted".to_string(),
+            event_key: None,
+            scope: "player".to_string(),
+            once: false,
+            sort_order: 0,
+        };
+        assert!(convert_trigger(&row).is_none());
     }
 
     #[test]

--- a/crates/content-engine/src/triggers.rs
+++ b/crates/content-engine/src/triggers.rs
@@ -95,6 +95,13 @@ pub enum Trigger {
 
     /// Fires when a dialog set is opened for a player.
     OnDialogSetOpen { dialog_set_name: String },
+
+    /// Fires immediately after a mission has been accepted, after the
+    /// mission/step/objective state has been updated. Used by chains that
+    /// need to perform setup work tied to mission start (e.g., highlighting
+    /// quest objects, granting starter items) without coupling that work
+    /// to the chain that did the accepting.
+    OnMissionAccepted { mission_id: i32 },
 }
 
 /// Runtime event payload passed to the chain engine when a game event occurs.
@@ -141,6 +148,7 @@ pub enum TriggerType {
     EffectRemoved,
     MissionCompleted,
     DialogSetOpen,
+    MissionAccepted,
 }
 
 impl Trigger {
@@ -171,6 +179,7 @@ impl Trigger {
             Trigger::OnEffectRemoved => TriggerType::EffectRemoved,
             Trigger::OnMissionCompleted { .. } => TriggerType::MissionCompleted,
             Trigger::OnDialogSetOpen { .. } => TriggerType::DialogSetOpen,
+            Trigger::OnMissionAccepted { .. } => TriggerType::MissionAccepted,
         }
     }
 
@@ -300,6 +309,9 @@ impl Trigger {
                 .get("dialog_set_name")
                 .and_then(|v| v.as_str())
                 .is_some_and(|actual| actual == dialog_set_name),
+            Trigger::OnMissionAccepted { mission_id } => {
+                event.params.get("mission_id").and_then(|v| v.as_i64()) == Some(*mission_id as i64)
+            }
         }
     }
 }
@@ -507,5 +519,25 @@ mod tests {
             vec![("mission_id", serde_json::json!(1559))],
         );
         assert!(trigger.matches(&event));
+    }
+
+    #[test]
+    fn mission_accepted_matches_correct_mission_id() {
+        let trigger = Trigger::OnMissionAccepted { mission_id: 687 };
+        let event = make_event(
+            TriggerType::MissionAccepted,
+            vec![("mission_id", serde_json::json!(687))],
+        );
+        assert!(trigger.matches(&event));
+    }
+
+    #[test]
+    fn mission_accepted_rejects_wrong_mission_id() {
+        let trigger = Trigger::OnMissionAccepted { mission_id: 687 };
+        let event = make_event(
+            TriggerType::MissionAccepted,
+            vec![("mission_id", serde_json::json!(641))],
+        );
+        assert!(!trigger.matches(&event));
     }
 }

--- a/crates/services/src/cell/content/chain_replay_tests.rs
+++ b/crates/services/src/cell/content/chain_replay_tests.rs
@@ -507,3 +507,413 @@ async fn chain_1012_does_not_match_non_jaffa_archetype() {
     const ARCHETYPE_SOLDIER: i32 = 1;
     assert_region_enter_does_not_resolve(1012, ARCHETYPE_SOLDIER).await;
 }
+
+// ── Mission 687 — Aftermath (issue #236) ────────────────────────────────
+
+/// Chain 1097: when mission 687 is accepted (Region6 entry triggers
+/// chain 1084, which calls accept_mission, which now fires the new
+/// `mission_accepted` follow-up event), chain 1097 matches and
+/// resolves a `SetInteractionType` action that highlights the
+/// Cellblock_WoodenCrate as a quest world object. Without this, the
+/// player has no visual cue that the crate is interactable.
+#[tokio::test]
+async fn chain_1097_highlights_wooden_crate_when_mission_687_accepted() {
+    use cimmeria_content_engine::actions::Action;
+
+    let pool = require_db_or_skip!();
+    let chain = load_single_chain_for_test(&pool, 1097)
+        .await
+        .expect("DB query for chain 1097 must succeed")
+        .expect("chain 1097 must exist in seeded content_chains");
+
+    let mut engine = ChainEngine::new();
+    engine.register_chain(chain);
+
+    let mut ctx = ExecutionContext::new();
+    ctx.set_param("mission_id".to_string(), serde_json::json!(687));
+
+    let event = TriggerEvent {
+        trigger_type: TriggerType::MissionAccepted,
+        source_entity: None,
+        target_entity: None,
+        params: ctx.params.clone(),
+    };
+
+    let resolved = engine.resolve_event(&event, &ctx);
+    let crate_highlights: Vec<&Action> = resolved
+        .actions
+        .iter()
+        .filter_map(|(id, action)| {
+            if *id != 1097 {
+                return None;
+            }
+            match action {
+                Action::SetInteractionType {
+                    entity_tag,
+                    operation,
+                    mask,
+                } if entity_tag == "Cellblock_WoodenCrate"
+                    && operation == "|"
+                    && *mask == cimmeria_entity::interaction_flags::INT_MISSION_WORLD_OBJECT =>
+                {
+                    Some(action)
+                }
+                _ => None,
+            }
+        })
+        .collect();
+    assert_eq!(
+        crate_highlights.len(),
+        1,
+        "chain 1097 must resolve exactly one SetInteractionType(crate, |, INT_MissionWorldObject) \
+         action when mission 687 is accepted; got {} matches in {:?}",
+        crate_highlights.len(),
+        resolved.actions,
+    );
+}
+
+/// Chain 1098: Tau'ri / non-Jaffa player searches the crate while
+/// step 2354 is active → grants the 5-piece Covert Stealth set + Combat
+/// Knife (6 items) to the backpack and advances to step 2355. The 5
+/// armor pieces and the knife are the load-bearing payload — drift
+/// (e.g. someone changes container_id away from 1, or drops one of
+/// the items) shows up here.
+#[tokio::test]
+async fn chain_1098_grants_stealth_set_and_advances_step_for_non_jaffa() {
+    use cimmeria_content_engine::actions::Action;
+
+    let pool = require_db_or_skip!();
+    let chain = load_single_chain_for_test(&pool, 1098)
+        .await
+        .expect("DB query for chain 1098 must succeed")
+        .expect("chain 1098 must exist in seeded content_chains");
+
+    let mut engine = ChainEngine::new();
+    engine.register_chain(chain);
+
+    let mut ctx = ExecutionContext::new();
+    ctx.set_param(
+        "entity_tag".to_string(),
+        serde_json::json!("Cellblock_WoodenCrate"),
+    );
+    ctx.set_param(
+        "mission_687_status".to_string(),
+        serde_json::json!("active"),
+    );
+    ctx.set_param(
+        "mission_687_step_2354_status".to_string(),
+        serde_json::json!("active"),
+    );
+    ctx.set_param("archetype".to_string(), serde_json::json!(1)); // Soldier
+
+    let event = TriggerEvent {
+        trigger_type: TriggerType::InteractTag,
+        source_entity: None,
+        target_entity: None,
+        params: ctx.params.clone(),
+    };
+
+    let resolved = engine.resolve_event(&event, &ctx);
+    let granted: Vec<i32> = resolved
+        .actions
+        .iter()
+        .filter_map(|(id, action)| match action {
+            Action::GrantItem {
+                item_id,
+                count,
+                container_id,
+            } if *id == 1098 && *count == 1 && *container_id == Some(1) => Some(*item_id),
+            _ => None,
+        })
+        .collect();
+    // Pin the exact set, not just the count — a future seed change
+    // that drops the Combat Knife or adds a stray item would slip
+    // past a count-only assertion. Order matches the action
+    // sort_order in the seed (helmet, vest, pants, gloves, boots, knife).
+    assert_eq!(
+        granted,
+        vec![3347, 3359, 3372, 3387, 3401, 3325],
+        "chain 1098 must grant the 5 stealth pieces + Combat Knife to the \
+         backpack (container 1) in the documented order; got {granted:?}"
+    );
+
+    let advance_step_2355 = resolved
+        .actions
+        .iter()
+        .filter(|(id, action)| {
+            *id == 1098
+                && matches!(
+                    action,
+                    Action::AdvanceStep {
+                        mission_id: 687,
+                        step_id: 2355
+                    }
+                )
+        })
+        .count();
+    assert_eq!(
+        advance_step_2355, 1,
+        "chain 1098 must advance to step 2355 after the rewards are granted"
+    );
+}
+
+/// Chain 1098 negative: a Jaffa player searching the crate must NOT
+/// match the non-Jaffa branch. Without the `archetype neq 8`
+/// condition, both archetype branches would fire and the player
+/// would receive both kits.
+#[tokio::test]
+async fn chain_1098_does_not_match_jaffa_archetype() {
+    let pool = require_db_or_skip!();
+    let chain = load_single_chain_for_test(&pool, 1098)
+        .await
+        .expect("DB query for chain 1098 must succeed")
+        .expect("chain 1098 must exist in seeded content_chains");
+
+    let mut engine = ChainEngine::new();
+    engine.register_chain(chain);
+
+    let mut ctx = ExecutionContext::new();
+    ctx.set_param(
+        "entity_tag".to_string(),
+        serde_json::json!("Cellblock_WoodenCrate"),
+    );
+    ctx.set_param(
+        "mission_687_status".to_string(),
+        serde_json::json!("active"),
+    );
+    ctx.set_param(
+        "mission_687_step_2354_status".to_string(),
+        serde_json::json!("active"),
+    );
+    ctx.set_param("archetype".to_string(), serde_json::json!(8)); // Jaffa
+
+    let event = TriggerEvent {
+        trigger_type: TriggerType::InteractTag,
+        source_entity: None,
+        target_entity: None,
+        params: ctx.params.clone(),
+    };
+
+    let resolved = engine.resolve_event(&event, &ctx);
+    let chain_1098_actions = resolved
+        .actions
+        .iter()
+        .filter(|(id, _)| *id == 1098)
+        .count();
+    assert_eq!(
+        chain_1098_actions, 0,
+        "chain 1098 must NOT match for archetype 8 (Jaffa) — the archetype \
+         neq 8 condition is what prevents both reward branches firing for \
+         the same player; got {chain_1098_actions} actions",
+    );
+}
+
+/// Chain 1099: Jaffa-branch sibling of 1098. Grants the Armored Prison
+/// Jacket + Serpent Staff to the backpack and advances to step 2355.
+#[tokio::test]
+async fn chain_1099_grants_jaffa_kit_and_advances_step_for_jaffa() {
+    use cimmeria_content_engine::actions::Action;
+
+    let pool = require_db_or_skip!();
+    let chain = load_single_chain_for_test(&pool, 1099)
+        .await
+        .expect("DB query for chain 1099 must succeed")
+        .expect("chain 1099 must exist in seeded content_chains");
+
+    let mut engine = ChainEngine::new();
+    engine.register_chain(chain);
+
+    let mut ctx = ExecutionContext::new();
+    ctx.set_param(
+        "entity_tag".to_string(),
+        serde_json::json!("Cellblock_WoodenCrate"),
+    );
+    ctx.set_param(
+        "mission_687_status".to_string(),
+        serde_json::json!("active"),
+    );
+    ctx.set_param(
+        "mission_687_step_2354_status".to_string(),
+        serde_json::json!("active"),
+    );
+    ctx.set_param("archetype".to_string(), serde_json::json!(8)); // Jaffa
+
+    let event = TriggerEvent {
+        trigger_type: TriggerType::InteractTag,
+        source_entity: None,
+        target_entity: None,
+        params: ctx.params.clone(),
+    };
+
+    let resolved = engine.resolve_event(&event, &ctx);
+    let granted: Vec<i32> = resolved
+        .actions
+        .iter()
+        .filter_map(|(id, action)| match action {
+            Action::GrantItem {
+                item_id,
+                count,
+                container_id,
+            } if *id == 1099 && *count == 1 && *container_id == Some(1) => Some(*item_id),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        granted,
+        vec![3482, 2797],
+        "chain 1099 must grant Armored Prison Jacket (3482) + Serpent Staff (2797) \
+         to the backpack; got {granted:?}"
+    );
+
+    let advance_step_2355 = resolved
+        .actions
+        .iter()
+        .filter(|(id, action)| {
+            *id == 1099
+                && matches!(
+                    action,
+                    Action::AdvanceStep {
+                        mission_id: 687,
+                        step_id: 2355
+                    }
+                )
+        })
+        .count();
+    assert_eq!(
+        advance_step_2355, 1,
+        "chain 1099 must advance to step 2355 after the rewards are granted"
+    );
+}
+
+/// Chain 1103 positive: the player has already killed two barracks
+/// guards (counter at 2), kills the third — counter is still at 2 at
+/// the moment chain conditions are evaluated (the increment chain
+/// 1100/1101/1102 mutates state during *execute*, not *resolve*, see
+/// the ordering note at chain 1087). With the counter at 2 and the
+/// `gte 2` threshold, chain 1103 must resolve `complete_mission 687`.
+///
+/// Loaded with `load_chain_expansions_for_test` because 1103 has three
+/// trigger rows (one per guard tag) — a single-expansion load would
+/// silently miss the OR shape and only test the Guard1 path.
+#[tokio::test]
+async fn chain_1103_completes_687_on_third_barracks_kill() {
+    use super::engine_loader::load_chain_expansions_for_test;
+    use cimmeria_content_engine::actions::Action;
+
+    let pool = require_db_or_skip!();
+    let expansions = load_chain_expansions_for_test(&pool, 1103)
+        .await
+        .expect("DB query for chain 1103 must succeed");
+    assert_eq!(
+        expansions.len(),
+        3,
+        "chain 1103 must materialize one in-memory Chain per Barracks_Guard \
+         trigger row (3 total); got {}",
+        expansions.len(),
+    );
+
+    let mut engine = ChainEngine::new();
+    for chain in expansions {
+        engine.register_chain(chain);
+    }
+
+    let mut ctx = ExecutionContext::new();
+    ctx.set_param(
+        "entity_tag".to_string(),
+        serde_json::json!("Barracks_Guard3"),
+    );
+    ctx.set_param(
+        "mission_687_status".to_string(),
+        serde_json::json!("active"),
+    );
+    ctx.set_param(
+        "mission_687_step_2355_status".to_string(),
+        serde_json::json!("active"),
+    );
+    // Counter at 2 simulates "two prior kills already incremented the
+    // counter; the third kill is the one being resolved now".
+    ctx.set_param("counter_barracks_kills".to_string(), serde_json::json!(2));
+
+    let event = TriggerEvent {
+        trigger_type: TriggerType::EntityDeath,
+        source_entity: None,
+        target_entity: None,
+        params: ctx.params.clone(),
+    };
+
+    let resolved = engine.resolve_event(&event, &ctx);
+    let complete_actions = resolved
+        .actions
+        .iter()
+        .filter(|(id, action)| {
+            *id == 1103 && matches!(action, Action::CompleteMission { mission_id: 687 })
+        })
+        .count();
+    assert_eq!(
+        complete_actions, 1,
+        "chain 1103 must resolve CompleteMission(687) when counter_barracks_kills >= 2 \
+         (target - 1 threshold) on the third guard kill; got {complete_actions} actions \
+         from chain 1103. Resolved actions: {:?}",
+        resolved.actions,
+    );
+}
+
+/// Chain 1103 negative: with `counter_barracks_kills = 0` (the player
+/// just killed the first guard — counter not yet incremented at
+/// resolve time), the `gte 2` condition fails and the completion
+/// chain must NOT fire. This is the load-bearing pin against a
+/// regression that lowers the threshold below 2 (which would
+/// complete the mission on the first kill).
+#[tokio::test]
+async fn chain_1103_does_not_complete_687_on_first_barracks_kill() {
+    use super::engine_loader::load_chain_expansions_for_test;
+    use cimmeria_content_engine::actions::Action;
+
+    let pool = require_db_or_skip!();
+    let expansions = load_chain_expansions_for_test(&pool, 1103)
+        .await
+        .expect("DB query for chain 1103 must succeed");
+
+    let mut engine = ChainEngine::new();
+    for chain in expansions {
+        engine.register_chain(chain);
+    }
+
+    let mut ctx = ExecutionContext::new();
+    ctx.set_param(
+        "entity_tag".to_string(),
+        serde_json::json!("Barracks_Guard1"),
+    );
+    ctx.set_param(
+        "mission_687_status".to_string(),
+        serde_json::json!("active"),
+    );
+    ctx.set_param(
+        "mission_687_step_2355_status".to_string(),
+        serde_json::json!("active"),
+    );
+    // First kill: counter has not been incremented yet at this point
+    // (resolve runs before execute), so the condition sees 0.
+    ctx.set_param("counter_barracks_kills".to_string(), serde_json::json!(0));
+
+    let event = TriggerEvent {
+        trigger_type: TriggerType::EntityDeath,
+        source_entity: None,
+        target_entity: None,
+        params: ctx.params.clone(),
+    };
+
+    let resolved = engine.resolve_event(&event, &ctx);
+    let complete_actions = resolved
+        .actions
+        .iter()
+        .filter(|(id, action)| {
+            *id == 1103 && matches!(action, Action::CompleteMission { mission_id: 687 })
+        })
+        .count();
+    assert_eq!(
+        complete_actions, 0,
+        "chain 1103 must NOT resolve CompleteMission on the first guard kill \
+         (counter at 0 < gte 2 threshold); got {complete_actions} actions",
+    );
+}

--- a/crates/services/src/cell/content/chain_replay_tests.rs
+++ b/crates/services/src/cell/content/chain_replay_tests.rs
@@ -508,7 +508,7 @@ async fn chain_1012_does_not_match_non_jaffa_archetype() {
     assert_region_enter_does_not_resolve(1012, ARCHETYPE_SOLDIER).await;
 }
 
-// ── Mission 687 — Aftermath (issue #236) ────────────────────────────────
+// ── Mission 687 — Aftermath ─────────────────────────────────────────────
 
 /// Chain 1097: when mission 687 is accepted (Region6 entry triggers
 /// chain 1084, which calls accept_mission, which now fires the new

--- a/crates/services/src/cell/content/engine_loader.rs
+++ b/crates/services/src/cell/content/engine_loader.rs
@@ -233,6 +233,106 @@ pub(super) async fn load_single_chain_for_test(
     )
 }
 
+/// Test helper: load every in-memory `Chain` expansion produced by the
+/// chain id. The loader materializes one `Chain` per `content_triggers`
+/// row, so chains with multi-trigger OR semantics (e.g., chain 1103
+/// firing on any of `Barracks_Guard1/2/3` deaths) need all expansions
+/// registered for the engine to match correctly. `load_single_chain_for_test`
+/// only returns the first expansion, which would silently mask drift in
+/// the 2nd+ trigger rows.
+#[cfg(test)]
+pub(super) async fn load_chain_expansions_for_test(
+    pool: &PgPool,
+    chain_id: i32,
+) -> Result<Vec<Chain>, sqlx::Error> {
+    use sqlx::Row;
+
+    let chain_rows: Vec<DbChainRow> = sqlx::query(
+        "SELECT chain_id, description, scope_type, scope_id, enabled, priority \
+         FROM resources.content_chains WHERE chain_id = $1",
+    )
+    .bind(chain_id)
+    .fetch_all(pool)
+    .await?
+    .into_iter()
+    .map(|r| DbChainRow {
+        chain_id: r.get("chain_id"),
+        description: r.get("description"),
+        scope_type: r.get("scope_type"),
+        scope_id: r.get("scope_id"),
+        enabled: r.get("enabled"),
+        priority: r.get("priority"),
+    })
+    .collect();
+
+    if chain_rows.is_empty() {
+        return Ok(vec![]);
+    }
+
+    let trigger_rows: Vec<DbTriggerRow> = sqlx::query(
+        "SELECT chain_id, event_type, event_key, scope, once, sort_order \
+         FROM resources.content_triggers WHERE chain_id = $1 ORDER BY sort_order",
+    )
+    .bind(chain_id)
+    .fetch_all(pool)
+    .await?
+    .into_iter()
+    .map(|r| DbTriggerRow {
+        chain_id: r.get("chain_id"),
+        event_type: r.get("event_type"),
+        event_key: r.get("event_key"),
+        scope: r.get("scope"),
+        once: r.get("once"),
+        sort_order: r.get("sort_order"),
+    })
+    .collect();
+
+    let condition_rows: Vec<DbConditionRow> = sqlx::query(
+        "SELECT chain_id, condition_type, target_id, target_key, operator, value, sort_order \
+         FROM resources.content_conditions WHERE chain_id = $1 ORDER BY sort_order",
+    )
+    .bind(chain_id)
+    .fetch_all(pool)
+    .await?
+    .into_iter()
+    .map(|r| DbConditionRow {
+        chain_id: r.get("chain_id"),
+        condition_type: r.get("condition_type"),
+        target_id: r.get("target_id"),
+        target_key: r.get("target_key"),
+        operator: r.get("operator"),
+        value: r.get("value"),
+        sort_order: r.get("sort_order"),
+    })
+    .collect();
+
+    let action_rows: Vec<DbActionRow> = sqlx::query(
+        "SELECT chain_id, action_type, target_id, target_key, params, delay_ms, sort_order \
+         FROM resources.content_actions WHERE chain_id = $1 ORDER BY sort_order",
+    )
+    .bind(chain_id)
+    .fetch_all(pool)
+    .await?
+    .into_iter()
+    .map(|r| DbActionRow {
+        chain_id: r.get("chain_id"),
+        action_type: r.get("action_type"),
+        target_id: r.get("target_id"),
+        target_key: r.get("target_key"),
+        params: r.get("params"),
+        delay_ms: r.get("delay_ms"),
+        sort_order: r.get("sort_order"),
+    })
+    .collect();
+
+    Ok(build_chains_from_rows(
+        chain_rows,
+        trigger_rows,
+        condition_rows,
+        action_rows,
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/services/src/cell/content/event_dispatch.rs
+++ b/crates/services/src/cell/content/event_dispatch.rs
@@ -487,6 +487,71 @@ pub async fn fire_teleport_in(
     executor::execute_actions(resolved, entity_id, player_id, tx, space_mgr, engine).await;
 }
 
+/// Fire `mission_accepted` immediately after a mission has been accepted
+/// and its state propagated. Called from the executor's `Action::AcceptMission`
+/// branch so chains tied to mission start (e.g., highlighting quest objects
+/// like the Cellblock_WoodenCrate for mission 687) run without coupling to
+/// the chain that triggered the accept.
+///
+/// The return type is an explicit `Pin<Box<dyn Future ...>>` rather than an
+/// `async fn` because this fires from inside `executor::execute_actions`
+/// (which itself awaits this via the `AcceptMission` branch). An `async fn`
+/// would compute its future size from the called future, and since
+/// `execute_actions` calls back into here, the type would be infinitely
+/// sized at compile time. Boxing breaks the cycle.
+///
+/// A `mission_accepted` chain that itself calls `accept_mission` for a
+/// different mission will re-fire this dispatcher — intentional, so chained
+/// accepts work without each one being wired by hand. Bounded in practice
+/// because chain authors don't write self-accepting cycles; if that turns
+/// out to be optimistic, guard with a depth counter here.
+pub(super) fn fire_mission_accepted<'a>(
+    entity_id: u32,
+    player_id: i32,
+    mission_id: i32,
+    engine: &'a ChainEngine,
+    tx: &'a mpsc::Sender<CellToBaseMsg>,
+    space_mgr: &'a mut SpaceManager,
+) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + 'a>> {
+    Box::pin(async move {
+        let mut ctx =
+            ExecutionContext::new().with_source(cimmeria_common::EntityId(entity_id as i32));
+        ctx.set_param("mission_id".to_string(), serde_json::json!(mission_id));
+
+        if let Some(entity) = space_mgr.get_entity(entity_id) {
+            populate_mission_context(entity, &mut ctx);
+            if let Some(archetype_id) = entity.archetype_id {
+                ctx.set_param("archetype".to_string(), serde_json::json!(archetype_id));
+            }
+        }
+
+        let event = TriggerEvent {
+            trigger_type: TriggerType::MissionAccepted,
+            source_entity: Some(cimmeria_common::EntityId(entity_id as i32)),
+            target_entity: None,
+            params: ctx.params.clone(),
+        };
+
+        let resolved = engine.resolve_event(&event, &ctx);
+        if !resolved.actions.is_empty() {
+            tracing::info!(
+                entity_id,
+                player_id,
+                mission_id,
+                actions = resolved.actions.len(),
+                "fire_mission_accepted: matched"
+            );
+            executor::execute_actions(resolved, entity_id, player_id, tx, space_mgr, engine).await;
+        } else {
+            tracing::debug!(
+                entity_id,
+                mission_id,
+                "fire_mission_accepted: no chains matched"
+            );
+        }
+    })
+}
+
 /// Fire a content chain directly by ID, bypassing trigger matching.
 ///
 /// Used for minigame victory callbacks — the chain has no trigger row,

--- a/crates/services/src/cell/content/event_dispatch.rs
+++ b/crates/services/src/cell/content/event_dispatch.rs
@@ -487,11 +487,19 @@ pub async fn fire_teleport_in(
     executor::execute_actions(resolved, entity_id, player_id, tx, space_mgr, engine).await;
 }
 
-/// Fire `mission_accepted` immediately after a mission has been accepted
-/// and its state propagated. Called from the executor's `Action::AcceptMission`
-/// branch so chains tied to mission start (e.g., highlighting quest objects
-/// like the Cellblock_WoodenCrate for mission 687) run without coupling to
+/// Fire `mission_accepted` immediately after the cell-side mission state
+/// has been committed for the calling entity. Called from the executor's
+/// combined `Action::AcceptMission | Action::AdvanceMission` branch so
+/// chains tied to mission start (e.g., highlighting quest objects like
+/// the Cellblock_WoodenCrate for mission 687) run without coupling to
 /// the chain that triggered the accept.
+///
+/// Fires after the in-process `accept_mission` helper updates the
+/// CellEntity's mission table — i.e., chain conditions reading
+/// `mission_<id>_status` see the post-accept state. The persistence
+/// path (the `MissionUpdate` send to base) is best-effort; this event
+/// fires whether or not that send succeeded, since the cell's view of
+/// mission state is the authoritative source for chain evaluation.
 ///
 /// The return type is an explicit `Pin<Box<dyn Future ...>>` rather than an
 /// `async fn` because this fires from inside `executor::execute_actions`

--- a/crates/services/src/cell/content/executor.rs
+++ b/crates/services/src/cell/content/executor.rs
@@ -86,6 +86,17 @@ pub(super) async fn execute_actions(
                             "MissionUpdate (accept) send to base failed -- mission progress not persisted"
                         );
                     }
+                    // Fire the follow-up `mission_accepted` event so chains
+                    // tied to mission start can run their setup work
+                    // (e.g., chain 1097 highlighting Cellblock_WoodenCrate
+                    // for mission 687). The in-process entity mutation is
+                    // already committed even if MissionUpdate failed to
+                    // persist, so the chain's view of mission state is
+                    // valid regardless.
+                    super::event_dispatch::fire_mission_accepted(
+                        entity_id, player_id, mission_id, engine, tx, space_mgr,
+                    )
+                    .await;
                 } else {
                     tracing::warn!(
                         mission_id,

--- a/db/resources/Content/Seed/castle_cellblock_chains.sql
+++ b/db/resources/Content/Seed/castle_cellblock_chains.sql
@@ -1098,7 +1098,7 @@ VALUES
   (1094, 'reset_counter', NULL, 'hallway05_kills', '{}', 0, 2);
 
 -- ============================================================
--- MISSION 687 — Aftermath (issue #236)
+-- MISSION 687 — Aftermath
 --
 -- Final mission of the Castle_Cellblock escape. Two steps:
 --   2354 — "Search the crate for any useful items."
@@ -1114,9 +1114,10 @@ VALUES
 --
 -- Reference: python/cell/missions/Castle_CellBlock/Aftermath.py covers
 -- step 2354 only; step 2355 has no python source (the original game
--- shipped that step uncompleted). Phase B/C of issue #236 is therefore
--- a new design call — three guards already spawn in the room behind
--- the wall from the crate, so we re-tag rather than insert new spawns.
+-- shipped that step uncompleted). The barracks-kill completion is
+-- therefore a new design call — three guards already spawn in the room
+-- behind the wall from the crate, so we re-tag rather than insert new
+-- spawns.
 -- ============================================================
 
 -- Chain 1097: mission 687 accepted → highlight Cellblock_WoodenCrate

--- a/db/resources/Content/Seed/castle_cellblock_chains.sql
+++ b/db/resources/Content/Seed/castle_cellblock_chains.sql
@@ -1096,3 +1096,195 @@ VALUES
   (1094, 'complete_mission', 686, NULL, '{}', 0, 0),
   (1094, 'accept_mission',   687, NULL, '{}', 0, 1),
   (1094, 'reset_counter', NULL, 'hallway05_kills', '{}', 0, 2);
+
+-- ============================================================
+-- MISSION 687 — Aftermath (issue #236)
+--
+-- Final mission of the Castle_Cellblock escape. Two steps:
+--   2354 — "Search the crate for any useful items."
+--          Right-click `Cellblock_WoodenCrate` → archetype-gated reward
+--          (Tau'ri stealth set + knife / Jaffa armor + serpent staff)
+--          → advance to step 2355.
+--   2355 — "Eliminate the guards in the barracks."
+--          Three NID Guards tagged `Barracks_Guard1/2/3` (re-tagged from
+--          previously-untagged spawn_ids 25/26/36, see
+--          db/resources/Worlds/Seed/spawnlist.sql).
+--          Counter `barracks_kills` reaches the `target - 1 = 2`
+--          threshold on the third kill → complete 687.
+--
+-- Reference: python/cell/missions/Castle_CellBlock/Aftermath.py covers
+-- step 2354 only; step 2355 has no python source (the original game
+-- shipped that step uncompleted). Phase B/C of issue #236 is therefore
+-- a new design call — three guards already spawn in the room behind
+-- the wall from the crate, so we re-tag rather than insert new spawns.
+-- ============================================================
+
+-- Chain 1097: mission 687 accepted → highlight Cellblock_WoodenCrate
+-- as a quest world object so the right-click cursor renders the
+-- attention-pulse. Mirrors how chain 1053 highlights Preparation_SMG1A
+-- on mission 641 accept. The matching `mission_accepted` trigger fires
+-- from `crates/services/src/cell/content/executor.rs::Action::AcceptMission`
+-- right after the mission state is committed (engine extension landed
+-- alongside this chain).
+INSERT INTO content_chains (chain_id, description, scope_type, scope_id, enabled, priority)
+VALUES (1097, '687 - Mission accepted: highlight wooden crate', 'mission', 687, true, 0);
+
+INSERT INTO content_triggers (chain_id, event_type, event_key, scope, once, sort_order)
+VALUES (1097, 'mission_accepted', '687', 'player', false, 0);
+
+INSERT INTO content_actions (chain_id, action_type, target_id, target_key, params, delay_ms, sort_order)
+VALUES (1097, 'set_interaction_type', NULL, 'Cellblock_WoodenCrate',
+        '{"op": "|", "mask": "INT_MissionWorldObject"}', 0, 0);
+
+-- Chain 1098: search crate (Tau'ri / non-Jaffa) → display dialog 3942,
+-- grant 5-piece Covert Stealth set + Combat Knife to backpack, advance
+-- to step 2355, clear crate highlight. Items go to container 1
+-- (backpack) per Aftermath.py — the original `inventory.addItem(1, ...)`
+-- path. Player learns to equip themselves rather than auto-equipping;
+-- earlier items in the cellblock arc were auto-handled.
+INSERT INTO content_chains (chain_id, description, scope_type, scope_id, enabled, priority)
+VALUES (1098, '687 - Search crate (non-Jaffa): grant stealth set', 'mission', 687, true, 0);
+
+INSERT INTO content_triggers (chain_id, event_type, event_key, scope, once, sort_order)
+VALUES (1098, 'interact_tag', 'Cellblock_WoodenCrate', 'player', false, 0);
+
+INSERT INTO content_conditions (chain_id, condition_type, target_id, target_key, operator, value, sort_order)
+VALUES
+  (1098, 'step_status', 687, '2354', 'eq', 'active', 0),
+  (1098, 'archetype',   NULL, NULL, 'neq', '8', 1);
+
+INSERT INTO content_actions (chain_id, action_type, target_id, target_key, params, delay_ms, sort_order)
+VALUES
+  (1098, 'display_dialog', 3942, NULL,   '{}',                         0, 0),
+  (1098, 'add_item',       3347, NULL,   '{"qty": 1, "container": 1}', 0, 1),  -- Covert Stealth Helmet
+  (1098, 'add_item',       3359, NULL,   '{"qty": 1, "container": 1}', 0, 2),  -- Covert Stealth Vest
+  (1098, 'add_item',       3372, NULL,   '{"qty": 1, "container": 1}', 0, 3),  -- Covert Stealth Pants
+  (1098, 'add_item',       3387, NULL,   '{"qty": 1, "container": 1}', 0, 4),  -- Covert Stealth Gloves
+  (1098, 'add_item',       3401, NULL,   '{"qty": 1, "container": 1}', 0, 5),  -- Covert Stealth Boots
+  (1098, 'add_item',       3325, NULL,   '{"qty": 1, "container": 1}', 0, 6),  -- Combat Knife
+  (1098, 'advance_step',   687,  '2355', '{}',                         0, 7),
+  (1098, 'set_interaction_type', NULL, 'Cellblock_WoodenCrate',
+   '{"op": "~", "mask": "INT_MissionWorldObject"}', 0, 8);
+
+-- Chain 1099: search crate (Jaffa) → display dialog 3943, grant
+-- Armored Prison Jacket + Serpent Staff to backpack, advance step,
+-- clear crate highlight. Same container-1 reasoning as 1098.
+INSERT INTO content_chains (chain_id, description, scope_type, scope_id, enabled, priority)
+VALUES (1099, '687 - Search crate (Jaffa): grant prison jacket + serpent staff', 'mission', 687, true, 0);
+
+INSERT INTO content_triggers (chain_id, event_type, event_key, scope, once, sort_order)
+VALUES (1099, 'interact_tag', 'Cellblock_WoodenCrate', 'player', false, 0);
+
+INSERT INTO content_conditions (chain_id, condition_type, target_id, target_key, operator, value, sort_order)
+VALUES
+  (1099, 'step_status', 687, '2354', 'eq', 'active', 0),
+  (1099, 'archetype',   NULL, NULL, 'eq',  '8', 1);
+
+INSERT INTO content_actions (chain_id, action_type, target_id, target_key, params, delay_ms, sort_order)
+VALUES
+  (1099, 'display_dialog', 3943, NULL,   '{}',                         0, 0),
+  (1099, 'add_item',       3482, NULL,   '{"qty": 1, "container": 1}', 0, 1),  -- Armored Prison Jacket
+  (1099, 'add_item',       2797, NULL,   '{"qty": 1, "container": 1}', 0, 2),  -- Serpent Staff
+  (1099, 'advance_step',   687,  '2355', '{}',                         0, 3),
+  (1099, 'set_interaction_type', NULL, 'Cellblock_WoodenCrate',
+   '{"op": "~", "mask": "INT_MissionWorldObject"}', 0, 4);
+
+-- ── Mission 687 step 2355 — Eliminate barracks guards (3 guards) ──
+--
+-- Same shape as chain 1085-1087 (Mess Hall, 2 guards): one increment
+-- chain per guard at priority 1, one completion chain at priority 0
+-- with the multi-trigger OR shape. Step gating is on 2355 specifically
+-- so a guard kill while step 2354 is active doesn't bleed counter
+-- progress into the next step. Three guards → target_value 3, gte 2
+-- (target - 1) per the resolve/execute ordering note at chain 1087.
+
+-- Chain 1100: kill Barracks_Guard1 → increment barracks_kills
+INSERT INTO content_chains (chain_id, description, scope_type, scope_id, enabled, priority)
+VALUES (1100, '687 - Kill Barracks_Guard1: increment barracks_kills', 'mission', 687, true, 1);
+
+INSERT INTO content_triggers (chain_id, event_type, event_key, scope, once, sort_order)
+VALUES (1100, 'entity_dead_tag', 'Barracks_Guard1', 'space', false, 0);
+
+INSERT INTO content_conditions (chain_id, condition_type, target_id, target_key, operator, value, sort_order)
+VALUES
+  (1100, 'mission_status', 687, NULL,   'eq', 'active', 0),
+  (1100, 'step_status',    687, '2355', 'eq', 'active', 1);
+
+INSERT INTO content_actions (chain_id, action_type, target_id, target_key, params, delay_ms, sort_order)
+VALUES (1100, 'increment_counter', NULL, 'barracks_kills', '{"amount": 1}', 0, 0);
+
+INSERT INTO content_counters (chain_id, counter_name, target_value, reset_on)
+VALUES (1100, 'barracks_kills', 3, 'mission_complete');
+
+-- Chain 1101: kill Barracks_Guard2 → increment barracks_kills
+INSERT INTO content_chains (chain_id, description, scope_type, scope_id, enabled, priority)
+VALUES (1101, '687 - Kill Barracks_Guard2: increment barracks_kills', 'mission', 687, true, 1);
+
+INSERT INTO content_triggers (chain_id, event_type, event_key, scope, once, sort_order)
+VALUES (1101, 'entity_dead_tag', 'Barracks_Guard2', 'space', false, 0);
+
+INSERT INTO content_conditions (chain_id, condition_type, target_id, target_key, operator, value, sort_order)
+VALUES
+  (1101, 'mission_status', 687, NULL,   'eq', 'active', 0),
+  (1101, 'step_status',    687, '2355', 'eq', 'active', 1);
+
+INSERT INTO content_actions (chain_id, action_type, target_id, target_key, params, delay_ms, sort_order)
+VALUES (1101, 'increment_counter', NULL, 'barracks_kills', '{"amount": 1}', 0, 0);
+
+-- Chain 1102: kill Barracks_Guard3 → increment barracks_kills
+INSERT INTO content_chains (chain_id, description, scope_type, scope_id, enabled, priority)
+VALUES (1102, '687 - Kill Barracks_Guard3: increment barracks_kills', 'mission', 687, true, 1);
+
+INSERT INTO content_triggers (chain_id, event_type, event_key, scope, once, sort_order)
+VALUES (1102, 'entity_dead_tag', 'Barracks_Guard3', 'space', false, 0);
+
+INSERT INTO content_conditions (chain_id, condition_type, target_id, target_key, operator, value, sort_order)
+VALUES
+  (1102, 'mission_status', 687, NULL,   'eq', 'active', 0),
+  (1102, 'step_status',    687, '2355', 'eq', 'active', 1);
+
+INSERT INTO content_actions (chain_id, action_type, target_id, target_key, params, delay_ms, sort_order)
+VALUES (1102, 'increment_counter', NULL, 'barracks_kills', '{"amount": 1}', 0, 0);
+
+-- Chain 1103: barracks_kills threshold reached on third kill → complete 687.
+-- Three trigger rows OR together (one per guard tag) so any of the
+-- three deaths can be the trigger. Counter `gte 2` (target - 1)
+-- because chain conditions evaluate against the PRE-increment counter
+-- value — see chain 1087 for the full ordering note.
+INSERT INTO content_chains (chain_id, description, scope_type, scope_id, enabled, priority)
+VALUES (1103, '687 - Kill counter reached: complete 687', 'mission', 687, true, 0);
+
+INSERT INTO content_triggers (chain_id, event_type, event_key, scope, once, sort_order)
+VALUES
+  (1103, 'entity_dead_tag', 'Barracks_Guard1', 'space', false, 0),
+  (1103, 'entity_dead_tag', 'Barracks_Guard2', 'space', false, 1),
+  (1103, 'entity_dead_tag', 'Barracks_Guard3', 'space', false, 2);
+
+INSERT INTO content_conditions (chain_id, condition_type, target_id, target_key, operator, value, sort_order)
+VALUES
+  (1103, 'mission_status', 687, NULL,   'eq',  'active', 0),
+  (1103, 'step_status',    687, '2355', 'eq',  'active', 1),
+  (1103, 'counter',        NULL, 'barracks_kills', 'gte', '2', 2);
+
+INSERT INTO content_actions (chain_id, action_type, target_id, target_key, params, delay_ms, sort_order)
+VALUES
+  (1103, 'complete_mission', 687, NULL, '{}', 0, 0),
+  (1103, 'reset_counter',    NULL, 'barracks_kills', '{}', 0, 1);
+
+-- Chain 1104: player_loaded + step 2354 active → restore crate highlight
+-- on login. interaction_type flags don't persist across server
+-- restarts, so a player who logs out mid-Aftermath at step 2354 would
+-- otherwise log back in to an unhighlighted crate. Mirrors chains
+-- 1062/1064/1065 (SMG1A / ColMarsh / Terminal restore patterns).
+INSERT INTO content_chains (chain_id, description, scope_type, scope_id, enabled, priority)
+VALUES (1104, '687 - Restore crate highlight on login (step 2354)', 'mission', 687, true, 0);
+
+INSERT INTO content_triggers (chain_id, event_type, event_key, scope, once, sort_order)
+VALUES (1104, 'player_loaded', 'Castle_CellBlock', 'player', false, 0);
+
+INSERT INTO content_conditions (chain_id, condition_type, target_id, target_key, operator, value, sort_order)
+VALUES (1104, 'step_status', 687, '2354', 'eq', 'active', 0);
+
+INSERT INTO content_actions (chain_id, action_type, target_id, target_key, params, delay_ms, sort_order)
+VALUES (1104, 'set_interaction_type', NULL, 'Cellblock_WoodenCrate',
+        '{"op": "|", "mask": "INT_MissionWorldObject"}', 0, 0);

--- a/db/resources/Worlds/Seed/spawnlist.sql
+++ b/db/resources/Worlds/Seed/spawnlist.sql
@@ -8,13 +8,13 @@ INSERT INTO spawnlist (spawn_id, x, y, z, heading, world_id, template_id, tag, s
 
 INSERT INTO spawnlist (spawn_id, x, y, z, heading, world_id, template_id, tag, set_name) VALUES (27, -49.6899986, 24.6700001, -127.110001, 3.1414969, 12, 24, NULL, NULL);
 
-INSERT INTO spawnlist (spawn_id, x, y, z, heading, world_id, template_id, tag, set_name) VALUES (26, -131.479996, 24.6700001, -116.969994, 0, 12, 24, NULL, NULL);
+INSERT INTO spawnlist (spawn_id, x, y, z, heading, world_id, template_id, tag, set_name) VALUES (26, -131.479996, 24.6700001, -116.969994, 0, 12, 24, 'Barracks_Guard2', NULL);
 
 INSERT INTO spawnlist (spawn_id, x, y, z, heading, world_id, template_id, tag, set_name) VALUES (29, -96.25, 34.5909996, -91.5899963, 2.09426737, 12, 24, 'MessHall_Guard1', NULL);
 
-INSERT INTO spawnlist (spawn_id, x, y, z, heading, world_id, template_id, tag, set_name) VALUES (36, -136.384995, 24.6709976, -135.671005, 0, 12, 24, NULL, NULL);
+INSERT INTO spawnlist (spawn_id, x, y, z, heading, world_id, template_id, tag, set_name) VALUES (36, -136.384995, 24.6709976, -135.671005, 0, 12, 24, 'Barracks_Guard3', NULL);
 
-INSERT INTO spawnlist (spawn_id, x, y, z, heading, world_id, template_id, tag, set_name) VALUES (25, -118.409996, 24.6700001, -118.349998, 1.57079637, 12, 24, NULL, NULL);
+INSERT INTO spawnlist (spawn_id, x, y, z, heading, world_id, template_id, tag, set_name) VALUES (25, -118.409996, 24.6700001, -118.349998, 1.57079637, 12, 24, 'Barracks_Guard1', NULL);
 
 INSERT INTO spawnlist (spawn_id, x, y, z, heading, world_id, template_id, tag, set_name) VALUES (78, 39.5439987, -51.9140015, -129.919998, 3.13986993, 18, 65, 'Omega_Site_Modi', NULL);
 

--- a/docs/content/content-engine.md
+++ b/docs/content/content-engine.md
@@ -107,7 +107,7 @@ Defined at [triggers.rs:20-98](../../crates/content-engine/src/triggers.rs#L20-L
 | `OnEffectInit / PulseBegin / PulseEnd / Removed` | Effect lifecycle hooks (unit variants) |
 | `OnMissionCompleted { mission_id }` | Mission marked complete |
 | `OnDialogSetOpen { dialog_set_name }` | Dialog set opened |
-| `OnMissionAccepted { mission_id }` | Mission just accepted or advanced (fired from the executor's combined `Action::AcceptMission | Action::AdvanceMission` branch after the cell-side state commit; used by chains that highlight quest objects on mission start — e.g. chain 1097 for Aftermath) |
+| `OnMissionAccepted { mission_id }` | Mission just accepted or advanced (fired from the executor's combined `Action::AcceptMission \| Action::AdvanceMission` branch after the cell-side state commit; used by chains that highlight quest objects on mission start — e.g. chain 1097 for Aftermath) |
 
 Within a single chain's bucket, `Trigger::matches` ([triggers.rs:178](../../crates/content-engine/src/triggers.rs#L178)) decides whether the event matches the chain's specific trigger variant + filter. Bucketing is by **`TriggerType` discriminant** — see §6.
 

--- a/docs/content/content-engine.md
+++ b/docs/content/content-engine.md
@@ -107,6 +107,7 @@ Defined at [triggers.rs:20-98](../../crates/content-engine/src/triggers.rs#L20-L
 | `OnEffectInit / PulseBegin / PulseEnd / Removed` | Effect lifecycle hooks (unit variants) |
 | `OnMissionCompleted { mission_id }` | Mission marked complete |
 | `OnDialogSetOpen { dialog_set_name }` | Dialog set opened |
+| `OnMissionAccepted { mission_id }` | Mission just accepted (fired from executor's `Action::AcceptMission` after state commit, used by chains that highlight quest objects on mission start — e.g. chain 1097 for Aftermath) |
 
 Within a single chain's bucket, `Trigger::matches` ([triggers.rs:178](../../crates/content-engine/src/triggers.rs#L178)) decides whether the event matches the chain's specific trigger variant + filter. Bucketing is by **`TriggerType` discriminant** — see §6.
 

--- a/docs/content/content-engine.md
+++ b/docs/content/content-engine.md
@@ -107,7 +107,7 @@ Defined at [triggers.rs:20-98](../../crates/content-engine/src/triggers.rs#L20-L
 | `OnEffectInit / PulseBegin / PulseEnd / Removed` | Effect lifecycle hooks (unit variants) |
 | `OnMissionCompleted { mission_id }` | Mission marked complete |
 | `OnDialogSetOpen { dialog_set_name }` | Dialog set opened |
-| `OnMissionAccepted { mission_id }` | Mission just accepted (fired from executor's `Action::AcceptMission` after state commit, used by chains that highlight quest objects on mission start — e.g. chain 1097 for Aftermath) |
+| `OnMissionAccepted { mission_id }` | Mission just accepted or advanced (fired from the executor's combined `Action::AcceptMission | Action::AdvanceMission` branch after the cell-side state commit; used by chains that highlight quest objects on mission start — e.g. chain 1097 for Aftermath) |
 
 Within a single chain's bucket, `Trigger::matches` ([triggers.rs:178](../../crates/content-engine/src/triggers.rs#L178)) decides whether the event matches the chain's specific trigger variant + filter. Bucketing is by **`TriggerType` discriminant** — see §6.
 


### PR DESCRIPTION
## Summary

Closes #236.

Mission 687 (Aftermath) — the final mission in the Castle_Cellblock escape sequence — was unwired in main. Player auto-accepted it on Region6 entry per chain 1084, then had nowhere to go: the wooden crate had no interactivity, no chain advanced step 2354 → 2355, and no completion path existed for step 2355 ("Eliminate the guards in the barracks").

This PR wires it end-to-end against the existing world geometry — including using the three barracks NID Guards that already spawn in the room behind the wall from the crate (just untagged in the seed) — and adds the `mission_accepted` engine trigger to do it cleanly.

## Engine extension — `mission_accepted` trigger

- `Trigger::OnMissionAccepted { mission_id }` + `TriggerType::MissionAccepted` discriminant + matcher.
- Loader maps `event_type = 'mission_accepted'` with mission id in `event_key`.
- New `fire_mission_accepted` dispatcher fires from `Action::AcceptMission`'s executor branch immediately after state commits, so chains tied to mission start can run setup work without coupling to whichever chain did the accepting.
- Returns `Pin<Box<dyn Future>>` rather than `async fn` — breaks the executor↔dispatcher async-recursion sizing cycle without pulling in an extra dep.

## SQL — chains 1097-1104 in `castle_cellblock_chains.sql`

| Chain | Trigger | Effect |
|---|---|---|
| 1097 | `mission_accepted 687` | Highlight Cellblock_WoodenCrate (mirrors chain 1053 for SMG1A) |
| 1098 | `interact_tag Cellblock_WoodenCrate` + step 2354 active + `archetype neq 8` | Display 3942, grant 5-piece Covert Stealth set + Combat Knife to backpack, advance to step 2355, clear highlight |
| 1099 | Same trigger + `archetype eq 8` | Display 3943, grant Armored Prison Jacket + Serpent Staff, advance step, clear highlight |
| 1100/1101/1102 | `entity_dead_tag Barracks_Guard{1,2,3}` + step 2355 active | `increment_counter barracks_kills` (priority 1) |
| 1103 | Multi-trigger OR on all three guard tags + counter `gte 2` | Complete mission 687, reset counter (priority 0) |
| 1104 | `player_loaded Castle_CellBlock` + step 2354 active | Restore crate highlight on login |

Inventory: all items go to container 1 (backpack) per `Aftermath.py`'s `inventory.addItem(1, ...)` calls — players learn to equip themselves rather than auto-equipping (intentional by user).

Counter threshold: `gte 2` (`target_value 3 - 1`) per the resolve/execute ordering note at chain 1087 — chain conditions evaluate against the PRE-increment counter value because resolve runs before execute.

## Spawnlist — re-tag existing barracks guards

Three previously-untagged NID Guards (`spawn_ids 25/26/36`, all at y=24.67 clustered south of the crate) become `Barracks_Guard1/2/3`. The room behind the wall from the crate already had three guards spawning — we just needed to tag them. No new spawn rows.

## Tests — 10 new (4 unit + 6 chain-replay)

- `triggers.rs`: `OnMissionAccepted` matcher positive + negative.
- `loader.rs`: `mission_accepted` event_type round-trip + missing-key drops.
- `chain_replay_tests.rs`: chains 1097 / 1098-positive / 1098-negative-jaffa / 1099 / 1103-third-kill-completes / 1103-first-kill-no-completion.
- `engine_loader.rs`: new `load_chain_expansions_for_test` helper (chain 1103 has multi-trigger OR; existing `load_single_chain_for_test` only returned the first expansion).

All green:
- `cargo test -p cimmeria-content-engine --lib` → 72 pass (was 68).
- `cargo test -p cimmeria-services --lib -- --test-threads=1` against fresh seed → 614 pass.
- `cargo fmt --all -- --check` clean.
- `cargo clippy -p cimmeria-content-engine -p cimmeria-services -p cimmeria-entity --all-targets -- -D warnings` clean.

## In-client verification

User confirmed full play-through works: walk into Region6 → auto-accept Aftermath → crate pulses with quest highlight → right-click → archetype-correct dialog + items in backpack → step 2355 in journal → kill three barracks guards → mission completes.

## Reference

`python/cell/missions/Castle_CellBlock/Aftermath.py` covers step 2354 only — step 2355 has no Python source. The original game shipped that step uncompleted, so the kill-counter completion is a new design call grounded in the existing world geometry (the three guards were already spawning, just untagged).

## Followups

- **Issue [TBD-A]** — Equipment system fixes: BeingAppearance broadcast on manual equip (drag from backpack into armor slot); right-click-to-equip with backpack-swap and bandolier "empty-slot-or-replace-last" rules; armor stat hookup audit (the granted items have no direct stat columns — equipped bonuses likely require effect plumbing we don't have today).
- **Issue [TBD-B]** — Cellblock-to-Castle completion: tag the 4th NID Guard (spawn_id 27 at `(-49.69, 24.67, -127.11)`); add new steps to mission 680 ("Escape the Cellblock") for breadcrumb hallway-guard kill → hack `Cellblock_TerminalX` → use `Cellblock_FakeRingSwitch`; spawn a Castle-side ring transporter destination near Sgt. Gerschon at `(354.42, 70.27, 952.80)` so the canonical ring transport flow has a valid target; chain wiring.
- **Issue [TBD-C]** — Seed cleanup: chains 5020 and 5021 in `space_castle_cellblock_chains.sql` are byte-identical (both `enter_region Castle_Cellblock.Region13` → `system_message 5185`). Script-to-chain conversion appears to have emitted node 159 twice. Cosmetically duplicate but stub action means harmless at runtime.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p cimmeria-content-engine -p cimmeria-services -p cimmeria-entity --all-targets -- -D warnings` clean
- [x] `cargo test -p cimmeria-content-engine --lib` (72 pass)
- [x] `cargo test -p cimmeria-services --lib -- --test-threads=1` against fresh seed (614 pass)
- [x] In-client play-through: auto-accept on Region6 entry, crate highlight, archetype-correct rewards, step advance, three barracks kills complete the mission

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a mission-accepted trigger that fires content chains when players accept missions, enabling reactions like highlighting objects and contextual dialogs.

* **Tests**
  * Expanded regression tests for mission 687 flows, archetype-specific rewards, counter-based kill tracking, and trigger matching.

* **Documentation**
  * Updated trigger docs to include mission-accepted usage and timing.

* **Data Updates**
  * Completed Mission 687 content: dialogs, item rewards, progression chains, spawnlist updates, and login-resilience behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->