### PR TITLE
fix(world-entry): cut reliable TX-window pressure on cold-cache login (closes #345)

### DIFF
--- a/crates/services/src/base/cooked_data.rs
+++ b/crates/services/src/base/cooked_data.rs
@@ -362,7 +362,7 @@ pub(crate) async fn handle_element_data_request(
     // INFO matches `push_overridden_elements`: every patched-XML push is
     // load-bearing for cache consistency, and the per-element byte count
     // is what surfaces a future PAK element crossing a chunk boundary
-    // and adding fragments to the cold-cache login burst (issue #345).
+    // and adding fragments to the cold-cache login burst.
     if is_override {
         tracing::info!(
             %addr, category_id, element_id,
@@ -414,3 +414,21 @@ pub(crate) async fn handle_element_data_request(
 
     Ok(())
 }
+
+/// Compile-time lower-bound guard for `MAX_CHUNK`. The wire-level tests in
+/// `mercury::protocol::tests` decrypt a resource fragment at the current
+/// `MAX_CHUNK` and assert it fits Mercury's body cap — but they'd happily
+/// pass at `MAX_CHUNK = 1000` too, since 1000-byte chunks also fit. This
+/// const assertion pins the lower bound at compile time: a future revert
+/// that drops `MAX_CHUNK` below 1390 fails to build instead of silently
+/// restoring the wasted ~28% per-packet headroom and re-widening the
+/// cold-cache login burst against the 32-slot reliable TX window.
+///
+/// Bump in tandem if a deliberate retreat from 1390 is ever needed (and
+/// document the reason in `MAX_CHUNK`'s docstring above).
+const _: () = assert!(
+    MAX_CHUNK >= 1390,
+    "MAX_CHUNK dropped below the 1390 floor — see the doc comment above \
+     for the cold-cache burst rationale; update the docstring + this \
+     guard together if the retreat is intentional."
+);

--- a/crates/services/src/base/cooked_data.rs
+++ b/crates/services/src/base/cooked_data.rs
@@ -13,6 +13,24 @@ use super::helpers::{drain_acks_and_seq, get_active_entity_id};
 use super::resources::{CategoryData, ResourceCache};
 use super::ConnectedClientState;
 
+/// Maximum XML bytes per `BASEMSG_RESOURCE_FRAGMENT` packet.
+///
+/// Mercury `MAX_BODY_LENGTH` is **1411 bytes**. The first fragment of a
+/// resource transfer carries 16 bytes of overhead inside the body — that
+/// is, `BASEMSG`(1) plus `WORD_LEN`(2) plus `data_id`(2) plus
+/// `chunk_id`(1) plus `frag_flags`(1) plus `msg_type`(1) plus
+/// `category_id`(4) plus `element_id`(4). Non-first fragments carry only
+/// 7 bytes (`BASEMSG` + `WORD_LEN` + `data_id` + `chunk_id` + `frag_flags`).
+///
+/// Picking 1390 leaves a 5-byte safety margin against the tighter
+/// first-fragment cap (1395) and packs the XML body at 99.6% utilization;
+/// the historical value of 1000 wasted ~28% of every packet.
+///
+/// The fragment-size guard test in `mercury::protocol::tests` pins this
+/// against `MercuryEncryption::decrypt(...)` for both first and non-first
+/// fragment shapes; bump in tandem if the wire-format overhead changes.
+const MAX_CHUNK: usize = 1390;
+
 /// Handle `versionInfoRequest` (0xC0).
 ///
 /// Client payload: [categoryId: u32][version: u32]
@@ -145,8 +163,6 @@ async fn push_overridden_elements(
     cache: &ResourceCache,
     connected: &Arc<Mutex<HashMap<SocketAddr, ConnectedClientState>>>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    const MAX_CHUNK: usize = 1000;
-
     for &element_id in element_ids {
         let xml_data = match cache.get(category_id, element_id) {
             Some(data) => data,
@@ -225,8 +241,6 @@ pub(crate) async fn send_category_resources(
     cat: &CategoryData,
     connected: &Arc<Mutex<HashMap<SocketAddr, ConnectedClientState>>>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    const MAX_CHUNK: usize = 1000;
-
     // Sort element IDs for deterministic ordering.
     let mut element_ids: Vec<u32> = cat.elements.keys().copied().collect();
     element_ids.sort();
@@ -326,18 +340,9 @@ pub(crate) async fn handle_element_data_request(
         }
     };
 
-    // Promote the log to INFO when we're shipping a Cimmeria-overridden
-    // element — operationally the load-bearing question is "did the
-    // patched mission XML actually go out to this client", and that
-    // answer is too important to bury at debug level on a noisy DB.
+    // Override status drives log level below: every patched-XML push is
+    // load-bearing for cache consistency, so it deserves INFO. Reads only.
     let is_override = cache.overridden_elements(category_id).contains(&element_id);
-    if is_override {
-        tracing::info!(
-            %addr, category_id, element_id,
-            bytes = xml_data.len(),
-            "Shipping overridden element to client"
-        );
-    }
 
     // Allocate a data_id for this transfer
     let data_id = {
@@ -351,19 +356,31 @@ pub(crate) async fn handle_element_data_request(
         }
     };
 
-    // Fragment into 1000-byte chunks
-    const MAX_CHUNK: usize = 1000;
     let chunks: Vec<&[u8]> = xml_data.chunks(MAX_CHUNK).collect();
     let total_chunks = chunks.len();
 
-    tracing::debug!(
-        %addr,
-        element_id,
-        total_size = xml_data.len(),
-        total_chunks,
-        data_id,
-        "Fragmenting resource data"
-    );
+    // INFO matches `push_overridden_elements`: every patched-XML push is
+    // load-bearing for cache consistency, and the per-element byte count
+    // is what surfaces a future PAK element crossing a chunk boundary
+    // and adding fragments to the cold-cache login burst (issue #345).
+    if is_override {
+        tracing::info!(
+            %addr, category_id, element_id,
+            bytes = xml_data.len(),
+            total_chunks,
+            data_id,
+            "Fragmenting overridden resource data"
+        );
+    } else {
+        tracing::debug!(
+            %addr,
+            element_id,
+            total_size = xml_data.len(),
+            total_chunks,
+            data_id,
+            "Fragmenting resource data"
+        );
+    }
 
     for (i, chunk) in chunks.iter().enumerate() {
         let frag_flags = match (i == 0, i == total_chunks - 1) {

--- a/crates/services/src/base/mod.rs
+++ b/crates/services/src/base/mod.rs
@@ -32,6 +32,7 @@ mod service;
 pub(crate) mod tick_sync;
 pub(crate) mod world_entry;
 pub(crate) mod world_entry_appearance;
+pub(crate) mod world_entry_chat;
 
 #[cfg(test)]
 mod smoke_tests;

--- a/crates/services/src/base/world_entry_appearance.rs
+++ b/crates/services/src/base/world_entry_appearance.rs
@@ -133,11 +133,17 @@ pub(crate) async fn handle_on_client_ready(
         }
     }
 
-    let pending = {
+    // Take the pending finalization AND copy out the player_name in the
+    // same lock so the welcome-message send below doesn't need a second
+    // round-trip. `player_name` is set during `playCharacter` and stays
+    // for the session, so reading it here is safe.
+    let (pending, player_name) = {
         let mut clients = connected.lock().map_err(|_| "connected lock poisoned")?;
-        clients
-            .get_mut(&addr)
-            .and_then(|c| c.pending_client_ready.take())
+        let entry = clients.get_mut(&addr);
+        match entry {
+            Some(c) => (c.pending_client_ready.take(), c.player_name.clone()),
+            None => (None, None),
+        }
     };
 
     let Some(pending) = pending else {
@@ -310,6 +316,85 @@ pub(crate) async fn handle_on_client_ready(
         },
     )
     .await;
+
+    // Chat-channel joins + welcome message. Original C++ path is
+    // `python/base/SGWPlayer.py onClientReady -> ChannelManager.playerLoggedIn`,
+    // so onClientReady (here) is the canonical fire-point. These used to
+    // live in the mapLoaded bundle and padded ~311 B onto the worst-case
+    // fragment burst — moved out per issue #345. Routed via
+    // `send_to_witness_reliable`: the player is a witness of their own
+    // entity, so this targets the connected client and keeps the bytes
+    // on the reliable channel.
+    for &(channel_name, channel_id) in &[
+        ("say", 0u8),
+        ("emote", 1),
+        ("yell", 2),
+        ("team", 3),
+        ("squad", 4),
+        ("command", 5),
+        ("server", 7),
+        ("tell", 9),
+    ] {
+        let mut args = Vec::new();
+        write_wstring(&mut args, channel_name);
+        args.push(channel_id);
+        send_to_witness_reliable(
+            socket,
+            connected,
+            entity_to_addr,
+            entity_id,
+            |key, seq, acks| {
+                build_entity_method_packet(
+                    key,
+                    seq,
+                    acks,
+                    entity_id,
+                    method_idx::ON_CHAT_JOINED,
+                    &args,
+                )
+            },
+        )
+        .await;
+    }
+
+    // Welcome message — `onPlayerCommunication(speaker, flags, channel, text)`
+    // on CHAN_TELL (9). Matches python `SGWPlayer.py:541`. Cosmetic-only;
+    // dropping it has no correctness impact, but it's the moment-of-arrival
+    // visible signal that the channel registration above actually landed.
+    if let Some(name) = player_name.as_deref() {
+        let mut args = Vec::new();
+        write_wstring(&mut args, name);
+        args.push(0u8); // SpeakerFlags
+        args.push(9u8); // Channel = CHAN_TELL
+        let welcome = format!(
+            "Welcome to Stargate Worlds. Your player id is: {}.",
+            entity_id
+        );
+        write_wstring(&mut args, &welcome);
+        send_to_witness_reliable(
+            socket,
+            connected,
+            entity_to_addr,
+            entity_id,
+            |key, seq, acks| {
+                build_entity_method_packet(
+                    key,
+                    seq,
+                    acks,
+                    entity_id,
+                    method_idx::ON_PLAYER_COMMUNICATION,
+                    &args,
+                )
+            },
+        )
+        .await;
+    } else {
+        tracing::warn!(
+            %addr,
+            entity_id,
+            "onClientReady: player_name not set on connected state — skipping welcome message"
+        );
+    }
 
     // First-login cinematic — fires AFTER appearance is bound to the now-live
     // possessed pawn. Sending it inside the mapLoaded bundle (before this

--- a/crates/services/src/base/world_entry_appearance.rs
+++ b/crates/services/src/base/world_entry_appearance.rs
@@ -16,6 +16,9 @@ use crate::mercury::{build_entity_method_packet, method_idx, write_wstring, SKIN
 
 use super::helpers::send_to_witness_reliable;
 use super::world_entry::handle_map_loaded;
+use super::world_entry_chat::{
+    build_chat_joined_args, build_welcome_message_args, DEFAULT_CHAT_CHANNELS,
+};
 use super::ConnectedClientState;
 
 // ── Appearance data builders ────────────────────────────────────────────────
@@ -31,55 +34,6 @@ pub(crate) fn build_appearance_args(bodyset: &str, components: &[String]) -> Vec
     for comp in components {
         write_wstring(&mut buf, comp);
     }
-    buf
-}
-
-/// Default chat channels registered on every world-entry `onClientReady`.
-///
-/// Each entry is `(channel_name, channel_id)`. The id values come from
-/// `python/common/Constants.py` and the channel set + ordering matches
-/// `python/base/SGWPlayer.py onClientReady -> ChannelManager.playerLoggedIn`.
-/// Pulled out as a module constant so it's covered by a byte-exact test
-/// in [`tests`] and so a future configuration knob (per-archetype
-/// channel sets, for example) has a single source to read from.
-pub(crate) const DEFAULT_CHAT_CHANNELS: &[(&str, u8)] = &[
-    ("say", 0),
-    ("emote", 1),
-    ("yell", 2),
-    ("team", 3),
-    ("squad", 4),
-    ("command", 5),
-    ("server", 7),
-    ("tell", 9),
-];
-
-/// `onPlayerCommunication`'s "tell" channel id (matches `CHAN_TELL` in
-/// `python/common/Constants.py` and `SGWPlayer.py:541`).
-pub(crate) const CHAN_TELL: u8 = 9;
-
-/// Build the `onChatJoined(WSTRING channelName, UINT8 channelID)` wire args.
-///
-/// Wire format: `[u32 char_count][UTF-16LE chars][u8 channel_id]`.
-pub(crate) fn build_chat_joined_args(channel_name: &str, channel_id: u8) -> Vec<u8> {
-    let mut buf = Vec::with_capacity(8 + channel_name.len() * 2);
-    write_wstring(&mut buf, channel_name);
-    buf.push(channel_id);
-    buf
-}
-
-/// Build the `onPlayerCommunication(speaker, speakerFlags, channel, text)`
-/// wire args for the post-`onClientReady` welcome message.
-///
-/// Wire format: `[wstring speaker][u8 speaker_flags=0][u8 channel][wstring text]`.
-/// The text is `"Welcome to Stargate Worlds. Your player id is: {entity_id}."`
-/// pinned by [`tests`]; matches the python reference at `SGWPlayer.py:541`.
-pub(crate) fn build_welcome_message_args(speaker: &str, entity_id: u32) -> Vec<u8> {
-    let welcome = format!("Welcome to Stargate Worlds. Your player id is: {entity_id}.");
-    let mut buf = Vec::with_capacity(16 + (speaker.len() + welcome.len()) * 2);
-    write_wstring(&mut buf, speaker);
-    buf.push(0u8); // SpeakerFlags
-    buf.push(CHAN_TELL);
-    write_wstring(&mut buf, &welcome);
     buf
 }
 
@@ -811,177 +765,10 @@ mod tests {
         let tint = u32::from_le_bytes([buf[8], buf[9], buf[10], buf[11]]);
         assert_eq!(tint, SKIN_TINTS[0]);
     }
-
-    /// `DEFAULT_CHAT_CHANNELS` must match the original python
-    /// `SGWPlayer.py onClientReady -> ChannelManager.playerLoggedIn`
-    /// channel set exactly — same names, same ids, same order. A
-    /// regression that adds, drops, or reorders entries silently
-    /// changes the wire-burst shape on every world entry; pinning
-    /// the full slice catches it.
-    #[test]
-    fn default_chat_channels_matches_sgwplayer_channel_set() {
-        let expected: &[(&str, u8)] = &[
-            ("say", 0),
-            ("emote", 1),
-            ("yell", 2),
-            ("team", 3),
-            ("squad", 4),
-            ("command", 5),
-            ("server", 7),
-            ("tell", 9),
-        ];
-        assert_eq!(
-            DEFAULT_CHAT_CHANNELS, expected,
-            "DEFAULT_CHAT_CHANNELS drifted from the SGWPlayer.py reference set",
-        );
-        // CHAN_TELL constant must agree with the "tell" entry in the slice;
-        // the welcome message in `handle_on_client_ready` reads from
-        // CHAN_TELL while the channel-join loop reads from the slice.
-        let tell_entry = DEFAULT_CHAT_CHANNELS
-            .iter()
-            .find(|(name, _)| *name == "tell")
-            .expect("'tell' channel must be in DEFAULT_CHAT_CHANNELS");
-        assert_eq!(
-            tell_entry.1, CHAN_TELL,
-            "CHAN_TELL ({}) must equal the 'tell' entry's id ({}) in DEFAULT_CHAT_CHANNELS",
-            CHAN_TELL, tell_entry.1
-        );
-    }
-
-    /// `build_chat_joined_args` wire layout: `[wstring channel_name][u8
-    /// channel_id]`. Byte-exact comparison so a regression that drops the
-    /// length prefix, swaps to UTF-8, or appends the id before the
-    /// wstring (matching the reverse-order python alias) fails here.
-    #[test]
-    fn build_chat_joined_args_emits_wstring_then_u8_id() {
-        let buf = build_chat_joined_args("say", 0);
-        let expected: &[u8] = &[
-            3, 0, 0, 0, b's', 0, b'a', 0, b'y', 0, // wstring "say"
-            0, // channel_id
-        ];
-        assert_eq!(buf, expected, "byte-exact wire layout for 'say'/0");
-
-        let buf = build_chat_joined_args("tell", 9);
-        let expected: &[u8] = &[
-            4, 0, 0, 0, b't', 0, b'e', 0, b'l', 0, b'l', 0, // wstring "tell"
-            9, // channel_id
-        ];
-        assert_eq!(buf, expected, "byte-exact wire layout for 'tell'/9");
-    }
-
-    /// All 8 channels in `DEFAULT_CHAT_CHANNELS` must produce well-formed
-    /// `onChatJoined` args. Sweeping the actual slice catches a future
-    /// channel addition that forgets to update `build_chat_joined_args`
-    /// (e.g. introducing a wider id type).
-    #[test]
-    fn build_chat_joined_args_round_trips_for_all_default_channels() {
-        for &(name, id) in DEFAULT_CHAT_CHANNELS {
-            let buf = build_chat_joined_args(name, id);
-            // Length prefix must equal name.chars().encode_utf16().count()
-            // (matches `write_wstring` semantics, not `name.len()`).
-            let utf16_units: u32 = name.encode_utf16().count() as u32;
-            assert_eq!(
-                &buf[0..4],
-                &utf16_units.to_le_bytes(),
-                "channel {name}: wstring length prefix must be UTF-16 code-unit count"
-            );
-            let payload_end = 4 + (utf16_units as usize) * 2;
-            assert_eq!(
-                buf.len(),
-                payload_end + 1,
-                "channel {name}: total length = 4 (count) + 2*units + 1 (id)",
-            );
-            assert_eq!(
-                buf[payload_end], id,
-                "channel {name}: id byte must follow the wstring",
-            );
-        }
-    }
-
-    /// `build_welcome_message_args` wire layout:
-    /// `[wstring speaker][u8 0=flags][u8 9=CHAN_TELL][wstring text]`.
-    /// Pin the full byte sequence so a regression that drops the
-    /// flags byte, picks a different channel, or rewrites the welcome
-    /// text fails here.
-    #[test]
-    fn build_welcome_message_args_emits_speaker_flags_chan_tell_then_text() {
-        let buf = build_welcome_message_args("S", 7);
-        // Expected text: "Welcome to Stargate Worlds. Your player id is: 7."
-        // (50 chars, all BMP, so 50 UTF-16 code units, 100 bytes).
-        let mut expected: Vec<u8> = Vec::new();
-        // speaker wstring "S"
-        expected.extend_from_slice(&1u32.to_le_bytes());
-        expected.extend_from_slice(&[b'S', 0]);
-        expected.push(0u8); // SpeakerFlags
-        expected.push(9u8); // CHAN_TELL
-                            // text wstring
-        let text = "Welcome to Stargate Worlds. Your player id is: 7.";
-        let utf16: Vec<u16> = text.encode_utf16().collect();
-        expected.extend_from_slice(&(utf16.len() as u32).to_le_bytes());
-        for unit in utf16 {
-            expected.extend_from_slice(&unit.to_le_bytes());
-        }
-        assert_eq!(buf, expected, "byte-exact wire layout for welcome");
-    }
-
-    /// Entity id substitution must actually thread into the text. A
-    /// regression that hard-codes a placeholder (or formats the wrong
-    /// variable) would leave the welcome message lying to the player —
-    /// catch it by varying entity_id and asserting the text reflects it.
-    #[test]
-    fn build_welcome_message_args_includes_entity_id_in_text() {
-        let buf = build_welcome_message_args("Tester", 12345);
-        // Skip the speaker wstring + flags + channel bytes to reach text.
-        let speaker_units = "Tester".encode_utf16().count();
-        let text_offset = 4 + speaker_units * 2 + 1 + 1;
-        let text_count = u32::from_le_bytes(
-            buf[text_offset..text_offset + 4]
-                .try_into()
-                .expect("4 bytes"),
-        ) as usize;
-        let text_bytes = &buf[text_offset + 4..text_offset + 4 + text_count * 2];
-        let text: String = char::decode_utf16(
-            text_bytes
-                .chunks_exact(2)
-                .map(|c| u16::from_le_bytes([c[0], c[1]])),
-        )
-        .map(|r| r.unwrap_or('?'))
-        .collect();
-        assert_eq!(
-            text, "Welcome to Stargate Worlds. Your player id is: 12345.",
-            "entity_id must be substituted into the welcome message"
-        );
-    }
-
-    /// Fallback speaker for the player_name=None branch in
-    /// `handle_on_client_ready` must produce a valid welcome message,
-    /// not panic or omit fields. The fallback string ("Server") is a
-    /// real channel name in `DEFAULT_CHAT_CHANNELS`, so a future
-    /// refactor that swaps the fallback for an empty string is
-    /// distinguishable from the legitimate case.
-    #[test]
-    fn build_welcome_message_args_handles_fallback_speaker() {
-        let buf = build_welcome_message_args("Server", 42);
-        // Just verify the speaker wstring is well-formed and reachable.
-        let speaker_count = u32::from_le_bytes(buf[0..4].try_into().expect("4 bytes")) as usize;
-        assert_eq!(speaker_count, 6, "'Server' has 6 UTF-16 code units");
-        let speaker_bytes = &buf[4..4 + speaker_count * 2];
-        let speaker: String = char::decode_utf16(
-            speaker_bytes
-                .chunks_exact(2)
-                .map(|c| u16::from_le_bytes([c[0], c[1]])),
-        )
-        .map(|r| r.unwrap_or('?'))
-        .collect();
-        assert_eq!(speaker, "Server");
-        // SpeakerFlags + Channel bytes are at the fixed offset after the
-        // speaker wstring.
-        let after_speaker = 4 + speaker_count * 2;
-        assert_eq!(buf[after_speaker], 0, "SpeakerFlags must be 0");
-        assert_eq!(
-            buf[after_speaker + 1],
-            CHAN_TELL,
-            "Channel must be CHAN_TELL"
-        );
-    }
 }
+
+// Chat-channel registration helpers (`DEFAULT_CHAT_CHANNELS`, `CHAN_TELL`,
+// `build_chat_joined_args`, `build_welcome_message_args`) and their
+// byte-exact tests live in `super::world_entry_chat`. They're imported
+// at the top of this file and used inside `handle_on_client_ready` for
+// the post-`onClientReady` `ChannelManager.playerLoggedIn` flow.

--- a/crates/services/src/base/world_entry_appearance.rs
+++ b/crates/services/src/base/world_entry_appearance.rs
@@ -34,6 +34,55 @@ pub(crate) fn build_appearance_args(bodyset: &str, components: &[String]) -> Vec
     buf
 }
 
+/// Default chat channels registered on every world-entry `onClientReady`.
+///
+/// Each entry is `(channel_name, channel_id)`. The id values come from
+/// `python/common/Constants.py` and the channel set + ordering matches
+/// `python/base/SGWPlayer.py onClientReady -> ChannelManager.playerLoggedIn`.
+/// Pulled out as a module constant so it's covered by a byte-exact test
+/// in [`tests`] and so a future configuration knob (per-archetype
+/// channel sets, for example) has a single source to read from.
+pub(crate) const DEFAULT_CHAT_CHANNELS: &[(&str, u8)] = &[
+    ("say", 0),
+    ("emote", 1),
+    ("yell", 2),
+    ("team", 3),
+    ("squad", 4),
+    ("command", 5),
+    ("server", 7),
+    ("tell", 9),
+];
+
+/// `onPlayerCommunication`'s "tell" channel id (matches `CHAN_TELL` in
+/// `python/common/Constants.py` and `SGWPlayer.py:541`).
+pub(crate) const CHAN_TELL: u8 = 9;
+
+/// Build the `onChatJoined(WSTRING channelName, UINT8 channelID)` wire args.
+///
+/// Wire format: `[u32 char_count][UTF-16LE chars][u8 channel_id]`.
+pub(crate) fn build_chat_joined_args(channel_name: &str, channel_id: u8) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(8 + channel_name.len() * 2);
+    write_wstring(&mut buf, channel_name);
+    buf.push(channel_id);
+    buf
+}
+
+/// Build the `onPlayerCommunication(speaker, speakerFlags, channel, text)`
+/// wire args for the post-`onClientReady` welcome message.
+///
+/// Wire format: `[wstring speaker][u8 speaker_flags=0][u8 channel][wstring text]`.
+/// The text is `"Welcome to Stargate Worlds. Your player id is: {entity_id}."`
+/// pinned by [`tests`]; matches the python reference at `SGWPlayer.py:541`.
+pub(crate) fn build_welcome_message_args(speaker: &str, entity_id: u32) -> Vec<u8> {
+    let welcome = format!("Welcome to Stargate Worlds. Your player id is: {entity_id}.");
+    let mut buf = Vec::with_capacity(16 + (speaker.len() + welcome.len()) * 2);
+    write_wstring(&mut buf, speaker);
+    buf.push(0u8); // SpeakerFlags
+    buf.push(CHAN_TELL);
+    write_wstring(&mut buf, &welcome);
+    buf
+}
+
 /// Build the onEntityTint wire args: `[u32 primary=0][u32 secondary=0][u32 skin_tint]`.
 ///
 /// Maps `skin_color_id` (DB index) through the SKIN_TINTS table, matching
@@ -321,23 +370,17 @@ pub(crate) async fn handle_on_client_ready(
     // `python/base/SGWPlayer.py onClientReady -> ChannelManager.playerLoggedIn`,
     // so onClientReady (here) is the canonical fire-point. These used to
     // live in the mapLoaded bundle and padded ~311 B onto the worst-case
-    // fragment burst — moved out per issue #345. Routed via
+    // fragment burst before being moved out. Routed via
     // `send_to_witness_reliable`: the player is a witness of their own
     // entity, so this targets the connected client and keeps the bytes
     // on the reliable channel.
-    for &(channel_name, channel_id) in &[
-        ("say", 0u8),
-        ("emote", 1),
-        ("yell", 2),
-        ("team", 3),
-        ("squad", 4),
-        ("command", 5),
-        ("server", 7),
-        ("tell", 9),
-    ] {
-        let mut args = Vec::new();
-        write_wstring(&mut args, channel_name);
-        args.push(channel_id);
+    //
+    // Arg-building is split into pure helpers (`build_chat_joined_args` /
+    // `build_welcome_message_args`) so they're independently unit-tested;
+    // this loop is the wire side that the test suite can't reach without
+    // a full async harness.
+    for &(channel_name, channel_id) in DEFAULT_CHAT_CHANNELS {
+        let args = build_chat_joined_args(channel_name, channel_id);
         send_to_witness_reliable(
             socket,
             connected,
@@ -361,16 +404,24 @@ pub(crate) async fn handle_on_client_ready(
     // on CHAN_TELL (9). Matches python `SGWPlayer.py:541`. Cosmetic-only;
     // dropping it has no correctness impact, but it's the moment-of-arrival
     // visible signal that the channel registration above actually landed.
-    if let Some(name) = player_name.as_deref() {
-        let mut args = Vec::new();
-        write_wstring(&mut args, name);
-        args.push(0u8); // SpeakerFlags
-        args.push(9u8); // Channel = CHAN_TELL
-        let welcome = format!(
-            "Welcome to Stargate Worlds. Your player id is: {}.",
-            entity_id
+    //
+    // `player_name` is normally set during `playCharacter` and stays for
+    // the session; falling back to a generic "Server" speaker keeps the
+    // welcome line visible even when the name didn't propagate (race
+    // during a synthesised cross-world `onClientReady`, or a future
+    // refactor that defers the name read). The warn log surfaces the
+    // unexpected case without dropping the message on the floor.
+    let speaker = player_name.as_deref().unwrap_or_else(|| {
+        tracing::warn!(
+            %addr,
+            entity_id,
+            "onClientReady: player_name not set on connected state — \
+             sending welcome with generic Server speaker"
         );
-        write_wstring(&mut args, &welcome);
+        "Server"
+    });
+    {
+        let args = build_welcome_message_args(speaker, entity_id);
         send_to_witness_reliable(
             socket,
             connected,
@@ -388,12 +439,6 @@ pub(crate) async fn handle_on_client_ready(
             },
         )
         .await;
-    } else {
-        tracing::warn!(
-            %addr,
-            entity_id,
-            "onClientReady: player_name not set on connected state — skipping welcome message"
-        );
     }
 
     // First-login cinematic — fires AFTER appearance is bound to the now-live
@@ -765,5 +810,178 @@ mod tests {
         let buf = build_tint_args(-1);
         let tint = u32::from_le_bytes([buf[8], buf[9], buf[10], buf[11]]);
         assert_eq!(tint, SKIN_TINTS[0]);
+    }
+
+    /// `DEFAULT_CHAT_CHANNELS` must match the original python
+    /// `SGWPlayer.py onClientReady -> ChannelManager.playerLoggedIn`
+    /// channel set exactly — same names, same ids, same order. A
+    /// regression that adds, drops, or reorders entries silently
+    /// changes the wire-burst shape on every world entry; pinning
+    /// the full slice catches it.
+    #[test]
+    fn default_chat_channels_matches_sgwplayer_channel_set() {
+        let expected: &[(&str, u8)] = &[
+            ("say", 0),
+            ("emote", 1),
+            ("yell", 2),
+            ("team", 3),
+            ("squad", 4),
+            ("command", 5),
+            ("server", 7),
+            ("tell", 9),
+        ];
+        assert_eq!(
+            DEFAULT_CHAT_CHANNELS, expected,
+            "DEFAULT_CHAT_CHANNELS drifted from the SGWPlayer.py reference set",
+        );
+        // CHAN_TELL constant must agree with the "tell" entry in the slice;
+        // the welcome message in `handle_on_client_ready` reads from
+        // CHAN_TELL while the channel-join loop reads from the slice.
+        let tell_entry = DEFAULT_CHAT_CHANNELS
+            .iter()
+            .find(|(name, _)| *name == "tell")
+            .expect("'tell' channel must be in DEFAULT_CHAT_CHANNELS");
+        assert_eq!(
+            tell_entry.1, CHAN_TELL,
+            "CHAN_TELL ({}) must equal the 'tell' entry's id ({}) in DEFAULT_CHAT_CHANNELS",
+            CHAN_TELL, tell_entry.1
+        );
+    }
+
+    /// `build_chat_joined_args` wire layout: `[wstring channel_name][u8
+    /// channel_id]`. Byte-exact comparison so a regression that drops the
+    /// length prefix, swaps to UTF-8, or appends the id before the
+    /// wstring (matching the reverse-order python alias) fails here.
+    #[test]
+    fn build_chat_joined_args_emits_wstring_then_u8_id() {
+        let buf = build_chat_joined_args("say", 0);
+        let expected: &[u8] = &[
+            3, 0, 0, 0, b's', 0, b'a', 0, b'y', 0, // wstring "say"
+            0, // channel_id
+        ];
+        assert_eq!(buf, expected, "byte-exact wire layout for 'say'/0");
+
+        let buf = build_chat_joined_args("tell", 9);
+        let expected: &[u8] = &[
+            4, 0, 0, 0, b't', 0, b'e', 0, b'l', 0, b'l', 0, // wstring "tell"
+            9, // channel_id
+        ];
+        assert_eq!(buf, expected, "byte-exact wire layout for 'tell'/9");
+    }
+
+    /// All 8 channels in `DEFAULT_CHAT_CHANNELS` must produce well-formed
+    /// `onChatJoined` args. Sweeping the actual slice catches a future
+    /// channel addition that forgets to update `build_chat_joined_args`
+    /// (e.g. introducing a wider id type).
+    #[test]
+    fn build_chat_joined_args_round_trips_for_all_default_channels() {
+        for &(name, id) in DEFAULT_CHAT_CHANNELS {
+            let buf = build_chat_joined_args(name, id);
+            // Length prefix must equal name.chars().encode_utf16().count()
+            // (matches `write_wstring` semantics, not `name.len()`).
+            let utf16_units: u32 = name.encode_utf16().count() as u32;
+            assert_eq!(
+                &buf[0..4],
+                &utf16_units.to_le_bytes(),
+                "channel {name}: wstring length prefix must be UTF-16 code-unit count"
+            );
+            let payload_end = 4 + (utf16_units as usize) * 2;
+            assert_eq!(
+                buf.len(),
+                payload_end + 1,
+                "channel {name}: total length = 4 (count) + 2*units + 1 (id)",
+            );
+            assert_eq!(
+                buf[payload_end], id,
+                "channel {name}: id byte must follow the wstring",
+            );
+        }
+    }
+
+    /// `build_welcome_message_args` wire layout:
+    /// `[wstring speaker][u8 0=flags][u8 9=CHAN_TELL][wstring text]`.
+    /// Pin the full byte sequence so a regression that drops the
+    /// flags byte, picks a different channel, or rewrites the welcome
+    /// text fails here.
+    #[test]
+    fn build_welcome_message_args_emits_speaker_flags_chan_tell_then_text() {
+        let buf = build_welcome_message_args("S", 7);
+        // Expected text: "Welcome to Stargate Worlds. Your player id is: 7."
+        // (50 chars, all BMP, so 50 UTF-16 code units, 100 bytes).
+        let mut expected: Vec<u8> = Vec::new();
+        // speaker wstring "S"
+        expected.extend_from_slice(&1u32.to_le_bytes());
+        expected.extend_from_slice(&[b'S', 0]);
+        expected.push(0u8); // SpeakerFlags
+        expected.push(9u8); // CHAN_TELL
+                            // text wstring
+        let text = "Welcome to Stargate Worlds. Your player id is: 7.";
+        let utf16: Vec<u16> = text.encode_utf16().collect();
+        expected.extend_from_slice(&(utf16.len() as u32).to_le_bytes());
+        for unit in utf16 {
+            expected.extend_from_slice(&unit.to_le_bytes());
+        }
+        assert_eq!(buf, expected, "byte-exact wire layout for welcome");
+    }
+
+    /// Entity id substitution must actually thread into the text. A
+    /// regression that hard-codes a placeholder (or formats the wrong
+    /// variable) would leave the welcome message lying to the player —
+    /// catch it by varying entity_id and asserting the text reflects it.
+    #[test]
+    fn build_welcome_message_args_includes_entity_id_in_text() {
+        let buf = build_welcome_message_args("Tester", 12345);
+        // Skip the speaker wstring + flags + channel bytes to reach text.
+        let speaker_units = "Tester".encode_utf16().count();
+        let text_offset = 4 + speaker_units * 2 + 1 + 1;
+        let text_count = u32::from_le_bytes(
+            buf[text_offset..text_offset + 4]
+                .try_into()
+                .expect("4 bytes"),
+        ) as usize;
+        let text_bytes = &buf[text_offset + 4..text_offset + 4 + text_count * 2];
+        let text: String = char::decode_utf16(
+            text_bytes
+                .chunks_exact(2)
+                .map(|c| u16::from_le_bytes([c[0], c[1]])),
+        )
+        .map(|r| r.unwrap_or('?'))
+        .collect();
+        assert_eq!(
+            text, "Welcome to Stargate Worlds. Your player id is: 12345.",
+            "entity_id must be substituted into the welcome message"
+        );
+    }
+
+    /// Fallback speaker for the player_name=None branch in
+    /// `handle_on_client_ready` must produce a valid welcome message,
+    /// not panic or omit fields. The fallback string ("Server") is a
+    /// real channel name in `DEFAULT_CHAT_CHANNELS`, so a future
+    /// refactor that swaps the fallback for an empty string is
+    /// distinguishable from the legitimate case.
+    #[test]
+    fn build_welcome_message_args_handles_fallback_speaker() {
+        let buf = build_welcome_message_args("Server", 42);
+        // Just verify the speaker wstring is well-formed and reachable.
+        let speaker_count = u32::from_le_bytes(buf[0..4].try_into().expect("4 bytes")) as usize;
+        assert_eq!(speaker_count, 6, "'Server' has 6 UTF-16 code units");
+        let speaker_bytes = &buf[4..4 + speaker_count * 2];
+        let speaker: String = char::decode_utf16(
+            speaker_bytes
+                .chunks_exact(2)
+                .map(|c| u16::from_le_bytes([c[0], c[1]])),
+        )
+        .map(|r| r.unwrap_or('?'))
+        .collect();
+        assert_eq!(speaker, "Server");
+        // SpeakerFlags + Channel bytes are at the fixed offset after the
+        // speaker wstring.
+        let after_speaker = 4 + speaker_count * 2;
+        assert_eq!(buf[after_speaker], 0, "SpeakerFlags must be 0");
+        assert_eq!(
+            buf[after_speaker + 1],
+            CHAN_TELL,
+            "Channel must be CHAN_TELL"
+        );
     }
 }

--- a/crates/services/src/base/world_entry_chat.rs
+++ b/crates/services/src/base/world_entry_chat.rs
@@ -1,0 +1,237 @@
+//! Chat-channel registration + welcome message for `onClientReady`.
+//!
+//! Pure arg-builders for the entity-method packets fired in
+//! [`super::world_entry_appearance::handle_on_client_ready`]. Split out
+//! of `world_entry_appearance.rs` so the byte-level wire-format logic
+//! has byte-exact unit tests without dragging in the file's async-handler
+//! surface; the wire-emit side stays next to the rest of the
+//! `onClientReady` finalisation.
+
+use crate::mercury::write_wstring;
+
+/// Default chat channels registered on every world-entry `onClientReady`.
+///
+/// Each entry is `(channel_name, channel_id)`. The id values come from
+/// `python/common/Constants.py` and the channel set + ordering matches
+/// `python/base/SGWPlayer.py onClientReady -> ChannelManager.playerLoggedIn`.
+/// Pulled out as a module constant so it's covered by a byte-exact test
+/// in [`tests`] and so a future configuration knob (per-archetype
+/// channel sets, for example) has a single source to read from.
+pub(crate) const DEFAULT_CHAT_CHANNELS: &[(&str, u8)] = &[
+    ("say", 0),
+    ("emote", 1),
+    ("yell", 2),
+    ("team", 3),
+    ("squad", 4),
+    ("command", 5),
+    ("server", 7),
+    ("tell", 9),
+];
+
+/// `onPlayerCommunication`'s "tell" channel id (matches `CHAN_TELL` in
+/// `python/common/Constants.py` and `SGWPlayer.py:541`).
+pub(crate) const CHAN_TELL: u8 = 9;
+
+/// Build the `onChatJoined(WSTRING channelName, UINT8 channelID)` wire args.
+///
+/// Wire format: `[u32 char_count][UTF-16LE chars][u8 channel_id]`.
+pub(crate) fn build_chat_joined_args(channel_name: &str, channel_id: u8) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(8 + channel_name.len() * 2);
+    write_wstring(&mut buf, channel_name);
+    buf.push(channel_id);
+    buf
+}
+
+/// Build the `onPlayerCommunication(speaker, speakerFlags, channel, text)`
+/// wire args for the post-`onClientReady` welcome message.
+///
+/// Wire format: `[wstring speaker][u8 speaker_flags=0][u8 channel][wstring text]`.
+/// The text is `"Welcome to Stargate Worlds. Your player id is: {entity_id}."`
+/// pinned by [`tests`]; matches the python reference at `SGWPlayer.py:541`.
+pub(crate) fn build_welcome_message_args(speaker: &str, entity_id: u32) -> Vec<u8> {
+    let welcome = format!("Welcome to Stargate Worlds. Your player id is: {entity_id}.");
+    let mut buf = Vec::with_capacity(16 + (speaker.len() + welcome.len()) * 2);
+    write_wstring(&mut buf, speaker);
+    buf.push(0u8); // SpeakerFlags
+    buf.push(CHAN_TELL);
+    write_wstring(&mut buf, &welcome);
+    buf
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `DEFAULT_CHAT_CHANNELS` must match the original python
+    /// `SGWPlayer.py onClientReady -> ChannelManager.playerLoggedIn`
+    /// channel set exactly — same names, same ids, same order. A
+    /// regression that adds, drops, or reorders entries silently
+    /// changes the wire-burst shape on every world entry; pinning
+    /// the full slice catches it.
+    #[test]
+    fn default_chat_channels_matches_sgwplayer_channel_set() {
+        let expected: &[(&str, u8)] = &[
+            ("say", 0),
+            ("emote", 1),
+            ("yell", 2),
+            ("team", 3),
+            ("squad", 4),
+            ("command", 5),
+            ("server", 7),
+            ("tell", 9),
+        ];
+        assert_eq!(
+            DEFAULT_CHAT_CHANNELS, expected,
+            "DEFAULT_CHAT_CHANNELS drifted from the SGWPlayer.py reference set",
+        );
+        // CHAN_TELL constant must agree with the "tell" entry in the slice;
+        // the welcome message in `handle_on_client_ready` reads from
+        // CHAN_TELL while the channel-join loop reads from the slice.
+        let tell_entry = DEFAULT_CHAT_CHANNELS
+            .iter()
+            .find(|(name, _)| *name == "tell")
+            .expect("'tell' channel must be in DEFAULT_CHAT_CHANNELS");
+        assert_eq!(
+            tell_entry.1, CHAN_TELL,
+            "CHAN_TELL ({}) must equal the 'tell' entry's id ({}) in DEFAULT_CHAT_CHANNELS",
+            CHAN_TELL, tell_entry.1
+        );
+    }
+
+    /// `build_chat_joined_args` wire layout: `[wstring channel_name][u8
+    /// channel_id]`. Byte-exact comparison so a regression that drops the
+    /// length prefix, swaps to UTF-8, or appends the id before the
+    /// wstring (matching the reverse-order python alias) fails here.
+    #[test]
+    fn build_chat_joined_args_emits_wstring_then_u8_id() {
+        let buf = build_chat_joined_args("say", 0);
+        let expected: &[u8] = &[
+            3, 0, 0, 0, b's', 0, b'a', 0, b'y', 0, // wstring "say"
+            0, // channel_id
+        ];
+        assert_eq!(buf, expected, "byte-exact wire layout for 'say'/0");
+
+        let buf = build_chat_joined_args("tell", 9);
+        let expected: &[u8] = &[
+            4, 0, 0, 0, b't', 0, b'e', 0, b'l', 0, b'l', 0, // wstring "tell"
+            9, // channel_id
+        ];
+        assert_eq!(buf, expected, "byte-exact wire layout for 'tell'/9");
+    }
+
+    /// All 8 channels in `DEFAULT_CHAT_CHANNELS` must produce well-formed
+    /// `onChatJoined` args. Sweeping the actual slice catches a future
+    /// channel addition that forgets to update `build_chat_joined_args`
+    /// (e.g. introducing a wider id type).
+    #[test]
+    fn build_chat_joined_args_round_trips_for_all_default_channels() {
+        for &(name, id) in DEFAULT_CHAT_CHANNELS {
+            let buf = build_chat_joined_args(name, id);
+            // Length prefix must equal name.chars().encode_utf16().count()
+            // (matches `write_wstring` semantics, not `name.len()`).
+            let utf16_units: u32 = name.encode_utf16().count() as u32;
+            assert_eq!(
+                &buf[0..4],
+                &utf16_units.to_le_bytes(),
+                "channel {name}: wstring length prefix must be UTF-16 code-unit count"
+            );
+            let payload_end = 4 + (utf16_units as usize) * 2;
+            assert_eq!(
+                buf.len(),
+                payload_end + 1,
+                "channel {name}: total length = 4 (count) + 2*units + 1 (id)",
+            );
+            assert_eq!(
+                buf[payload_end], id,
+                "channel {name}: id byte must follow the wstring",
+            );
+        }
+    }
+
+    /// `build_welcome_message_args` wire layout:
+    /// `[wstring speaker][u8 0=flags][u8 9=CHAN_TELL][wstring text]`.
+    /// Pin the full byte sequence so a regression that drops the
+    /// flags byte, picks a different channel, or rewrites the welcome
+    /// text fails here.
+    #[test]
+    fn build_welcome_message_args_emits_speaker_flags_chan_tell_then_text() {
+        let buf = build_welcome_message_args("S", 7);
+        // Expected text: "Welcome to Stargate Worlds. Your player id is: 7."
+        // (50 chars, all BMP, so 50 UTF-16 code units, 100 bytes).
+        let mut expected: Vec<u8> = Vec::new();
+        // speaker wstring "S"
+        expected.extend_from_slice(&1u32.to_le_bytes());
+        expected.extend_from_slice(&[b'S', 0]);
+        expected.push(0u8); // SpeakerFlags
+        expected.push(9u8); // CHAN_TELL
+                            // text wstring
+        let text = "Welcome to Stargate Worlds. Your player id is: 7.";
+        let utf16: Vec<u16> = text.encode_utf16().collect();
+        expected.extend_from_slice(&(utf16.len() as u32).to_le_bytes());
+        for unit in utf16 {
+            expected.extend_from_slice(&unit.to_le_bytes());
+        }
+        assert_eq!(buf, expected, "byte-exact wire layout for welcome");
+    }
+
+    /// Entity id substitution must actually thread into the text. A
+    /// regression that hard-codes a placeholder (or formats the wrong
+    /// variable) would leave the welcome message lying to the player —
+    /// catch it by varying entity_id and asserting the text reflects it.
+    #[test]
+    fn build_welcome_message_args_includes_entity_id_in_text() {
+        let buf = build_welcome_message_args("Tester", 12345);
+        // Skip the speaker wstring + flags + channel bytes to reach text.
+        let speaker_units = "Tester".encode_utf16().count();
+        let text_offset = 4 + speaker_units * 2 + 1 + 1;
+        let text_count = u32::from_le_bytes(
+            buf[text_offset..text_offset + 4]
+                .try_into()
+                .expect("4 bytes"),
+        ) as usize;
+        let text_bytes = &buf[text_offset + 4..text_offset + 4 + text_count * 2];
+        let text: String = char::decode_utf16(
+            text_bytes
+                .chunks_exact(2)
+                .map(|c| u16::from_le_bytes([c[0], c[1]])),
+        )
+        .map(|r| r.unwrap_or('?'))
+        .collect();
+        assert_eq!(
+            text, "Welcome to Stargate Worlds. Your player id is: 12345.",
+            "entity_id must be substituted into the welcome message"
+        );
+    }
+
+    /// Fallback speaker for the player_name=None branch in
+    /// `handle_on_client_ready` must produce a valid welcome message,
+    /// not panic or omit fields. The fallback string ("Server") is a
+    /// real channel name in `DEFAULT_CHAT_CHANNELS`, so a future
+    /// refactor that swaps the fallback for an empty string is
+    /// distinguishable from the legitimate case.
+    #[test]
+    fn build_welcome_message_args_handles_fallback_speaker() {
+        let buf = build_welcome_message_args("Server", 42);
+        // Just verify the speaker wstring is well-formed and reachable.
+        let speaker_count = u32::from_le_bytes(buf[0..4].try_into().expect("4 bytes")) as usize;
+        assert_eq!(speaker_count, 6, "'Server' has 6 UTF-16 code units");
+        let speaker_bytes = &buf[4..4 + speaker_count * 2];
+        let speaker: String = char::decode_utf16(
+            speaker_bytes
+                .chunks_exact(2)
+                .map(|c| u16::from_le_bytes([c[0], c[1]])),
+        )
+        .map(|r| r.unwrap_or('?'))
+        .collect();
+        assert_eq!(speaker, "Server");
+        // SpeakerFlags + Channel bytes are at the fixed offset after the
+        // speaker wstring.
+        let after_speaker = 4 + speaker_count * 2;
+        assert_eq!(buf[after_speaker], 0, "SpeakerFlags must be 0");
+        assert_eq!(
+            buf[after_speaker + 1],
+            CHAN_TELL,
+            "Channel must be CHAN_TELL"
+        );
+    }
+}

--- a/crates/services/src/mercury/protocol/tests.rs
+++ b/crates/services/src/mercury/protocol/tests.rs
@@ -415,17 +415,40 @@ fn resource_fragment_uses_u16_length_prefix() {
 /// 1390 (5-byte safety margin); this guard makes sure the resulting
 /// first-fragment body decrypts cleanly and lands within that cap.
 ///
-/// Without this, a bump of `MAX_CHUNK` (e.g. issue #345 raising it
-/// from 1000 → 1390 to cut the cold-cache login burst) has no
-/// regression net — a future overhead change in `build_resource_fragment`
-/// would silently push us over the wire limit on every patched-mission
-/// push. See `crates/services/src/base/cooked_data.rs::MAX_CHUNK`.
+/// Without this, a bump of `MAX_CHUNK` (e.g. the 1000 → 1390 raise that
+/// cut the cold-cache login burst) has no regression net — a future
+/// overhead change in `build_resource_fragment` would silently push us
+/// over the wire limit on every patched-mission push. See
+/// `crates/services/src/base/cooked_data.rs::MAX_CHUNK`.
+/// Mercury `MAX_BODY_LENGTH` (plaintext body length, post-decrypt).
+const MERCURY_MAX_BODY_LENGTH: usize = 1411;
+
+/// Read the actual `BASEMSG_RESOURCE_FRAGMENT` body length from a decrypted
+/// Mercury plaintext. Returns `(word_len_payload, total_body_len)` where
+/// `total_body_len = 1 (BASEMSG) + 2 (WORD_LEN) + word_len_payload` — i.e.
+/// the full slice the wire-format cap applies to. Pulling these from the
+/// actual decoded bytes (instead of a hand-computed sum) makes the
+/// downstream guards survive a future change to the in-body header layout
+/// in `build_resource_fragment`: the math sanity-check would shift, but
+/// the cap-fits assertion still works against ground truth.
+fn measure_resource_fragment_body(plaintext: &[u8]) -> (usize, usize) {
+    assert_eq!(
+        plaintext[1], BASEMSG_RESOURCE_FRAGMENT,
+        "decrypted plaintext does not start with BASEMSG_RESOURCE_FRAGMENT"
+    );
+    let word_len = u16::from_le_bytes([plaintext[2], plaintext[3]]) as usize;
+    let total_body_len = 1 + 2 + word_len; // BASEMSG + WORD_LEN(u16) + payload
+    (word_len, total_body_len)
+}
+
 #[test]
 fn resource_fragment_first_frag_at_max_chunk_fits_within_mercury_body_limit() {
-    // Mercury MAX_BODY_LENGTH (plaintext body, after decrypt).
-    const MAX_BODY_LENGTH: usize = 1411;
-    // First-fragment max chunk = MAX_BODY_LENGTH - 16-byte in-body header.
-    const FIRST_FRAG_MAX_CHUNK: usize = MAX_BODY_LENGTH - 16;
+    // First-fragment in-body payload (after BASEMSG + WORD_LEN(u16)) is
+    // data_id(2) + chunk_id(1) + frag_flags(1) + msg_type(1) +
+    // category_id(4) + element_id(4) + xml = 13 + xml bytes. So the
+    // largest XML that still fits MAX_BODY_LENGTH = 1411 is
+    // 1411 - 3 (BASEMSG + WORD_LEN) - 13 = 1395 bytes.
+    const FIRST_FRAG_MAX_CHUNK: usize = MERCURY_MAX_BODY_LENGTH - 16;
 
     let xml = vec![b'X'; FIRST_FRAG_MAX_CHUNK];
     let out = build_resource_fragment(
@@ -444,22 +467,22 @@ fn resource_fragment_first_frag_at_max_chunk_fits_within_mercury_body_limit() {
     let enc = MercuryEncryption::from_session_key(TEST_KEY);
     let plaintext = enc.decrypt(&out).expect("first-frag decrypt failed");
 
-    // Plaintext = [flags:u8][body...][footers]. Body starts at offset 1.
-    // Body itself = BASEMSG(1) + WORD_LEN(2) + payload.
-    // Asserting the full plaintext stays within MAX_BODY_LENGTH covers
-    // the body — the footers (seq_id + acks) live outside this cap by
-    // construction.
-    let body_len = 1 + 2 + 2 + 1 + 1 + 1 + 4 + 4 + xml.len();
-    assert_eq!(body_len, MAX_BODY_LENGTH, "math sanity check");
-    // Body slice = plaintext[1..1 + body_len]; assert the body fits.
-    assert!(
-        plaintext.len() > body_len,
-        "plaintext truncated below expected body size: got {} bytes",
-        plaintext.len()
+    let (word_len, total_body_len) = measure_resource_fragment_body(&plaintext);
+    // The first-fragment payload (BASEMSG + WORD_LEN consumed) is:
+    // data_id(2) + chunk_id(1) + frag_flags(1) + msg_type(1) +
+    // category_id(4) + element_id(4) + xml.len() = 13 + xml.len()
+    assert_eq!(
+        word_len,
+        13 + xml.len(),
+        "WORD_LEN prefix should match expected first-fragment payload size",
     );
     assert!(
-        body_len <= MAX_BODY_LENGTH,
-        "first-fragment body ({body_len}) exceeded MAX_BODY_LENGTH ({MAX_BODY_LENGTH})",
+        total_body_len <= MERCURY_MAX_BODY_LENGTH,
+        "first-fragment body ({total_body_len}) exceeded MAX_BODY_LENGTH ({MERCURY_MAX_BODY_LENGTH})"
+    );
+    assert_eq!(
+        total_body_len, MERCURY_MAX_BODY_LENGTH,
+        "first-fragment at FIRST_FRAG_MAX_CHUNK should pack to exactly MAX_BODY_LENGTH",
     );
 }
 
@@ -471,10 +494,9 @@ fn resource_fragment_first_frag_at_max_chunk_fits_within_mercury_body_limit() {
 /// not be caught by the first-fragment guard above.
 #[test]
 fn resource_fragment_non_first_frag_at_max_chunk_fits_within_mercury_body_limit() {
-    const MAX_BODY_LENGTH: usize = 1411;
-    // Non-first fragment in-body header = BASEMSG(1) + WORD_LEN(2) +
-    // data_id(2) + chunk_id(1) + frag_flags(1) = 7 bytes.
-    const NON_FIRST_FRAG_MAX_CHUNK: usize = MAX_BODY_LENGTH - 7;
+    // Non-first in-body payload: data_id(2) + chunk_id(1) + frag_flags(1)
+    // + xml = 4 + xml. Max xml = 1411 - 3 (BASEMSG + WORD_LEN) - 4 = 1404.
+    const NON_FIRST_FRAG_MAX_CHUNK: usize = MERCURY_MAX_BODY_LENGTH - 7;
 
     let xml = vec![b'Y'; NON_FIRST_FRAG_MAX_CHUNK];
     let out = build_resource_fragment(
@@ -493,23 +515,30 @@ fn resource_fragment_non_first_frag_at_max_chunk_fits_within_mercury_body_limit(
     let enc = MercuryEncryption::from_session_key(TEST_KEY);
     let plaintext = enc.decrypt(&out).expect("non-first-frag decrypt failed");
 
-    let body_len = 1 + 2 + 2 + 1 + 1 + xml.len();
-    assert_eq!(body_len, MAX_BODY_LENGTH, "math sanity check");
+    let (word_len, total_body_len) = measure_resource_fragment_body(&plaintext);
+    assert_eq!(
+        word_len,
+        4 + xml.len(),
+        "WORD_LEN prefix should match expected non-first payload size",
+    );
     assert!(
-        plaintext.len() > body_len,
-        "plaintext truncated below expected body size: got {} bytes",
-        plaintext.len()
+        total_body_len <= MERCURY_MAX_BODY_LENGTH,
+        "non-first body ({total_body_len}) exceeded MAX_BODY_LENGTH ({MERCURY_MAX_BODY_LENGTH})"
+    );
+    assert_eq!(
+        total_body_len, MERCURY_MAX_BODY_LENGTH,
+        "non-first at NON_FIRST_FRAG_MAX_CHUNK should pack to exactly MAX_BODY_LENGTH",
     );
 }
 
-/// The cooked-data layer chunks at `MAX_CHUNK = 1390` (issue #345).
-/// Pin that the resulting first-fragment body decrypts cleanly and
-/// stays under MAX_BODY_LENGTH with the actual 5-byte safety margin —
-/// the two tests above prove the theoretical absolute cap; this one
-/// proves the production chunker value still has headroom.
+/// The cooked-data layer chunks at `MAX_CHUNK = 1390`. Pin that the
+/// resulting first-fragment body decrypts cleanly and stays under
+/// MAX_BODY_LENGTH with the actual 5-byte safety margin — the two
+/// tests above prove the theoretical absolute cap; this one proves
+/// the production chunker value still has headroom against the
+/// decoded WORD_LEN, not just a hand-computed body sum.
 #[test]
 fn resource_fragment_first_frag_at_cooked_data_max_chunk_has_safety_margin() {
-    const MAX_BODY_LENGTH: usize = 1411;
     const COOKED_DATA_MAX_CHUNK: usize = 1390; // crates/services/src/base/cooked_data.rs
 
     let xml = vec![b'Z'; COOKED_DATA_MAX_CHUNK];
@@ -529,21 +558,18 @@ fn resource_fragment_first_frag_at_cooked_data_max_chunk_has_safety_margin() {
     let enc = MercuryEncryption::from_session_key(TEST_KEY);
     let plaintext = enc.decrypt(&out).expect("decrypt failed");
 
-    let body_len = 1 + 2 + 2 + 1 + 1 + 1 + 4 + 4 + xml.len();
+    let (_word_len, total_body_len) = measure_resource_fragment_body(&plaintext);
     assert!(
-        body_len <= MAX_BODY_LENGTH,
-        "cooked-data first-fragment body ({body_len}) must fit MAX_BODY_LENGTH ({MAX_BODY_LENGTH})",
+        total_body_len <= MERCURY_MAX_BODY_LENGTH,
+        "cooked-data first-fragment body ({total_body_len}) must fit \
+         MAX_BODY_LENGTH ({MERCURY_MAX_BODY_LENGTH})",
     );
     // 5-byte safety margin: 1395 (first-frag cap) - 1390 (chunk size).
-    let safety_margin = MAX_BODY_LENGTH - body_len;
+    let safety_margin = MERCURY_MAX_BODY_LENGTH - total_body_len;
     assert!(
         safety_margin >= 5,
         "safety margin under first-fragment cap dropped to {safety_margin} bytes \
-         — if this fires, either bump MAX_CHUNK back down or audit the in-body header"
-    );
-    assert!(
-        plaintext.len() > body_len,
-        "plaintext truncated below expected body size"
+         — if this fires, either lower MAX_CHUNK or audit the in-body header"
     );
 }
 

--- a/crates/services/src/mercury/protocol/tests.rs
+++ b/crates/services/src/mercury/protocol/tests.rs
@@ -406,6 +406,147 @@ fn resource_fragment_uses_u16_length_prefix() {
     );
 }
 
+/// Pin the chunk-size budget for `BASEMSG_RESOURCE_FRAGMENT`: a
+/// **first** fragment carries 16 bytes of in-body header overhead
+/// (`BASEMSG + WORD_LEN(2) + data_id(2) + chunk_id + frag_flags +
+/// msg_type + category_id(4) + element_id(4)`), so the largest XML
+/// chunk that still fits in Mercury's 1411-byte `MAX_BODY_LENGTH`
+/// plaintext body is 1395 bytes. The cooked-data senders chunk at
+/// 1390 (5-byte safety margin); this guard makes sure the resulting
+/// first-fragment body decrypts cleanly and lands within that cap.
+///
+/// Without this, a bump of `MAX_CHUNK` (e.g. issue #345 raising it
+/// from 1000 → 1390 to cut the cold-cache login burst) has no
+/// regression net — a future overhead change in `build_resource_fragment`
+/// would silently push us over the wire limit on every patched-mission
+/// push. See `crates/services/src/base/cooked_data.rs::MAX_CHUNK`.
+#[test]
+fn resource_fragment_first_frag_at_max_chunk_fits_within_mercury_body_limit() {
+    // Mercury MAX_BODY_LENGTH (plaintext body, after decrypt).
+    const MAX_BODY_LENGTH: usize = 1411;
+    // First-fragment max chunk = MAX_BODY_LENGTH - 16-byte in-body header.
+    const FIRST_FRAG_MAX_CHUNK: usize = MAX_BODY_LENGTH - 16;
+
+    let xml = vec![b'X'; FIRST_FRAG_MAX_CHUNK];
+    let out = build_resource_fragment(
+        &TEST_KEY,
+        5,
+        &[],
+        1, // data_id
+        0, // chunk_id
+        FRAG_FIRST_AND_LAST,
+        Some(0),  // msg_type
+        Some(7),  // category_id
+        Some(42), // element_id
+        &xml,
+    );
+
+    let enc = MercuryEncryption::from_session_key(TEST_KEY);
+    let plaintext = enc.decrypt(&out).expect("first-frag decrypt failed");
+
+    // Plaintext = [flags:u8][body...][footers]. Body starts at offset 1.
+    // Body itself = BASEMSG(1) + WORD_LEN(2) + payload.
+    // Asserting the full plaintext stays within MAX_BODY_LENGTH covers
+    // the body — the footers (seq_id + acks) live outside this cap by
+    // construction.
+    let body_len = 1 + 2 + 2 + 1 + 1 + 1 + 4 + 4 + xml.len();
+    assert_eq!(body_len, MAX_BODY_LENGTH, "math sanity check");
+    // Body slice = plaintext[1..1 + body_len]; assert the body fits.
+    assert!(
+        plaintext.len() > body_len,
+        "plaintext truncated below expected body size: got {} bytes",
+        plaintext.len()
+    );
+    assert!(
+        body_len <= MAX_BODY_LENGTH,
+        "first-fragment body ({body_len}) exceeded MAX_BODY_LENGTH ({MAX_BODY_LENGTH})",
+    );
+}
+
+/// Non-first fragments drop msg_type + category_id + element_id (-9
+/// bytes), so the in-body header collapses to 7 bytes and the chunk
+/// cap rises to 1404. Pin that separately — the 5-byte safety margin
+/// in `MAX_CHUNK = 1390` exists for the tighter first-fragment cap,
+/// and a refactor that accidentally treats non-first like first would
+/// not be caught by the first-fragment guard above.
+#[test]
+fn resource_fragment_non_first_frag_at_max_chunk_fits_within_mercury_body_limit() {
+    const MAX_BODY_LENGTH: usize = 1411;
+    // Non-first fragment in-body header = BASEMSG(1) + WORD_LEN(2) +
+    // data_id(2) + chunk_id(1) + frag_flags(1) = 7 bytes.
+    const NON_FIRST_FRAG_MAX_CHUNK: usize = MAX_BODY_LENGTH - 7;
+
+    let xml = vec![b'Y'; NON_FIRST_FRAG_MAX_CHUNK];
+    let out = build_resource_fragment(
+        &TEST_KEY,
+        5,
+        &[],
+        1, // data_id
+        1, // chunk_id (non-first)
+        super::super::FRAG_MIDDLE,
+        None, // msg_type omitted on non-first
+        None, // category_id omitted
+        None, // element_id omitted
+        &xml,
+    );
+
+    let enc = MercuryEncryption::from_session_key(TEST_KEY);
+    let plaintext = enc.decrypt(&out).expect("non-first-frag decrypt failed");
+
+    let body_len = 1 + 2 + 2 + 1 + 1 + xml.len();
+    assert_eq!(body_len, MAX_BODY_LENGTH, "math sanity check");
+    assert!(
+        plaintext.len() > body_len,
+        "plaintext truncated below expected body size: got {} bytes",
+        plaintext.len()
+    );
+}
+
+/// The cooked-data layer chunks at `MAX_CHUNK = 1390` (issue #345).
+/// Pin that the resulting first-fragment body decrypts cleanly and
+/// stays under MAX_BODY_LENGTH with the actual 5-byte safety margin —
+/// the two tests above prove the theoretical absolute cap; this one
+/// proves the production chunker value still has headroom.
+#[test]
+fn resource_fragment_first_frag_at_cooked_data_max_chunk_has_safety_margin() {
+    const MAX_BODY_LENGTH: usize = 1411;
+    const COOKED_DATA_MAX_CHUNK: usize = 1390; // crates/services/src/base/cooked_data.rs
+
+    let xml = vec![b'Z'; COOKED_DATA_MAX_CHUNK];
+    let out = build_resource_fragment(
+        &TEST_KEY,
+        5,
+        &[],
+        1,
+        0,
+        FRAG_FIRST_AND_LAST,
+        Some(0),
+        Some(7),
+        Some(42),
+        &xml,
+    );
+
+    let enc = MercuryEncryption::from_session_key(TEST_KEY);
+    let plaintext = enc.decrypt(&out).expect("decrypt failed");
+
+    let body_len = 1 + 2 + 2 + 1 + 1 + 1 + 4 + 4 + xml.len();
+    assert!(
+        body_len <= MAX_BODY_LENGTH,
+        "cooked-data first-fragment body ({body_len}) must fit MAX_BODY_LENGTH ({MAX_BODY_LENGTH})",
+    );
+    // 5-byte safety margin: 1395 (first-frag cap) - 1390 (chunk size).
+    let safety_margin = MAX_BODY_LENGTH - body_len;
+    assert!(
+        safety_margin >= 5,
+        "safety margin under first-fragment cap dropped to {safety_margin} bytes \
+         — if this fires, either bump MAX_CHUNK back down or audit the in-body header"
+    );
+    assert!(
+        plaintext.len() > body_len,
+        "plaintext truncated below expected body size"
+    );
+}
+
 #[test]
 fn logged_off_produces_output() {
     let out = build_logged_off(&TEST_KEY, 10, &[]);

--- a/crates/services/src/mercury/world_data/map_loaded.rs
+++ b/crates/services/src/mercury/world_data/map_loaded.rs
@@ -377,23 +377,14 @@ fn build_map_loaded_body_inner(
         append_method!(method_idx::ON_UPDATE_KNOWN_CRAFTS, &args);
     }
 
-    // 24. onChatJoined — notify client about default channels
-    //     Reference: python/base/SGWPlayer.py onClientReady -> ChannelManager.playerLoggedIn
-    for &(channel_name, channel_id) in &[
-        ("say", 0u8),
-        ("emote", 1),
-        ("yell", 2),
-        ("team", 3),
-        ("squad", 4),
-        ("command", 5),
-        ("server", 7),
-        ("tell", 9),
-    ] {
-        let mut args = Vec::new();
-        write_wstring(&mut args, channel_name);
-        args.push(channel_id);
-        append_method!(method_idx::ON_CHAT_JOINED, &args);
-    }
+    // NOTE: `onChatJoined` × 8 channels and `onPlayerCommunication` (welcome
+    // message) used to live here but were moved to `handle_on_client_ready`
+    // — that's where the original `python/base/SGWPlayer.py onClientReady
+    // -> ChannelManager.playerLoggedIn` flow runs them. Keeping them in the
+    // mapLoaded bundle padded ~311 B onto the worst-case fragment burst
+    // (issue #345), and the one-RTT window where the player is in the world
+    // without registered chat channels is identical to the original game's
+    // behavior.
 
     // NOTE: onPlayMovie (first-login cinematic) is intentionally NOT in this
     // bundle. It is deferred to `handle_on_client_ready` and fired AFTER the
@@ -405,24 +396,9 @@ fn build_map_loaded_body_inner(
     // issue #288 and python/cell/SGWPlayer.py:558-565 (the original flow
     // gated mapLoaded() ITSELF on onClientReady, which had the same effect).
 
-    // 25. onPlayerDataLoaded (no args) — client transitions to gameplay
+    // 24. onPlayerDataLoaded (no args) — client transitions to gameplay
     append_method!(method_idx::ON_PLAYER_DATA_LOADED, &[]);
 
-    // 26. onTargetUpdate(INT32) — default 0 (no target)
+    // 25. onTargetUpdate(INT32) — default 0 (no target)
     append_method!(method_idx::ON_TARGET_UPDATE, &0i32.to_le_bytes());
-
-    // 27. onPlayerCommunication(WSTRING speaker, UINT8 flags, UINT8 channel, WSTRING text)
-    //     Welcome message on the feedback channel.
-    {
-        let mut args = Vec::new();
-        write_wstring(&mut args, &data.player_name); // Speaker
-        args.push(0u8); // SpeakerFlags
-        args.push(9u8); // Channel = CHAN_TELL (matches C++ SGWPlayer.py:541)
-        let welcome = format!(
-            "Welcome to Stargate Worlds. Your player id is: {}.",
-            entity_id
-        );
-        write_wstring(&mut args, &welcome); // Text
-        append_method!(method_idx::ON_PLAYER_COMMUNICATION, &args);
-    }
 }

--- a/crates/services/src/mercury/world_data/map_loaded.rs
+++ b/crates/services/src/mercury/world_data/map_loaded.rs
@@ -381,10 +381,9 @@ fn build_map_loaded_body_inner(
     // message) used to live here but were moved to `handle_on_client_ready`
     // — that's where the original `python/base/SGWPlayer.py onClientReady
     // -> ChannelManager.playerLoggedIn` flow runs them. Keeping them in the
-    // mapLoaded bundle padded ~311 B onto the worst-case fragment burst
-    // (issue #345), and the one-RTT window where the player is in the world
-    // without registered chat channels is identical to the original game's
-    // behavior.
+    // mapLoaded bundle padded ~311 B onto the worst-case fragment burst, and
+    // the one-RTT window where the player is in the world without registered
+    // chat channels is identical to the original game's behavior.
 
     // NOTE: onPlayMovie (first-login cinematic) is intentionally NOT in this
     // bundle. It is deferred to `handle_on_client_ready` and fired AFTER the

--- a/crates/services/src/mercury/world_data/tests/map_loaded.rs
+++ b/crates/services/src/mercury/world_data/tests/map_loaded.rs
@@ -87,11 +87,12 @@ fn build_map_loaded_produces_multiple_packets() {
 /// This guard pins `build_map_loaded` itself — by far the dominant
 /// fragment source in the burst — at well under the 32-packet ceiling.
 /// The fixture loads the **full inventory caps** from
-/// `python/common/Constants.py`: 40 main-bag slots + 100 mission-bag
-/// slots + 100 crafting + 4 bandolier + 12 armor slots. The original
-/// fixture used `items: vec![]`, which let an inventory regression
-/// (a future +5kB body from filling these bags) silently slip past
-/// this guard until a real player logged in. Issue #345.
+/// `python/common/Constants.py`: 40 main-bag + 100 mission-bag + 100
+/// crafting + 4 bandolier + 11 equipment slots
+/// (head/face/neck/chest/hands/waist/back/legs/feet/artifact1/artifact2).
+/// The original fixture used `items: vec![]`, which let an inventory
+/// regression — a future +5kB body from filling these bags — silently
+/// slip past this guard until a real player logged in.
 ///
 /// Adding new entity-method records to the bundle is fine; pushing the
 /// fragment count above the ceiling is a wire-format regression that
@@ -101,16 +102,18 @@ fn build_map_loaded_produces_multiple_packets() {
 #[test]
 fn build_map_loaded_fragment_count_fits_within_reliable_tx_window() {
     use cimmeria_entity::inventory::{
-        InvItem, INV_BANDOLIER, INV_CHEST, INV_CRAFTING, INV_FACE, INV_FEET, INV_HANDS, INV_HEAD,
-        INV_LEGS, INV_MAIN, INV_MISSION, INV_NECK, INV_WAIST,
+        InvItem, INV_ARTIFACT1, INV_ARTIFACT2, INV_BACK, INV_BANDOLIER, INV_CHEST, INV_CRAFTING,
+        INV_FACE, INV_FEET, INV_HANDS, INV_HEAD, INV_LEGS, INV_MAIN, INV_MISSION, INV_NECK,
+        INV_WAIST,
     };
     use cimmeria_mercury::consts::TX_WINDOW_SIZE;
 
     // Build a full-capacity inventory fixture. Item shape mirrors the
     // serialiser in `crates/entity/src/inventory.rs::InvItem::serialize`
-    // (~37 B per item with an empty ammo_types). The five wearables
-    // (head/face/neck/chest/hands/waist/legs/feet) and the four
-    // bandolier slots are pre-equipped to mimic a max-decorated player.
+    // (~37 B per item with an empty ammo_types). The 11 equipment slots
+    // (head/face/neck/chest/hands/waist/back/legs/feet/artifact1/artifact2)
+    // and the four bandolier slots are pre-equipped to mimic a
+    // max-decorated player.
     fn fill_bag(items: &mut Vec<InvItem>, container_id: i32, slots: i32) {
         for slot in 0..slots {
             items.push(InvItem {
@@ -132,10 +135,20 @@ fn build_map_loaded_fragment_count_fits_within_reliable_tx_window() {
     fill_bag(&mut items, INV_MISSION, 100);
     fill_bag(&mut items, INV_CRAFTING, 100);
     fill_bag(&mut items, INV_BANDOLIER, 4);
-    for armor_slot in [
-        INV_HEAD, INV_FACE, INV_NECK, INV_CHEST, INV_HANDS, INV_WAIST, INV_LEGS, INV_FEET,
+    for equip_slot in [
+        INV_HEAD,
+        INV_FACE,
+        INV_NECK,
+        INV_CHEST,
+        INV_HANDS,
+        INV_WAIST,
+        INV_BACK,
+        INV_LEGS,
+        INV_FEET,
+        INV_ARTIFACT1,
+        INV_ARTIFACT2,
     ] {
-        fill_bag(&mut items, armor_slot, 1);
+        fill_bag(&mut items, equip_slot, 1);
     }
 
     // Worst-case mapLoaded: a level-20 player with all archetype slots
@@ -489,22 +502,25 @@ fn build_map_loaded_omits_first_login_cinematic_from_bundle() {
          in mapLoaded bundle bytes"
     );
 }
-/// Issue #345 regression guard: `onChatJoined` (method index 31) and
-/// `onPlayerCommunication` (method index 28) MUST NOT appear in the
-/// mapLoaded entity-method bundle. Both used to live there and padded
-/// ~311 B onto the worst-case fragment burst — roughly 156 B for the 8 ×
-/// `onChatJoined` plus 155 B for the welcome `onPlayerCommunication`.
-/// They're now fired from `handle_on_client_ready`, matching the original
+/// Regression guard: `onChatJoined` and `onPlayerCommunication` MUST NOT
+/// appear in the mapLoaded entity-method bundle. Both used to live there
+/// and padded ~311 B onto the worst-case fragment burst — roughly 156 B
+/// for the 8 × `onChatJoined` plus 155 B for the welcome
+/// `onPlayerCommunication`. They're now fired from
+/// `handle_on_client_ready`, matching the original
 /// `python/base/SGWPlayer.py` flow where `onClientReady` calls into
 /// `ChannelManager.playerLoggedIn`.
 ///
-/// Structural check: walking entity-method records over the body must
-/// not yield method indices 28 or 31. Reverting the fix (re-adding
+/// Structural check: walking entity-method records over the body must not
+/// yield indices `method_idx::ON_PLAYER_COMMUNICATION` or
+/// `method_idx::ON_CHAT_JOINED`. Reverting the fix (re-adding
 /// `append_method!(method_idx::ON_CHAT_JOINED, ...)` or
 /// `append_method!(method_idx::ON_PLAYER_COMMUNICATION, ...)` to
 /// `build_map_loaded_body_inner`) must break this test.
 #[test]
 fn build_map_loaded_omits_chat_joined_and_player_communication_from_bundle() {
+    use crate::mercury::method_idx;
+
     let data = sample_player_load_data();
     let entry = sample_world_entry();
 
@@ -513,16 +529,23 @@ fn build_map_loaded_omits_chat_joined_and_player_communication_from_bundle() {
     let method_indices: Vec<u16> = records.iter().map(|(idx, _)| *idx).collect();
 
     assert!(
-        !records.iter().any(|(idx, _)| *idx == 31),
-        "onChatJoined (method 31) must not appear in mapLoaded bundle; \
-         it is deferred to handle_on_client_ready per issue #345. \
-         Indices found: {method_indices:?}"
+        !records
+            .iter()
+            .any(|(idx, _)| *idx == method_idx::ON_CHAT_JOINED),
+        "onChatJoined (method {}) must not appear in mapLoaded bundle; \
+         it is deferred to handle_on_client_ready to match the original \
+         SGWPlayer.py onClientReady → ChannelManager.playerLoggedIn flow. \
+         Indices found: {method_indices:?}",
+        method_idx::ON_CHAT_JOINED,
     );
     assert!(
-        !records.iter().any(|(idx, _)| *idx == 28),
-        "onPlayerCommunication (method 28) must not appear in mapLoaded bundle; \
-         it is deferred to handle_on_client_ready per issue #345. \
-         Indices found: {method_indices:?}"
+        !records
+            .iter()
+            .any(|(idx, _)| *idx == method_idx::ON_PLAYER_COMMUNICATION),
+        "onPlayerCommunication (method {}) must not appear in mapLoaded \
+         bundle; the welcome message is deferred to handle_on_client_ready. \
+         Indices found: {method_indices:?}",
+        method_idx::ON_PLAYER_COMMUNICATION,
     );
 }
 

--- a/crates/services/src/mercury/world_data/tests/map_loaded.rs
+++ b/crates/services/src/mercury/world_data/tests/map_loaded.rs
@@ -86,6 +86,13 @@ fn build_map_loaded_produces_multiple_packets() {
 ///
 /// This guard pins `build_map_loaded` itself — by far the dominant
 /// fragment source in the burst — at well under the 32-packet ceiling.
+/// The fixture loads the **full inventory caps** from
+/// `python/common/Constants.py`: 40 main-bag slots + 100 mission-bag
+/// slots + 100 crafting + 4 bandolier + 12 armor slots. The original
+/// fixture used `items: vec![]`, which let an inventory regression
+/// (a future +5kB body from filling these bags) silently slip past
+/// this guard until a real player logged in. Issue #345.
+///
 /// Adding new entity-method records to the bundle is fine; pushing the
 /// fragment count above the ceiling is a wire-format regression that
 /// would re-introduce the bug the split-counter design was meant to
@@ -93,13 +100,47 @@ fn build_map_loaded_produces_multiple_packets() {
 /// tickSync split tightens the unreliable side).
 #[test]
 fn build_map_loaded_fragment_count_fits_within_reliable_tx_window() {
+    use cimmeria_entity::inventory::{
+        InvItem, INV_BANDOLIER, INV_CHEST, INV_CRAFTING, INV_FACE, INV_FEET, INV_HANDS, INV_HEAD,
+        INV_LEGS, INV_MAIN, INV_MISSION, INV_NECK, INV_WAIST,
+    };
     use cimmeria_mercury::consts::TX_WINDOW_SIZE;
 
+    // Build a full-capacity inventory fixture. Item shape mirrors the
+    // serialiser in `crates/entity/src/inventory.rs::InvItem::serialize`
+    // (~37 B per item with an empty ammo_types). The five wearables
+    // (head/face/neck/chest/hands/waist/legs/feet) and the four
+    // bandolier slots are pre-equipped to mimic a max-decorated player.
+    fn fill_bag(items: &mut Vec<InvItem>, container_id: i32, slots: i32) {
+        for slot in 0..slots {
+            items.push(InvItem {
+                id: items.len() as i32 + 1,
+                dbid: 5000 + slot,
+                stack_size: 1,
+                slot_id: slot,
+                container_id,
+                is_bound: false,
+                durability: 100,
+                ammo_types: vec![],
+                cur_ammo_type: 0,
+                charges: 0,
+            });
+        }
+    }
+    let mut items = Vec::new();
+    fill_bag(&mut items, INV_MAIN, 40);
+    fill_bag(&mut items, INV_MISSION, 100);
+    fill_bag(&mut items, INV_CRAFTING, 100);
+    fill_bag(&mut items, INV_BANDOLIER, 4);
+    for armor_slot in [
+        INV_HEAD, INV_FACE, INV_NECK, INV_CHEST, INV_HANDS, INV_WAIST, INV_LEGS, INV_FEET,
+    ] {
+        fill_bag(&mut items, armor_slot, 1);
+    }
+
     // Worst-case mapLoaded: a level-20 player with all archetype slots
-    // populated, a non-trivial component list, a full ability tree, and
-    // every stargate already discovered. If a fresh-character fixture
-    // fits, a more decorated one must too, but explicitly biasing toward
-    // worst-case makes the guard meaningful.
+    // populated, a non-trivial component list, a full ability tree, every
+    // stargate already discovered, and the full bag-of-bags above.
     let data = PlayerLoadData {
         player_id: 1,
         level: 20,
@@ -128,7 +169,7 @@ fn build_map_loaded_fragment_count_fits_within_reliable_tx_window() {
         access_level: 0,
         skin_color_id: 0,
         ability_tree: archetype_ability_tree(2),
-        items: vec![],
+        items,
         active_bandolier_slot: 0,
         bandolier_items: vec![],
     };
@@ -150,11 +191,12 @@ fn build_map_loaded_fragment_count_fits_within_reliable_tx_window() {
     );
     assert!(
         packets.len() < TX_WINDOW_SIZE,
-        "mapLoaded emitted {} fragments — meets or exceeds the {}-slot reliable TX \
-         window cap (must be strictly less than {} to leave headroom for other \
-         in-flight packets). Adding a new entity-method record pushed the bundle \
-         to or past the wire-format ceiling; either split the new record off into \
-         a separate phase or shrink an existing one.",
+        "mapLoaded emitted {} fragments with a full-inventory fixture — meets or \
+         exceeds the {}-slot reliable TX window cap (must be strictly less than {} \
+         to leave headroom for other in-flight packets). Adding a new entity-method \
+         record or growing an existing record (e.g. wire format bloat in onUpdateItem) \
+         pushed the bundle to or past the wire-format ceiling; either split the new \
+         record off into a separate phase or shrink an existing one.",
         packets.len(),
         TX_WINDOW_SIZE,
         TX_WINDOW_SIZE
@@ -447,6 +489,43 @@ fn build_map_loaded_omits_first_login_cinematic_from_bundle() {
          in mapLoaded bundle bytes"
     );
 }
+/// Issue #345 regression guard: `onChatJoined` (method index 31) and
+/// `onPlayerCommunication` (method index 28) MUST NOT appear in the
+/// mapLoaded entity-method bundle. Both used to live there and padded
+/// ~311 B onto the worst-case fragment burst — roughly 156 B for the 8 ×
+/// `onChatJoined` plus 155 B for the welcome `onPlayerCommunication`.
+/// They're now fired from `handle_on_client_ready`, matching the original
+/// `python/base/SGWPlayer.py` flow where `onClientReady` calls into
+/// `ChannelManager.playerLoggedIn`.
+///
+/// Structural check: walking entity-method records over the body must
+/// not yield method indices 28 or 31. Reverting the fix (re-adding
+/// `append_method!(method_idx::ON_CHAT_JOINED, ...)` or
+/// `append_method!(method_idx::ON_PLAYER_COMMUNICATION, ...)` to
+/// `build_map_loaded_body_inner`) must break this test.
+#[test]
+fn build_map_loaded_omits_chat_joined_and_player_communication_from_bundle() {
+    let data = sample_player_load_data();
+    let entry = sample_world_entry();
+
+    let body = build_map_loaded_body(42, &data, &entry);
+    let records = walk_entity_method_records(&body);
+    let method_indices: Vec<u16> = records.iter().map(|(idx, _)| *idx).collect();
+
+    assert!(
+        !records.iter().any(|(idx, _)| *idx == 31),
+        "onChatJoined (method 31) must not appear in mapLoaded bundle; \
+         it is deferred to handle_on_client_ready per issue #345. \
+         Indices found: {method_indices:?}"
+    );
+    assert!(
+        !records.iter().any(|(idx, _)| *idx == 28),
+        "onPlayerCommunication (method 28) must not appear in mapLoaded bundle; \
+         it is deferred to handle_on_client_ready per issue #345. \
+         Indices found: {method_indices:?}"
+    );
+}
+
 /// Encode `s` the same way `write_wstring` does (length-prefixed UTF-16LE)
 /// and return the **payload bytes only** — the UTF-16LE code units, no
 /// length prefix. That's the substring a reader needs to grep for inside


### PR DESCRIPTION
## Summary

Two independent budget cuts on the cold-cache world-entry burst so it
stays well under Mercury's 32-slot reliable TX window as content grows.

**Item 3 — resourceFragment chunk size 1000 → 1390**
Single shared module constant in [`cooked_data.rs`](crates/services/src/base/cooked_data.rs); chunks pack at 99.6% utilization vs the historical 72%. No fragment savings today (all 4 patched mission overrides are sub-3 kB) but every new PAK override or large dialog element now costs `ceil(size/1390)` packets instead of `ceil(size/1000)`. Three byte-exact guard tests in `mercury::protocol::tests` pin first-fragment / non-first-fragment / production-chunker decrypt-cleanly against `MAX_BODY_LENGTH`.

**Item 4 — onChatJoined ×8 + onPlayerCommunication out of mapLoaded**
Moved into `handle_on_client_ready` to match the original `python/base/SGWPlayer.py onClientReady -> ChannelManager.playerLoggedIn` flow. The Cimmeria placement padded ~311 B onto the worst-case fragment burst. The one-RTT window where the player is in-world without registered chat channels is identical to original game behavior; the welcome message is cosmetic. Regression guard added that mirrors the `onPlayMovie` guard from #288.

**Fragment-count guard hardening**
`build_map_loaded_fragment_count_fits_within_reliable_tx_window` now loads a full-capacity inventory fixture (40 main + 100 mission + 100 crafting + 4 bandolier + 8 armor slots) instead of `items: vec![]`. The original would have let a +5 kB body growth silently slip past until a real player logged in.

## Test plan

- [x] `cargo check -p cimmeria-services`
- [x] `cargo clippy -p cimmeria-services --all-targets -- -D warnings`
- [x] `cargo test -p cimmeria-services --lib` — 779/779 pass
- [x] `cargo fmt --all`
- [x] New tests: 3 resource_fragment size guards + chat-omission guard
- [x] Existing fragment-count guard extended with the full-inventory fixture
- [ ] CI: full workspace clippy + nextest + live-DB

Closes #345

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Chat channel registration and welcome messages now occur earlier during player connection establishment, ensuring chat functionality is available sooner for connecting players.

* **Tests**
  * Added regression tests to validate chat message delivery and wire protocol compliance during client initialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SandboxServers/Cimmeria/pull/350?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->