### PR TITLE
test(holster): pin RefreshAppearance on fire-while-holstered queue (closes #339, #333)

### DIFF
--- a/crates/services/src/cell/abilities/use_ability/tests.rs
+++ b/crates/services/src/cell/abilities/use_ability/tests.rs
@@ -315,7 +315,7 @@ async fn attack_while_holstered_queues_and_draws_without_committing() {
     }
     // required_ammo=1 → triggers the weapon-attack queue.
     mgr.ability_defs.insert(7, make_ability(7, 1, 30));
-    let (tx, _rx) = mpsc::channel(64);
+    let (tx, mut rx) = mpsc::channel(64);
 
     let committed = handle_use_ability(1, 7, 0, &tx, &mut mgr).await;
     assert!(
@@ -346,6 +346,37 @@ async fn attack_while_holstered_queues_and_draws_without_committing() {
     assert_eq!(
         e.bandolier_items[&0].current_ammo, 30,
         "Phase A must NOT consume ammo — ammo check happens in Phase B",
+    );
+
+    // Pin the runtime rebroadcast (#339): Phase A must dispatch exactly
+    // one `RefreshAppearance(holstered=false)` so the base-side handler
+    // unwraps the weapon mesh in the `ComponentList` and rebroadcasts
+    // `BeingAppearance` to self + AoI witnesses. Without this assertion
+    // the test would pass even if a refactor dropped the
+    // `request_appearance_refresh` call — the bug shape #339 was filed
+    // against (server state mutates correctly but other players still
+    // see the player in the holstered pose).
+    let mut refresh_count = 0;
+    while let Ok(msg) = rx.try_recv() {
+        if let CellToBaseMsg::RefreshAppearance {
+            entity_id,
+            holstered,
+            ..
+        } = msg
+        {
+            assert_eq!(entity_id, 1, "RefreshAppearance must target the attacker");
+            assert!(
+                !holstered,
+                "Phase A must broadcast holstered=false (mesh attaches)",
+            );
+            refresh_count += 1;
+        }
+    }
+    assert_eq!(
+        refresh_count, 1,
+        "Phase A must dispatch exactly one RefreshAppearance — \
+         dropping it leaves AoI witnesses stuck on the holstered pose \
+         while the attacker animates an invisible draw",
     );
 }
 

--- a/crates/services/src/cell/abilities/use_ability/tests.rs
+++ b/crates/services/src/cell/abilities/use_ability/tests.rs
@@ -356,27 +356,28 @@ async fn attack_while_holstered_queues_and_draws_without_committing() {
     // `request_appearance_refresh` call — the bug shape this guards
     // against (server state mutates correctly but other players still
     // see the player in the holstered pose).
-    let mut refresh_count = 0;
-    while let Ok(msg) = rx.try_recv() {
-        if let CellToBaseMsg::RefreshAppearance {
-            entity_id,
-            holstered,
-            ..
-        } = msg
-        {
-            assert_eq!(entity_id, 1, "RefreshAppearance must target the attacker");
-            assert!(
-                !holstered,
-                "Phase A must broadcast holstered=false (mesh attaches)",
-            );
-            refresh_count += 1;
-        }
-    }
+    let refreshes: Vec<_> = drain(&mut rx)
+        .into_iter()
+        .filter_map(|m| match m {
+            CellToBaseMsg::RefreshAppearance {
+                entity_id,
+                holstered,
+                ..
+            } => Some((entity_id, holstered)),
+            _ => None,
+        })
+        .collect();
     assert_eq!(
-        refresh_count, 1,
+        refreshes.len(),
+        1,
         "Phase A must dispatch exactly one RefreshAppearance — \
          dropping it leaves AoI witnesses stuck on the holstered pose \
          while the attacker animates an invisible draw",
+    );
+    assert_eq!(
+        refreshes[0],
+        (1, false),
+        "RefreshAppearance must target the attacker with holstered=false",
     );
 }
 

--- a/crates/services/src/cell/abilities/use_ability/tests.rs
+++ b/crates/services/src/cell/abilities/use_ability/tests.rs
@@ -348,12 +348,12 @@ async fn attack_while_holstered_queues_and_draws_without_committing() {
         "Phase A must NOT consume ammo — ammo check happens in Phase B",
     );
 
-    // Pin the runtime rebroadcast (#339): Phase A must dispatch exactly
-    // one `RefreshAppearance(holstered=false)` so the base-side handler
+    // Pin the runtime rebroadcast: Phase A must dispatch exactly one
+    // `RefreshAppearance(holstered=false)` so the base-side handler
     // unwraps the weapon mesh in the `ComponentList` and rebroadcasts
     // `BeingAppearance` to self + AoI witnesses. Without this assertion
     // the test would pass even if a refactor dropped the
-    // `request_appearance_refresh` call — the bug shape #339 was filed
+    // `request_appearance_refresh` call — the bug shape this guards
     // against (server state mutates correctly but other players still
     // see the player in the holstered pose).
     let mut refresh_count = 0;

--- a/docs/gameplay/weapon-ammo-reload.md
+++ b/docs/gameplay/weapon-ammo-reload.md
@@ -98,7 +98,7 @@ Client                       Cell                                       Base / D
   │                           │   reload_slot_id = Some(active_bandolier_slot)  ← pin
   │                           │   abilities.start_ability_cooldown(596, warmup+cooldown)
   │ ◀── onTimerUpdate (m12) ──│  cooldown bar starts
-  │ ◀── onEntityProperty (m25)│  ammo-type sync (cur_ammo_type)
+  │ ◀── onEntityProperty (m7)│  ammo-type sync (cur_ammo_type)
   │                           │
   │  Note: handle_reload does NOT touch bStateField — BSF_IN_COMBAT is
   │  derived from `threatened_mobs` and only flips via combat::generate_threat.
@@ -247,7 +247,7 @@ Client                       Cell                              Base / DB
   │ requestReload(0) ─────────▶│  reload_complete_at = now + 2.0s
   │                            │  start_ability_cooldown(596, 3.0s)
   │ ◀── onTimerUpdate(m12) ────│  cooldown bar
-  │ ◀── onEntityProperty(m25) ─│  ammo-type sync
+  │ ◀── onEntityProperty(m7) ──│  ammo-type sync
   │                            │  (weapon already drawn from the fire above,
   │                            │   so no BeingAppearance — and handle_reload
   │                            │   intentionally does NOT touch bStateField)

--- a/docs/gameplay/weapon-ammo-reload.md
+++ b/docs/gameplay/weapon-ammo-reload.md
@@ -97,13 +97,14 @@ Client                       Cell                                       Base / D
   │                           │   reload_complete_at = now + warmup
   │                           │   reload_slot_id = Some(active_bandolier_slot)  ← pin
   │                           │   abilities.start_ability_cooldown(596, warmup+cooldown)
-  │ ◀── onTimerUpdate (m12) ──│
-  │ ◀── onStateFieldUpdate ───│  (BSF_IN_COMBAT — bit 3 only)
-  │ ◀── BeingAppearance ──────│  ComponentList includes weapon_visual
-  │                           │  (if reload-while-holstered: Phase A first
-  │                           │   draws weapon via RefreshAppearance →
-  │                           │   BeingAppearance, then defers the actual
-  │                           │   reload by UNHOLSTER_DRAW_DURATION)
+  │ ◀── onTimerUpdate (m12) ──│  cooldown bar starts
+  │ ◀── onEntityProperty (m25)│  ammo-type sync (cur_ammo_type)
+  │                           │
+  │  Note: handle_reload does NOT touch bStateField — BSF_IN_COMBAT is
+  │  derived from `threatened_mobs` and only flips via combat::generate_threat.
+  │  A BeingAppearance rebroadcast only fires on the reload-while-holstered
+  │  Phase A path (request_appearance_refresh draws the weapon, the actual
+  │  reload defers by UNHOLSTER_DRAW_DURATION).
   │                           │
   │  (warmup elapses, e.g. 2 s later)
   │                           │
@@ -246,10 +247,10 @@ Client                       Cell                              Base / DB
   │ requestReload(0) ─────────▶│  reload_complete_at = now + 2.0s
   │                            │  start_ability_cooldown(596, 3.0s)
   │ ◀── onTimerUpdate(m12) ────│  cooldown bar
-  │ ◀── onStateFieldUpdate ────│  +BSF_IN_COMBAT (bit 3 only — see
-  │                            │   docs/architecture/state-field-bits.md;
-  │                            │   bit 8 / BSF_HOLSTER was retired in #333)
-  │ ◀── BeingAppearance ───────│  weapon mesh stays attached during reload
+  │ ◀── onEntityProperty(m25) ─│  ammo-type sync
+  │                            │  (weapon already drawn from the fire above,
+  │                            │   so no BeingAppearance — and handle_reload
+  │                            │   intentionally does NOT touch bStateField)
   │
   │   (≈2 s later — next reload_completion_tick after deadline)
   │                            │  refill_active_slot()  → cur=5

--- a/docs/gameplay/weapon-ammo-reload.md
+++ b/docs/gameplay/weapon-ammo-reload.md
@@ -98,7 +98,12 @@ Client                       Cell                                       Base / D
   │                           │   reload_slot_id = Some(active_bandolier_slot)  ← pin
   │                           │   abilities.start_ability_cooldown(596, warmup+cooldown)
   │ ◀── onTimerUpdate (m12) ──│
-  │ ◀── onStateFieldUpdate ───│  (BSF_IN_COMBAT | clear BSF_HOLSTER)
+  │ ◀── onStateFieldUpdate ───│  (BSF_IN_COMBAT — bit 3 only)
+  │ ◀── BeingAppearance ──────│  ComponentList includes weapon_visual
+  │                           │  (if reload-while-holstered: Phase A first
+  │                           │   draws weapon via RefreshAppearance →
+  │                           │   BeingAppearance, then defers the actual
+  │                           │   reload by UNHOLSTER_DRAW_DURATION)
   │                           │
   │  (warmup elapses, e.g. 2 s later)
   │                           │
@@ -241,7 +246,10 @@ Client                       Cell                              Base / DB
   │ requestReload(0) ─────────▶│  reload_complete_at = now + 2.0s
   │                            │  start_ability_cooldown(596, 3.0s)
   │ ◀── onTimerUpdate(m12) ────│  cooldown bar
-  │ ◀── onStateFieldUpdate ────│  +BSF_IN_COMBAT, -BSF_HOLSTER
+  │ ◀── onStateFieldUpdate ────│  +BSF_IN_COMBAT (bit 3 only — see
+  │                            │   docs/architecture/state-field-bits.md;
+  │                            │   bit 8 / BSF_HOLSTER was retired in #333)
+  │ ◀── BeingAppearance ───────│  weapon mesh stays attached during reload
   │
   │   (≈2 s later — next reload_completion_tick after deadline)
   │                            │  refill_active_slot()  → cur=5

--- a/docs/reverse-engineering/findings/animation-system.md
+++ b/docs/reverse-engineering/findings/animation-system.md
@@ -300,8 +300,8 @@ Server sends Event_NetIn_BeingAppearance {BodySet, ComponentList}
 Resolution:
 
 - **#249** (spawn-holstered) — fixed in PR #338. World-entry path emits `BeingAppearance` with `weapon_visual` filtered from `ComponentList`.
-- **#333** (BSF_HOLSTER retirement) — fixed in PR #338. Constant removed; dead clear-on-fire / clear-on-reload writes removed.
-- **#339** (runtime toggle rebroadcast) — fixed in PR #338. `combatant.rs requestHolsterWeapon`, `use_ability.rs` fire-while-holstered queue, and `player/world.rs` reload-while-holstered queue all call `request_appearance_refresh` → base-side `BeingAppearance` rebroadcast to self + AoI witnesses.
+- **#333** (BSF_HOLSTER retirement) — fixed in PR #338. Constant removed; dead clear-on-fire / clear-on-reload writes removed. Test-and-docs follow-up in PR #362 refreshed the wire-flow annotations in [`docs/gameplay/weapon-ammo-reload.md`](../../gameplay/weapon-ammo-reload.md) and added this resolution note.
+- **#339** (runtime toggle rebroadcast) — fixed in PR #338. `combatant.rs requestHolsterWeapon`, `use_ability.rs` fire-while-holstered queue, and `player/world.rs` reload-while-holstered queue all call `request_appearance_refresh` → base-side `BeingAppearance` rebroadcast to self + AoI witnesses. PR #362 closed the missing test gap (the use_ability fire path's regression guard previously discarded `rx`, so dropping the rebroadcast call would have silently passed).
 
 ### Key addresses (appearance system)
 

--- a/docs/reverse-engineering/findings/animation-system.md
+++ b/docs/reverse-engineering/findings/animation-system.md
@@ -293,11 +293,15 @@ Server sends Event_NetIn_BeingAppearance {BodySet, ComponentList}
 | 4 | WEAP_Melee (confirmed as the fallback in FUN_00ec0840) |
 | others | Decoded from BeingAppearance ComponentList cooked data — not fully enumerated |
 
-### Implication for issue #249 (BSF_Holster)
+### Implication for issues #249 / #333 / #339 (BSF_Holster — resolved)
 
-**BSF_Holster (bit 8 of bStateField) does NOT write entity+0x3D2.** The posture byte is exclusively driven by the appearance pipeline. The holster animation blend in `USGWAnim_BlendByPosture` reads `entity+0x3D2` directly — the correct server behavior is to send a `BeingAppearance` with the weapon unequipped (or weapon category = relaxed/no-weapon) when the player holsters. BSF_Holster may be a persistence/query bit only (allowing new witnesses to query holster state) rather than an animation trigger.
+**BSF_Holster (bit 8 of bStateField) does NOT write entity+0x3D2.** The posture byte is exclusively driven by the appearance pipeline. The holster animation blend in `USGWAnim_BlendByPosture` reads `entity+0x3D2` directly — the correct server behavior is to send a `BeingAppearance` with the weapon visual filtered out of `ComponentList` when the player holsters. BSF_Holster is not even a persistence/query bit — the 2009 client stores the full 32-bit `bStateField` at `+0x158` but `GameBeing_OnStateFieldUpdate` (`ghidra://SGW.exe@0x00e01c90`) only dispatches on bits 0-7. See [`docs/architecture/state-field-bits.md`](../../architecture/state-field-bits.md) for the verified bit→side-effect table.
 
-This finding changes the analysis of issue #249: the fix may need to include sending an updated `BeingAppearance` to witnesses (not just an `onStateFieldUpdate` broadcast) when holster/draw occurs.
+Resolution:
+
+- **#249** (spawn-holstered) — fixed in PR #338. World-entry path emits `BeingAppearance` with `weapon_visual` filtered from `ComponentList`.
+- **#333** (BSF_HOLSTER retirement) — fixed in PR #338. Constant removed; dead clear-on-fire / clear-on-reload writes removed.
+- **#339** (runtime toggle rebroadcast) — fixed in PR #338. `combatant.rs requestHolsterWeapon`, `use_ability.rs` fire-while-holstered queue, and `player/world.rs` reload-while-holstered queue all call `request_appearance_refresh` → base-side `BeingAppearance` rebroadcast to self + AoI witnesses.
 
 ### Key addresses (appearance system)
 


### PR DESCRIPTION
## Summary

PR #338 already implemented everything #339 and #333 asked for — but the GitHub auto-close didn't fire (the PR body used a `## Closes` markdown header rather than a `Closes #N` keyword), so both issues stayed open. This PR closes the coverage gap I found while auditing and properly closes the tickets.

## What was already done in PR #338

**#333 (BSF_HOLSTER cleanup):**

- `BSF_HOLSTER` constant removed from `cell/combat/state.rs` and the re-export in `combat/mod.rs`.
- Dead clear-on-fire write in `use_ability.rs` and clear-on-reload write in `cell_methods/player/world.rs` deleted.
- `requestHolsterWeapon` switched from the dead bit to `CellEntity::set_weapon_holstered`.
- New canonical doc [`docs/architecture/state-field-bits.md`](docs/architecture/state-field-bits.md) with the verified bit→side-effect table, pinned to Ghidra anchors.
- [`docs/architecture/state-flag-conventions.md`](docs/architecture/state-flag-conventions.md) row dropped + cross-link added.

**#339 (runtime toggle rebroadcast):** all three callsites already wired:

- `crates/services/src/cell/cell_methods/combatant.rs:91` — `requestHolsterWeapon` → `request_appearance_refresh`.
- `crates/services/src/cell/abilities/use_ability/mod.rs:254` — fire-while-holstered queue → `request_appearance_refresh`.
- `crates/services/src/cell/cell_methods/player/world/mod.rs:354` — reload-while-holstered queue → `request_appearance_refresh`.

The `request_appearance_refresh` helper sends `CellToBaseMsg::RefreshAppearance`, which the base-side `refresh_appearance` handler turns into a fan-out of `BeingAppearance` to the owner + all AoI witnesses via `refresh_player_appearance`.

## What this PR adds

### Test coverage gap

The combatant.rs path (`request_holster_weapon_dispatches_refresh_appearance`) and the reload path (`reload_while_holstered_phase_a_defers_reload`) each have a strict test that drains the `tx` receiver and asserts a `RefreshAppearance` was sent. The use_ability fire path's existing test (`attack_while_holstered_queues_and_draws_without_committing`) only checked state mutation — it discarded `_rx`, so dropping the `request_appearance_refresh` call would silently pass.

Adversarial verification: commenting out `request_appearance_refresh` at `use_ability/mod.rs:254` makes the new assertion fail (`left: 0, right: 1`) — exactly the #339 bug shape (server state correct, AoI witnesses stuck on holstered pose).

### Ghidra re-verification of the wire contract

I re-decompiled both anchor functions against the live `SGW.exe` binary to confirm the design's bedrock claims still hold:

- **`GameBeing_OnStateFieldUpdate @ ghidra://SGW.exe@0x00e01c90`** — XORs current ^ new at `+0x158`, then dispatches on masks `0x01, 0x02, 0x08, 0xC4, 0x10, 0x20`. Bit 8 (mask `0x100`) is **never tested**. Confirms #333's premise.
- **`CompositedAppearanceProxy::ApplyToPawn @ ghidra://SGW.exe@0x00ec0840`** — `iVar2 = *(int*)(this+0x34)` (proxy weapon-category, defaults to 4=WEAP_Melee on zero), then `*(char*)(param_5+0x3d2) = (char)iVar2`. The animation-key posture byte is fed from the appearance compositor, never from `bStateField`. Confirms #339's wire contract.

### Sidewalks

Two stale `BSF_HOLSTER` references in wire-flow diagrams refreshed:

- `docs/gameplay/weapon-ammo-reload.md` — two `onStateFieldUpdate (… | clear BSF_HOLSTER)` annotations updated to reflect the actual mechanism (BSF_IN_COMBAT bit only + separate `BeingAppearance` broadcast).
- `docs/reverse-engineering/findings/animation-system.md` — the "Implication for #249" section consolidated into a resolution note covering #249 + #333 + #339.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --exclude cimmeria-app --exclude cimmeria-content-editor --exclude cimmeria-scene-editor --exclude sgw-launcher --all-targets -- -D warnings` clean
- [x] `cargo test -p cimmeria-services --lib` — **835 / 835 passing**
- [x] `cargo test -p cimmeria-entity --lib` — **160 / 160 passing**
- [x] Adversarial: commented out the `request_appearance_refresh` call at `use_ability/mod.rs:254` → new assertion fails with `left: 0, right: 1`. Restored.
- [x] Ghidra wire-contract verification (above).
- [x] Markdown lint: my two doc edits introduce no new lint violations (pre-existing violations in adjacent docs remain — that's a separate cleanup).

## Closes

- Closes #339
- Closes #333

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for attack behavior while holstered to ensure proper character appearance refresh and unholster state synchronization.

* **Documentation**
  * Updated weapon reload sequence documentation to clarify visual behavior and timing during reload while holstered.
  * Refined animation system documentation to explain how holster state changes drive weapon appearance updates during combat scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SandboxServers/Cimmeria/pull/362?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->