### PR TITLE
ops(docker): expose minigame port 30000/TCP

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -260,7 +260,7 @@ ENV AUTH_HOST=0.0.0.0 \
 # Ports actually bound by the Rust server. The legacy Python console
 # (port 8989 in the original C++ BaseApp) is not implemented in Rust,
 # so we don't EXPOSE it.
-EXPOSE 13001 32832/udp 50000/udp 8081 8443
+EXPOSE 13001 32832/udp 50000/udp 8081 8443 30000
 
 VOLUME ["/var/lib/postgresql/data", "/var/log/cimmeria"]
 

--- a/docker/compose.colo.yml
+++ b/docker/compose.colo.yml
@@ -23,6 +23,7 @@ services:
       - "50000:50000/udp"    # CellApp
       - "8081:8081"          # SOAP login (TCP)
       - "8443:8443"          # admin REST API (TCP)
+      - "30000:30000"        # minigame SmartFoxServer (TCP)
     environment:
       # MUST be overridden for any client that isn't on this host.
       # Defaults to 127.0.0.1 inside the image, which only works for

--- a/docs/operations/container.md
+++ b/docs/operations/container.md
@@ -35,6 +35,7 @@ docker run -d --name cimmeria \
   -p 50000:50000/udp \
   -p 8081:8081 \
   -p 8443:8443 \
+  -p 30000:30000 \
   -e BASE_EXTERNAL=<your-LAN-or-WAN-ip> \
   -v cimmeria-data:/var/lib/postgresql/data \
   ghcr.io/sandboxservers/cimmeria-server:latest-prerelease
@@ -47,6 +48,7 @@ docker run -d --name cimmeria \
 | 50000 | UDP | CellApp |
 | 8081  | TCP | Auth HTTP (SOAP login) |
 | 8443  | TCP | Admin REST API |
+| 30000 | TCP | Minigame SmartFoxServer (Livewire, Hack, Bypass, GoauldCrystals, Alignment, Activate, Analyze, Converse) |
 
 > The legacy C++ BaseApp had a Python console on port 8989; the Rust server does not implement it, so the container does not expose it.
 
@@ -152,7 +154,7 @@ docker run -d --name cimmeria \
   --cap-add=CHOWN --cap-add=SETUID --cap-add=SETGID --cap-add=DAC_OVERRIDE --cap-add=FOWNER \
   --security-opt=no-new-privileges \
   -p 13001:13001 -p 32832:32832/udp -p 50000:50000/udp \
-  -p 8081:8081 -p 8443:8443 \
+  -p 8081:8081 -p 8443:8443 -p 30000:30000 \
   -e BASE_EXTERNAL=<your-LAN-or-WAN-ip> \
   -v cimmeria-data:/var/lib/postgresql/data \
   ghcr.io/sandboxservers/cimmeria-server:latest-prerelease


### PR DESCRIPTION
## Summary

- `docker/compose.colo.yml` publishes `30000:30000` so the minigame SmartFoxServer TCP listener (orchestrator.rs:228, default in common/src/config.rs:84) is actually reachable from outside the container.
- `docker/Dockerfile` adds `30000` to the `EXPOSE` directive (metadata hygiene; the compose mapping is what does the real work).
- `docs/operations/container.md` adds the port to the basic + hardened `docker run` examples and the port table.

Without this, every minigame the client tries to open against the colo deployment (Livewire, Hack, Bypass, GoauldCrystals, Alignment, Activate, Analyze, Converse) silently fails the TCP connect — the listener is bound on `0.0.0.0:30000` inside the container but Docker never bridges it out. Discovered during the Mercury §2 live capture (PR #285) when Livewire failed to start.

Fixes #286.

## Test plan

- [ ] After Watchtower pulls the next release image: `docker port cimmeria` shows `0.0.0.0:30000->30000/tcp`.
- [ ] `nc -vz <colo-public-ip> 30000` connects from outside the colo (router/firewall side opens TCP/30000 — out of repo scope, tracked in the issue).
- [ ] In-game: reach a Livewire-trigger NPC (e.g. Castle Cellblock) — the Flash overlay opens instead of stalling.
- [ ] `docker logs cimmeria | grep -i 'Minigame server'` shows `Minigame server started port=30000`.

## Out of scope

- Op #3 from the issue (open `TCP/30000` on the colo router/firewall) — handled by the runbook owner.
- No `MINIGAME_PORT` env override exists in `crates/server/src/main.rs` today despite the issue's "Considerations" note. If a future deployment wants a non-default port, that env wiring is a separate change.

Generated with [Claude Code](https://claude.com/claude-code)
