### PR TITLE
chore(deps): bump cipher 0.4→0.5 + aes 0.8→0.9 + cbc 0.1→0.2 (coupled)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.4.4",
  "cpufeatures 0.2.17",
 ]
 
@@ -383,7 +383,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -594,7 +594,7 @@ dependencies = [
  "bytes",
  "cbc",
  "cimmeria-common",
- "cipher",
+ "cipher 0.5.1",
  "digest",
  "hmac",
  "md-5",
@@ -724,8 +724,18 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
- "inout",
+ "crypto-common 0.1.7",
+ "inout 0.1.4",
+]
+
+[[package]]
+name = "cipher"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e34d8227fe1ba289043aeb13792056ff80fd6de1a9f49137a5f499de8e8c78ea"
+dependencies = [
+ "crypto-common 0.2.1",
+ "inout 0.2.2",
 ]
 
 [[package]]
@@ -893,6 +903,15 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1066,7 +1085,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "const-oid",
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -2008,6 +2027,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2288,6 +2316,15 @@ checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "block-padding",
  "generic-array",
+]
+
+[[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -6105,9 +6142,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unarray"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,13 +10,13 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aes"
-version = "0.8.4"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+checksum = "66bd29a732b644c0431c6140f370d097879203d79b80c94a6747ba0872adaef8"
 dependencies = [
- "cfg-if",
- "cipher 0.4.4",
- "cpufeatures 0.2.17",
+ "cipher",
+ "cpubits",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -240,11 +240,11 @@ dependencies = [
 
 [[package]]
 name = "block-padding"
-version = "0.3.3"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+checksum = "710f1dd022ef4e93f8a438b4ba958de7f64308434fa6a87104481645cc30068b"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -379,11 +379,11 @@ dependencies = [
 
 [[package]]
 name = "cbc"
-version = "0.1.2"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+checksum = "ce2dc9ee5f88d11e0beb842c88b33c8a5cf0d1329c4b19494af42b07dbfe8896"
 dependencies = [
- "cipher 0.4.4",
+ "cipher",
 ]
 
 [[package]]
@@ -594,7 +594,7 @@ dependencies = [
  "bytes",
  "cbc",
  "cimmeria-common",
- "cipher 0.5.1",
+ "cipher",
  "digest",
  "hmac",
  "md-5",
@@ -720,22 +720,12 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.4.4"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
- "crypto-common 0.1.7",
- "inout 0.1.4",
-]
-
-[[package]]
-name = "cipher"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34d8227fe1ba289043aeb13792056ff80fd6de1a9f49137a5f499de8e8c78ea"
-dependencies = [
- "crypto-common 0.2.1",
- "inout 0.2.2",
+ "crypto-common 0.2.2",
+ "inout",
 ]
 
 [[package]]
@@ -830,6 +820,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -907,9 +903,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
 ]
@@ -2310,20 +2306,11 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
-dependencies = [
- "block-padding",
- "generic-array",
-]
-
-[[package]]
-name = "inout"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
+ "block-padding",
  "hybrid-array",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,8 +74,8 @@ bytes = "1"
 quick-xml = "0.38"
 
 # Cryptography (client requires AES-256-CBC + HMAC-MD5)
-aes = "0.8"
-cbc = "0.1"
+aes = "0.9"
+cbc = "0.2"
 hmac = "0.12"
 md-5 = "0.10"
 rand = "0.10"

--- a/crates/mercury/Cargo.toml
+++ b/crates/mercury/Cargo.toml
@@ -22,7 +22,7 @@ md-5 = { workspace = true }
 
 # Codec / framing
 tokio-util = { version = "0.7", features = ["codec"] }
-cipher = "0.4"
+cipher = "0.5"
 digest = "0.10"
 
 [dev-dependencies]

--- a/crates/mercury/src/encryption.rs
+++ b/crates/mercury/src/encryption.rs
@@ -17,7 +17,7 @@
 
 use aes::Aes256;
 use cbc::{Decryptor, Encryptor};
-use cipher::{BlockDecryptMut, BlockEncryptMut, KeyIvInit};
+use cipher::{BlockModeDecrypt, BlockModeEncrypt, KeyIvInit};
 use hmac::{Hmac, Mac};
 use md5::Md5;
 
@@ -91,14 +91,14 @@ impl MercuryEncryption {
         // PKCS7 pad the plaintext to a multiple of AES_BLOCK_SIZE.
         let padded = pkcs7_pad(plaintext);
 
-        // Encrypt with AES-256-CBC.
-        let encryptor = Aes256CbcEnc::new_from_slices(&self.aes_key, &self.iv)
-            .map_err(|e| CimmeriaError::Encryption(format!("AES init failed: {e}")))?;
+        // Encrypt with AES-256-CBC. Key/IV are fixed-size arrays, so the
+        // `KeyIvInit::new` constructor is infallible — no Result to unwrap.
+        let encryptor = Aes256CbcEnc::new(&self.aes_key.into(), &self.iv.into());
 
         let mut buf = padded;
         let n = buf.len();
         encryptor
-            .encrypt_padded_mut::<cipher::block_padding::NoPadding>(&mut buf, n)
+            .encrypt_padded::<cipher::block_padding::NoPadding>(&mut buf, n)
             .map_err(|e| CimmeriaError::Encryption(format!("AES encrypt failed: {e}")))?;
         let ciphertext = buf;
 
@@ -160,13 +160,12 @@ impl MercuryEncryption {
             CimmeriaError::Encryption("HMAC-MD5 verification failed".into())
         })?;
 
-        // Decrypt with AES-256-CBC.
-        let decryptor = Aes256CbcDec::new_from_slices(&self.aes_key, &self.iv)
-            .map_err(|e| CimmeriaError::Encryption(format!("AES init failed: {e}")))?;
+        // Decrypt with AES-256-CBC. Fixed-size key/IV make `new` infallible.
+        let decryptor = Aes256CbcDec::new(&self.aes_key.into(), &self.iv.into());
 
         let mut buf = ciphertext.to_vec();
         decryptor
-            .decrypt_padded_mut::<cipher::block_padding::NoPadding>(&mut buf)
+            .decrypt_padded::<cipher::block_padding::NoPadding>(&mut buf)
             .map_err(|e| CimmeriaError::Encryption(format!("AES decrypt failed: {e}")))?;
 
         // Strip PKCS7 padding.


### PR DESCRIPTION
## Summary

Supersedes #323 (cipher 0.5) and #325 (aes 0.9). Dependabot split the
three deps but they cannot move independently — aes 0.9 only implements
the new cipher 0.5 trait set, and cipher 0.5 moves `block_padding` into
the `inout` crate and renames the block-mode traits. cbc 0.2 is the
matching block-mode crate for the new cipher API.

## API changes in `crates/mercury/src/encryption.rs`

| Before (cipher 0.4) | After (cipher 0.5) |
|---|---|
| `BlockEncryptMut` / `BlockDecryptMut` | `BlockModeEncrypt` / `BlockModeDecrypt` |
| `new_from_slices(&key, &iv) -> Result` | `new(&key.into(), &iv.into())` (infallible) |
| `encrypt_padded_mut::<NoPadding>(&mut buf, n)` | `encrypt_padded::<NoPadding>(&mut buf, n)` |
| `decrypt_padded_mut::<NoPadding>(&mut buf)` | `decrypt_padded::<NoPadding>(&mut buf)` |

The fixed-size `[u8; 32]` AES key and `[u8; 16]` IV mean the new
`KeyIvInit::new` constructor is infallible (no Result), so the two
"AES init failed" error branches are dropped.

## Wire-format compatibility

CBC math is identical — only the Rust API wrapping changed. All 14
existing mercury encryption tests pass, including
`deterministic_output` which pins byte-identical output to the C++
OpenSSL implementation.

## Test plan

- [x] `cargo check -p cimmeria-mercury`
- [x] `cargo clippy -p cimmeria-mercury --all-targets -- -D warnings`
- [x] `cargo test -p cimmeria-mercury encryption::` — 14/14 pass
- [ ] CI: full workspace clippy + nextest

Closes #323
Closes #325

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal cryptographic dependencies to latest compatible versions for improved security and stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SandboxServers/Cimmeria/pull/349?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->