### PR TITLE
chore(deps): bump rand 0.10 + rand_distr 0.6 + rand_chacha 0.10 + quick-xml 0.38

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -430,6 +430,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -496,7 +507,7 @@ name = "cimmeria-common"
 version = "0.1.0"
 dependencies = [
  "bytes",
- "quick-xml 0.37.5",
+ "quick-xml",
  "serde",
  "thiserror 2.0.18",
  "tracing",
@@ -507,7 +518,7 @@ name = "cimmeria-content-editor"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "quick-xml 0.37.5",
+ "quick-xml",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -539,7 +550,7 @@ version = "0.1.0"
 dependencies = [
  "bytes",
  "cimmeria-common",
- "quick-xml 0.37.5",
+ "quick-xml",
  "serde",
  "thiserror 2.0.18",
 ]
@@ -567,7 +578,7 @@ dependencies = [
  "cimmeria-commands",
  "cimmeria-common",
  "cimmeria-entity",
- "rand 0.9.2",
+ "rand 0.10.1",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -588,7 +599,7 @@ dependencies = [
  "hmac",
  "md-5",
  "proptest",
- "rand 0.9.2",
+ "rand 0.10.1",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
@@ -626,7 +637,7 @@ dependencies = [
  "cimmeria-common",
  "cimmeria-services",
  "hmac",
- "rand 0.9.2",
+ "rand 0.10.1",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -651,9 +662,9 @@ dependencies = [
  "cimmeria-game",
  "cimmeria-mercury",
  "proptest",
- "quick-xml 0.37.5",
- "rand 0.9.2",
- "rand_chacha 0.9.0",
+ "quick-xml",
+ "rand 0.10.1",
+ "rand_chacha 0.10.0",
  "rand_distr",
  "reqwest 0.12.28",
  "serde",
@@ -813,6 +824,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -1671,6 +1691,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -3482,7 +3503,7 @@ checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.13.0",
- "quick-xml 0.38.4",
+ "quick-xml",
  "serde",
  "time",
 ]
@@ -3654,15 +3675,6 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
-version = "0.37.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "quick-xml"
 version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
@@ -3727,6 +3739,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3757,6 +3780,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e6af7f3e25ded52c41df4e0b1af2d047e45896c2f3281792ed68a1c243daedb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3784,13 +3817,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_distr"
-version = "0.5.1"
+name = "rand_core"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_distr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d431c2703ccf129de4d45253c03f49ebb22b97d6ad79ee3ecfc7e3f4862c1d8"
 dependencies = [
  "num-traits",
- "rand 0.9.2",
+ "rand 0.10.1",
 ]
 
 [[package]]
@@ -4567,7 +4606,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -4578,7 +4617,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,16 +71,16 @@ serde_json = "1"
 bytes = "1"
 
 # XML parsing
-quick-xml = "0.37"
+quick-xml = "0.38"
 
 # Cryptography (client requires AES-256-CBC + HMAC-MD5)
 aes = "0.8"
 cbc = "0.1"
 hmac = "0.12"
 md-5 = "0.10"
-rand = "0.9"
-rand_distr = "0.5"
-rand_chacha = "0.9"
+rand = "0.10"
+rand_distr = "0.6"
+rand_chacha = "0.10"
 
 # HTTP client
 reqwest = { version = "0.12", features = ["json"] }

--- a/crates/defs/build/def_parser.rs
+++ b/crates/defs/build/def_parser.rs
@@ -145,8 +145,8 @@ pub fn parse_def_file(path: &Path, type_name: &str) -> Result<EntityDef, String>
             }
             Ok(Event::Text(ref e)) => {
                 let text = e
-                    .unescape()
-                    .map_err(|err| format!("XML unescape error: {}", err))?
+                    .decode()
+                    .map_err(|err| format!("XML decode error: {}", err))?
                     .trim()
                     .to_string();
                 if text.is_empty() {

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -494,7 +494,7 @@ fn init_logging(
 /// Combines the archive timestamp format with a short random suffix to
 /// avoid collisions on rapid restarts. Used as the Cosmos DB partition key.
 fn generate_session_id() -> String {
-    use rand::Rng;
+    use rand::RngExt;
     let ts = chrono_timestamp();
     let suffix: u16 = rand::rng().random();
     format!("{}_{:04x}", ts, suffix)

--- a/crates/services/src/auth/handlers.rs
+++ b/crates/services/src/auth/handlers.rs
@@ -11,7 +11,7 @@ use axum::{
     response::{IntoResponse, Response},
 };
 use quick_xml::{events::Event, Reader};
-use rand::Rng;
+use rand::RngExt;
 use sqlx::PgPool;
 
 use crate::audit::emit_login_event;

--- a/crates/services/src/minigame/games/livewire/setup.rs
+++ b/crates/services/src/minigame/games/livewire/setup.rs
@@ -3,7 +3,7 @@
 
 use std::collections::HashMap;
 
-use rand::Rng;
+use rand::RngExt;
 
 use crate::minigame::protocol::SfsValue;
 use crate::sfs_vars;

--- a/crates/services/src/minigame/protocol.rs
+++ b/crates/services/src/minigame/protocol.rs
@@ -137,7 +137,7 @@ pub fn parse_message(xml: &str) -> Option<SfsMessage> {
                 }
             }
             Ok(Event::Text(e)) => {
-                let text = e.unescape().unwrap_or_default().to_string();
+                let text = e.decode().unwrap_or_default().to_string();
                 if in_nick {
                     nick = text;
                 } else if in_pword {
@@ -250,7 +250,7 @@ fn parse_extension_data(xml: &str) -> Option<(String, HashMap<String, SfsValue>)
                 }
             }
             Ok(Event::Text(e)) => {
-                let text = e.unescape().unwrap_or_default().to_string();
+                let text = e.decode().unwrap_or_default().to_string();
                 if in_var && !in_obj {
                     if var_name == "cmd" {
                         cmd = text;

--- a/crates/services/src/minigame/session.rs
+++ b/crates/services/src/minigame/session.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Instant;
 
-use rand::Rng;
+use rand::RngExt;
 use tokio::sync::Mutex;
 
 /// A registered minigame session awaiting client connection.

--- a/tools/ContentEditor/src/script/definitions.rs
+++ b/tools/ContentEditor/src/script/definitions.rs
@@ -347,7 +347,7 @@ fn parse_nodes_xml(path: &Path) -> Result<(Vec<NodeTemplate>, Vec<DatabaseRef>, 
                 }
             }
             Ok(Event::Text(ref e)) => {
-                let text = e.unescape()?.to_string();
+                let text = e.decode()?.to_string();
                 match &mut state {
                     State::InDatabaseRef(_) | State::InNode(_) => {
                         text_buf.push_str(&text);
@@ -619,7 +619,7 @@ fn parse_enumerations_xml(path: &Path) -> Result<Vec<EnumDefinition>> {
                 let _ = tag;
             }
             Ok(Event::Text(ref e)) => {
-                let text = e.unescape()?.to_string();
+                let text = e.decode()?.to_string();
                 text_buf.push_str(&text);
             }
             Ok(Event::End(ref e)) => {


### PR DESCRIPTION
## Summary

Combines the three breaking-change dependabot bumps into one PR with the source fixes they need:

- **#258** — `rand` 0.9.2 → 0.10.1
- **#257** — `rand_chacha` 0.9.0 → 0.10.0
- **#259** — `quick-xml` 0.37.5 → 0.38.4
- (plus `rand_distr` 0.5.1 → 0.6.0 — required by rand 0.10's semver)

Supersedes #257, #258, #259 — those should be closed once this lands.

## API migrations applied

**rand 0.10** split the trait formerly named `Rng` (renamed to `RngExt` for the high-level methods like `.random()`, `.random_range()`) from `Rng` (now the low-level byte-source trait formerly `RngCore`). `use rand::Rng;` → `use rand::RngExt;` at every call site that uses `.random()` or `.random_range()`:

- `crates/services/src/auth/handlers.rs`
- `crates/services/src/minigame/session.rs`
- `crates/services/src/minigame/games/livewire/setup.rs`
- `crates/server/src/main.rs`

**rand_chacha 0.10 + rand 0.10** align on rand_core 0.10. The CI failures on PR #257 / #258 in isolation were cross-version trait mismatches (`ChaCha8Rng` implemented rand_core 0.10's `SeedableRng`, but the damage.rs site imported rand 0.9's). Bumping both together makes the existing `use rand::SeedableRng;` in `damage.rs` match again with no source change required there.

**quick-xml 0.38** removed `BytesText::unescape()` in favor of `BytesText::decode()`; entity references (`&amp;`, etc.) are now surfaced as a separate `Event::GeneralRef` event rather than expanded inline in `Event::Text`. Replaced `.unescape()` → `.decode()` at:

- `crates/defs/build/def_parser.rs` (build-time .def parser; def files are entity-free)
- `crates/services/src/minigame/protocol.rs` (SmartFoxServer XML codec)
- `tools/ContentEditor/src/script/definitions.rs` (build-time tool)

**Behavioral note:** if any of these inputs ever contains a literal `&amp;` etc. it will now be silently dropped rather than expanded. None of our current inputs use entities, but a follow-up to handle `Event::GeneralRef` would harden `protocol.rs` against pathological client input.

## Test plan

- [x] `cargo check --workspace` (excluding tauri apps) — clean locally
- [x] `cargo clippy --workspace -- -D warnings` (same exclusions) — clean locally
- [ ] CI nextest pass (relying on CI for the test run)
- [ ] Live-DB nextest pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
