### PR TITLE
feat(cell/messaging): witness-fanout helpers for entity-method dispatch (#278)

### DIFF
--- a/crates/services/src/cell/abilities/messaging.rs
+++ b/crates/services/src/cell/abilities/messaging.rs
@@ -314,14 +314,8 @@ mod tests {
         let (mgr, _rx) = make_mgr_two_players_and_npc();
         let (tx, mut rx) = mpsc::channel(64);
 
-        let witness_count = send_entity_method_to_self_and_witnesses(
-            1,
-            19,
-            vec![0xBE, 0xEF],
-            &tx,
-            &mgr,
-        )
-        .await;
+        let witness_count =
+            send_entity_method_to_self_and_witnesses(1, 19, vec![0xBE, 0xEF], &tx, &mgr).await;
         assert_eq!(witness_count, 1);
 
         let msgs = drain(&mut rx);
@@ -346,14 +340,8 @@ mod tests {
         let (tx, mut rx) = mpsc::channel(64);
 
         // Entity 3 is the NPC; both players witness it.
-        let witness_count = send_entity_method_to_self_and_witnesses(
-            3,
-            19,
-            vec![],
-            &tx,
-            &mgr,
-        )
-        .await;
+        let witness_count =
+            send_entity_method_to_self_and_witnesses(3, 19, vec![], &tx, &mgr).await;
         // Both players are co-located and see the NPC.
         assert_eq!(witness_count, 2);
 

--- a/crates/services/src/cell/abilities/messaging.rs
+++ b/crates/services/src/cell/abilities/messaging.rs
@@ -1,10 +1,24 @@
-//! Entity-method routing helpers for the abilities flow.
+//! Entity-method routing helpers for the cell-side wire dispatch.
 //!
-//! Keeps the wire-routing decision (player → direct EntityMethodCall, NPC →
-//! fan-out to witnesses) in one place so every callsite in `use_ability` and
-//! `dispatch` ends up with identical behavior. Also hosts the dirty-stat
-//! flush helper that pushes a queued `onStatUpdate` to the attacker's client
-//! after an ammo decrement.
+//! Three routing modes live here:
+//!
+//! - [`send_entity_method`] — entity-aware default. Player → self only; NPC →
+//!   witnesses only. Used by paths where the state change is meaningful to
+//!   one audience (the owner OR the observers, not both).
+//! - [`send_entity_method_to_witnesses`] — strict witness-only fanout. Never
+//!   sends to the entity's own client even if it's a player. Use when the
+//!   event is for observers regardless of who owns the entity (e.g., a
+//!   corpse-loot indicator, an NPC cleanup signal).
+//! - [`send_entity_method_to_self_and_witnesses`] — owner + witnesses. Use for
+//!   player state changes that must propagate to other players in AoI — the
+//!   five cases in [#278](https://github.com/SandboxServers/Cimmeria/issues/278):
+//!   `BSF_IN_COMBAT` flip, death/respawn state-field, `BSF_HOLSTER` posture,
+//!   `BeingAppearance` equip recomposite, `setMovementType`. For NPC entities
+//!   the "self" send is degenerate (NPCs have no client) and this collapses
+//!   to the witnesses-only path.
+//!
+//! Also hosts the dirty-stat flush helper that pushes a queued `onStatUpdate`
+//! to the attacker's client after an ammo decrement.
 
 use tokio::sync::mpsc;
 
@@ -17,6 +31,11 @@ use super::super::space_manager::SpaceManager;
 /// In BigWorld, method calls on ghost entities are forwarded to all players who
 /// have that entity in their AoI. This is how players see NPC attack animations,
 /// health changes, death states, etc.
+///
+/// This is the **entity-aware default**. If you need a player's state change
+/// to also reach other players in AoI, use
+/// [`send_entity_method_to_self_and_witnesses`] instead — this function alone
+/// does not fan out for players.
 pub(crate) async fn send_entity_method(
     entity_id: u32,
     method_index: u16,
@@ -62,6 +81,102 @@ pub(crate) async fn send_entity_method(
     }
 }
 
+/// Fan out an entity-method call to all AoI witnesses of `entity_id`.
+///
+/// Strict witness-only: never sends to `entity_id`'s own client even if it's
+/// a player. Returns the witness count actually addressed so callers can
+/// `tracing::debug!` the fanout shape without re-querying the space manager.
+///
+/// An empty result (no AoI witnesses) is a debug-level signal, not a warning —
+/// many state changes legitimately have no observers (player alone in a space,
+/// NPC outside any player's AoI, etc.). Use [`send_entity_method`] if you want
+/// the "NPC with no witnesses" warning — that signal indicates a routing bug
+/// for ghost entities, which doesn't apply when the caller has explicitly
+/// asked for witness-only fanout.
+//
+// Allowed until #278's first child PR (#232, #249, #270, …) adopts this
+// helper at a callsite. Tests in this file exercise it directly.
+#[allow(dead_code)]
+pub(crate) async fn send_entity_method_to_witnesses(
+    entity_id: u32,
+    method_index: u16,
+    args: Vec<u8>,
+    tx: &mpsc::Sender<CellToBaseMsg>,
+    space_mgr: &SpaceManager,
+) -> usize {
+    let witnesses = space_mgr.get_witnesses_of(entity_id);
+    let count = witnesses.len();
+    if count == 0 {
+        tracing::debug!(
+            entity_id,
+            method_index,
+            "send_entity_method_to_witnesses: no witnesses; nothing emitted"
+        );
+        return 0;
+    }
+    for witness_id in witnesses {
+        let _ = tx
+            .send(CellToBaseMsg::WitnessEntityMethod {
+                witness_id,
+                entity_id,
+                method_index,
+                args: args.clone(),
+            })
+            .await;
+    }
+    tracing::debug!(
+        entity_id,
+        method_index,
+        witness_count = count,
+        "send_entity_method_to_witnesses: fanned out"
+    );
+    count
+}
+
+/// Emit an entity-method call to `entity_id`'s own client AND fan out to all
+/// AoI witnesses.
+///
+/// This is the helper [#278](https://github.com/SandboxServers/Cimmeria/issues/278)
+/// names — use it for player state changes that must also propagate to other
+/// players who can see them (BSF_IN_COMBAT, death/respawn flips, holster pose,
+/// equip BeingAppearance, movement-type transitions).
+///
+/// For an NPC entity (`is_player == false`), the "self" path degenerates —
+/// NPCs don't have a client — and this collapses to a witness-only fanout,
+/// equivalent to [`send_entity_method_to_witnesses`]. That keeps the helper
+/// callable from paths that don't statically know whether the entity is a
+/// player without forcing a branch at every callsite.
+///
+/// Returns the witness count actually addressed (excludes the self send).
+//
+// Allowed until #278's first child PR (#232, #249, #270, …) adopts this
+// helper at a callsite. Tests in this file exercise it directly.
+#[allow(dead_code)]
+pub(crate) async fn send_entity_method_to_self_and_witnesses(
+    entity_id: u32,
+    method_index: u16,
+    args: Vec<u8>,
+    tx: &mpsc::Sender<CellToBaseMsg>,
+    space_mgr: &SpaceManager,
+) -> usize {
+    let is_player = space_mgr.get_entity(entity_id).is_some_and(|e| e.is_player);
+
+    if is_player {
+        let _ = tx
+            .send(CellToBaseMsg::EntityMethodCall {
+                entity_id,
+                method_index,
+                args: args.clone(),
+            })
+            .await;
+    }
+    // For NPCs the self send is a no-op; the witness fanout below is the only
+    // path that does anything. For players the fanout sits on top of the self
+    // send above. Either way the witnesses-only helper handles the empty case
+    // (no warning, debug-only) so an alone-in-space player doesn't log noise.
+    send_entity_method_to_witnesses(entity_id, method_index, args, tx, space_mgr).await
+}
+
 /// Drain the attacker's dirty stats and push `onStatUpdate` (method 20) to its
 /// client. Used by `handle_use_ability` after a successful ammo consume — and
 /// crucially before any early-return that follows the consume — so the client
@@ -81,5 +196,200 @@ pub(super) async fn flush_attacker_ammo_stat(
     };
     if !payload.is_empty() {
         send_entity_method(entity_id, 20, payload, tx, space_mgr).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cell::messages::CellToBaseMsg;
+    use crate::cell::space_manager::SpaceManager;
+
+    /// Two players + one NPC in the same Castle space. Both players are
+    /// connected and AoI is computed, so each player sees the others +
+    /// the NPC. Returns the manager + an mpsc rx for asserting on emitted
+    /// `CellToBaseMsg` traffic.
+    fn make_mgr_two_players_and_npc() -> (SpaceManager, mpsc::Receiver<CellToBaseMsg>) {
+        let mut mgr = SpaceManager::new(1);
+        let xml = r#"<?xml version="1.0"?><Spaces><Space WorldName="Castle" Instanced="false" MinX="-800" MaxX="800" MinY="-800" MaxY="800" /></Spaces>"#;
+        mgr.parse_spaces_xml(xml).unwrap();
+        mgr.create_startup_spaces(
+            r#"<?xml version="1.0"?><Spaces><Space WorldName="Castle" /></Spaces>"#,
+        )
+        .unwrap();
+        // Two players + one NPC, all co-located so AoI naturally captures all.
+        mgr.create_entity(1, "Castle", [0.0; 3], [0.0; 3]).unwrap();
+        mgr.create_entity(2, "Castle", [0.0; 3], [0.0; 3]).unwrap();
+        mgr.create_entity(3, "Castle", [0.0; 3], [0.0; 3]).unwrap();
+        if let Some(p) = mgr.get_entity_mut(1) {
+            p.is_player = true;
+            p.player_id = Some(100);
+        }
+        if let Some(p) = mgr.get_entity_mut(2) {
+            p.is_player = true;
+            p.player_id = Some(200);
+        }
+        // entity 3 stays an NPC.
+        mgr.connect_entity(1);
+        mgr.connect_entity(2);
+        let _ = mgr.compute_aoi_changes();
+        let (_tx, rx) = mpsc::channel(64);
+        (mgr, rx)
+    }
+
+    fn drain(rx: &mut mpsc::Receiver<CellToBaseMsg>) -> Vec<CellToBaseMsg> {
+        let mut out = Vec::new();
+        while let Ok(msg) = rx.try_recv() {
+            out.push(msg);
+        }
+        out
+    }
+
+    /// Witness-only fanout for a player who has one other player in AoI:
+    /// emits exactly one `WitnessEntityMethod` to that other player, and
+    /// zero `EntityMethodCall` to self.
+    #[tokio::test]
+    async fn witnesses_only_fanout_skips_self_and_addresses_each_observer() {
+        let (mgr, _rx) = make_mgr_two_players_and_npc();
+        let (tx, mut rx) = mpsc::channel(64);
+        let count = send_entity_method_to_witnesses(
+            1,
+            19, // ON_STATE_FIELD_UPDATE — arbitrary; the helper is method-agnostic
+            vec![0xDE, 0xAD],
+            &tx,
+            &mgr,
+        )
+        .await;
+        // Player 2 sees player 1, so exactly one witness.
+        assert_eq!(count, 1);
+        let msgs = drain(&mut rx);
+        assert_eq!(msgs.len(), 1);
+        match &msgs[0] {
+            CellToBaseMsg::WitnessEntityMethod {
+                witness_id,
+                entity_id,
+                method_index,
+                args,
+            } => {
+                assert_eq!(*witness_id, 2);
+                assert_eq!(*entity_id, 1);
+                assert_eq!(*method_index, 19);
+                assert_eq!(args, &vec![0xDE, 0xAD]);
+            }
+            other => panic!("expected WitnessEntityMethod, got {other:?}"),
+        }
+    }
+
+    /// Witness-only with no observers: returns 0, emits nothing, does NOT
+    /// log a warning. This is the path a player alone in a space hits when
+    /// their state flips — the helper must stay silent rather than spam.
+    #[tokio::test]
+    async fn witnesses_only_with_no_observers_is_a_clean_zero() {
+        let mut mgr = SpaceManager::new(1);
+        let xml = r#"<?xml version="1.0"?><Spaces><Space WorldName="Castle" Instanced="false" MinX="-800" MaxX="800" MinY="-800" MaxY="800" /></Spaces>"#;
+        mgr.parse_spaces_xml(xml).unwrap();
+        mgr.create_startup_spaces(
+            r#"<?xml version="1.0"?><Spaces><Space WorldName="Castle" /></Spaces>"#,
+        )
+        .unwrap();
+        mgr.create_entity(1, "Castle", [0.0; 3], [0.0; 3]).unwrap();
+        if let Some(p) = mgr.get_entity_mut(1) {
+            p.is_player = true;
+            p.player_id = Some(100);
+        }
+        mgr.connect_entity(1);
+        let _ = mgr.compute_aoi_changes();
+        let (tx, mut rx) = mpsc::channel(64);
+
+        let count = send_entity_method_to_witnesses(1, 19, vec![], &tx, &mgr).await;
+        assert_eq!(count, 0);
+        assert!(drain(&mut rx).is_empty());
+    }
+
+    /// Self + witnesses for a player: one `EntityMethodCall` to self, one
+    /// `WitnessEntityMethod` per observer. Returns the witness count
+    /// (not counting the self send).
+    #[tokio::test]
+    async fn self_and_witnesses_for_player_sends_both() {
+        let (mgr, _rx) = make_mgr_two_players_and_npc();
+        let (tx, mut rx) = mpsc::channel(64);
+
+        let witness_count = send_entity_method_to_self_and_witnesses(
+            1,
+            19,
+            vec![0xBE, 0xEF],
+            &tx,
+            &mgr,
+        )
+        .await;
+        assert_eq!(witness_count, 1);
+
+        let msgs = drain(&mut rx);
+        let self_sends: Vec<_> = msgs
+            .iter()
+            .filter(|m| matches!(m, CellToBaseMsg::EntityMethodCall { entity_id: 1, .. }))
+            .collect();
+        let witness_sends: Vec<_> = msgs
+            .iter()
+            .filter(|m| matches!(m, CellToBaseMsg::WitnessEntityMethod { entity_id: 1, .. }))
+            .collect();
+        assert_eq!(self_sends.len(), 1, "expected exactly one self send");
+        assert_eq!(witness_sends.len(), 1, "expected exactly one witness send");
+    }
+
+    /// Self + witnesses for an NPC: the "self" path is a no-op (NPCs have
+    /// no client), and the helper collapses to witnesses-only. Verifies
+    /// no `EntityMethodCall` is emitted for the NPC.
+    #[tokio::test]
+    async fn self_and_witnesses_for_npc_skips_self_send() {
+        let (mgr, _rx) = make_mgr_two_players_and_npc();
+        let (tx, mut rx) = mpsc::channel(64);
+
+        // Entity 3 is the NPC; both players witness it.
+        let witness_count = send_entity_method_to_self_and_witnesses(
+            3,
+            19,
+            vec![],
+            &tx,
+            &mgr,
+        )
+        .await;
+        // Both players are co-located and see the NPC.
+        assert_eq!(witness_count, 2);
+
+        let msgs = drain(&mut rx);
+        let self_sends: Vec<_> = msgs
+            .iter()
+            .filter(|m| matches!(m, CellToBaseMsg::EntityMethodCall { entity_id: 3, .. }))
+            .collect();
+        let witness_sends: Vec<_> = msgs
+            .iter()
+            .filter(|m| matches!(m, CellToBaseMsg::WitnessEntityMethod { entity_id: 3, .. }))
+            .collect();
+        assert!(
+            self_sends.is_empty(),
+            "NPC must not receive an EntityMethodCall — NPCs have no client"
+        );
+        assert_eq!(witness_sends.len(), 2);
+    }
+
+    /// Behavior parity: `send_entity_method` for an NPC fans out to the same
+    /// witness set `send_entity_method_to_witnesses` would. This pins that
+    /// the new witness-only helper is a non-disruptive extension — paths
+    /// that already use the entity-aware default keep their existing
+    /// behavior unchanged when the new helper lands.
+    #[tokio::test]
+    async fn npc_send_entity_method_matches_witnesses_only_helper() {
+        let (mgr, _rx) = make_mgr_two_players_and_npc();
+        let (tx_a, mut rx_a) = mpsc::channel(64);
+        let (tx_b, mut rx_b) = mpsc::channel(64);
+
+        send_entity_method(3, 19, vec![1, 2, 3], &tx_a, &mgr).await;
+        let count_b = send_entity_method_to_witnesses(3, 19, vec![1, 2, 3], &tx_b, &mgr).await;
+
+        let msgs_a = drain(&mut rx_a);
+        let msgs_b = drain(&mut rx_b);
+        assert_eq!(msgs_a.len(), msgs_b.len());
+        assert_eq!(msgs_a.len(), count_b);
     }
 }

--- a/crates/services/src/cell/abilities/mod.rs
+++ b/crates/services/src/cell/abilities/mod.rs
@@ -32,4 +32,8 @@ mod tests;
 pub use dispatch::handle_use_ability_on_ground;
 pub(crate) use loot_drop::INT_NORMAL_LOOT;
 pub(crate) use messaging::send_entity_method;
+// `send_entity_method_to_witnesses` and `send_entity_method_to_self_and_witnesses`
+// land here for #278 child PRs to adopt. They stay private to the `messaging`
+// module until the first child callsite migrates — at which point the
+// migrating PR adds the re-exports it needs.
 pub use use_ability::handle_use_ability;


### PR DESCRIPTION
## Summary

Lands the parent helper [#278](https://github.com/SandboxServers/Cimmeria/issues/278) names — the cell-side routing primitives that the witness-fanout child issues (#232, #249, #270, #240 Gap-N) each need. **Helper-only PR**: no callsite migrations, no behavior change. The existing `send_entity_method` is unchanged.

## What changed

[`crates/services/src/cell/abilities/messaging.rs`](crates/services/src/cell/abilities/messaging.rs) now exposes three routing modes:

| Mode | Function | Player path | NPC path |
|---|---|---|---|
| Entity-aware default *(existing)* | `send_entity_method` | self only | witnesses only |
| Witness-only *(new)* | `send_entity_method_to_witnesses` | witnesses (skips self) | witnesses |
| Self + witnesses *(new)* | `send_entity_method_to_self_and_witnesses` | self **and** witnesses | witnesses only (no client to self-send to) |

Both new helpers return `usize` — the witness count actually addressed — so callers can `tracing::debug!` the fanout shape without re-querying the space manager.

The new helpers are `pub(crate)` and stay module-private until a child PR migrates a callsite. Each carries `#[allow(dead_code)]` with a pointer to #278 so the attribute lifts naturally when the first child PR adds the re-exports it needs.

## Behavior distinction worth pinning

`send_entity_method` for an NPC with no witnesses emits a `tracing::warn!("NPC has no witnesses, method dropped")` — that signal is a routing-bug indicator for ghost entities, which is the only audience an NPC method has. `send_entity_method_to_witnesses` does **not** warn on an empty fanout — a player alone in a space hitting their state-field flip is legitimate, and warning there would spam the log.

This distinction is pinned by the test `witnesses_only_with_no_observers_is_a_clean_zero` (and exists explicitly in the module-level docstring).

## Tests added

[`crates/services/src/cell/abilities/messaging.rs`](crates/services/src/cell/abilities/messaging.rs) `#[cfg(test)] mod tests`:

- `witnesses_only_fanout_skips_self_and_addresses_each_observer` — happy path, byte-exact payload check
- `witnesses_only_with_no_observers_is_a_clean_zero` — empty-witness case stays silent
- `self_and_witnesses_for_player_sends_both` — exactly one self send + one witness send
- `self_and_witnesses_for_npc_skips_self_send` — NPC degenerate path collapses cleanly
- `npc_send_entity_method_matches_witnesses_only_helper` — parity guard: existing `send_entity_method` for NPCs emits identically to the new helper

All five pass. Broader sweep (`cargo nextest -p cimmeria-services -E 'test(/.*combat.*/) | test(/.*abilit.*/) | test(/.*messag.*/) | test(/.*threat.*/) | test(/.*regen.*/) | test(/.*witness.*/) | test(/.*aoi.*/)'`) → **176 passed, 0 failed**. `cargo clippy -D warnings` and `cargo fmt --check` both green.

## Out of scope

- **No callsite migrations.** The five child issues each pick which of the three routing modes fits their state change and adopt the helper themselves. Each child PR removes the `#[allow(dead_code)]` (or both, if both helpers get adopted at once) and adds the re-exports they need.
- **No protocol-level wire change.** Only the cell-side dispatch routing decision moves — the actual wire messages emitted are the same `CellToBaseMsg::EntityMethodCall` / `CellToBaseMsg::WitnessEntityMethod` variants that already exist.
- **`send_entity_method` is not deprecated.** Many existing callsites (NPC attack animations, stat updates, timer broadcasts) correctly want the entity-aware default. Only the player-state-change paths in #232 / #249 / #270 / #240 are the migration targets.

## Test plan

- [x] `cargo check -p cimmeria-services` — clean, no warnings
- [x] `cargo clippy -p cimmeria-services --all-targets -- -D warnings` — clean
- [x] `cargo fmt -p cimmeria-services --check` — clean
- [x] `cargo nextest run -p cimmeria-services -E 'test(/witnesses_only|self_and_witnesses|npc_send_entity_method/)'` — 5/5 pass
- [x] `cargo nextest run -p cimmeria-services -E '<broader sweep>'` — 176/176 pass
- [ ] Manual verify after first child PR adoption (one of #232 / #249 / #270 / #240): player A's state flip is visible to player B in the same AoI

## Related

- Parent: [#278](https://github.com/SandboxServers/Cimmeria/issues/278) — witness-fanout helper (this PR)
- Sibling parent: [#279](https://github.com/SandboxServers/Cimmeria/issues/279) — BeingAppearance recomposite broadcast
- Children unblocked: [#232](https://github.com/SandboxServers/Cimmeria/issues/232), [#249](https://github.com/SandboxServers/Cimmeria/issues/249) (will need #333 redirect first), [#270](https://github.com/SandboxServers/Cimmeria/issues/270), [#240](https://github.com/SandboxServers/Cimmeria/issues/240) Gap-2/3
- Prior shipped: [#327](https://github.com/SandboxServers/Cimmeria/pull/327) (#240 Gap 1), [#328](https://github.com/SandboxServers/Cimmeria/pull/328) (#219 BSF_IN_COMBAT funnel)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced message routing for entity method calls to observers and witnesses.
  * Improved handling of witness-only fanout scenarios and observer awareness updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SandboxServers/Cimmeria/pull/336?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->