### PR TITLE
fix(combat): funnel BSF_InCombat writes through threatened_mobs (#219)

### DIFF
--- a/crates/services/src/cell/abilities/damage_apply/tests.rs
+++ b/crates/services/src/cell/abilities/damage_apply/tests.rs
@@ -261,14 +261,21 @@ async fn lethal_hit_drains_threatened_mobs_and_clears_bsf_in_combat() {
 /// outcome.
 #[tokio::test]
 async fn one_shot_kill_does_not_strand_attacker_bsf_in_combat() {
+    use crate::cell::abilities::handle_use_ability;
     use crate::cell::combat::state::BSF_IN_COMBAT;
 
     let mut mgr = make_mgr_player_vs_npc();
     let ability = make_ability(7, vec![100]);
-    mgr.ability_defs.insert(7, ability.clone());
+    mgr.ability_defs.insert(7, ability);
     // Overkill damage on a 1-HP NPC — guarantees target_died = true
     // and `generate_threat` is skipped entirely on this hit.
     mgr.effect_defs.insert(100, make_effect(100, 9999));
+    if let Some(player) = mgr.get_entity_mut(1) {
+        // `handle_use_ability` validates the attacker owns the ability
+        // before the damage path runs; the previous `apply_damage_to_target`
+        // shortcut bypassed this check.
+        player.abilities.add_ability(7);
+    }
     if let Some(npc) = mgr.get_entity_mut(2) {
         npc.level = 5;
         if let Some(stat) = npc.stats.get_mut(cimmeria_entity::stats::HEALTH) {
@@ -280,7 +287,14 @@ async fn one_shot_kill_does_not_strand_attacker_bsf_in_combat() {
     assert_eq!(mgr.get_entity(1).unwrap().state_field & BSF_IN_COMBAT, 0);
 
     let (tx, _rx) = mpsc::channel(64);
-    apply_damage_to_target(1, 2, 7, &Some(ability), 1, false, &tx, &mut mgr).await;
+    // Drive the full public entry point — the previous regression
+    // path was a raw `state_field |= BSF_IN_COMBAT` inside
+    // `handle_use_ability` *before* `apply_damage_to_target`
+    // decided to skip `generate_threat` on `target_died=true`.
+    // Bypassing into `apply_damage_to_target` directly would have
+    // hidden the regression. Use the public entrypoint instead.
+    let committed = handle_use_ability(1, 7, 2, &tx, &mut mgr).await;
+    assert!(committed, "use_ability should commit on a valid one-shot");
 
     let attacker = mgr.get_entity(1).unwrap();
     assert_eq!(

--- a/crates/services/src/cell/abilities/damage_apply/tests.rs
+++ b/crates/services/src/cell/abilities/damage_apply/tests.rs
@@ -246,6 +246,58 @@ async fn lethal_hit_drains_threatened_mobs_and_clears_bsf_in_combat() {
     );
 }
 
+/// One-shot kill regression guard: a single lethal hit against an NPC
+/// must NOT leave the attacker stranded with BSF_InCombat set. The
+/// previous bug: `use_ability` set the bit raw before damage_apply
+/// ran, but `generate_threat` (which is what calls
+/// `enter_player_combat` to populate `threatened_mobs` and broadcast
+/// the bit) is gated on `!target_died` (mod.rs:413). So a one-shot
+/// kill set the bit and never cleared it — the corpse's `threat_list`
+/// stayed empty, `clear_dead_npc_from_all_player_threat` found
+/// nothing to drain, and the bit stuck forever.
+///
+/// After the funnel fix, use_ability doesn't set the bit raw; the
+/// kill path never sets the bit; the assertion below pins that
+/// outcome.
+#[tokio::test]
+async fn one_shot_kill_does_not_strand_attacker_bsf_in_combat() {
+    use crate::cell::combat::state::BSF_IN_COMBAT;
+
+    let mut mgr = make_mgr_player_vs_npc();
+    let ability = make_ability(7, vec![100]);
+    mgr.ability_defs.insert(7, ability.clone());
+    // Overkill damage on a 1-HP NPC — guarantees target_died = true
+    // and `generate_threat` is skipped entirely on this hit.
+    mgr.effect_defs.insert(100, make_effect(100, 9999));
+    if let Some(npc) = mgr.get_entity_mut(2) {
+        npc.level = 5;
+        if let Some(stat) = npc.stats.get_mut(cimmeria_entity::stats::HEALTH) {
+            stat.update(0, 1, 100);
+            stat.clear_dirty();
+        }
+    }
+    // Pre-condition: attacker is NOT in combat (fresh).
+    assert_eq!(mgr.get_entity(1).unwrap().state_field & BSF_IN_COMBAT, 0);
+
+    let (tx, _rx) = mpsc::channel(64);
+    apply_damage_to_target(1, 2, 7, &Some(ability), 1, false, &tx, &mut mgr).await;
+
+    let attacker = mgr.get_entity(1).unwrap();
+    assert_eq!(
+        attacker.state_field & BSF_IN_COMBAT,
+        0,
+        "one-shot kill must not strand BSF_InCombat on the attacker — \
+         the previous raw setter in use_ability set the bit before \
+         generate_threat decided to skip on target_died=true, and no \
+         clear path ever ran"
+    );
+    assert!(
+        attacker.threatened_mobs.is_empty(),
+        "one-shot kill must leave threatened_mobs empty — the gate the \
+         out-of-combat regen tick reads"
+    );
+}
+
 /// Player target dying: onBeginAidWait must fire so the client shows
 /// the Defeat Window. Carries a TimeToAid prefix and a respawner array.
 #[tokio::test]

--- a/crates/services/src/cell/abilities/use_ability.rs
+++ b/crates/services/src/cell/abilities/use_ability.rs
@@ -241,7 +241,7 @@ pub async fn handle_use_ability(
                 let new_state = e.state_field;
                 send_entity_method(
                     entity_id,
-                    19,
+                    crate::mercury::method_idx::ON_STATE_FIELD_UPDATE,
                     new_state.to_le_bytes().to_vec(),
                     tx,
                     space_mgr,

--- a/crates/services/src/cell/abilities/use_ability.rs
+++ b/crates/services/src/cell/abilities/use_ability.rs
@@ -219,20 +219,24 @@ pub async fn handle_use_ability(
 
     send_entity_method(entity_id, 12, timer_args, tx, space_mgr).await;
 
-    // ── Set combat state on the attacker ──
-    // BSF_InCombat (bit 3): The client's SeqEvent_CombatStateChanged fires when
-    // this changes, transitioning the animation state machine.
-    // BSF_Holster (bit 8): When set, weapon is holstered. Must be CLEARED for
-    // combat — USGWAnim_BlendByWeapon uses active weapon to select animations.
-    // Reference: SGWBeing.py:751-754, SGWMob.py:162
+    // ── Clear holster on weapon-fire ──
+    // BSF_Holster (bit 8): When set, weapon is holstered. Must be CLEARED on
+    // fire — USGWAnim_BlendByWeapon uses active weapon to select animations.
+    // Reference: SGWBeing.py:751-754, SGWMob.py:162.
+    //
+    // BSF_InCombat (bit 3) is intentionally NOT set here. The bit is now
+    // derived from `threatened_mobs` and flips on via
+    // `combat::generate_threat` → `enter_player_combat` when this attack
+    // actually generates threat on a surviving NPC target (handled in
+    // `damage_apply::apply_damage_to_target`). Setting it raw here used to
+    // strand it for one-shot kills (target dies before generate_threat
+    // runs) and target-less casts (early-return before damage_apply).
     {
-        const BSF_IN_COMBAT: u32 = 1 << 3;
         const BSF_HOLSTER: u32 = 1 << 8;
         let entity = space_mgr.get_entity_mut(entity_id);
         if let Some(e) = entity {
             let old_state = e.state_field;
-            e.state_field |= BSF_IN_COMBAT; // Enter combat
-            e.state_field &= !BSF_HOLSTER; // Unholster weapon
+            e.state_field &= !BSF_HOLSTER;
             if e.state_field != old_state {
                 let new_state = e.state_field;
                 send_entity_method(
@@ -546,12 +550,21 @@ mod tests {
         );
     }
 
-    /// On commit, BSF_InCombat (bit 3) is set and BSF_Holster (bit 8) is
-    /// cleared on the attacker. Pin both transitions because the client's
-    /// USGWAnim_BlendByWeapon path depends on the holster bit being clear
+    /// On commit, BSF_Holster (bit 8) is cleared on the attacker — the
+    /// client's USGWAnim_BlendByWeapon path needs the holster bit clear
     /// for the combat animation to render.
+    ///
+    /// BSF_InCombat (bit 3) is intentionally NOT set by this path. The
+    /// bit is derived from `threatened_mobs` and flips on via
+    /// `combat::generate_threat` → `enter_player_combat` from
+    /// `damage_apply::apply_damage_to_target` when this attack actually
+    /// hits a surviving NPC. A self-cast (target_id == 0) commits
+    /// cooldown + ammo but produces no threat, so the bit stays
+    /// unchanged — pinned here so a regression that re-introduces a raw
+    /// `state_field |= BSF_IN_COMBAT` setter on this path doesn't slip
+    /// through (stuck-bit hazard for target-less casts).
     #[tokio::test]
-    async fn commit_sets_bsf_in_combat_and_clears_bsf_holster() {
+    async fn commit_clears_bsf_holster_and_leaves_bsf_in_combat_alone() {
         let mut mgr = make_mgr();
         make_player(&mut mgr, 1, [0.0; 3]);
         if let Some(p) = mgr.get_entity_mut(1) {
@@ -565,8 +578,47 @@ mod tests {
         assert!(committed);
 
         let s = mgr.get_entity(1).unwrap().state_field;
-        assert_eq!(s & (1 << 3), 1 << 3, "BSF_InCombat must be set");
         assert_eq!(s & (1 << 8), 0, "BSF_Holster must be cleared");
+        assert_eq!(
+            s & (1 << 3),
+            0,
+            "BSF_InCombat must NOT be set by use_ability — \
+             it's now derived from threatened_mobs via enter_player_combat"
+        );
+    }
+
+    /// Target-less / no-target cast (target_id == 0) must not set
+    /// BSF_InCombat on the attacker. Stuck-bit regression guard: the
+    /// previous raw `state_field |= BSF_IN_COMBAT` here ran before the
+    /// `if target_id <= 0` early-return downstream, so a self-cast
+    /// would flip the in-combat HUD forever (no NPC death ever runs
+    /// the clear path).
+    #[tokio::test]
+    async fn no_target_cast_does_not_set_bsf_in_combat() {
+        let mut mgr = make_mgr();
+        make_player(&mut mgr, 1, [0.0; 3]);
+        if let Some(p) = mgr.get_entity_mut(1) {
+            p.abilities.add_ability(7);
+        }
+        mgr.ability_defs.insert(7, make_ability(7, 0, 30));
+        let (tx, _rx) = mpsc::channel(64);
+
+        let committed = handle_use_ability(1, 7, 0, &tx, &mut mgr).await;
+        assert!(committed, "self-cast still commits (cooldown + ammo)");
+
+        let s = mgr.get_entity(1).unwrap().state_field;
+        assert_eq!(
+            s & (1 << 3),
+            0,
+            "no-target cast must not strand BSF_InCombat — no NPC death \
+             would ever run the clear path"
+        );
+        // threatened_mobs must also stay empty so the regen tick (which
+        // gates on the set) is free to fire.
+        assert!(
+            mgr.get_entity(1).unwrap().threatened_mobs.is_empty(),
+            "no-target cast must leave threatened_mobs empty"
+        );
     }
 
     /// Self-target (target_id == 0) commits cooldown and ammo consume but

--- a/crates/services/src/cell/cell_methods/player/world.rs
+++ b/crates/services/src/cell/cell_methods/player/world.rs
@@ -222,11 +222,16 @@ async fn handle_reload(
         })
         .await;
 
+    // Clear holster on reload — the reload animation needs the weapon-up
+    // posture. BSF_InCombat is intentionally NOT touched here: a reload
+    // in isolation (no aggro) must not flip the in-combat HUD/cursor.
+    // The bit is derived from `threatened_mobs` and only flips on via
+    // `combat::generate_threat` → `enter_player_combat` when the player
+    // actually generates threat on a surviving NPC.
     {
-        use crate::cell::combat::{BSF_HOLSTER, BSF_IN_COMBAT};
+        use crate::cell::combat::BSF_HOLSTER;
         if let Some(e) = space_mgr.get_entity_mut(entity_id) {
             let old = e.state_field;
-            e.state_field |= BSF_IN_COMBAT;
             e.state_field &= !BSF_HOLSTER;
             if e.state_field != old {
                 let new_state = e.state_field;
@@ -639,6 +644,81 @@ mod tests {
             "reload-start must send exactly one onSequence with the Ability_Begin \
              sequence id; without it the client plays no visible reload animation. \
              Got {begin_count}.",
+        );
+    }
+
+    /// Reload-in-isolation regression: reloading without any aggro must
+    /// NOT flip BSF_InCombat on the player. The previous bug: the
+    /// reload handler set the bit raw, but reload doesn't generate
+    /// threat on anything — so no NPC death would ever clear the bit,
+    /// stranding the player in the in-combat HUD/cursor forever (and
+    /// blocking the out-of-combat regen tick, which gates on
+    /// `threatened_mobs.is_empty()`).
+    ///
+    /// BSF_Holster (bit 8) IS still cleared on reload — the reload
+    /// animation needs the weapon-up posture. Pin both ends here so a
+    /// refactor that re-introduces the BSF_InCombat setter (or
+    /// accidentally drops the BSF_Holster clear) gets caught.
+    #[tokio::test]
+    async fn reload_in_isolation_clears_holster_without_setting_bsf_in_combat() {
+        use crate::cell::combat::{BSF_HOLSTER, BSF_IN_COMBAT};
+
+        let mut mgr = make_mgr_with_player();
+        if let Some(e) = mgr.get_entity_mut(1) {
+            e.bandolier_items.insert(
+                0,
+                BandolierItem {
+                    item_id: 1,
+                    clip_size: 30,
+                    default_ammo_type: 2,
+                    current_ammo: 0,
+                    cur_ammo_type: 2,
+                },
+            );
+            e.active_bandolier_slot = 0;
+            e.state_field |= BSF_HOLSTER; // start holstered so the clear is observable
+        }
+        // Seed the reload AbilityDef so the warmup path runs.
+        mgr.ability_defs.insert(
+            596,
+            AbilityDef {
+                ability_id: 596,
+                name: "reload".to_string(),
+                cooldown: 1.0,
+                warmup: 0.5,
+                flags: 0,
+                is_ranged: false,
+                min_range: 0,
+                max_range: 0,
+                target_type_id: 0,
+                effect_ids: vec![],
+                moniker_ids: vec![],
+                required_ammo: 0,
+                event_set_id: None,
+                velocity: 0.0,
+            },
+        );
+
+        let (tx, _rx) = mpsc::channel(64);
+        handle_reload(1, &tx, &mut mgr).await;
+
+        let s = mgr.get_entity(1).unwrap().state_field;
+        assert_eq!(
+            s & BSF_HOLSTER,
+            0,
+            "reload must still clear BSF_Holster — the reload animation needs \
+             the weapon-up posture"
+        );
+        assert_eq!(
+            s & BSF_IN_COMBAT,
+            0,
+            "reload MUST NOT flip BSF_InCombat — reload-without-aggro had no \
+             NPC-death clear path and the bit would strand forever"
+        );
+        assert!(
+            mgr.get_entity(1).unwrap().threatened_mobs.is_empty(),
+            "reload must leave threatened_mobs empty — the source of truth \
+             for the in-combat state"
         );
     }
 }


### PR DESCRIPTION
## Summary

Fixes [#219](https://github.com/SandboxServers/Cimmeria/issues/219). Removes the two raw `state_field |= BSF_IN_COMBAT` writes that bypassed `threatened_mobs` (the source of truth that drives the only clear path). The bit is now derived from `threatened_mobs` and flips on only via `combat::generate_threat` → `enter_player_combat` when a player attack actually generates threat on a surviving NPC — the canonical path in [`damage_apply/mod.rs:413`](https://github.com/SandboxServers/Cimmeria/blob/main/crates/services/src/cell/abilities/damage_apply/mod.rs#L413).

## What changed

| File | Before | After |
|---|---|---|
| `use_ability.rs:234` | `state_field \|= BSF_IN_COMBAT` (raw) on every attack | removed |
| `world.rs:229` | `state_field \|= BSF_IN_COMBAT` (raw) on every reload | removed |
| both sites | combined holster-clear + in-combat-set block | holster-only clear block |

The inline `state_field &= !BSF_HOLSTER` at both sites is preserved — animation-state coupling to weapon-up posture, not aggro (per #219's explicit caveat and what #249 will continue to depend on).

## Behavior changes (intentional)

- **Reload no longer flips the in-combat HUD/cursor.** A reload in isolation never put you in real combat; the previous behavior stranded the bit because no NPC death would ever clear it.
- **One-shotting an NPC no longer briefly puts you in combat.** Matches typical MMO behavior. If a combat-tag duration is wanted, it belongs in a separate timer that doesn't depend on `threatened_mobs`.

## Out of scope (deferred)

The V5 RE finding on this issue and the parent **#232** identify a separate witness-fanout bug at [`cell/abilities/messaging.rs::send_entity_method:27`](https://github.com/SandboxServers/Cimmeria/blob/main/crates/services/src/cell/abilities/messaging.rs#L27): for `is_player == true`, it only sends `EntityMethodCall` to the player's own client. So even after this funnel fix, other players in the same space still don't see the `BSF_IN_COMBAT` flip. That's a broadcast-architecture change with its own scope — tracked in #232.

## Tests

- Updated `commit_sets_bsf_in_combat_and_clears_bsf_holster` → `commit_clears_bsf_holster_and_leaves_bsf_in_combat_alone`. The holster pin stays load-bearing for #249 and the animation system; the in-combat pin flips to "must NOT be set."
- Added three regression guards covering the three stranded-bit scenarios from the issue:
  - `one_shot_kill_does_not_strand_attacker_bsf_in_combat` (damage_apply)
  - `no_target_cast_does_not_set_bsf_in_combat` (use_ability)
  - `reload_in_isolation_clears_holster_without_setting_bsf_in_combat` (world.rs)
- The existing `regen_tick_runs_when_bsf_in_combat_is_stuck` defensive guard still passes — its raw-set fixture remains a valid simulation of future regressions.

## Test plan

- [x] `cargo nextest run -p cimmeria-services -E 'package(cimmeria-services) & (test(/.*combat.*/) | test(/.*abilit.*/) | test(/.*threat.*/) | test(/.*regen.*/))'` — **129 passed, 0 failed**
- [ ] In-game: one-shot kill an enemy, confirm HUD/cursor drop out of combat immediately. Reload mid-explore, confirm HUD/cursor stay out of combat. Multi-mob fight (kill one of two), confirm HUD stays in combat (other aggro still active).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed combat-state handling so players are not incorrectly left marked "in combat" after reloading, casting without a target, or performing a one-shot kill; holster/posture updates no longer force the in-combat flag.

* **Tests**
  * Added regression tests validating commit behavior and that in-combat state and threat lists remain correct in these edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SandboxServers/Cimmeria/pull/328?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->