### PR TITLE
ci(test): adopt cargo-nextest + Codecov Test Analytics

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,35 @@
+# cargo-nextest configuration. Two CI profiles mirror the two test
+# jobs in .github/workflows/test.yml:
+#
+#   * `ci`         — workspace pass without DATABASE_URL; the live-DB
+#                    tests self-skip via require_db_or_skip!. Parallel.
+#   * `ci-live-db` — services-only pass against a live Postgres. Must
+#                    be serialised because some live-DB tests share
+#                    sentinel id ranges in the resources.* tables and
+#                    collide under parallel execution against a single
+#                    shared DB. That's a fixture-design constraint, not
+#                    a bug in the handlers.
+#
+# JUnit XML is emitted under target/nextest/<profile>/junit.xml and
+# uploaded to Codecov Test Analytics by the workflow.
+
+[profile.ci]
+fail-fast = false
+
+[profile.ci.junit]
+path = "junit.xml"
+report-name = "cimmeria"
+
+[profile.ci-live-db]
+fail-fast = false
+
+[profile.ci-live-db.junit]
+path = "junit.xml"
+report-name = "cimmeria-live-db"
+
+# Replaces the `cargo test -- --test-threads=1` flag we used before
+# nextest. Each test claims every available test thread, so nextest
+# runs them strictly one-at-a-time even on a multi-core runner.
+[[profile.ci-live-db.overrides]]
+filter = "all()"
+threads-required = "num-test-threads"

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -39,7 +39,7 @@ A PR that changes runtime behaviour must add or update a test. **Read [TESTING.m
 - Tighten assertions: composite keys, exact final positions, `== 1` not `>= 1`, exact byte strings for serializers.
 - Don't hard-code seed ids — re-fetch baselines or assert by relationship (`slot.cur_ammo_type == slot.default_ammo_type`).
 - Sentinel ids fit in `i32`; cleanup deletes by exact sentinel, not by range.
-- Live-DB tests use `require_db_or_skip!` and run serialised — `cargo nextest run --profile=ci-live-db` (the profile in `.config/nextest.toml` pins `threads-required = num-test-threads`), or `cargo test ... -- --test-threads=1` if you're not on nextest.
+- Live-DB tests use `require_db_or_skip!` and run serialised — `cargo nextest run --profile=ci-live-db` (the profile in `.config/nextest.toml` pins `threads-required = "num-test-threads"`), or `cargo test ... -- --test-threads=1` if you're not on nextest.
 - Test names match the assertion. If the assertion changes, rename.
 - No PR or issue numbers in source comments — provenance lives in the PR body.
 - Update [docs/testing/inventory/<crate>.md](../docs/testing/inventory/) **only when a single PR adds or removes ≥5% of the workspace test count** (~55 tests against the current 1071 baseline). Smaller drifts get folded in by periodic sweep updates — don't block review on per-PR inventory churn for a handful of tests in a 1071-test repo.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -39,7 +39,7 @@ A PR that changes runtime behaviour must add or update a test. **Read [TESTING.m
 - Tighten assertions: composite keys, exact final positions, `== 1` not `>= 1`, exact byte strings for serializers.
 - Don't hard-code seed ids — re-fetch baselines or assert by relationship (`slot.cur_ammo_type == slot.default_ammo_type`).
 - Sentinel ids fit in `i32`; cleanup deletes by exact sentinel, not by range.
-- Live-DB tests use `require_db_or_skip!` and run with `--test-threads=1`.
+- Live-DB tests use `require_db_or_skip!` and run serialised — `cargo nextest run --profile=ci-live-db` (the profile in `.config/nextest.toml` pins `threads-required = num-test-threads`), or `cargo test ... -- --test-threads=1` if you're not on nextest.
 - Test names match the assertion. If the assertion changes, rename.
 - No PR or issue numbers in source comments — provenance lives in the PR body.
 - Update [docs/testing/inventory/<crate>.md](../docs/testing/inventory/) **only when a single PR adds or removes ≥5% of the workspace test count** (~55 tests against the current 1071 baseline). Smaller drifts get folded in by periodic sweep updates — don't block review on per-PR inventory churn for a handful of tests in a 1071-test repo.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,19 +98,30 @@ jobs:
       - name: cargo build
         run: cargo build --workspace ${{ env.WORKSPACE_EXCLUDES }} --all-targets
 
-  # cargo test (no DB). Live-DB tests in cimmeria-services use
+  # cargo nextest (no DB). Live-DB tests in cimmeria-services use
   # test_support::require_db_or_skip! and self-skip when DATABASE_URL is
   # unset, so this job covers the unit + non-DB integration tests across
   # the whole workspace (mercury, content-engine, services unit tests, etc.).
   # The live-DB suite runs in the dedicated `test-live-db` job below.
+  #
+  # nextest emits JUnit XML at target/nextest/ci/junit.xml (configured in
+  # .config/nextest.toml); the upload step feeds it to Codecov Test
+  # Analytics for per-test history and flake detection.
+  #
+  # nextest cannot run doctests (upstream limitation: nextest-rs/nextest#16),
+  # so they run separately via `cargo test --doc` after the main pass. Only
+  # cimmeria-commands has runnable doctests today; the rest of the workspace
+  # uses ```text / ```ignore fences that don't compile.
   test:
-    name: cargo test (workspace, no DB)
+    name: cargo nextest (workspace, no DB)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - name: install clang + mold
         run: sudo apt-get update && sudo apt-get install -y clang mold
+      - name: install nextest
+        uses: taiki-e/install-action@nextest
       - name: hydrate external/recast
         run: |
           mkdir -p external
@@ -123,21 +134,32 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: test
-      - name: cargo test
-        run: cargo test --workspace ${{ env.WORKSPACE_EXCLUDES }}
+      - name: cargo nextest run
+        run: cargo nextest run --profile=ci --workspace ${{ env.WORKSPACE_EXCLUDES }}
+      - name: cargo test --doc (cimmeria-commands)
+        run: cargo test --doc -p cimmeria-commands
+      - name: upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: target/nextest/ci/junit.xml
+          flags: workspace
 
-  # cargo test against a live Postgres. Schema is loaded from
+  # cargo nextest against a live Postgres. Schema is loaded from
   # db/database.sql (which `\ir`-includes everything in db/sgw and
   # db/resources, including seed data). The live-DB regression guards
   # we've written for vendor / inventory / progression / mail / missions
   # actually fire in this job — the prior `test` job's
   # require_db_or_skip! short-circuits without DATABASE_URL.
   #
-  # --test-threads=1 because some live-DB tests share sentinel id ranges
-  # and collide under parallel execution against a single shared DB.
-  # That's a fixture-design constraint, not a bug in the handlers.
+  # The `ci-live-db` profile in .config/nextest.toml serialises every
+  # test (threads-required = num-test-threads). Some live-DB tests share
+  # sentinel id ranges in resources.* and collide under parallel
+  # execution against a single shared DB; that's a fixture-design
+  # constraint, not a bug in the handlers.
   test-live-db:
-    name: cargo test -p cimmeria-services (live DB)
+    name: cargo nextest -p cimmeria-services (live DB)
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -161,6 +183,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - name: install clang + mold + psql
         run: sudo apt-get update && sudo apt-get install -y clang mold postgresql-client
+      - name: install nextest
+        uses: taiki-e/install-action@nextest
       - name: hydrate external/recast
         run: |
           mkdir -p external
@@ -178,9 +202,15 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: test-live-db
-      - name: cargo test (live DB)
-        run: |
-          cargo test -p cimmeria-services --lib -- --test-threads=1
+      - name: cargo nextest run (live DB)
+        run: cargo nextest run --profile=ci-live-db -p cimmeria-services --lib
+      - name: upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: target/nextest/ci-live-db/junit.xml
+          flags: live-db
 
   # Coverage report. Same matrix as the test + test-live-db jobs combined,
   # instrumented under cargo-llvm-cov. Two passes share counter data via
@@ -188,6 +218,12 @@ jobs:
   # coverage, the second pass runs `-p cimmeria-services --lib` against a
   # live Postgres so the require_db_or_skip! guards actually count.
   # `cargo llvm-cov report` then merges them into one HTML/cobertura/summary.
+  #
+  # Both passes drive nextest under llvm-cov so a single test execution
+  # produces both coverage counter data and the (unused here — the
+  # `test`/`test-live-db` jobs own JUnit upload) per-test JUnit. Keeping
+  # JUnit upload off this job avoids double-counting in Codecov Test
+  # Analytics.
   #
   # Non-blocking: continue-on-error so a coverage-tool flake doesn't gate
   # merges. The artifact + summary log are advisory — the PR-gating signal
@@ -238,19 +274,23 @@ jobs:
           shared-key: coverage
       - name: install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
+      - name: install nextest
+        uses: taiki-e/install-action@nextest
       - name: clean stale counter data
         run: cargo llvm-cov clean --workspace
       - name: workspace pass (no DB)
         # DATABASE_URL is set on the job, but we deliberately unset it here so
         # the live-DB tests skip in this pass — they're owned by the second
-        # pass below, which runs with --test-threads=1.
+        # pass below, which serialises via the ci-live-db nextest profile.
         env:
           DATABASE_URL: ""
         run: |
-          cargo llvm-cov --workspace ${{ env.WORKSPACE_EXCLUDES }} --no-report
+          cargo llvm-cov --no-report nextest \
+            --profile=ci --workspace ${{ env.WORKSPACE_EXCLUDES }}
       - name: services live-DB pass
         run: |
-          cargo llvm-cov -p cimmeria-services --lib --no-report -- --test-threads=1
+          cargo llvm-cov --no-report nextest \
+            --profile=ci-live-db -p cimmeria-services --lib
       - name: render reports
         run: |
           mkdir -p target/coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -139,12 +139,17 @@ jobs:
       - name: cargo test --doc (cimmeria-commands)
         run: cargo test --doc -p cimmeria-commands
       - name: upload test results to Codecov
+        # `!cancelled()` runs this step on both success and failure (but not
+        # on cancellation), so failing tests still get their JUnit uploaded
+        # for Test Analytics annotations on the PR.
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: target/nextest/ci/junit.xml
+          report_type: test_results
           flags: workspace
+          fail_ci_if_error: false
 
   # cargo nextest against a live Postgres. Schema is loaded from
   # db/database.sql (which `\ir`-includes everything in db/sgw and
@@ -154,7 +159,7 @@ jobs:
   # require_db_or_skip! short-circuits without DATABASE_URL.
   #
   # The `ci-live-db` profile in .config/nextest.toml serialises every
-  # test (threads-required = num-test-threads). Some live-DB tests share
+  # test (threads-required = "num-test-threads"). Some live-DB tests share
   # sentinel id ranges in resources.* and collide under parallel
   # execution against a single shared DB; that's a fixture-design
   # constraint, not a bug in the handlers.
@@ -206,11 +211,13 @@ jobs:
         run: cargo nextest run --profile=ci-live-db -p cimmeria-services --lib
       - name: upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: target/nextest/ci-live-db/junit.xml
+          report_type: test_results
           flags: live-db
+          fail_ci_if_error: false
 
   # Coverage report. Same matrix as the test + test-live-db jobs combined,
   # instrumented under cargo-llvm-cov. Two passes share counter data via

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ pkill -f "cargo|rustc"
 
 ## Pre-PR checklist
 
-CI (`.github/workflows/test.yml`) gates five checks on every PR — run all five locally before pushing or the pipeline will fail and you'll round-trip:
+CI (`.github/workflows/test.yml`) gates five checks on every PR — run all five locally before pushing or the pipeline will fail and you'll round-trip. The test runner in CI is [`cargo-nextest`](https://nexte.st/); install it once with `cargo install cargo-nextest --locked` (or `taiki-e/install-action@nextest` if you already use that pattern).
 
 ```bash
 cargo fmt --all -- --check
@@ -68,20 +68,25 @@ cargo clippy --workspace \
 cargo build --workspace \
   --exclude cimmeria-app --exclude cimmeria-content-editor \
   --exclude cimmeria-scene-editor --exclude sgw-launcher --all-targets
-cargo test --workspace \
+cargo nextest run --profile=ci --workspace \
   --exclude cimmeria-app --exclude cimmeria-content-editor \
   --exclude cimmeria-scene-editor --exclude sgw-launcher
+# Doctests aren't run by nextest — only cimmeria-commands has runnable
+# doctests today, so this is a one-crate sanity check:
+cargo test --doc -p cimmeria-commands
 
 # Live-DB tests — start the bundled Postgres first, then:
 DATABASE_URL=postgres://w-testing:w-testing@localhost:5433/sgw \
-  cargo test -p cimmeria-services --lib -- --test-threads=1
+  cargo nextest run --profile=ci-live-db -p cimmeria-services --lib
 ```
+
+`cargo test -p <crate>` still works for quick crate-level iteration. Use nextest for anything you'd be uploading to CI.
 
 - **fmt fails** → `cargo fmt --all` and commit the result. The CI job tells you exactly that.
 - **clippy fails** → fix the warning. Project-level thresholds for `too_many_arguments` (14) and `type_complexity` (500) live in `clippy.toml`; bumping those further requires the same kind of justification any other lint suppression would. Don't sprinkle `#[allow(clippy::…)]` per call site.
 - **build fails** → typically a stale path or unused-symbol cleanup needed; check matches `cargo check`.
 - **test fails (no DB)** → unit + non-DB integration tests. Live-DB tests in `crates/services` self-skip via `require_db_or_skip!` when `DATABASE_URL` is unset, so this run can be green even with broken DB code.
-- **test-live-db fails** → CI runs `cargo test -p cimmeria-services --lib -- --test-threads=1` against a fresh `postgres:17.9` service container loaded from `db/database.sql`. `--test-threads=1` is required: some live-DB tests share sentinel id ranges and would collide under parallel execution against a single shared DB. To repro locally, start the bundled Postgres on `:5433` and run the command in the snippet above.
+- **test-live-db fails** → CI runs `cargo nextest run --profile=ci-live-db -p cimmeria-services --lib` against a fresh `postgres:17.9` service container loaded from `db/database.sql`. The `ci-live-db` profile in `.config/nextest.toml` serialises every test (`threads-required = num-test-threads`) because some live-DB tests share sentinel id ranges and would collide under parallel execution against a single shared DB. To repro locally, start the bundled Postgres on `:5433` and run the command in the snippet above.
 
 ## Required testing for every PR
 
@@ -92,7 +97,7 @@ The non-negotiables:
 - **Pick the right type.** If you change a `WHERE` clause or `rows_affected` invariant, you need a live-DB regression guard, not a unit test. If you change a serializer, you need a byte-exact wire-format test. The picker table is in TESTING.md.
 - **Reproduce the bug shape.** A regression guard must fail when the fix is reverted; if it doesn't, it's a happy-path test, not a guard. PR reviewers will check.
 - **One feature can need multiple tests.** Vendor stack changes typically need unit + wire-format + live-DB + smoke. Don't skip a layer because "the next layer up will catch it" — that's the bug shape TESTING.md exists to prevent.
-- **Live-DB tests use `require_db_or_skip!`** and run with `--test-threads=1`. Sentinels fit in `i32`. Cleanup deletes by exact sentinel, not by range. See `crates/services/src/test_support.rs`.
+- **Live-DB tests use `require_db_or_skip!`** and run serialised. Under nextest the `ci-live-db` profile pins this with `threads-required = num-test-threads`; with `cargo test`, pass `-- --test-threads=1`. Sentinels fit in `i32`. Cleanup deletes by exact sentinel, not by range. See `crates/services/src/test_support.rs`.
 
 ## Required documentation for every PR
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,7 @@ DATABASE_URL=postgres://w-testing:w-testing@localhost:5433/sgw \
 - **clippy fails** → fix the warning. Project-level thresholds for `too_many_arguments` (14) and `type_complexity` (500) live in `clippy.toml`; bumping those further requires the same kind of justification any other lint suppression would. Don't sprinkle `#[allow(clippy::…)]` per call site.
 - **build fails** → typically a stale path or unused-symbol cleanup needed; check matches `cargo check`.
 - **test fails (no DB)** → unit + non-DB integration tests. Live-DB tests in `crates/services` self-skip via `require_db_or_skip!` when `DATABASE_URL` is unset, so this run can be green even with broken DB code.
-- **test-live-db fails** → CI runs `cargo nextest run --profile=ci-live-db -p cimmeria-services --lib` against a fresh `postgres:17.9` service container loaded from `db/database.sql`. The `ci-live-db` profile in `.config/nextest.toml` serialises every test (`threads-required = num-test-threads`) because some live-DB tests share sentinel id ranges and would collide under parallel execution against a single shared DB. To repro locally, start the bundled Postgres on `:5433` and run the command in the snippet above.
+- **test-live-db fails** → CI runs `cargo nextest run --profile=ci-live-db -p cimmeria-services --lib` against a fresh `postgres:17.9` service container loaded from `db/database.sql`. The `ci-live-db` profile in `.config/nextest.toml` serialises every test (`threads-required = "num-test-threads"`) because some live-DB tests share sentinel id ranges and would collide under parallel execution against a single shared DB. To repro locally, start the bundled Postgres on `:5433` and run the command in the snippet above.
 
 ## Required testing for every PR
 
@@ -97,7 +97,7 @@ The non-negotiables:
 - **Pick the right type.** If you change a `WHERE` clause or `rows_affected` invariant, you need a live-DB regression guard, not a unit test. If you change a serializer, you need a byte-exact wire-format test. The picker table is in TESTING.md.
 - **Reproduce the bug shape.** A regression guard must fail when the fix is reverted; if it doesn't, it's a happy-path test, not a guard. PR reviewers will check.
 - **One feature can need multiple tests.** Vendor stack changes typically need unit + wire-format + live-DB + smoke. Don't skip a layer because "the next layer up will catch it" — that's the bug shape TESTING.md exists to prevent.
-- **Live-DB tests use `require_db_or_skip!`** and run serialised. Under nextest the `ci-live-db` profile pins this with `threads-required = num-test-threads`; with `cargo test`, pass `-- --test-threads=1`. Sentinels fit in `i32`. Cleanup deletes by exact sentinel, not by range. See `crates/services/src/test_support.rs`.
+- **Live-DB tests use `require_db_or_skip!`** and run serialised. Under nextest the `ci-live-db` profile pins this with `threads-required = "num-test-threads"`; with `cargo test`, pass `-- --test-threads=1`. Sentinels fit in `i32`. Cleanup deletes by exact sentinel, not by range. See `crates/services/src/test_support.rs`.
 
 ## Required documentation for every PR
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ See [docs/project-status.md](docs/project-status.md) for the detailed breakdown.
 
 ## Tests & CI
 
-The Rust workspace currently carries **878 `#[test]` / `#[tokio::test]` cases** across **136 files**, of which **84 are live-DB regression guards** (gated by `require_db_or_skip!`) and **3 are end-to-end PL/pgSQL smoke scripts** (vendor stack, inventory move, progression). GitHub Actions runs five gating jobs on every PR — `cargo fmt --check`, `cargo clippy -D warnings`, `cargo build`, `cargo test` (workspace, no DB), and `cargo test -p cimmeria-services --lib -- --test-threads=1` against a `postgres:17.9` service container loaded from `db/database.sql`.
+The Rust workspace currently carries **878 `#[test]` / `#[tokio::test]` cases** across **136 files**, of which **84 are live-DB regression guards** (gated by `require_db_or_skip!`) and **3 are end-to-end PL/pgSQL smoke scripts** (vendor stack, inventory move, progression). GitHub Actions runs five gating jobs on every PR — `cargo fmt --check`, `cargo clippy -D warnings`, `cargo build`, `cargo nextest run` (workspace, no DB), and `cargo nextest run -p cimmeria-services --lib` against a `postgres:17.9` service container loaded from `db/database.sql`. nextest's JUnit output is uploaded to Codecov Test Analytics for per-test history and flake detection.
 
 For the test-type taxonomy (unit / wire-format / live-DB / smoke / concurrency / chain-replay), when each is appropriate, common gotchas, and the patterns reviewers expect to see, read **[TESTING.md](TESTING.md)**.
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -60,7 +60,7 @@ This guide is the playbook for writing tests that survive review and catch real 
 **Patterns to follow:**
 - Pick a **positive `0x7000_xxxx` sentinel base** for the module's test ids (e.g., `const TEST_BASE: i32 = 0x7000_0400;` for missions, `0x7000_1000` for character-list, `0x7000_0800` for vendor sell). Each module reserves its own slot in this range; the existing modules document neighbours in a doc-comment so the next contributor can step past them. See `crates/services/src/base/character.rs:281` and `crates/services/src/base/world_entry/methods/missions.rs:146-148` for the canonical comment shape.
 - The base must fit in `i32` because the `entity_id`/`account_id`/`player_id` columns are `INTEGER`. `0x7000_xxxx` does (it's well below `i32::MAX`); a `u32` like `0xDEAD_0000` wraps to a negative when bound `as i32` and lands in another module's territory — don't reach for high-bit constants.
-- Run serialised. Under nextest the `ci-live-db` profile in `.config/nextest.toml` pins `threads-required = num-test-threads`, which makes each test claim every available thread; under raw `cargo test`, pass `-- --test-threads=1`. Even within the partitioned-range scheme, some guards share rows in `resources.*` and collide under parallel execution. CI enforces this; local repro must match.
+- Run serialised. Under nextest the `ci-live-db` profile in `.config/nextest.toml` pins `threads-required = "num-test-threads"`, which makes each test claim every available thread; under raw `cargo test`, pass `-- --test-threads=1`. Even within the partitioned-range scheme, some guards share rows in `resources.*` and collide under parallel execution. CI enforces this; local repro must match.
 - Cleanup must `DELETE WHERE <id> = $sentinel` (or `IN (...)` over the exact ids the test inserted), not a range predicate like `WHERE entity_id < 0` or `WHERE account_id BETWEEN base AND base+0xFF`. Range deletes can reach into a sibling module's slot if the partitioning ever drifts.
 - For shared rows (resources.items inserts), use `ON CONFLICT DO NOTHING` so test B's insert doesn't conflict with test A's leftover, and **don't `DELETE` shared rows in cleanup** — let them leak for the next run.
 - **Reproduce the bug shape.** A `handle_grant_cash` regression guard must seed two characters on the same account, grant to one, and assert the other's balance is unchanged. That's the shape the bug took (PR #143). A test that just grants and asserts the credit went through is a happy-path test, not a regression guard.
@@ -179,7 +179,7 @@ This section is mined from review comments since the test push began. Each item 
 - **Two `join!`ed handler futures often serialize by accident.** Use a barrier-coordinated start or a small loop so a no-lock regression actually fails (PR #145).
 - **Wrap each `JoinHandle::await` in `tokio::time::timeout(...)`.** A deadlock regression should fail the test, not wedge the suite (PR #150).
 - **Capture and assert each spawned task's `Result`.** Dropping it lets an `Err` that left the DB in a satisfying state become a false positive (PR #150).
-- **Run live-DB tests serialised.** Sentinel ranges are shared and parallel runs collide. The `ci-live-db` nextest profile pins `threads-required = num-test-threads`; with `cargo test`, pass `-- --test-threads=1`. CI enforces this in the `test-live-db` job.
+- **Run live-DB tests serialised.** Sentinel ranges are shared and parallel runs collide. The `ci-live-db` nextest profile pins `threads-required = "num-test-threads"`; with `cargo test`, pass `-- --test-threads=1`. CI enforces this in the `test-live-db` job.
 
 ### Regression-guard shape
 
@@ -239,7 +239,7 @@ DATABASE_URL=postgres://w-testing:w-testing@localhost:5433/sgw \
   cargo nextest run --profile=ci-live-db -p cimmeria-services --lib
 ```
 
-The `ci-live-db` profile in `.config/nextest.toml` serialises every test (`threads-required = num-test-threads`) — equivalent to the old `cargo test ... -- --test-threads=1`. Without `DATABASE_URL`, those 84 tests self-skip with `module_path!: skipping live-DB test (DATABASE_URL not set)`. **Self-skipped tests are not failures** — but a green "no DB" run does not prove the live-DB suite passes. Always run both before declaring a PR ready.
+The `ci-live-db` profile in `.config/nextest.toml` serialises every test (`threads-required = "num-test-threads"`) — equivalent to the old `cargo test ... -- --test-threads=1`. Without `DATABASE_URL`, those 84 tests self-skip with `module_path!: skipping live-DB test (DATABASE_URL not set)`. **Self-skipped tests are not failures** — but a green "no DB" run does not prove the live-DB suite passes. Always run both before declaring a PR ready.
 
 ### CI (every PR)
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -5,7 +5,7 @@
 > **Companion docs**: [docs/architecture/integration-test-infra.md](docs/architecture/integration-test-infra.md) (live-DB infra rationale and local setup), [CLAUDE.md](CLAUDE.md) (pre-PR checklist), [.github/copilot-instructions.md](.github/copilot-instructions.md) (review checklist).
 > **See also**: [docs/testing/inventory/README.md](docs/testing/inventory/README.md) — catalogue of every test in the workspace (the "what tests exist" reference; this file is the "how to write a test" playbook).
 
-The Rust workspace currently has **1071 `#[test]` / `#[tokio::test]` cases across 166 files**: 110 are live-DB regression guards (`require_db_or_skip!`) and 3 are end-to-end PL/pgSQL smoke scripts. Per-test catalogue lives at [docs/testing/inventory/](docs/testing/inventory/) — PRs that add or remove ≥5% of the workspace test count (~55 tests at the current 1071 baseline) update it in the same PR; smaller drifts get folded in by periodic sweeps. CI gates every PR on five jobs — `cargo fmt --check`, `cargo clippy -D warnings`, `cargo build`, `cargo test` (workspace, no DB), and `cargo test -p cimmeria-services --lib -- --test-threads=1` against a live `postgres:17.9` service container.
+The Rust workspace currently has **1071 `#[test]` / `#[tokio::test]` cases across 166 files**: 110 are live-DB regression guards (`require_db_or_skip!`) and 3 are end-to-end PL/pgSQL smoke scripts. Per-test catalogue lives at [docs/testing/inventory/](docs/testing/inventory/) — PRs that add or remove ≥5% of the workspace test count (~55 tests at the current 1071 baseline) update it in the same PR; smaller drifts get folded in by periodic sweeps. CI gates every PR on five jobs — `cargo fmt --check`, `cargo clippy -D warnings`, `cargo build`, `cargo nextest run --profile=ci` (workspace, no DB), and `cargo nextest run --profile=ci-live-db -p cimmeria-services --lib` against a live `postgres:17.9` service container. nextest emits JUnit XML which is uploaded to Codecov Test Analytics for per-test history and flake detection.
 
 This guide is the playbook for writing tests that survive review and catch real regressions. **Read it before opening a PR that adds tests.**
 
@@ -60,7 +60,7 @@ This guide is the playbook for writing tests that survive review and catch real 
 **Patterns to follow:**
 - Pick a **positive `0x7000_xxxx` sentinel base** for the module's test ids (e.g., `const TEST_BASE: i32 = 0x7000_0400;` for missions, `0x7000_1000` for character-list, `0x7000_0800` for vendor sell). Each module reserves its own slot in this range; the existing modules document neighbours in a doc-comment so the next contributor can step past them. See `crates/services/src/base/character.rs:281` and `crates/services/src/base/world_entry/methods/missions.rs:146-148` for the canonical comment shape.
 - The base must fit in `i32` because the `entity_id`/`account_id`/`player_id` columns are `INTEGER`. `0x7000_xxxx` does (it's well below `i32::MAX`); a `u32` like `0xDEAD_0000` wraps to a negative when bound `as i32` and lands in another module's territory — don't reach for high-bit constants.
-- Run with `--test-threads=1`. Even within the partitioned-range scheme, some guards share rows in `resources.*` and collide under parallel execution. CI enforces this; local repro must match.
+- Run serialised. Under nextest the `ci-live-db` profile in `.config/nextest.toml` pins `threads-required = num-test-threads`, which makes each test claim every available thread; under raw `cargo test`, pass `-- --test-threads=1`. Even within the partitioned-range scheme, some guards share rows in `resources.*` and collide under parallel execution. CI enforces this; local repro must match.
 - Cleanup must `DELETE WHERE <id> = $sentinel` (or `IN (...)` over the exact ids the test inserted), not a range predicate like `WHERE entity_id < 0` or `WHERE account_id BETWEEN base AND base+0xFF`. Range deletes can reach into a sibling module's slot if the partitioning ever drifts.
 - For shared rows (resources.items inserts), use `ON CONFLICT DO NOTHING` so test B's insert doesn't conflict with test A's leftover, and **don't `DELETE` shared rows in cleanup** — let them leak for the next run.
 - **Reproduce the bug shape.** A `handle_grant_cash` regression guard must seed two characters on the same account, grant to one, and assert the other's balance is unchanged. That's the shape the bug took (PR #143). A test that just grants and asserts the credit went through is a happy-path test, not a regression guard.
@@ -179,7 +179,7 @@ This section is mined from review comments since the test push began. Each item 
 - **Two `join!`ed handler futures often serialize by accident.** Use a barrier-coordinated start or a small loop so a no-lock regression actually fails (PR #145).
 - **Wrap each `JoinHandle::await` in `tokio::time::timeout(...)`.** A deadlock regression should fail the test, not wedge the suite (PR #150).
 - **Capture and assert each spawned task's `Result`.** Dropping it lets an `Err` that left the DB in a satisfying state become a false positive (PR #150).
-- **Run live-DB tests with `--test-threads=1`.** Sentinel ranges are shared and parallel runs collide (PRs #153, #164). CI enforces this in the `test-live-db` job.
+- **Run live-DB tests serialised.** Sentinel ranges are shared and parallel runs collide. The `ci-live-db` nextest profile pins `threads-required = num-test-threads`; with `cargo test`, pass `-- --test-threads=1`. CI enforces this in the `test-live-db` job.
 
 ### Regression-guard shape
 
@@ -220,10 +220,15 @@ This section is mined from review comments since the test push began. Each item 
 ### Locally (no DB — covers ~794 tests)
 
 ```bash
-cargo test --workspace \
+cargo nextest run --profile=ci --workspace \
   --exclude cimmeria-app --exclude cimmeria-content-editor \
   --exclude cimmeria-scene-editor --exclude sgw-launcher
+# nextest can't run doctests; cimmeria-commands is the only crate
+# with runnable ones today.
+cargo test --doc -p cimmeria-commands
 ```
+
+`cargo test --workspace ...` still works for quick sanity checks if you don't have nextest installed, but CI uses nextest and that's what the JUnit upload to Codecov Test Analytics expects.
 
 ### Locally (live DB — adds the 84 `require_db_or_skip!` guards + 3 smokes)
 
@@ -231,14 +236,14 @@ Start the bundled Postgres on port 5433 (via `setup.ps1`'s bootstrap), then:
 
 ```bash
 DATABASE_URL=postgres://w-testing:w-testing@localhost:5433/sgw \
-  cargo test -p cimmeria-services --lib -- --test-threads=1
+  cargo nextest run --profile=ci-live-db -p cimmeria-services --lib
 ```
 
-Without `DATABASE_URL`, those 84 tests self-skip with `module_path!: skipping live-DB test (DATABASE_URL not set)`. **Self-skipped tests are not failures** — but a green "no DB" run does not prove the live-DB suite passes. Always run both before declaring a PR ready.
+The `ci-live-db` profile in `.config/nextest.toml` serialises every test (`threads-required = num-test-threads`) — equivalent to the old `cargo test ... -- --test-threads=1`. Without `DATABASE_URL`, those 84 tests self-skip with `module_path!: skipping live-DB test (DATABASE_URL not set)`. **Self-skipped tests are not failures** — but a green "no DB" run does not prove the live-DB suite passes. Always run both before declaring a PR ready.
 
 ### CI (every PR)
 
-`.github/workflows/test.yml` runs five jobs: `fmt`, `clippy`, `build`, `test` (workspace, no DB), `test-live-db` (postgres:17.9 service container). All must pass before merge.
+`.github/workflows/test.yml` runs five jobs: `fmt`, `clippy`, `build`, `test` (workspace, no DB, nextest), `test-live-db` (postgres:17.9 service container, nextest). All must pass before merge. Nextest's JUnit XML output from the `test` and `test-live-db` jobs is uploaded to Codecov Test Analytics, which surfaces per-test history, flaky-test detection, and PR comments naming the failed tests.
 
 ---
 
@@ -256,7 +261,7 @@ Before opening a PR that adds tests:
 - [ ] No PR/issue numbers in source comments.
 - [ ] Setup helper reused, not cloned.
 - [ ] Reverting the fix makes the test fail (regression-guard test).
-- [ ] Test runs locally with `--test-threads=1` against a live DB if applicable.
+- [ ] Test runs locally serialised against a live DB if applicable (`cargo nextest run --profile=ci-live-db ...`, or `cargo test ... -- --test-threads=1`).
 
 ---
 

--- a/docs/architecture/integration-test-infra.md
+++ b/docs/architecture/integration-test-infra.md
@@ -156,7 +156,8 @@ sentinel `entity_id`.
   Actions / Azure Pipelines have first-class support for this without
   introducing testcontainers as a dependency).
 - If parallel-test contention becomes a real problem (today the
-  integration suite is small enough that `cargo test --test-threads=1`
+  integration suite is small enough that serialising via the
+  `ci-live-db` nextest profile, or `cargo test --test-threads=1`,
   on the integration target is acceptable), revisit `sqlx::test`'s
   per-test-DB mode.
 

--- a/docs/architecture/integration-test-infra.md
+++ b/docs/architecture/integration-test-infra.md
@@ -157,7 +157,7 @@ sentinel `entity_id`.
   introducing testcontainers as a dependency).
 - If parallel-test contention becomes a real problem (today the
   integration suite is small enough that serialising via the
-  `ci-live-db` nextest profile, or `cargo test --test-threads=1`,
+  `ci-live-db` nextest profile, or `cargo test ... -- --test-threads=1`,
   on the integration target is acceptable), revisit `sqlx::test`'s
   per-test-DB mode.
 


### PR DESCRIPTION
## Summary

Closes #215.

- Switches the `test` and `test-live-db` CI jobs from `cargo test` to `cargo nextest run`, with a new [`.config/nextest.toml`](.config/nextest.toml) defining `ci` and `ci-live-db` profiles.
- Wires `codecov/test-results-action@v1` into both jobs so JUnit XML lands in Codecov Test Analytics — per-test pass/fail history, flake detection, and "the failed test was X" PR comments.
- Live-DB serialisation moves from the `cargo test ... -- --test-threads=1` flag to a per-profile `threads-required = "num-test-threads"` override. Same end result; less per-job ceremony.
- Coverage job switches its two `cargo llvm-cov` passes to `cargo llvm-cov --no-report nextest --profile=...` so a single test execution drives both coverage counter data and JUnit. JUnit upload is intentionally left off the coverage job to avoid double-counting in Test Analytics.
- Doctests: `cargo test --doc -p cimmeria-commands` runs as a small extra step in the `test` job. nextest [can't run doctests yet](https://github.com/nextest-rs/nextest/issues/16); `cimmeria-commands` (`parser.rs`, `permissions.rs`) is the only crate with runnable rust doctests in the workspace today (4 cases). The rest of the workspace uses ```text```/```ignore``` fences that don't compile.
- Docs: `CLAUDE.md`, `TESTING.md`, `README.md`, `.github/copilot-instructions.md`, and `docs/architecture/integration-test-infra.md` updated to point at nextest as the canonical CI runner. `cargo test -p <crate>` still works for crate-level iteration.

Out of scope (per the issue, fair game but not blocking): `.cargo/config.toml`'s `[alias] test-workspace`, and replacing `cargo build --workspace --all-targets` with `cargo nextest list`.

## Test plan

- [ ] CI's new `test` job goes green and shows the "upload test results to Codecov" step succeeding.
- [ ] CI's new `test-live-db` job goes green; Codecov Test Analytics tab populates with two report names (`cimmeria` + `cimmeria-live-db`) within ~24h of merge.
- [ ] Coverage job still runs both passes and uploads cobertura.xml as before; numbers shouldn't drift materially since nextest runs the same test set.
- [ ] First failed-test PR after merge gets the Codecov Test Analytics PR comment naming the failed test.
- [ ] Validate the orchestrator_shards flake (referenced in #215) is auto-flagged as flaky after a few CI runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated CI/CD pipeline to use cargo-nextest for test execution with dedicated profiles for workspace and live-database scenarios.
  * Configured test result uploads to Codecov Test Analytics via JUnit reports.

* **Documentation**
  * Updated testing guides and contribution documentation to reflect new test execution procedures.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SandboxServers/Cimmeria/pull/248)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->