### PR TITLE
fix(inventory): refresh appearance on equipment-slot moves (#240 Gap 1)

### DIFF
--- a/crates/services/src/base/world_entry/methods/inventory/move_/mod.rs
+++ b/crates/services/src/base/world_entry/methods/inventory/move_/mod.rs
@@ -8,7 +8,9 @@ use tokio::sync::mpsc;
 
 use super::super::super::super::resources::{bag_max_slots, bag_min_slot};
 use super::super::super::super::ConnectedClientState;
+use super::super::player_load::core::EQUIPMENT_CONTAINERS;
 use super::super::vendor::helpers::sync_bandolier_after_inventory_change;
+use super::appearance::refresh_player_appearance;
 use super::core::send_full_inventory_update;
 use super::grant::item_allows_container;
 use crate::cell::messages::BaseToCellMsg;
@@ -544,6 +546,29 @@ pub async fn handle_move_inventory_item(
             player_id,
             db_pool,
             cell_tx,
+            socket,
+            connected,
+            entity_to_addr,
+        )
+        .await;
+    }
+
+    // Equipment containers (4..=14) — armor and other slotted visuals.
+    // The grant path already refreshes appearance on equipment grants;
+    // the bandolier branch above handles weapons. Without this, manually
+    // dragging armor into (or out of) a slot persists to DB but the
+    // player-visible model on every client keeps the pre-move components.
+    // `item_allows_container` already rejects moves into a slot the item
+    // can't occupy, so a non-visual item can't sneak into an equipment
+    // container by this path; refresh is idempotent on the wire even
+    // when the visual set hasn't actually changed.
+    if EQUIPMENT_CONTAINERS.contains(&source.container_id)
+        || EQUIPMENT_CONTAINERS.contains(&target_container_id)
+    {
+        refresh_player_appearance(
+            entity_id,
+            player_id,
+            db_pool,
             socket,
             connected,
             entity_to_addr,

--- a/crates/services/src/base/world_entry/methods/inventory/move_/mod.rs
+++ b/crates/services/src/base/world_entry/methods/inventory/move_/mod.rs
@@ -555,25 +555,45 @@ pub async fn handle_move_inventory_item(
 
     // Equipment containers (4..=14) — armor and other slotted visuals.
     // The grant path already refreshes appearance on equipment grants;
-    // the bandolier branch above handles weapons. Without this, manually
-    // dragging armor into (or out of) a slot persists to DB but the
-    // player-visible model on every client keeps the pre-move components.
-    // `item_allows_container` already rejects moves into a slot the item
-    // can't occupy, so a non-visual item can't sneak into an equipment
-    // container by this path; refresh is idempotent on the wire even
-    // when the visual set hasn't actually changed.
+    // the bandolier branch above handles weapons. Without this branch,
+    // manually dragging armor into (or out of) a slot persists to DB but
+    // the player-visible model on every client keeps the pre-move
+    // components.
+    //
+    // Gated on `visual_component IS NOT NULL` to match the grant path's
+    // shape (grant\mod.rs:425) — non-visual items (charms, ID-only
+    // artifacts) can legally occupy equipment slots without contributing
+    // to the appearance composite, so refreshing for them is wasted
+    // wire traffic. Lookup is keyed by `source.type_id`, which is the
+    // type both the equip leg (bag→slot) and the unequip leg (slot→bag)
+    // are moving; for a swap, only the source item's visual matters
+    // (the displaced occupant's container also changes, but that case
+    // is already covered when the swap's source/target straddles
+    // equipment).
     if EQUIPMENT_CONTAINERS.contains(&source.container_id)
         || EQUIPMENT_CONTAINERS.contains(&target_container_id)
     {
-        refresh_player_appearance(
-            entity_id,
-            player_id,
-            db_pool,
-            socket,
-            connected,
-            entity_to_addr,
+        let has_visual: bool = sqlx::query_scalar(
+            "SELECT visual_component IS NOT NULL FROM resources.items WHERE item_id = $1",
         )
-        .await;
+        .bind(source.type_id)
+        .fetch_optional(pool.as_ref())
+        .await
+        .ok()
+        .flatten()
+        .unwrap_or(false);
+
+        if has_visual {
+            refresh_player_appearance(
+                entity_id,
+                player_id,
+                db_pool,
+                socket,
+                connected,
+                entity_to_addr,
+            )
+            .await;
+        }
     }
 }
 

--- a/crates/services/src/base/world_entry/methods/inventory/move_/tests.rs
+++ b/crates/services/src/base/world_entry/methods/inventory/move_/tests.rs
@@ -360,12 +360,19 @@ async fn source_item_not_found_makes_no_changes() {
 }
 
 /// Pick `count` distinct item_ids from resources.items whose
-/// container_sets includes `container_id`. Symmetric to
-/// [`pick_main_bag_type_ids`] but for a specific equipment slot.
+/// container_sets includes `container_id` AND have a non-null
+/// `visual_component`. Symmetric to [`pick_main_bag_type_ids`] but for
+/// a specific equipment slot. The visual filter matters because the
+/// production refresh gate requires it — picking a non-visual
+/// equipment item (e.g. helmet 2998, `visual_component IS NULL`) would
+/// make the equip/unequip tests silently no-op the assertion they're
+/// trying to guard.
 async fn pick_type_ids_for_container(pool: &PgPool, container_id: i32, count: usize) -> Vec<i32> {
     let ids: Vec<i32> = sqlx::query_scalar::<_, i32>(
         "SELECT item_id FROM resources.items \
-         WHERE container_sets IS NOT NULL AND $1 = ANY(container_sets) \
+         WHERE container_sets IS NOT NULL \
+           AND $1 = ANY(container_sets) \
+           AND visual_component IS NOT NULL \
          ORDER BY item_id LIMIT $2",
     )
     .bind(container_id)
@@ -376,7 +383,7 @@ async fn pick_type_ids_for_container(pool: &PgPool, container_id: i32, count: us
     assert_eq!(
         ids.len(),
         count,
-        "resources.items has fewer than {count} items allowed in container {container_id} — \
+        "resources.items has fewer than {count} visual items allowed in container {container_id} — \
          the bundled seed must be loaded before running live-DB tests",
     );
     ids
@@ -414,23 +421,24 @@ fn make_state_with_connected(
     (socket, entity_to_addr, connected, fake_addr)
 }
 
-/// Regression for #240 Gap 1: dragging armor from a bag slot into an
-/// equipment slot must trigger `refresh_player_appearance`, which the
-/// helper records by populating `cached_appearance_args` on the
-/// connected-client state. Without this branch in `move_/mod.rs`, the
-/// DB row updates but the player-visible model on every client keeps
-/// the pre-move components — the symptom that surfaced testing PR #239
-/// where weapons (which go through the bandolier branch) showed up but
-/// armor did not.
+/// Regression for the equip-visual gap: dragging armor from a bag slot
+/// into an equipment slot must trigger `refresh_player_appearance`,
+/// which the helper records by populating `cached_appearance_args` on
+/// the connected-client state. Without the equipment-container branch
+/// in the move handler, the DB row updates but the player-visible
+/// model on every client keeps the pre-move components — weapons
+/// (which go through the bandolier branch) showed up but armor did
+/// not.
 #[tokio::test]
 async fn move_into_equipment_slot_refreshes_appearance() {
     let pool = require_db_or_skip!();
-    let account_id = TEST_BASE + 500;
-    let player_id = TEST_BASE + 501;
+    let account_id = TEST_BASE + 900;
+    let player_id = TEST_BASE + 901;
     cleanup(&pool, account_id, player_id).await;
     insert_account_and_player(&pool, account_id, player_id).await;
 
-    // Container 4 = head slot. Pick a helmet (e.g. item_id 2998).
+    // Container 4 = head slot. Helper restricts to items with a
+    // non-null visual_component (matches the production refresh gate).
     let head_type = pick_type_ids_for_container(&pool, 4, 1).await[0];
     let helmet = insert_item(&pool, player_id, head_type, 1, 0, 1).await;
 
@@ -479,8 +487,8 @@ async fn move_into_equipment_slot_refreshes_appearance() {
 #[tokio::test]
 async fn move_out_of_equipment_slot_refreshes_appearance() {
     let pool = require_db_or_skip!();
-    let account_id = TEST_BASE + 600;
-    let player_id = TEST_BASE + 601;
+    let account_id = TEST_BASE + 1000;
+    let player_id = TEST_BASE + 1001;
     cleanup(&pool, account_id, player_id).await;
     insert_account_and_player(&pool, account_id, player_id).await;
 
@@ -517,8 +525,8 @@ async fn move_out_of_equipment_slot_refreshes_appearance() {
 #[tokio::test]
 async fn bag_to_bag_move_does_not_refresh_appearance() {
     let pool = require_db_or_skip!();
-    let account_id = TEST_BASE + 700;
-    let player_id = TEST_BASE + 701;
+    let account_id = TEST_BASE + 1100;
+    let player_id = TEST_BASE + 1101;
     cleanup(&pool, account_id, player_id).await;
     insert_account_and_player(&pool, account_id, player_id).await;
 

--- a/crates/services/src/base/world_entry/methods/inventory/move_/tests.rs
+++ b/crates/services/src/base/world_entry/methods/inventory/move_/tests.rs
@@ -358,3 +358,192 @@ async fn source_item_not_found_makes_no_changes() {
 
     cleanup(&pool, account_id, player_id).await;
 }
+
+/// Pick `count` distinct item_ids from resources.items whose
+/// container_sets includes `container_id`. Symmetric to
+/// [`pick_main_bag_type_ids`] but for a specific equipment slot.
+async fn pick_type_ids_for_container(pool: &PgPool, container_id: i32, count: usize) -> Vec<i32> {
+    let ids: Vec<i32> = sqlx::query_scalar::<_, i32>(
+        "SELECT item_id FROM resources.items \
+         WHERE container_sets IS NOT NULL AND $1 = ANY(container_sets) \
+         ORDER BY item_id LIMIT $2",
+    )
+    .bind(container_id)
+    .bind(count as i64)
+    .fetch_all(pool)
+    .await
+    .expect("pick item_ids by container");
+    assert_eq!(
+        ids.len(),
+        count,
+        "resources.items has fewer than {count} items allowed in container {container_id} — \
+         the bundled seed must be loaded before running live-DB tests",
+    );
+    ids
+}
+
+/// Variant of [`make_state`] that populates the connected-client map with
+/// a placeholder state so a `refresh_player_appearance` invocation can
+/// resolve the addr → state lookup and write `cached_appearance_args`.
+/// Returns the placeholder addr so the test can re-read state from `conn`.
+fn make_state_with_connected(
+    entity_id: u32,
+    account_id: u32,
+) -> (
+    Arc<UdpSocket>,
+    Arc<Mutex<HashMap<u32, SocketAddr>>>,
+    Arc<Mutex<HashMap<SocketAddr, ConnectedClientState>>>,
+    SocketAddr,
+) {
+    let std_sock = std::net::UdpSocket::bind("127.0.0.1:0").expect("bind UDP");
+    std_sock.set_nonblocking(true).unwrap();
+    let socket = Arc::new(UdpSocket::from_std(std_sock).expect("from_std"));
+    let fake_addr: SocketAddr = "127.0.0.1:65534".parse().unwrap();
+    let entity_to_addr = Arc::new(Mutex::new({
+        let mut m = HashMap::new();
+        m.insert(entity_id, fake_addr);
+        m
+    }));
+    let connected = Arc::new(Mutex::new({
+        let mut m = HashMap::new();
+        let mut s = crate::test_support::test_default_connected_client_state();
+        s.account_id = account_id;
+        m.insert(fake_addr, s);
+        m
+    }));
+    (socket, entity_to_addr, connected, fake_addr)
+}
+
+/// Regression for #240 Gap 1: dragging armor from a bag slot into an
+/// equipment slot must trigger `refresh_player_appearance`, which the
+/// helper records by populating `cached_appearance_args` on the
+/// connected-client state. Without this branch in `move_/mod.rs`, the
+/// DB row updates but the player-visible model on every client keeps
+/// the pre-move components — the symptom that surfaced testing PR #239
+/// where weapons (which go through the bandolier branch) showed up but
+/// armor did not.
+#[tokio::test]
+async fn move_into_equipment_slot_refreshes_appearance() {
+    let pool = require_db_or_skip!();
+    let account_id = TEST_BASE + 500;
+    let player_id = TEST_BASE + 501;
+    cleanup(&pool, account_id, player_id).await;
+    insert_account_and_player(&pool, account_id, player_id).await;
+
+    // Container 4 = head slot. Pick a helmet (e.g. item_id 2998).
+    let head_type = pick_type_ids_for_container(&pool, 4, 1).await[0];
+    let helmet = insert_item(&pool, player_id, head_type, 1, 0, 1).await;
+
+    let entity_id = 9_999_015;
+    let (socket, e2a, conn, addr) = make_state_with_connected(entity_id, account_id as u32);
+    let db_pool = Some(Arc::new(pool.clone()));
+
+    // Sanity: cache starts empty so the post-move assertion is meaningful.
+    assert!(
+        conn.lock()
+            .unwrap()
+            .get(&addr)
+            .unwrap()
+            .cached_appearance_args
+            .is_none(),
+        "test setup invariant: cache must start empty"
+    );
+
+    handle_move_inventory_item(
+        entity_id, player_id, helmet, 4, 0, 1, &db_pool, &None, &socket, &conn, &e2a,
+    )
+    .await;
+
+    assert_eq!(
+        slot_of(&pool, player_id, helmet).await,
+        Some((4, 0, 1)),
+        "helmet must persist to container 4 slot 0"
+    );
+    assert!(
+        conn.lock()
+            .unwrap()
+            .get(&addr)
+            .unwrap()
+            .cached_appearance_args
+            .is_some(),
+        "move into equipment container must invoke refresh_player_appearance \
+         (cached_appearance_args populated as the observable side effect)"
+    );
+
+    cleanup(&pool, account_id, player_id).await;
+}
+
+/// Reverse direction: unequip from an equipment slot back to a bag slot
+/// must also refresh appearance. The witness model otherwise keeps
+/// rendering the previously-equipped piece until the player relogs.
+#[tokio::test]
+async fn move_out_of_equipment_slot_refreshes_appearance() {
+    let pool = require_db_or_skip!();
+    let account_id = TEST_BASE + 600;
+    let player_id = TEST_BASE + 601;
+    cleanup(&pool, account_id, player_id).await;
+    insert_account_and_player(&pool, account_id, player_id).await;
+
+    let head_type = pick_type_ids_for_container(&pool, 4, 1).await[0];
+    // Start equipped: helmet already in the head slot.
+    let helmet = insert_item(&pool, player_id, head_type, 4, 0, 1).await;
+
+    let entity_id = 9_999_016;
+    let (socket, e2a, conn, addr) = make_state_with_connected(entity_id, account_id as u32);
+    let db_pool = Some(Arc::new(pool.clone()));
+
+    handle_move_inventory_item(
+        entity_id, player_id, helmet, 1, 5, 1, &db_pool, &None, &socket, &conn, &e2a,
+    )
+    .await;
+
+    assert_eq!(slot_of(&pool, player_id, helmet).await, Some((1, 5, 1)));
+    assert!(
+        conn.lock()
+            .unwrap()
+            .get(&addr)
+            .unwrap()
+            .cached_appearance_args
+            .is_some(),
+        "unequip (equipment slot → bag) must also refresh appearance",
+    );
+
+    cleanup(&pool, account_id, player_id).await;
+}
+
+/// Negative control: a plain bag-to-bag move with no equipment slot
+/// involved must NOT trigger the appearance refresh. Otherwise every
+/// inventory reshuffle would generate witness traffic.
+#[tokio::test]
+async fn bag_to_bag_move_does_not_refresh_appearance() {
+    let pool = require_db_or_skip!();
+    let account_id = TEST_BASE + 700;
+    let player_id = TEST_BASE + 701;
+    cleanup(&pool, account_id, player_id).await;
+    insert_account_and_player(&pool, account_id, player_id).await;
+
+    let types = pick_main_bag_type_ids(&pool, 1).await;
+    let item = insert_item(&pool, player_id, types[0], 1, 0, 1).await;
+
+    let entity_id = 9_999_017;
+    let (socket, e2a, conn, addr) = make_state_with_connected(entity_id, account_id as u32);
+    let db_pool = Some(Arc::new(pool.clone()));
+
+    handle_move_inventory_item(
+        entity_id, player_id, item, 1, 10, 1, &db_pool, &None, &socket, &conn, &e2a,
+    )
+    .await;
+
+    assert_eq!(slot_of(&pool, player_id, item).await, Some((1, 10, 1)));
+    assert!(
+        conn.lock()
+            .unwrap()
+            .get(&addr)
+            .unwrap()
+            .cached_appearance_args
+            .is_none(),
+        "bag-to-bag moves must not invoke refresh_player_appearance",
+    );
+
+    cleanup(&pool, account_id, player_id).await;
+}


### PR DESCRIPTION
## Summary

Fixes [#240](https://github.com/SandboxServers/Cimmeria/issues/240) **Gap 1 only** — manually equipping armor (head/chest/hands/legs/feet) now triggers a `BeingAppearance` rebroadcast to the player + AoI witnesses.

Before: dragging armor into an equipment container persisted to DB but the player-visible model on every client kept the pre-move components. Weapons worked because the move path explicitly calls `sync_bandolier_after_inventory_change` → `refresh_player_appearance` whenever source or target is container 3 (bandolier); armor (containers 4–14) had no equivalent branch.

After: a sibling check on `EQUIPMENT_CONTAINERS` (exported from `player_load/core.rs:11`) runs `refresh_player_appearance` directly. The helper already populates `cached_appearance_args` so subsequent AoI re-broadcasts and `world_entry` replays ship the new appearance — same plumbing the bandolier and grant paths use.

## Out of scope (deferred to follow-up issues)

- **Gap 2** (right-click-to-equip with swap) — the V5 finding on this issue surfaced an unresolved policy contradiction between the original issue body ("displaced item to source bag slot") and W-inventory-state's recommendation ("displaced item to INV_MAIN for equipment↔equipment swaps"). Needs design discussion before implementation.
- **Gap 3** (armor stat audit) — separate server-side architecture question. Not waiting on more RE.

## Test plan

- [x] `cargo nextest run -p cimmeria-services -E 'package(cimmeria-services) & test(/.*inventory.*/)' ` — 52 passed, 0 failed
- [x] New live-DB regression guards (require `DATABASE_URL`):
  - `move_into_equipment_slot_refreshes_appearance` — equip path (bag → head slot)
  - `move_out_of_equipment_slot_refreshes_appearance` — unequip path (head slot → bag)
  - `bag_to_bag_move_does_not_refresh_appearance` — negative control, keeps the gate narrow
- [ ] In-game: confirm dragging armor between bag and equipment slot updates the visible model for both the source player and an AoI witness.

## Related

- Unblocks #249 Part 2 (the holster animation) — once any weapon-equip-state change triggers `refresh_player_appearance`, the holster animation rides the same plumbing.
- Same witness-fanout pattern as #219 / #232 / #249 (`refresh_player_appearance` already calls `send_to_witness_reliable`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Player appearance now correctly refreshes when equipping or unequipping items in equipment slots
  * Appearance updates are optimized and no longer triggered when moving items between regular inventory slots

* **Tests**
  * Added regression tests to verify appearance refresh behavior for equipment slot changes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SandboxServers/Cimmeria/pull/327?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->