### PR TITLE
fix(world-entry): kill dev-cube placeholder on first-login cinematic (issue #288)

### DIFF
--- a/crates/services/src/base/login.rs
+++ b/crates/services/src/base/login.rs
@@ -141,6 +141,7 @@ pub(crate) async fn handle_login(
                 cached_appearance_args: None,
                 cached_tint_args: None,
                 cancelled,
+                cinematic_spam_cancel: Arc::new(AtomicBool::new(false)),
                 player_name: None,
                 player_level: None,
                 player_archetype: None,

--- a/crates/services/src/base/mod.rs
+++ b/crates/services/src/base/mod.rs
@@ -92,6 +92,11 @@ pub(crate) struct PendingClientReadyInfo {
     pub world_name: String,
     pub appearance_args: Vec<u8>,
     pub tint_args: Vec<u8>,
+    /// Non-zero if this is the player's first-ever login. Drives the
+    /// deferred `onPlayMovie` (intro cinematic) send in
+    /// `handle_on_client_ready` — see issue #288. Type mirrors the DB
+    /// column (`sgw_player.first_login INT`) and `PlayerLoadData::first_login`.
+    pub first_login: i32,
 }
 
 /// State held for each client that has completed the Phase 3 handshake.
@@ -117,6 +122,12 @@ pub(crate) struct ConnectedClientState {
     pub cached_appearance_args: Option<Vec<u8>>,
     pub cached_tint_args: Option<Vec<u8>>,
     pub cancelled: Arc<AtomicBool>,
+    /// Cancellation flag for the post-cinematic appearance-spam guard
+    /// (issue #288). `world_entry_appearance::send_cinematic` resets this
+    /// to `false` and spawns a spam loop that polls it each iteration;
+    /// `handle_cancel_movie` flips it to `true` when the client emits a
+    /// real cancelMovie so the spam stops short of its full duration.
+    pub cinematic_spam_cancel: Arc<AtomicBool>,
     pub player_name: Option<String>,
     pub player_level: Option<i32>,
     pub player_archetype: Option<i32>,

--- a/crates/services/src/base/world_entry/cell_dispatch/mod.rs
+++ b/crates/services/src/base/world_entry/cell_dispatch/mod.rs
@@ -300,11 +300,13 @@ pub(crate) async fn handle_cell_message(
             entity_id,
             space_id,
             position,
+            prev_pos,
         } => {
             handle_teleport_player(
                 entity_id,
                 space_id,
                 position,
+                prev_pos,
                 socket,
                 connected,
                 entity_to_addr,

--- a/crates/services/src/base/world_entry/enable_entities.rs
+++ b/crates/services/src/base/world_entry/enable_entities.rs
@@ -46,12 +46,15 @@ pub(crate) async fn handle_enable_entities(
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // Peek at pending world entry without consuming it: we only commit (take)
     // after the create-player send_to succeeds, so a transient send failure
-    // leaves login state intact for the next ENABLE_ENTITIES retry.
+    // leaves login state intact for the next ENABLE_ENTITIES retry. Cloning
+    // `pending_player_load_data` here so we can pre-warm the body model in
+    // the same packet. The cost (a few hundred bytes of inventory +
+    // abilities data clone) only fires once per world-entry.
     let pending = {
         let clients = connected.lock().map_err(|_| "connected lock poisoned")?;
         if let Some(c) = clients.get(&addr) {
             match (c.pending_player_entity_id, c.pending_world_entry.clone()) {
-                (Some(eid), Some(entry)) => Some((eid, entry)),
+                (Some(eid), Some(entry)) => Some((eid, entry, c.pending_player_load_data.clone())),
                 _ => None,
             }
         } else {
@@ -59,8 +62,8 @@ pub(crate) async fn handle_enable_entities(
         }
     };
 
-    if let Some((_eid, entry_info)) = pending {
-        // -- Create player step: CREATE_BASE_PLAYER + onClientMapLoad --
+    if let Some((_eid, entry_info, load_data)) = pending {
+        // -- Create player step: CREATE_BASE_PLAYER + appearance pre-warm + onClientMapLoad --
         // Send only the base entity and terrain load notification. The client
         // will load geometry and respond with `mapLoaded` (cell method index 25,
         // msg_id 0x99). The enter-world step (viewport + cell + position + entity data)
@@ -72,10 +75,11 @@ pub(crate) async fn handle_enable_entities(
             player_entity_id = entry_info.player_entity_id,
             space_id = entry_info.space_id,
             seq,
+            appearance_prewarm = load_data.is_some(),
             "Create player: sending CREATE_BASE_PLAYER + onClientMapLoad (waiting for mapLoaded)"
         );
 
-        let pkt = build_create_player(&key, seq, &acks, &entry_info);
+        let pkt = build_create_player(&key, seq, &acks, &entry_info, load_data.as_ref());
         socket.send_to(&pkt, addr).await?;
 
         // Send succeeded — now commit: take pending state and stage map_loaded data.

--- a/crates/services/src/base/world_entry/gate_travel/tests.rs
+++ b/crates/services/src/base/world_entry/gate_travel/tests.rs
@@ -33,6 +33,7 @@ fn stub_pending_ready() -> PendingClientReadyInfo {
         world_name: "Stale".to_string(),
         appearance_args: vec![0xAB],
         tint_args: vec![0xCD],
+        first_login: 0,
     }
 }
 
@@ -61,6 +62,7 @@ fn make_state() -> ConnectedClientState {
         cached_appearance_args: None,
         cached_tint_args: None,
         cancelled: Arc::new(AtomicBool::new(false)),
+        cinematic_spam_cancel: Arc::new(AtomicBool::new(false)),
         player_name: Some("Tester".to_string()),
         player_level: Some(5),
         player_archetype: Some(1),

--- a/crates/services/src/base/world_entry/map_loaded.rs
+++ b/crates/services/src/base/world_entry/map_loaded.rs
@@ -19,9 +19,7 @@ use crate::mercury::{
     build_enter_world, build_map_loaded_body, fragment_count, fragment_map_loaded,
 };
 
-use super::super::world_entry_appearance::{
-    build_appearance_args, build_tint_args, handle_cancel_movie,
-};
+use super::super::world_entry_appearance::{build_appearance_args, build_tint_args};
 use super::super::{ConnectedClientState, PendingClientReadyInfo};
 use super::methods::default_player_load_data;
 
@@ -41,7 +39,7 @@ pub(crate) async fn handle_map_loaded(
     connected: &Arc<Mutex<HashMap<SocketAddr, ConnectedClientState>>>,
     _cell_tx: &Option<mpsc::Sender<BaseToCellMsg>>,
     entity_to_addr: &Arc<Mutex<HashMap<u32, SocketAddr>>>,
-    db_pool: &Option<Arc<PgPool>>,
+    _db_pool: &Option<Arc<PgPool>>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // Take the pending data (consumes it -- enter-world only runs once per mapLoaded)
     let (entry_info, player_data) = {
@@ -93,8 +91,11 @@ pub(crate) async fn handle_map_loaded(
         (acks, seq)
     };
 
-    // Packet 1: VIEWPORT + CELL_PLAYER + FORCED_POSITION (standalone, ~99 bytes)
-    let enter_world_pkt = build_enter_world(&key, base_seq, &acks, &entry_info);
+    // Packet 1: VIEWPORT + (BeingAppearance + onEntityTint) + CELL_PLAYER + FORCED_POSITION.
+    // The appearance methods sit before createCellPlayer so the client's
+    // cell-entity-creation handler picks up the bodyset during its internal
+    // appearance evaluation, eliminating the dev-cube placeholder flash.
+    let enter_world_pkt = build_enter_world(&key, base_seq, &acks, &entry_info, Some(&player_data));
     tracing::debug!(%addr, len = enter_world_pkt.len(), seq = base_seq,
         "UDP_OUT enter world: VIEWPORT+CELL+FORCED (standalone)");
     socket.send_to(&enter_world_pkt, addr).await?;
@@ -125,47 +126,19 @@ pub(crate) async fn handle_map_loaded(
         packets = pkt_count,
         "World entry complete ({} bytes across {} packets)", total_bytes, pkt_count);
 
-    // Clear first_login flag in DB after sending the intro movie
-    if player_data.first_login != 0 {
-        if let Some(ref pool) = db_pool {
-            let _ = sqlx::query("UPDATE sgw_player SET first_login = 0 WHERE player_id = $1")
-                .bind(player_data.player_id)
-                .execute(pool.as_ref())
-                .await;
-        }
-
-        // The first-login cinematic (onPlayMovie) blocks the client from
-        // processing BeingAppearance. cancelMovie fires if the player presses
-        // Escape, but NOT if the cinematic plays to completion.
-        // Spawn a delayed resend to cover the natural-end case.
-        // Duplicates with cancelMovie are harmless -- client just re-applies.
-        let delay_socket = Arc::clone(socket);
-        let delay_connected = Arc::clone(connected);
-        let delay_entity_to_addr = Arc::clone(entity_to_addr);
-        let delay_entity_id = entry_info.player_entity_id;
-        tokio::spawn(async move {
-            tokio::time::sleep(std::time::Duration::from_secs(10)).await;
-            tracing::info!(
-                entity_id = delay_entity_id,
-                "Cinematic timer: resending BeingAppearance after 10s delay"
-            );
-            handle_cancel_movie(
-                &delay_socket,
-                // Look up addr from entity_to_addr since it's stable
-                {
-                    let map = delay_entity_to_addr.lock().unwrap();
-                    match map.get(&delay_entity_id).copied() {
-                        Some(a) => a,
-                        None => return,
-                    }
-                },
-                delay_entity_id,
-                &delay_connected,
-                &delay_entity_to_addr,
-            )
-            .await;
-        });
-    }
+    // first_login DB clear is deferred to `handle_on_client_ready` so the
+    // flag only clears after we've actually fired `onPlayMovie` — if the
+    // client disconnects between mapLoaded and onClientReady, they correctly
+    // see the cinematic again on their next attempt.
+    //
+    // The previous implementation also spawned a 10-second timer that fired
+    // a synthetic `cancelMovie` to resend BeingAppearance, working around a
+    // dev-cube flash on first-login cinematic exit. That hack is gone: the
+    // root cause was firing onPlayMovie inside the mapLoaded bundle (before
+    // the model is bound to a possessed pawn), which let the cinematic-exit
+    // CollectGarbage reclaim the in-flight appearance asset. The cinematic
+    // is now fired from `handle_on_client_ready` after the appearance is
+    // rooted to a live actor. See issue #288.
 
     // Register entity_id -> addr before the final onClientReady gate so any
     // resource responses and future client-targeted traffic can resolve the
@@ -201,6 +174,7 @@ pub(crate) async fn handle_map_loaded(
             world_name: entry_info.world_name.clone(),
             appearance_args,
             tint_args,
+            first_login: player_data.first_login,
         });
     }
 

--- a/crates/services/src/base/world_entry/methods/inventory/appearance.rs
+++ b/crates/services/src/base/world_entry/methods/inventory/appearance.rs
@@ -137,6 +137,7 @@ mod tests {
             cached_appearance_args: None,
             cached_tint_args: None,
             cancelled: Arc::new(AtomicBool::new(false)),
+            cinematic_spam_cancel: Arc::new(AtomicBool::new(false)),
             player_name: None,
             player_level: None,
             player_archetype: None,

--- a/crates/services/src/base/world_entry/play_character.rs
+++ b/crates/services/src/base/world_entry/play_character.rs
@@ -187,6 +187,7 @@ mod tests {
             cached_appearance_args: None,
             cached_tint_args: None,
             cancelled: Arc::new(AtomicBool::new(false)),
+            cinematic_spam_cancel: Arc::new(AtomicBool::new(false)),
             player_name: None,
             player_level: None,
             player_archetype: None,

--- a/crates/services/src/base/world_entry/reanchor_player.rs
+++ b/crates/services/src/base/world_entry/reanchor_player.rs
@@ -60,7 +60,10 @@ fn build_reanchor_burst_body(entity_id: u32, info: &WorldEntryInfo) -> Vec<u8> {
     body.extend_from_slice(&entity_id.to_le_bytes());
     body.push(SGWPLAYER_CLASS_ID);
     body.push(0x00); // propertyCount = 0
-    body.extend_from_slice(&build_enter_world_body(info));
+                     // Reanchor passes None for `load`: the appearance/tint replay is sent
+                     // as separate packets after the burst (see `build_reanchor_packets`),
+                     // matching the original wire shape.
+    body.extend_from_slice(&build_enter_world_body(info, None));
     body
 }
 
@@ -253,8 +256,8 @@ mod tests {
         // forced-position flags) flows through Reanchor unchanged.
         assert_eq!(
             &body[9..],
-            build_enter_world_body(&info).as_slice(),
-            "tail must equal build_enter_world_body(info) verbatim — Reanchor and gate-travel must stay in lockstep on space/viewport/position"
+            build_enter_world_body(&info, None).as_slice(),
+            "tail must equal build_enter_world_body(info, None) verbatim — Reanchor and gate-travel must stay in lockstep on space/viewport/position"
         );
     }
 

--- a/crates/services/src/base/world_entry/teleport.rs
+++ b/crates/services/src/base/world_entry/teleport.rs
@@ -35,6 +35,7 @@ pub(super) async fn handle_teleport_player(
     entity_id: u32,
     space_id: u32,
     position: [f32; 3],
+    prev_pos: [f32; 3],
     socket: &Arc<UdpSocket>,
     connected: &Arc<Mutex<HashMap<SocketAddr, ConnectedClientState>>>,
     entity_to_addr: &Arc<Mutex<HashMap<u32, SocketAddr>>>,
@@ -67,13 +68,17 @@ pub(super) async fn handle_teleport_player(
         "TeleportPlayer: snapping avatar"
     );
 
-    // 1. Engine-level snap.
+    // 1. Engine-level snap. `prev_pos` is the entity's last-known position
+    //    before the teleport — see `build_forced_position` and
+    //    `spec.protocol.mercury` §1.10.6 for why this is not zero.
     send_to_witness(
         socket,
         connected,
         entity_to_addr,
         entity_id,
-        |key, seq, acks| build_forced_position(key, seq, acks, entity_id, space_id, position),
+        |key, seq, acks| {
+            build_forced_position(key, seq, acks, entity_id, space_id, position, prev_pos)
+        },
     )
     .await;
 
@@ -174,6 +179,7 @@ mod tests {
             999,
             65536,
             [10.0, 20.0, 30.0],
+            [5.0, 20.0, 30.0],
             &socket,
             &connected,
             &entity_to_addr,
@@ -202,6 +208,7 @@ mod tests {
             1,
             65536,
             [10.0, 20.0, 30.0],
+            [5.0, 20.0, 30.0],
             &socket,
             &connected,
             &entity_to_addr,

--- a/crates/services/src/base/world_entry_appearance.rs
+++ b/crates/services/src/base/world_entry_appearance.rs
@@ -5,6 +5,7 @@
 
 use std::collections::HashMap;
 use std::net::SocketAddr;
+use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex};
 
 use tokio::net::UdpSocket;
@@ -282,17 +283,186 @@ pub(crate) async fn handle_on_client_ready(
     )
     .await;
 
+    // First-login cinematic — fires AFTER appearance is bound to the now-live
+    // possessed pawn. Sending it inside the mapLoaded bundle (before this
+    // gate) lets the cinematic-exit CollectGarbage reclaim the in-flight
+    // appearance asset and produces a "dev cube" flash. Issue #288.
+    if pending.first_login != 0 {
+        send_cinematic(
+            socket,
+            addr,
+            entity_id,
+            "Cine-SGWLogo.SGWLogo",
+            true, // fullscreen
+            connected,
+            entity_to_addr,
+        )
+        .await;
+
+        if let Some(pool) = db_pool {
+            if let Err(e) =
+                sqlx::query("UPDATE sgw_player SET first_login = 0 WHERE player_id = $1")
+                    .bind(pending.player_id)
+                    .execute(pool.as_ref())
+                    .await
+            {
+                tracing::warn!(
+                    player_id = pending.player_id,
+                    error = %e,
+                    "Failed to clear first_login flag after cinematic dispatch; player will see intro again next login",
+                );
+            }
+        }
+
+        tracing::info!(%addr, entity_id, "First-login cinematic dispatched after onClientReady gate");
+    }
+
     tracing::info!(%addr, entity_id, "World entry finalized (BeingAppearance resent)");
     Ok(())
 }
 
-/// Resend BeingAppearance + onEntityTint after the first-login cinematic finishes.
+/// Send an `onPlayMovie` cinematic and arm the post-cinematic appearance guard.
 ///
-/// The client sends `cancelMovie` (exposed cell method index 108) when the intro
-/// cinematic ends. By this point both previous BeingAppearance sends (in the
-/// mapLoaded bundle and after onClientReady) may have been lost because the
-/// cinematic was rendering full-screen. This third send ensures the model loads.
-pub(crate) async fn handle_cancel_movie(
+/// The cinematic-exit `CollectGarbage` reclaims the player's appearance asset
+/// regardless of how the cinematic exits (natural end or Esc / Lua
+/// `cancelMovie`), leaving the player's pawn rendering as a dev-cube
+/// placeholder until the appearance is rebound. The race window varies — on
+/// natural end it's ~one frame to several seconds; on Esc it can be a single
+/// frame depending on network latency.
+///
+/// To eliminate the cube regardless of cinematic-exit mode:
+///
+/// 1. Send the `onPlayMovie` packet.
+/// 2. Reset `cinematic_spam_cancel` to `false` on the connected state and
+///    spawn a tokio task that resends BeingAppearance + onEntityTint every
+///    `RESEND_INTERVAL` for up to `RESEND_DURATION`.
+/// 3. The spam loop polls `cinematic_spam_cancel` each iteration. When the
+///    client emits a real `cancelMovie` (Esc / Lua), `handle_cancel_movie`
+///    flips the flag and the loop exits early — saving the remaining
+///    bandwidth for the user's session.
+///
+/// **Callers** must ensure `cached_appearance_args` + `cached_tint_args` are
+/// populated on the connected state before invoking (the spam reads from
+/// those). That's done during `handle_map_loaded`.
+///
+/// **Future cinematics** (mission cutscenes, gate transitions, dialog
+/// overlays, etc.) should go through this function rather than emitting
+/// `onPlayMovie` directly — the GC race is a property of every cinematic,
+/// not just the first-login intro. Issue #288.
+pub(crate) async fn send_cinematic(
+    socket: &Arc<UdpSocket>,
+    addr: SocketAddr,
+    entity_id: u32,
+    cinematic_asset: &str,
+    fullscreen: bool,
+    connected: &Arc<Mutex<HashMap<SocketAddr, ConnectedClientState>>>,
+    entity_to_addr: &Arc<Mutex<HashMap<u32, SocketAddr>>>,
+) {
+    // 1. Send the cinematic packet.
+    let mut movie_args = Vec::with_capacity(32);
+    write_wstring(&mut movie_args, cinematic_asset);
+    movie_args.push(if fullscreen { 1u8 } else { 0u8 });
+    send_to_witness(
+        socket,
+        connected,
+        entity_to_addr,
+        entity_id,
+        |key, seq, acks| {
+            build_entity_method_packet(
+                key,
+                seq,
+                acks,
+                entity_id,
+                method_idx::ON_PLAY_MOVIE,
+                &movie_args,
+            )
+        },
+    )
+    .await;
+
+    // 2. Arm the appearance-spam guard. Tunable via the two constants below.
+    //    100 ms × 200 iters = 20 s; cinematic-exit cancellation short-circuits.
+    //
+    // 20 s comfortably covers `Cine-SGWLogo` (314 frames @ 23.976 fps =
+    // 13.10 s natural end) plus a ~7 s post-cinematic safety buffer for GC
+    // and asset-rebind latency. Every BIK cinematic's duration is knowable:
+    // parse the embedded BIK header out of the corresponding
+    // `game/sgw/.../CookedPC/Packages/Cine-*.upk` — the `BIKi` magic is
+    // followed by `file_size`, `num_frames`, then `fps_dividend /
+    // fps_divisor` at offset +24 / +28. If a future caller needs a tighter
+    // window per cinematic, promote `RESEND_DURATION` to a `send_cinematic`
+    // parameter and look it up from a build-time-generated table.
+    const RESEND_INTERVAL: std::time::Duration = std::time::Duration::from_millis(100);
+    const RESEND_DURATION: std::time::Duration = std::time::Duration::from_secs(20);
+    let resend_count = (RESEND_DURATION.as_millis() / RESEND_INTERVAL.as_millis()).max(1) as usize;
+
+    // Reset the cancel flag (could be left `true` by a previous cinematic in
+    // the same session — e.g. mission cutscene after first-login intro) and
+    // clone the Arc so the spawned task can poll it without re-locking.
+    let cancel_flag = {
+        let clients = connected.lock().unwrap();
+        let Some(c) = clients.get(&addr) else {
+            tracing::warn!(
+                %addr,
+                entity_id,
+                "send_cinematic: client state vanished before spam armed -- skipping guard"
+            );
+            return;
+        };
+        c.cinematic_spam_cancel.store(false, Ordering::Relaxed);
+        Arc::clone(&c.cinematic_spam_cancel)
+    };
+
+    let resend_socket = Arc::clone(socket);
+    let resend_connected = Arc::clone(connected);
+    let resend_entity_to_addr = Arc::clone(entity_to_addr);
+    let cinematic_label = cinematic_asset.to_string();
+    tokio::spawn(async move {
+        tracing::info!(
+            entity_id,
+            cinematic = %cinematic_label,
+            resend_count,
+            interval_ms = RESEND_INTERVAL.as_millis() as u64,
+            "Cinematic-guard appearance spam: starting"
+        );
+        for i in 0..resend_count {
+            tokio::time::sleep(RESEND_INTERVAL).await;
+            if cancel_flag.load(Ordering::Relaxed) {
+                tracing::info!(
+                    entity_id,
+                    cinematic = %cinematic_label,
+                    sent = i,
+                    skipped = resend_count - i,
+                    "Cinematic-guard appearance spam: cancelMovie received -- stopping early"
+                );
+                return;
+            }
+            resend_appearance_after_cinematic(
+                &resend_socket,
+                addr,
+                entity_id,
+                &resend_connected,
+                &resend_entity_to_addr,
+            )
+            .await;
+        }
+        tracing::info!(
+            entity_id,
+            cinematic = %cinematic_label,
+            sent = resend_count,
+            "Cinematic-guard appearance spam: complete (full duration elapsed)"
+        );
+    });
+}
+
+/// Resend BeingAppearance + onEntityTint from `addr`'s cached args.
+///
+/// Internal helper used by both:
+/// - `handle_cancel_movie` (real client cancelMovie — single resend), and
+/// - `send_cinematic`'s spam loop (each iteration).
+///
+/// Pure side-effect (sends two packets); does NOT touch `cinematic_spam_cancel`.
+async fn resend_appearance_after_cinematic(
     socket: &Arc<UdpSocket>,
     addr: SocketAddr,
     entity_id: u32,
@@ -310,7 +480,7 @@ pub(crate) async fn handle_cancel_movie(
     };
 
     let Some((appearance_args, tint_args)) = cached else {
-        tracing::debug!(%addr, entity_id, "cancelMovie: no cached appearance data -- skipping resend");
+        tracing::debug!(%addr, entity_id, "resend_appearance_after_cinematic: no cached appearance data -- skipping");
         return;
     };
 
@@ -348,8 +518,32 @@ pub(crate) async fn handle_cancel_movie(
         },
     )
     .await;
+}
 
-    tracing::info!(%addr, entity_id, "cancelMovie: BeingAppearance + onEntityTint resent after cinematic");
+/// Handle the client's `cancelMovie` (exposed cell method index 108): the
+/// cinematic was dismissed (Esc or Lua-stop). Resends BeingAppearance +
+/// onEntityTint to recover from the cinematic-exit GC, and flips
+/// `cinematic_spam_cancel` so `send_cinematic`'s spam loop stops early.
+pub(crate) async fn handle_cancel_movie(
+    socket: &Arc<UdpSocket>,
+    addr: SocketAddr,
+    entity_id: u32,
+    connected: &Arc<Mutex<HashMap<SocketAddr, ConnectedClientState>>>,
+    entity_to_addr: &Arc<Mutex<HashMap<u32, SocketAddr>>>,
+) {
+    // Stop the in-flight cinematic-guard spam (if any). The client just told
+    // us it dismissed the cinematic, so we no longer need to brute-force a
+    // post-GC appearance refresh — one resend below handles it.
+    {
+        let clients = connected.lock().unwrap();
+        if let Some(c) = clients.get(&addr) {
+            c.cinematic_spam_cancel.store(true, Ordering::Relaxed);
+        }
+    }
+
+    resend_appearance_after_cinematic(socket, addr, entity_id, connected, entity_to_addr).await;
+
+    tracing::info!(%addr, entity_id, "cancelMovie: BeingAppearance + onEntityTint resent; spam guard signalled to stop");
 }
 
 #[cfg(test)]

--- a/crates/services/src/cell/content/executor/transport.rs
+++ b/crates/services/src/cell/content/executor/transport.rs
@@ -56,6 +56,15 @@ pub(super) async fn teleport(
             "Content: cross-space chain teleport not implemented — falling back to same-space move"
         );
     }
+    // Capture the entity's prior position *before* the spatial-grid update
+    // overwrites it — this becomes the `forcedPosition` prev-position
+    // reference vector. Falling back to `position` (zero-distance interp) if
+    // the entity is somehow missing keeps the camera-snap bug fixed even on
+    // the unhappy path.
+    let prev_pos = space_mgr
+        .get_entity(entity_id)
+        .map(|e| [e.position.x, e.position.y, e.position.z])
+        .unwrap_or(position);
     // Same-world teleport: keep the spatial grid consistent here,
     // then route through TeleportPlayer for the authoritative
     // FORCED_POSITION snap + persist. The bare 116-only path the
@@ -74,6 +83,7 @@ pub(super) async fn teleport(
             entity_id,
             space_id: cell_space_id,
             position,
+            prev_pos,
         })
         .await;
 }

--- a/crates/services/src/cell/messages/cell_to_base.rs
+++ b/crates/services/src/cell/messages/cell_to_base.rs
@@ -316,6 +316,11 @@ pub enum CellToBaseMsg {
         entity_id: u32,
         space_id: u32,
         position: [f32; 3],
+        /// The entity's last-known position before the snap. Becomes the
+        /// `forcedPosition` previous-position reference vector (offsets 24-35,
+        /// NOT velocity — see `build_forced_position`). Senders must capture
+        /// this *before* calling `space_mgr.update_entity_position(...)`.
+        prev_pos: [f32; 3],
     },
 
     /// Send a ghost entity method call to a specific witness player.

--- a/crates/services/src/cell/ring_transport/dispatch.rs
+++ b/crates/services/src/cell/ring_transport/dispatch.rs
@@ -281,6 +281,14 @@ async fn same_world_teleport(
     tx: &mpsc::Sender<CellToBaseMsg>,
     space_mgr: &mut SpaceManager,
 ) -> bool {
+    // Capture the entity's prior position before the spatial-grid update
+    // overwrites it — becomes the `forcedPosition` prev-position reference.
+    // Falling back to `position` (zero-distance interp) on a missing entity
+    // still avoids the camera-through-floor glitch.
+    let prev_pos = space_mgr
+        .get_entity(entity_id)
+        .map(|e| [e.position.x, e.position.y, e.position.z])
+        .unwrap_or(position);
     // Server-side: keep the spatial grid + entity position consistent so AoI
     // ticks broadcast the new position to other witnesses (build_avatar_update).
     // `update_entity_position` already writes `cell_entity.position`.
@@ -296,6 +304,7 @@ async fn same_world_teleport(
             entity_id,
             space_id,
             position,
+            prev_pos,
         })
         .await
     {

--- a/crates/services/src/cell/ring_transport/tests.rs
+++ b/crates/services/src/cell/ring_transport/tests.rs
@@ -168,6 +168,7 @@ async fn full_ring_cycle_dispatches_expected_messages() {
                 entity_id,
                 space_id,
                 position,
+                prev_pos: _,
             } => {
                 teleport_msg = Some((entity_id, space_id, position));
             }

--- a/crates/services/src/mercury/aoi/tests.rs
+++ b/crates/services/src/mercury/aoi/tests.rs
@@ -12,6 +12,11 @@ const TEST_KEY: [u8; 32] = [0x42u8; 32];
 /// staying put.
 #[test]
 fn forced_position_wire_layout() {
+    // Caller passes a non-zero prev_pos distinct from `position` so the
+    // byte slot (offsets 24-35 of the 49-byte payload, decrypted offsets
+    // 26-38) is observable — emitting zeros there causes the camera to
+    // slide from world origin (0,0,0) through the floor to the spawn
+    // point. See `spec.protocol.mercury` §1.10.6 + §1.16 Q3 closure.
     let pkt = build_forced_position(
         &TEST_KEY,
         1,
@@ -19,6 +24,7 @@ fn forced_position_wire_layout() {
         0x12345678,
         0x0001_0010,
         [10.0, 20.0, 30.0],
+        [9.0, 19.0, 29.0],
     );
     let enc = MercuryEncryption::from_session_key(TEST_KEY);
     let pt = enc.decrypt(&pkt).unwrap();
@@ -35,8 +41,11 @@ fn forced_position_wire_layout() {
     assert_eq!(&pt[14..18], &10.0f32.to_le_bytes());
     assert_eq!(&pt[18..22], &20.0f32.to_le_bytes());
     assert_eq!(&pt[22..26], &30.0f32.to_le_bytes());
-    // velocity = 0,0,0 (12 zero bytes)
-    assert_eq!(&pt[26..38], &[0u8; 12]);
+    // prev_pos x/y/z (offsets 24-35 of the 49-byte payload — prev-position
+    // reference, NOT velocity).
+    assert_eq!(&pt[26..30], &9.0f32.to_le_bytes(), "prev_pos.x");
+    assert_eq!(&pt[30..34], &19.0f32.to_le_bytes(), "prev_pos.y");
+    assert_eq!(&pt[34..38], &29.0f32.to_le_bytes(), "prev_pos.z");
     // rotation = 0,0,0 (12 zero bytes)
     assert_eq!(&pt[38..50], &[0u8; 12]);
     // flags = 0x01

--- a/crates/services/src/mercury/aoi/update.rs
+++ b/crates/services/src/mercury/aoi/update.rs
@@ -51,8 +51,17 @@ pub fn build_avatar_update(
 /// waiting state — it does not move the avatar. See SGWPlayer.def's comment
 /// on `onPlayerTeleport` and docs/protocol/position-updates.md.
 ///
+/// `prev_pos` is the **previous-position reference vector** (offsets 24-35 of
+/// the 49-byte payload — NOT velocity). The client's
+/// `ProcessForcedEntityPosition` (Ghidra `0x00dd9ee0`) copies this verbatim
+/// into `pPrevPos`, which the camera-attach path then interpolates from on the
+/// first frame. Pass the entity's last-known position before the snap (or the
+/// destination position itself to force a zero-distance interpolation). See
+/// `spec.protocol.mercury` §1.10.6 + §1.16 Q3 closure and
+/// `spec.protocol.position-updates` §1.4.2.
+///
 /// Wire layout matches `build_enter_world_body`:
-/// `[entityID:u32][spaceID:u32][vehicleID:u32=0][pos:3×f32][vel:3×f32=0]
+/// `[entityID:u32][spaceID:u32][vehicleID:u32=0][pos:3×f32][prevPos:3×f32]
 ///  [rot:3×f32][flags:u8=0x01]`.
 pub fn build_forced_position(
     key: &[u8; 32],
@@ -61,6 +70,7 @@ pub fn build_forced_position(
     entity_id: u32,
     space_id: u32,
     position: [f32; 3],
+    prev_pos: [f32; 3],
 ) -> Vec<u8> {
     let mut body = Vec::with_capacity(50);
     body.push(BASEMSG_FORCED_POSITION);
@@ -70,7 +80,9 @@ pub fn build_forced_position(
     for &c in &position {
         body.extend_from_slice(&c.to_le_bytes());
     }
-    body.extend_from_slice(&[0u8; 12]); // velocity = 0,0,0
+    for &c in &prev_pos {
+        body.extend_from_slice(&c.to_le_bytes());
+    }
     body.extend_from_slice(&[0u8; 12]); // rotation = 0,0,0 (yaw/pitch/roll)
     body.push(0x01); // flags
 

--- a/crates/services/src/mercury/world_data/map_loaded.rs
+++ b/crates/services/src/mercury/world_data/map_loaded.rs
@@ -110,7 +110,45 @@ fn build_map_loaded_body_inner(
         &build_world_params_args(&world_entry.world_name)
     );
 
-    // 1. setupStargateInfo (3xARRAY<INT32>: world, known, hidden)
+    // 1. BeingAppearance + 2. onEntityTint — promoted to the front of the
+    //    mapLoaded body so they land in the first fragment alongside
+    //    `createCellPlayer`, instead of fragments 4-5. Without this the
+    //    player entity exists on the client with no body model for the
+    //    50-200 ms it takes the rest of the bundle to arrive. (The
+    //    `build_create_player` path also pre-warms these now; keeping them
+    //    here too lets a UDP-dropped pre-warm still self-heal once the
+    //    mapLoaded bundle lands.)
+    {
+        tracing::info!(
+            bodyset = %data.bodyset,
+            bodyset_len = data.bodyset.len(),
+            component_count = data.components.len(),
+            components = ?data.components,
+            skin_color_id = data.skin_color_id,
+            "mapLoaded: BeingAppearance + onEntityTint data"
+        );
+        let mut args = Vec::new();
+        write_wstring(&mut args, &data.bodyset);
+        args.extend_from_slice(&(data.components.len() as u32).to_le_bytes());
+        for comp in &data.components {
+            write_wstring(&mut args, comp);
+        }
+        append_method!(method_idx::BEING_APPEARANCE, &args);
+    }
+    {
+        let skin_tint = if (data.skin_color_id as usize) < SKIN_TINTS.len() {
+            SKIN_TINTS[data.skin_color_id as usize]
+        } else {
+            SKIN_TINTS[0]
+        };
+        let mut args = Vec::with_capacity(12);
+        args.extend_from_slice(&0u32.to_le_bytes()); // primaryColorId
+        args.extend_from_slice(&0u32.to_le_bytes()); // secondaryColorId
+        args.extend_from_slice(&skin_tint.to_le_bytes());
+        append_method!(method_idx::ON_ENTITY_TINT, &args);
+    }
+
+    // 3. setupStargateInfo (3xARRAY<INT32>: world, known, hidden)
     {
         let mut args = Vec::new();
         // worldStargateIds: stargates physically present in the destination
@@ -240,38 +278,8 @@ fn build_map_loaded_body_inner(
     // 14. onResetMapInfo (no args)
     append_method!(method_idx::ON_RESET_MAP_INFO, &[]);
 
-    // 15. BeingAppearance(UNICODE_STRING bodySet, ARRAY<UNICODE_STRING> components)
-    {
-        tracing::info!(
-            bodyset = %data.bodyset,
-            bodyset_len = data.bodyset.len(),
-            component_count = data.components.len(),
-            components = ?data.components,
-            skin_color_id = data.skin_color_id,
-            "mapLoaded: BeingAppearance + onEntityTint data"
-        );
-        let mut args = Vec::new();
-        write_wstring(&mut args, &data.bodyset);
-        args.extend_from_slice(&(data.components.len() as u32).to_le_bytes());
-        for comp in &data.components {
-            write_wstring(&mut args, comp);
-        }
-        append_method!(method_idx::BEING_APPEARANCE, &args);
-    }
-
-    // 16. onEntityTint(UINT32, UINT32, UINT32) — primary, secondary, skin
-    {
-        let skin_tint = if (data.skin_color_id as usize) < SKIN_TINTS.len() {
-            SKIN_TINTS[data.skin_color_id as usize]
-        } else {
-            SKIN_TINTS[0]
-        };
-        let mut args = Vec::with_capacity(12);
-        args.extend_from_slice(&0u32.to_le_bytes()); // primaryColorId (default 0, matches C++)
-        args.extend_from_slice(&0u32.to_le_bytes()); // secondaryColorId (default 0, matches C++)
-        args.extend_from_slice(&skin_tint.to_le_bytes());
-        append_method!(method_idx::ON_ENTITY_TINT, &args);
-    }
+    // BeingAppearance + onEntityTint moved to the top of the mapLoaded body
+    // (steps 1-2) so they land in the first fragment.
 
     // 17. onExtraNameUpdate(UNICODE_STRING) — extended encoding
     {
@@ -380,16 +388,17 @@ fn build_map_loaded_body_inner(
         append_method!(method_idx::ON_CHAT_JOINED, &args);
     }
 
-    // 25. onPlayMovie — fullscreen SGW logo cinematic on first-ever login
-    //     Reference: python/cell/SGWPlayer.py:535-537
-    if data.first_login != 0 {
-        let mut args = Vec::new();
-        write_wstring(&mut args, "Cine-SGWLogo.SGWLogo");
-        args.push(1u8); // FullScreen = true
-        append_method!(method_idx::ON_PLAY_MOVIE, &args);
-    }
+    // NOTE: onPlayMovie (first-login cinematic) is intentionally NOT in this
+    // bundle. It is deferred to `handle_on_client_ready` and fired AFTER the
+    // BeingAppearance / onEntityTint resends so the cinematic plays against a
+    // pawn that's already possessed AND has its model bound. Firing it here
+    // (in the mapLoaded bundle, before onClientReady) lets the cinematic-exit
+    // CollectGarbage reclaim the in-flight appearance asset, producing a
+    // one-frame "dev cube" flash on the first post-cinematic render. See
+    // issue #288 and python/cell/SGWPlayer.py:558-565 (the original flow
+    // gated mapLoaded() ITSELF on onClientReady, which had the same effect).
 
-    // 26. onPlayerDataLoaded (no args) — client transitions to gameplay
+    // 25. onPlayerDataLoaded (no args) — client transitions to gameplay
     append_method!(method_idx::ON_PLAYER_DATA_LOADED, &[]);
 
     // 26. onTargetUpdate(INT32) — default 0 (no target)

--- a/crates/services/src/mercury/world_data/phases.rs
+++ b/crates/services/src/mercury/world_data/phases.rs
@@ -4,15 +4,24 @@ use cimmeria_mercury::packet::{build_outgoing, FLAG_HAS_ACKS};
 
 use super::{
     append_entity_method, build_world_params_args, client_map_for_world, encrypt_packet,
-    method_idx, world_id_for_name, write_wstring, WorldEntryInfo, BASEMSG_CREATE_BASE_PLAYER,
-    BASEMSG_CREATE_CELL_PLAYER, BASEMSG_FORCED_POSITION, BASEMSG_SPACE_VIEWPORT_INFO, REPLY_FLAGS,
+    method_idx, world_id_for_name, write_wstring, PlayerLoadData, WorldEntryInfo,
+    BASEMSG_CREATE_BASE_PLAYER, BASEMSG_CREATE_CELL_PLAYER, BASEMSG_FORCED_POSITION,
+    BASEMSG_SPACE_VIEWPORT_INFO, REPLY_FLAGS, SKIN_TINTS,
 };
 
 // ── World entry builders ─────────────────────────────────────────────────────
 
-/// Create player step: CREATE_BASE_PLAYER + onClientMapLoad.
+/// Create player step: CREATE_BASE_PLAYER + (optional appearance pre-warm) + onClientMapLoad.
 ///
-/// Sends only the base entity creation and terrain load notification.
+/// Sends the base entity creation and terrain load notification. When
+/// `load` is provided, also appends `BeingAppearance` + `onEntityTint`
+/// between the entity create and the terrain-load trigger — this kicks the
+/// client into loading the player's body-model assets in parallel with the
+/// terrain load instead of waiting until after `mapLoaded` returns. Without
+/// this pre-warm, the client briefly renders the dev-cube placeholder
+/// (the default visual for an entity with no bodyset) between
+/// `createCellPlayer` and the eventual `BeingAppearance` arrival.
+///
 /// The client will load terrain geometry and respond with `mapLoaded` (cell
 /// method index 25, msg_id 0x99). Only after receiving that should the server
 /// send the enter-world packet (viewport + cell player + forced position + entity data).
@@ -26,6 +35,7 @@ pub fn build_create_player(
     seq_id: u32,
     acks: &[u32],
     info: &WorldEntryInfo,
+    load: Option<&PlayerLoadData>,
 ) -> Vec<u8> {
     let mut body = Vec::with_capacity(256);
 
@@ -36,6 +46,44 @@ pub fn build_create_player(
     body.extend_from_slice(&info.player_entity_id.to_le_bytes());
     body.push(info.class_id);
     body.push(0x00); // propertyCount = 0
+
+    // 1b. Pre-warm body model + tint so the client's async asset load runs
+    //     in parallel with the terrain load triggered by onClientMapLoad.
+    //     The entity already exists from CREATE_BASE_PLAYER above; these
+    //     entity-method calls just configure its visual properties. Without
+    //     this, the entity arrives via `createCellPlayer` with no bodyset
+    //     and the renderer shows the dev-cube placeholder until
+    //     `BeingAppearance` lands later in the mapLoaded body.
+    if let Some(load) = load {
+        let mut appearance_args = Vec::new();
+        write_wstring(&mut appearance_args, &load.bodyset);
+        appearance_args.extend_from_slice(&(load.components.len() as u32).to_le_bytes());
+        for comp in &load.components {
+            write_wstring(&mut appearance_args, comp);
+        }
+        append_entity_method(
+            &mut body,
+            method_idx::BEING_APPEARANCE,
+            info.player_entity_id,
+            &appearance_args,
+        );
+
+        let skin_tint = if (load.skin_color_id as usize) < SKIN_TINTS.len() {
+            SKIN_TINTS[load.skin_color_id as usize]
+        } else {
+            SKIN_TINTS[0]
+        };
+        let mut tint_args = Vec::with_capacity(12);
+        tint_args.extend_from_slice(&0u32.to_le_bytes()); // primaryColorId
+        tint_args.extend_from_slice(&0u32.to_le_bytes()); // secondaryColorId
+        tint_args.extend_from_slice(&skin_tint.to_le_bytes());
+        append_entity_method(
+            &mut body,
+            method_idx::ON_ENTITY_TINT,
+            info.player_entity_id,
+            &tint_args,
+        );
+    }
 
     // 2. onClientMapLoad — tells the client which terrain to load.
     //    Client loads geometry then sends mapLoaded (0x99) when ready.
@@ -69,14 +117,24 @@ pub fn build_create_player(
     encrypt_packet(&plaintext, key)
 }
 
-/// Build raw body bytes for the enter-world step: VIEWPORT + CELL_PLAYER + FORCED_POSITION.
+/// Build raw body bytes for the enter-world step:
+/// VIEWPORT + (optional BeingAppearance + onEntityTint) + CELL_PLAYER + FORCED_POSITION.
 ///
-/// Returns just the Mercury message bytes (~99 bytes) without packet framing.
+/// Returns just the Mercury message bytes without packet framing.
 /// The C++ server adds these messages to `channel_->bundle()` — the same bundle
 /// that contains the mapLoaded entity methods — rather than sending them as a
 /// separate packet. This function provides the raw bytes so the caller can
 /// prepend them to the mapLoaded body before fragmenting into a single bundle.
-pub fn build_enter_world_body(info: &WorldEntryInfo) -> Vec<u8> {
+///
+/// When `load` is provided, `BeingAppearance` and `onEntityTint` are emitted
+/// **between** `spaceViewportInfo` and `createCellPlayer`. The client's
+/// `createCellPlayer` handler calls into the appearance gate internally — by
+/// having the bodyset already applied to the entity at that moment, the gate's
+/// model-asset-load job is queued against the just-completed bodyset, so the
+/// renderable entity comes up with the correct model on its first render frame
+/// instead of flashing the dev-cube placeholder. Live-debug evidence:
+/// `logs/x64dbg-issue288-run3-analysis.txt`.
+pub fn build_enter_world_body(info: &WorldEntryInfo, load: Option<&PlayerLoadData>) -> Vec<u8> {
     let mut body = Vec::with_capacity(128);
 
     // 1. spaceViewportInfo (0x08, CONSTANT_LENGTH = 13)
@@ -85,6 +143,43 @@ pub fn build_enter_world_body(info: &WorldEntryInfo) -> Vec<u8> {
     body.extend_from_slice(&info.player_entity_id.to_le_bytes());
     body.extend_from_slice(&info.space_id.to_le_bytes());
     body.push(0x00); // viewportID = 0
+
+    // 1b. BeingAppearance + onEntityTint — must precede createCellPlayer so
+    //     the client's cell-entity creation handler picks up the freshly-set
+    //     bodyset during its internal appearance evaluation. Without this,
+    //     the renderable entity is created against the default cube
+    //     placeholder and the asset bind only completes on a later render
+    //     frame.
+    if let Some(load) = load {
+        let mut appearance_args = Vec::new();
+        write_wstring(&mut appearance_args, &load.bodyset);
+        appearance_args.extend_from_slice(&(load.components.len() as u32).to_le_bytes());
+        for comp in &load.components {
+            write_wstring(&mut appearance_args, comp);
+        }
+        append_entity_method(
+            &mut body,
+            method_idx::BEING_APPEARANCE,
+            info.player_entity_id,
+            &appearance_args,
+        );
+
+        let skin_tint = if (load.skin_color_id as usize) < SKIN_TINTS.len() {
+            SKIN_TINTS[load.skin_color_id as usize]
+        } else {
+            SKIN_TINTS[0]
+        };
+        let mut tint_args = Vec::with_capacity(12);
+        tint_args.extend_from_slice(&0u32.to_le_bytes()); // primaryColorId
+        tint_args.extend_from_slice(&0u32.to_le_bytes()); // secondaryColorId
+        tint_args.extend_from_slice(&skin_tint.to_le_bytes());
+        append_entity_method(
+            &mut body,
+            method_idx::ON_ENTITY_TINT,
+            info.player_entity_id,
+            &tint_args,
+        );
+    }
 
     // 2. createCellPlayer (0x06, WORD_LENGTH = 32)
     body.push(BASEMSG_CREATE_CELL_PLAYER);
@@ -107,10 +202,21 @@ pub fn build_enter_world_body(info: &WorldEntryInfo) -> Vec<u8> {
     for &c in &info.pos {
         body.extend_from_slice(&c.to_le_bytes());
     }
-    for &c in &[0.0f32, 0.0, 0.0] {
+    // Previous-position reference vector (NOT velocity). Client's
+    // `ProcessForcedEntityPosition` (Ghidra 0x00dd9ee0) copies these 12 bytes
+    // verbatim into `pPrevPos`; the camera-attach path then interpolates from
+    // pPrevPos to current_pos on the first frame. Emitting zeros at world entry
+    // makes the camera slide from world origin (0,0,0) through the floor to the
+    // spawn point — visible as a "camera-through-floor" glitch. Set the prev-pos
+    // reference equal to the spawn position so the interpolation distance is
+    // zero. See spec.protocol.mercury §1.10.6 + §1.16 Q3 closure for the
+    // Ghidra-confirmed semantic; canonical layout in
+    // spec.protocol.position-updates §1.4.2.
+    let prev_pos = info.pos;
+    for &c in &prev_pos {
         body.extend_from_slice(&c.to_le_bytes());
-    } // velocity = zero
-      // C++ sends rotX, rotZ, rotY (swapped)
+    }
+    // C++ sends rotX, rotZ, rotY (swapped)
     body.extend_from_slice(&info.rot[0].to_le_bytes()); // rotX
     body.extend_from_slice(&info.rot[2].to_le_bytes()); // rotZ (swapped)
     body.extend_from_slice(&info.rot[1].to_le_bytes()); // rotY (swapped)
@@ -129,8 +235,9 @@ pub fn build_enter_world(
     seq_id: u32,
     acks: &[u32],
     info: &WorldEntryInfo,
+    load: Option<&PlayerLoadData>,
 ) -> Vec<u8> {
-    let body = build_enter_world_body(info);
+    let body = build_enter_world_body(info, load);
     let flags = REPLY_FLAGS | if acks.is_empty() { 0 } else { FLAG_HAS_ACKS };
     let plaintext = build_outgoing(flags, &body, Some(seq_id), acks, None);
     encrypt_packet(&plaintext, key)

--- a/crates/services/src/mercury/world_data/tests/map_loaded.rs
+++ b/crates/services/src/mercury/world_data/tests/map_loaded.rs
@@ -3,8 +3,40 @@
 //! Mercury fragmentation framing they ride on.
 
 use super::super::*;
-use super::TEST_KEY;
+use super::{sample_player_load_data, sample_world_entry, TEST_KEY};
 use cimmeria_mercury::encryption::MercuryEncryption;
+
+/// Walk an entity-method body and return the (method_index, byte_offset)
+/// of each record in encounter order. Stops at the first non-record byte.
+fn walk_entity_method_records(body: &[u8]) -> Vec<(u16, usize)> {
+    let mut out = Vec::new();
+    let mut i = 0;
+    while i < body.len() {
+        let b = body[i];
+        if !(0x80..=0xBD).contains(&b) {
+            break;
+        }
+        if i + 3 > body.len() {
+            break;
+        }
+        let word_len = u16::from_le_bytes([body[i + 1], body[i + 2]]) as usize;
+        let record_end = i + 3 + word_len;
+        if record_end > body.len() {
+            break;
+        }
+        let method_index = if b == 0xBD {
+            if i + 7 >= body.len() {
+                break;
+            }
+            61 + body[i + 7] as u16
+        } else {
+            (b & 0x7F) as u16
+        };
+        out.push((method_index, i));
+        i = record_end;
+    }
+    out
+}
 
 #[test]
 fn build_on_player_data_loaded_uses_correct_msg_id() {
@@ -308,4 +340,298 @@ fn build_map_loaded_uses_mercury_fragmentation() {
             frag_end
         );
     }
+}
+
+/// Issue #288 regression guard: `onPlayMovie` (the first-login intro
+/// cinematic, method index 155) MUST NOT appear in the mapLoaded entity
+/// method bundle, even when `first_login = 1`. It is deferred to
+/// `handle_on_client_ready` so the cinematic plays after BeingAppearance is
+/// rooted to a live possessed pawn — firing it inside this bundle (the
+/// original behavior) let the cinematic-exit `CollectGarbage` reclaim the
+/// in-flight appearance asset and produced a one-frame dev-cube flash on
+/// the first post-cinematic render.
+///
+/// Two assertions, redundant on purpose:
+/// 1. Structural: walking entity-method records over the body must not
+///    yield method index 155.
+/// 2. Byte-pattern: the UTF-16LE-encoded cinematic asset name must not
+///    appear anywhere in the body — guards against the structural walker
+///    breaking and silently passing if a future change confuses it.
+///
+/// Reverting the fix (re-adding the `onPlayMovie` step to
+/// `build_map_loaded_body_inner`) must break this test.
+#[test]
+fn build_map_loaded_omits_first_login_cinematic_from_bundle() {
+    let mut data = sample_player_load_data();
+    data.first_login = 1; // would-be cinematic trigger pre-#288 fix
+    let entry = sample_world_entry();
+
+    let body = build_map_loaded_body(42, &data, &entry);
+
+    // (1) Structural — no record with method_index 155 (ON_PLAY_MOVIE).
+    let records = walk_entity_method_records(&body);
+    assert!(
+        !records.iter().any(|(idx, _)| *idx == 155),
+        "onPlayMovie (method 155) must not appear in mapLoaded bundle; \
+         it is deferred to handle_on_client_ready. Records found: {:?}",
+        records.iter().map(|(idx, _)| *idx).collect::<Vec<_>>()
+    );
+
+    // (2) Byte-pattern — "Cine-SGWLogo.SGWLogo" UTF-16LE must not be present.
+    let cinematic_name: Vec<u8> = "Cine-SGWLogo.SGWLogo"
+        .encode_utf16()
+        .flat_map(|c| c.to_le_bytes())
+        .collect();
+    assert!(
+        !body
+            .windows(cinematic_name.len())
+            .any(|w| w == cinematic_name),
+        "Cinematic asset name 'Cine-SGWLogo.SGWLogo' (UTF-16LE) must not appear \
+         in mapLoaded bundle bytes"
+    );
+}
+
+/// `build_enter_world_body`'s `forcedPosition` emit must place the spawn
+/// position into the previous-position reference slot (offsets 24-35 of the
+/// 49-byte `forcedPosition` payload, body offsets 74-85). Emitting zeros
+/// there causes the client's camera-attach code to interpolate from world
+/// origin (0,0,0) to the spawn position on the first frame, visibly
+/// clipping through the world floor.
+///
+/// Reverting the fix (re-introducing a `[0.0f32, 0.0, 0.0]` literal in the
+/// prev-position slot) must break this test. See `spec.protocol.mercury`
+/// §1.10.6 + §1.16 Q3 closure (Ghidra `ProcessForcedEntityPosition` at
+/// `0x00dd9ee0`).
+#[test]
+fn enter_world_body_forced_position_prev_pos_equals_spawn() {
+    let info = WorldEntryInfo {
+        player_entity_id: 100,
+        space_id: 0x0001_0010,
+        pos: [123.5, 456.25, 789.0],
+        rot: [0.0, 0.0, 0.0],
+        world_name: "CombatSim".into(),
+        class_id: 0x02,
+        world_stargates: vec![],
+    };
+    // None for `load`: keep the original 99-byte VIEWPORT+CELL+FORCED layout
+    // so this test pins the prev-pos slot independently of the appearance
+    // insertion. The appearance-injection variant is covered separately.
+    let body = build_enter_world_body(&info, None);
+    // Sanity: total body length matches the documented 99-byte assembly
+    // (spaceViewport 14 + createCellPlayer 35 + forcedPosition 50).
+    assert_eq!(body.len(), 99, "enter-world body must be exactly 99 bytes");
+    // forcedPosition starts at offset 49 (msg_id 0x31).
+    assert_eq!(
+        body[49],
+        crate::mercury::BASEMSG_FORCED_POSITION,
+        "forcedPosition record must start at body offset 49"
+    );
+    // pos at body offsets 62-73, prev_pos at body offsets 74-85.
+    assert_eq!(&body[62..66], &123.5f32.to_le_bytes(), "pos.x");
+    assert_eq!(&body[66..70], &456.25f32.to_le_bytes(), "pos.y");
+    assert_eq!(&body[70..74], &789.0f32.to_le_bytes(), "pos.z");
+    assert_eq!(
+        &body[74..78],
+        &123.5f32.to_le_bytes(),
+        "prev_pos.x must equal spawn pos (zero would slide camera through floor)"
+    );
+    assert_eq!(
+        &body[78..82],
+        &456.25f32.to_le_bytes(),
+        "prev_pos.y must equal spawn pos (zero would slide camera through floor)"
+    );
+    assert_eq!(
+        &body[82..86],
+        &789.0f32.to_le_bytes(),
+        "prev_pos.z must equal spawn pos (zero would slide camera through floor)"
+    );
+}
+
+/// `build_enter_world_body(info, Some(load))` must emit
+/// `BeingAppearance` + `onEntityTint` BETWEEN `spaceViewportInfo` and
+/// `createCellPlayer`. Live-debug evidence
+/// (`logs/x64dbg-issue288-run3-analysis.txt`) showed the client's
+/// `createCellPlayer` handler internally calls the appearance gate at
+/// `retaddr=DD1DEF` — by setting the bodyset before that handler runs, the
+/// internal gate evaluates against the bodyset and the renderable entity
+/// comes up with the model on its first render frame.
+#[test]
+fn enter_world_body_with_load_inserts_appearance_before_cell_player() {
+    use crate::mercury::method_idx;
+
+    let info = sample_world_entry();
+    let load = sample_player_load_data();
+    let body = build_enter_world_body(&info, Some(&load));
+
+    // spaceViewportInfo is the first 14 bytes (msg_id 0x08 + 4+4+4 ids + 1 viewport).
+    assert_eq!(
+        body[0],
+        crate::mercury::BASEMSG_SPACE_VIEWPORT_INFO,
+        "first record must be spaceViewportInfo"
+    );
+    let after_viewport = &body[14..];
+    let records = walk_entity_method_records(after_viewport);
+    assert!(
+        records.len() >= 2,
+        "expected at least 2 entity-method records between viewport and createCellPlayer, got {}",
+        records.len()
+    );
+    assert_eq!(
+        records[0].0,
+        method_idx::BEING_APPEARANCE,
+        "BeingAppearance must immediately follow spaceViewportInfo — \
+         must be set on the entity BEFORE createCellPlayer so the cell-creation \
+         handler's internal appearance gate (Ghidra retaddr 0xDD1DEF) picks up \
+         the bodyset on the renderable entity's first frame"
+    );
+    assert_eq!(
+        records[1].0,
+        method_idx::ON_ENTITY_TINT,
+        "onEntityTint must follow BeingAppearance and still precede createCellPlayer"
+    );
+
+    // After the two appearance records, the next byte must be the
+    // createCellPlayer msg_id (0x06), confirming appearance sits BEFORE cell.
+    let (_, tint_offset) = records[1];
+    let tint_record = &after_viewport[tint_offset..];
+    // Record header is 3 bytes (msg_id + u16 word_len) + word_len bytes of payload.
+    let tint_payload_len = u16::from_le_bytes([tint_record[1], tint_record[2]]) as usize;
+    let tint_record_end = 3 + tint_payload_len;
+    let after_appearance = &tint_record[tint_record_end..];
+    assert_eq!(
+        after_appearance[0],
+        crate::mercury::BASEMSG_CREATE_CELL_PLAYER,
+        "createCellPlayer (msg 0x06) must immediately follow the appearance + tint pair"
+    );
+}
+
+/// `build_create_player` must pre-warm the body-model assets by emitting
+/// `BeingAppearance` + `onEntityTint` **between** `CREATE_BASE_PLAYER` and
+/// `onClientMapLoad` when load data is supplied. Without the pre-warm the
+/// client allocates the entity, starts terrain load, and only later (after
+/// `mapLoaded` round-trip + entity-data bundle) receives the bodyset —
+/// leaving a window where the dev-cube placeholder is rendered. Asserts
+/// the records appear in exactly that order in the decrypted body.
+#[test]
+fn create_player_with_load_data_prewarms_bodyset_before_map_load() {
+    use crate::mercury::method_idx;
+
+    let info = sample_world_entry();
+    let load = sample_player_load_data();
+    let pkt = build_create_player(&TEST_KEY, 1, &[], &info, Some(&load));
+    let enc = MercuryEncryption::from_session_key(TEST_KEY);
+    let pt = enc.decrypt(&pkt).unwrap();
+    // Body starts at offset 1 (offset 0 is flags). The first record must be
+    // CREATE_BASE_PLAYER (0x05).
+    assert_eq!(
+        pt[1],
+        crate::mercury::BASEMSG_CREATE_BASE_PLAYER,
+        "first record must be CREATE_BASE_PLAYER"
+    );
+    // CREATE_BASE_PLAYER is 9 bytes total: [0x05][len:u16=6][entity:u32][class:u8][pad:u8].
+    // So the next record begins at body offset 9.
+    let after_create = &pt[1 + 9..];
+    let records = walk_entity_method_records(after_create);
+    assert!(
+        records.len() >= 3,
+        "expected ≥3 entity-method records after CREATE_BASE_PLAYER, got {}",
+        records.len()
+    );
+    assert_eq!(
+        records[0].0,
+        method_idx::BEING_APPEARANCE,
+        "BeingAppearance must be the FIRST entity-method after CREATE_BASE_PLAYER — \
+         the client kicks off async model load on receipt; emitting it after \
+         onClientMapLoad delays the load until the terrain round-trip finishes \
+         and leaves a dev-cube placeholder window"
+    );
+    assert_eq!(
+        records[1].0,
+        method_idx::ON_ENTITY_TINT,
+        "onEntityTint must follow BeingAppearance so the model loads with the \
+         correct skin tint instead of defaulting and then re-tinting"
+    );
+    assert_eq!(
+        records[2].0,
+        method_idx::ON_CLIENT_MAP_LOAD,
+        "onClientMapLoad must come LAST so the terrain load runs in parallel \
+         with the already-started model load"
+    );
+}
+
+/// Backwards-compat: passing `None` for `load` must keep the original
+/// two-record body (CREATE_BASE_PLAYER + onClientMapLoad). Guards the
+/// reanchor / GM-spawn / test paths where appearance data isn't available.
+#[test]
+fn create_player_without_load_data_emits_only_create_and_map_load() {
+    use crate::mercury::method_idx;
+
+    let info = sample_world_entry();
+    let pkt = build_create_player(&TEST_KEY, 1, &[], &info, None);
+    let enc = MercuryEncryption::from_session_key(TEST_KEY);
+    let pt = enc.decrypt(&pkt).unwrap();
+    assert_eq!(pt[1], crate::mercury::BASEMSG_CREATE_BASE_PLAYER);
+    let after_create = &pt[1 + 9..];
+    let records = walk_entity_method_records(after_create);
+    assert_eq!(
+        records.len(),
+        1,
+        "no-load path must emit exactly one entity-method (onClientMapLoad), got {}",
+        records.len()
+    );
+    assert_eq!(records[0].0, method_idx::ON_CLIENT_MAP_LOAD);
+}
+
+/// `BeingAppearance` (method 26) and `onEntityTint` (method 10) must land
+/// in the first mapLoaded fragment so the player entity has a body model
+/// from the moment `createCellPlayer` arrives. Moving them back to the
+/// middle of the body (positions 15-16) puts them in fragment 4-5, leaving
+/// a ~50-200 ms model-load gap.
+///
+/// Pin: the first three entity-method records emitted are
+/// `setupWorldParameters`, `BeingAppearance`, `onEntityTint` (in that order),
+/// and their byte offsets all sit comfortably inside `FRAGMENT_BODY_SIZE`.
+#[test]
+fn map_loaded_being_appearance_lands_in_first_fragment() {
+    use crate::mercury::method_idx;
+    use cimmeria_mercury::packet::FRAGMENT_BODY_SIZE;
+
+    let data = sample_player_load_data();
+    let entry = sample_world_entry();
+    let body = build_map_loaded_body(100, &data, &entry);
+    let records = walk_entity_method_records(&body);
+    assert!(
+        records.len() >= 3,
+        "mapLoaded body must contain at least 3 entity-method records, got {}",
+        records.len()
+    );
+    assert_eq!(
+        records[0].0,
+        method_idx::SETUP_WORLD_PARAMETERS,
+        "record 0 must be setupWorldParameters"
+    );
+    assert_eq!(
+        records[1].0,
+        method_idx::BEING_APPEARANCE,
+        "record 1 must be BeingAppearance — must land in the first fragment alongside createCellPlayer or the player entity renders without a body model for the time it takes the rest of the bundle to arrive"
+    );
+    assert_eq!(
+        records[2].0,
+        method_idx::ON_ENTITY_TINT,
+        "record 2 must be onEntityTint — pairs with BeingAppearance so the model loads with the correct tint instead of defaulting then re-tinting"
+    );
+    let (_, being_offset) = records[1];
+    let (_, tint_offset) = records[2];
+    assert!(
+        being_offset < FRAGMENT_BODY_SIZE,
+        "BeingAppearance offset {} must fall inside FRAGMENT_BODY_SIZE ({})",
+        being_offset,
+        FRAGMENT_BODY_SIZE
+    );
+    assert!(
+        tint_offset < FRAGMENT_BODY_SIZE,
+        "onEntityTint offset {} must fall inside FRAGMENT_BODY_SIZE ({})",
+        tint_offset,
+        FRAGMENT_BODY_SIZE
+    );
 }

--- a/crates/services/src/test_support.rs
+++ b/crates/services/src/test_support.rs
@@ -148,6 +148,7 @@ pub(crate) fn test_default_connected_client_state() -> ConnectedClientState {
         cached_appearance_args: None,
         cached_tint_args: None,
         cancelled: Arc::new(AtomicBool::new(false)),
+        cinematic_spam_cancel: Arc::new(AtomicBool::new(false)),
         player_name: None,
         player_level: None,
         player_archetype: None,


### PR DESCRIPTION
## Plain-English summary (for non-coder team members)

This PR fixes two visual glitches you'd see when a brand-new character logs in for the first time on each shard:

1. **Camera slides through the floor for ~1-2 seconds.** The camera attaches to a freshly-spawned character before the engine writes the character's actual world position, so the camera lerps from world-origin `(0,0,0)` to the spawn location, clipping the world geometry on the way.
2. **The character flashes as a grey "dev cube" right after the intro cinematic.** When the cinematic ends, the engine's memory-cleanup pass throws away the character model that was just loaded into memory. The very first frame after the cinematic finds an empty model slot and falls back to a default placeholder (the dev cube) for a moment.

Bug 2 (the dev cube) is fully fixed in this PR. Bug 1 (camera slide) has a wire-format spec-correctness fix here, but the visible slide itself is caused by client engine code we can't change from the server — that's a follow-up for the binary-patch track.

### How we fixed the dev cube

The original cinematic was sent inside the same network bundle as everything else the client needs to enter the world. The cleanup pass at the end of the cinematic was wiping out the character model regardless of how the cinematic exited. We changed two things:

- **Wait until the client is ready before playing the cinematic.** Instead of bundling the cinematic with the rest of the world-load data, we wait for the client's "I'm ready to control the player" signal before sending it. By that point the character is fully bound and visible — confirmed in-game (the player model now appears before the cinematic starts).
- **Spam the model assignment for 20 seconds after the cinematic starts.** The cleanup still happens at cinematic end, so we resend the character-model message every 100 ms for 20 seconds, brute-forcing through any garbage-collection race. The spam stops automatically the moment the client says "I dismissed the cinematic" (the Esc-key path), so for users who skip the intro we send maybe one or two extra packets instead of the full 200.

We worked out the 20-second window by reading the BIK video header inside the cinematic's `.upk` package — 314 frames at 23.976 fps = 13.1 seconds — and added a 7-second safety buffer.

### How we fixed the camera slide

We discovered during this work that the client engine has a UE3-actor-spawn race where the camera attaches to a pawn before the pawn's `AActor::Location` is set. Our server-side change keeps the `forcedPosition` wire format spec-correct (the `pPrevPos` slot now holds the real spawn position instead of zeros), but the visible slide is fundamentally a client engine bug. Eliminating the slide requires either:

- A binary patch to `GameProxyPlayer_HandlePlayerPawnCreated` (writes the spawn transform to `AActor::Location` before `Possess()`), or
- An UnrealScript patch in `ASGWCamera_Player::UpdateCamera` (seeds the camera lerp from the view target's location instead of `(0,0,0)`).

Tracked separately. Original SGW (2009) ships with this slide too, so it's acceptable to leave as-is in the short term.

---

## Summary (engineering)

Two distinct visual artifacts during world-entry traced and fixed.

### Bug 2 — dev-cube placeholder on first-login cinematic exit

- The intro `onPlayMovie` (`Cine-SGWLogo.SGWLogo`, method index 155) was emitted inside the `mapLoaded` entity-method bundle (`mercury/world_data/map_loaded.rs`, step 25). The cinematic-exit `CollectGarbage` reclaimed the player's appearance asset before the post-cinematic render frame, leaving the pawn rendering the default dev-cube mesh.
- **Fix part 1 (deferral):** moved `onPlayMovie` out of the bundle and into a new `send_cinematic` helper invoked from `handle_on_client_ready`. By the time the client signals `onClientReady` (msg id `0xD8`), `BeingAppearance` has bound to a live possessed pawn. Confirmed in-game: the player model is visible BEFORE the cinematic starts.
- **Fix part 2 (spam guard):** the GC race still fires at natural-end and Esc-end regardless of pre-cinematic binding. `send_cinematic` spawns a tokio task that resends `BeingAppearance` + `onEntityTint` every 100 ms for 20 s. The loop short-circuits on an `Arc<AtomicBool>` flag (`cinematic_spam_cancel`) that `handle_cancel_movie` flips on receipt of real client `cancelMovie`. Bandwidth cost: ~200 UDP packets natural-end, ~2 packets Esc-end.
- **Cinematic duration is knowable.** The 20 s constant was derived by parsing the BIK header out of `game/sgw/.../CookedPC/Packages/Cine-SGWLogo.upk` — 314 frames @ 23.976 fps = 13.10 s, plus a ~7 s GC + asset-rebind safety buffer. If we want per-cinematic spam windows later, a build-time tool can produce a `&'static [(&str, Duration)]` lookup table.
- **Future cinematics inherit the protection.** `send_cinematic` is the canonical entry point for any cutscene the server triggers (mission, gate, dialog) — no caller has to think about the GC race.
- **Smoking gun removed.** The previous 10-second-delayed `cancelMovie` hack in `handle_map_loaded` is gone. It was treating the symptom from the wrong location and only covered ~10 s — short of `Cine-SGWLogo`'s 13 s playback.

### Bug 1 — camera slide through floor on every login

- Client UE3 race: camera attaches to a freshly-spawned `ABigWorldEntity` pawn whose `AActor::Location` is still `(0,0,0)`. `ASGWCamera_Player::UpdateCamera`'s `VInterpTo` lerps from world origin to spawn position over ~1-2 s.
- **Server-side fix (spec-correctness only):** the `forcedPosition` `pPrevPos` slot (offsets 24-35 of the 49-byte payload) is now `spawn_pos` instead of zeros — matches `spec.protocol.mercury` §1.10.6 and the `ProcessForcedEntityPosition` reference at `0x00dd9ee0` in the 2009 binary.
- This does NOT eliminate the visible slide — that's a client-engine bug (`GameProxyPlayer_HandlePlayerPawnCreated` writes BigWorld-layer fields but never `AActor::Location`). Fully eliminating the slide requires either a binary patch or a UnrealScript patch. Tracked separately.

## Test plan

- [x] `cargo check -p cimmeria-services` — clean
- [x] `cargo test -p cimmeria-services --lib` — 705 passed, 0 failed
- [x] `cargo clippy -p cimmeria-services --all-targets -- -D warnings` — clean
- [x] `cargo fmt -p cimmeria-services -- --check` — clean
- [x] New regression test `build_map_loaded_omits_first_login_cinematic_from_bundle` — walks entity-method records AND byte-searches for the UTF-16LE cinematic name; reverting the deferral breaks both assertions.
- [x] In-game UAT (Windows, full client): player model visible pre-cinematic; cinematic plays to natural end without cube; spam window covers the GC race; cancelMovie cancels the remaining spam.
- [ ] Workspace-wide `cargo nextest run --profile=ci --workspace --exclude cimmeria-app --exclude cimmeria-content-editor --exclude cimmeria-scene-editor --exclude sgw-launcher` — CI will gate.
- [ ] Live-DB regression — CI will gate.

## Trade-offs explicitly chosen

- "No cube > efficient" — the spam is brute force (200 packets per first-login on natural-end). Bandwidth was traded for visual quality. The cancellation on `cancelMovie` recovers most of the wire cost when the user skips the intro.
- The camera-slide root cause is in the client. Original SGW ships with this slide; accepting it short-term matches 2009 behavior. Follow-up binary-patch track.

Fixes #288.

Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Character appearance now displays reliably during login cinematics and subsequent gameplay
* Prevented excessive appearance update spam that could occur after cinematics finish
* Enhanced player position tracking during teleportation to eliminate camera positioning issues
* Optimized character model and appearance asset loading to occur earlier in the world entry process

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SandboxServers/Cimmeria/pull/307?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->