### PR TITLE
feat(mercury): bundle onClientReady appearance/chat burst (#360)

### DIFF
--- a/crates/services/src/base/world_entry_appearance.rs
+++ b/crates/services/src/base/world_entry_appearance.rs
@@ -8,13 +8,14 @@ use std::net::SocketAddr;
 use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex};
 
+use cimmeria_mercury::channel_bundle::ChannelBundle;
 use cimmeria_mercury::transport::Transport;
 use tokio::sync::mpsc;
 
 use crate::cell::messages::BaseToCellMsg;
 use crate::mercury::{build_entity_method_packet, method_idx, write_wstring, SKIN_TINTS};
 
-use super::helpers::send_to_witness_reliable;
+use super::helpers::{send_bundle_to_witness_reliable, send_to_witness_reliable};
 use super::world_entry::handle_map_loaded;
 use super::world_entry_chat::{
     build_chat_joined_args, build_welcome_message_args, DEFAULT_CHAT_CHANNELS,
@@ -52,6 +53,38 @@ pub(crate) fn build_tint_args(skin_color_id: i32) -> Vec<u8> {
     buf.extend_from_slice(&0u32.to_le_bytes());
     buf.extend_from_slice(&skin_tint.to_le_bytes());
     buf
+}
+
+/// Compose the post-onClientReady burst into a single Mercury bundle.
+///
+/// Order matches the original per-message dispatch sequence so a regression
+/// that swaps two entries can't slip past via the packet-count check:
+///   1. `BeingAppearance` resend  (heals HOLD-FOR-TRANSACTION drop from
+///      `handle_map_loaded`'s bundle — see issue #356 / map_loaded.rs:66)
+///   2. `onEntityTint` resend     (same reason)
+///   3. `onChatJoined` × N        (channel registration — N = DEFAULT_CHAT_CHANNELS.len())
+///   4. `onPlayerCommunication`   (cosmetic welcome line)
+///
+/// Extracted as a pure builder so the burst-shape regression guard
+/// [`tests::on_client_ready_burst_bundles_to_single_packet`] can pin
+/// `num_messages = 2 + N + 1` and `estimated_packet_count() = 1` against
+/// realistic arg sizes — the same composition the handler actually emits
+/// (call-site duplication would let the test and the handler drift).
+fn build_on_client_ready_burst_bundle(
+    entity_id: u32,
+    appearance_args: &[u8],
+    tint_args: &[u8],
+    welcome_args: &[u8],
+) -> ChannelBundle {
+    let mut bundle = ChannelBundle::new(true);
+    bundle.append_entity_method(method_idx::BEING_APPEARANCE, entity_id, appearance_args);
+    bundle.append_entity_method(method_idx::ON_ENTITY_TINT, entity_id, tint_args);
+    for &(channel_name, channel_id) in DEFAULT_CHAT_CHANNELS {
+        let args = build_chat_joined_args(channel_name, channel_id);
+        bundle.append_entity_method(method_idx::ON_CHAT_JOINED, entity_id, &args);
+    }
+    bundle.append_entity_method(method_idx::ON_PLAYER_COMMUNICATION, entity_id, welcome_args);
+    bundle
 }
 
 // ── Visual resend handlers ──────────────────────────────────────────────────
@@ -282,89 +315,30 @@ pub(crate) async fn handle_on_client_ready(
         }
     }
 
-    // Resend BeingAppearance + onEntityTint now that the entity is fully ready.
+    // Bundle the post-onClientReady burst: BeingAppearance resend +
+    // onEntityTint resend + 8× onChatJoined + onPlayerCommunication welcome.
+    //
+    // **Transaction-state audit** (see
+    // [docs/architecture/mercury-bundle.md](../../../docs/architecture/mercury-bundle.md)):
+    // every message below targets the player's own `entity_id`, which was
+    // created in `handle_map_loaded`'s prior bundle. The CREATE_BASE_PLAYER
+    // transaction released at that bundle's end-of-frame, so same-entity
+    // messages in THIS bundle bind to the now-live entity and are NOT
+    // HOLD-FOR-TRANSACTION dropped. No CREATE_ENTITY / CELL_PLAYER fires
+    // inside this handler, so the bundle is exclusively post-transaction
+    // property/method updates — the canonical "safe to combine" case.
+    //
+    // Pre-bundle: 11 reliable packets (1 appearance + 1 tint + 8 chat-joined
+    // + 1 welcome), each consuming a TX-window slot. Post-bundle: 1 reliable
+    // packet (the burst body is ~700 B, well under FRAGMENT_BODY_SIZE=1300),
+    // pinned by `on_client_ready_burst_bundles_to_single_packet` in
+    // `world_data/tests/player_creation.rs`.
+    //
+    // `speaker` resolution mirrors the pre-bundle path: prefer the session's
+    // `player_name`, fall back to "Server" (a real DEFAULT_CHAT_CHANNELS
+    // entry) with a WARN so the unexpected missing-name case stays visible.
     let appearance_args = pending.appearance_args;
     let tint_args = pending.tint_args;
-    send_to_witness_reliable(
-        transport,
-        connected,
-        entity_to_addr,
-        entity_id,
-        |key, seq, acks| {
-            build_entity_method_packet(
-                key,
-                seq,
-                acks,
-                entity_id,
-                method_idx::BEING_APPEARANCE,
-                &appearance_args,
-            )
-        },
-    )
-    .await;
-    send_to_witness_reliable(
-        transport,
-        connected,
-        entity_to_addr,
-        entity_id,
-        |key, seq, acks| {
-            build_entity_method_packet(
-                key,
-                seq,
-                acks,
-                entity_id,
-                method_idx::ON_ENTITY_TINT,
-                &tint_args,
-            )
-        },
-    )
-    .await;
-
-    // Chat-channel joins + welcome message. Original C++ path is
-    // `python/base/SGWPlayer.py onClientReady -> ChannelManager.playerLoggedIn`,
-    // so onClientReady (here) is the canonical fire-point. These used to
-    // live in the mapLoaded bundle and padded ~311 B onto the worst-case
-    // fragment burst before being moved out. Routed via
-    // `send_to_witness_reliable`: the player is a witness of their own
-    // entity, so this targets the connected client and keeps the bytes
-    // on the reliable channel.
-    //
-    // Arg-building is split into pure helpers (`build_chat_joined_args` /
-    // `build_welcome_message_args`) so they're independently unit-tested;
-    // this loop is the wire side that the test suite can't reach without
-    // a full async harness.
-    for &(channel_name, channel_id) in DEFAULT_CHAT_CHANNELS {
-        let args = build_chat_joined_args(channel_name, channel_id);
-        send_to_witness_reliable(
-            transport,
-            connected,
-            entity_to_addr,
-            entity_id,
-            |key, seq, acks| {
-                build_entity_method_packet(
-                    key,
-                    seq,
-                    acks,
-                    entity_id,
-                    method_idx::ON_CHAT_JOINED,
-                    &args,
-                )
-            },
-        )
-        .await;
-    }
-
-    // Welcome message — `onPlayerCommunication(speaker, flags, channel, text)`
-    // on CHAN_TELL (9). Matches python `SGWPlayer.py:541`. Cosmetic-only;
-    // dropping it has no correctness impact, but it's the moment-of-arrival
-    // visible signal that the channel registration above actually landed.
-    //
-    // `player_name` is normally set during `playCharacter` and stays for
-    // the session; falling back to a generic "Server" speaker keeps the
-    // welcome line visible even when the name didn't propagate (race
-    // during a synthesised cross-world `onClientReady`, or a future
-    // refactor that defers the name read). The warn log surfaces the
-    // unexpected case without dropping the message on the floor.
     let speaker = player_name.as_deref().unwrap_or_else(|| {
         tracing::warn!(
             %addr,
@@ -374,26 +348,11 @@ pub(crate) async fn handle_on_client_ready(
         );
         "Server"
     });
-    {
-        let args = build_welcome_message_args(speaker, entity_id);
-        send_to_witness_reliable(
-            transport,
-            connected,
-            entity_to_addr,
-            entity_id,
-            |key, seq, acks| {
-                build_entity_method_packet(
-                    key,
-                    seq,
-                    acks,
-                    entity_id,
-                    method_idx::ON_PLAYER_COMMUNICATION,
-                    &args,
-                )
-            },
-        )
-        .await;
-    }
+    let welcome_args = build_welcome_message_args(speaker, entity_id);
+
+    let bundle =
+        build_on_client_ready_burst_bundle(entity_id, &appearance_args, &tint_args, &welcome_args);
+    send_bundle_to_witness_reliable(transport, connected, entity_to_addr, entity_id, bundle).await;
 
     // First-login cinematic — fires AFTER appearance is bound to the now-live
     // possessed pawn. Sending it inside the mapLoaded bundle (before this
@@ -611,40 +570,17 @@ async fn resend_appearance_after_cinematic(
         return;
     };
 
-    send_to_witness_reliable(
-        transport,
-        connected,
-        entity_to_addr,
-        entity_id,
-        |key, seq, acks| {
-            build_entity_method_packet(
-                key,
-                seq,
-                acks,
-                entity_id,
-                method_idx::BEING_APPEARANCE,
-                &appearance_args,
-            )
-        },
-    )
-    .await;
-    send_to_witness_reliable(
-        transport,
-        connected,
-        entity_to_addr,
-        entity_id,
-        |key, seq, acks| {
-            build_entity_method_packet(
-                key,
-                seq,
-                acks,
-                entity_id,
-                method_idx::ON_ENTITY_TINT,
-                &tint_args,
-            )
-        },
-    )
-    .await;
+    // Bundle the BeingAppearance + onEntityTint pair into one fragment.
+    // Both methods target the player's own entity (long since created in
+    // map_loaded's bundle), so the transaction-state rule allows combining
+    // them — see [docs/architecture/mercury-bundle.md] for the safe-combine
+    // catalogue. Called per-iteration of the cinematic-guard spam loop
+    // (every 100 ms for up to 20 s), so the per-iter packet-count halving
+    // compounds across the spam window.
+    let mut bundle = ChannelBundle::new(true);
+    bundle.append_entity_method(method_idx::BEING_APPEARANCE, entity_id, &appearance_args);
+    bundle.append_entity_method(method_idx::ON_ENTITY_TINT, entity_id, &tint_args);
+    send_bundle_to_witness_reliable(transport, connected, entity_to_addr, entity_id, bundle).await;
 }
 
 /// Handle the client's `cancelMovie` (exposed cell method index 108): the
@@ -777,6 +713,94 @@ mod tests {
         let buf = build_tint_args(-1);
         let tint = u32::from_le_bytes([buf[8], buf[9], buf[10], buf[11]]);
         assert_eq!(tint, SKIN_TINTS[0]);
+    }
+
+    /// **Burst-shape regression guard for the issue #360 onClientReady
+    /// bundle migration.**
+    ///
+    /// Before the migration, `handle_on_client_ready` emitted 11 reliable
+    /// packets at world entry (1 BeingAppearance + 1 onEntityTint + 8
+    /// onChatJoined + 1 onPlayerCommunication welcome), each consuming a
+    /// slot in the per-channel 32-slot reliable TX window. After the
+    /// migration, the burst rides one `ChannelBundle` that finalizes to a
+    /// single fragment whenever the body fits inside `FRAGMENT_BODY_SIZE`.
+    ///
+    /// Pin two invariants the migration depends on:
+    ///   - `num_messages == 2 + DEFAULT_CHAT_CHANNELS.len() + 1` — every
+    ///     message expected in the burst is appended. A regression that
+    ///     drops one of the methods (or skips the channel loop) fails here
+    ///     before the wire desync reaches the client.
+    ///   - `estimated_packet_count() == 1` — realistic-sized inputs
+    ///     comfortably fit a single fragment. A future regression that
+    ///     either bloats one of the appended args past
+    ///     `FRAGMENT_BODY_SIZE - other_messages` OR adds a 9th chat channel
+    ///     would tip this to 2+ packets and fire here, prompting an
+    ///     explicit re-audit of the bundle shape (and potentially a
+    ///     transaction-state re-audit if the second fragment lands after
+    ///     a same-entity CREATE in the same client frame).
+    ///
+    /// Args sizes mirror the production wire: appearance is a typical
+    /// 8-component humanoid set (~120 B), tint is the fixed 12 B layout
+    /// from `build_tint_args`, welcome uses the realistic entity_id 12345
+    /// to exercise the multi-digit branch of the welcome text formatter.
+    #[test]
+    fn on_client_ready_burst_bundles_to_single_packet() {
+        use cimmeria_mercury::packet::FRAGMENT_BODY_SIZE;
+
+        const ENTITY_ID: u32 = 12345;
+
+        // Realistic 8-component humanoid appearance (Castle_CellBlock spawn
+        // shape — see `build_appearance_args` test cases for the canonical
+        // wire layout).
+        let appearance = build_appearance_args(
+            "MaleBody",
+            &[
+                "Hair".to_string(),
+                "Head".to_string(),
+                "Torso".to_string(),
+                "Legs".to_string(),
+                "Hands".to_string(),
+                "Feet".to_string(),
+                "Belt".to_string(),
+                "Backpack".to_string(),
+            ],
+        );
+        let tint = build_tint_args(3);
+        let welcome = build_welcome_message_args("Cadacious", ENTITY_ID);
+
+        let bundle = build_on_client_ready_burst_bundle(ENTITY_ID, &appearance, &tint, &welcome);
+
+        // Count check: every burst message must land in the bundle. The
+        // expected number is parameterised on DEFAULT_CHAT_CHANNELS so an
+        // addition to the chat-channel set updates both sides at once.
+        let expected_count = 2 + DEFAULT_CHAT_CHANNELS.len() + 1;
+        assert_eq!(
+            bundle.num_messages(),
+            expected_count,
+            "burst must contain BeingAppearance + onEntityTint + N onChatJoined + welcome \
+             (where N = DEFAULT_CHAT_CHANNELS.len() = {})",
+            DEFAULT_CHAT_CHANNELS.len()
+        );
+
+        // Single-fragment shape: the burst is small enough that
+        // estimated_packet_count drops to 1 for the current channel set + arg
+        // sizes. If realistic args grow past the fragment size, this assert
+        // forces an explicit re-audit (the migration's "1 frame == 1 bundle"
+        // safety claim hinges on the post-finalize fragment count).
+        assert!(
+            bundle.body_len() < FRAGMENT_BODY_SIZE,
+            "burst body ({} B) must fit one fragment (limit {} B) — a regression here \
+             means the chat channel set grew or an arg ballooned, and the migration's \
+             single-packet shape needs a re-audit",
+            bundle.body_len(),
+            FRAGMENT_BODY_SIZE
+        );
+        assert_eq!(
+            bundle.estimated_packet_count(),
+            1,
+            "post-bundle burst must collapse to a single reliable packet \
+             (was 11 pre-bundle)"
+        );
     }
 }
 

--- a/crates/services/src/base/world_entry_appearance.rs
+++ b/crates/services/src/base/world_entry_appearance.rs
@@ -60,7 +60,10 @@ pub(crate) fn build_tint_args(skin_color_id: i32) -> Vec<u8> {
 /// Order matches the original per-message dispatch sequence so a regression
 /// that swaps two entries can't slip past via the packet-count check:
 ///   1. `BeingAppearance` resend  (heals HOLD-FOR-TRANSACTION drop from
-///      `handle_map_loaded`'s bundle — see issue #356 / map_loaded.rs:66)
+///      `handle_map_loaded`'s bundle — see the two-bundle split comment
+///      block in [`crate::base::world_entry::map_loaded`] for the
+///      transaction-state rationale, and `docs/architecture/mercury-bundle.md`
+///      for the ADR.)
 ///   2. `onEntityTint` resend     (same reason)
 ///   3. `onChatJoined` × N        (channel registration — N = DEFAULT_CHAT_CHANNELS.len())
 ///   4. `onPlayerCommunication`   (cosmetic welcome line)
@@ -331,8 +334,8 @@ pub(crate) async fn handle_on_client_ready(
     // Pre-bundle: 11 reliable packets (1 appearance + 1 tint + 8 chat-joined
     // + 1 welcome), each consuming a TX-window slot. Post-bundle: 1 reliable
     // packet (the burst body is ~700 B, well under FRAGMENT_BODY_SIZE=1300),
-    // pinned by `on_client_ready_burst_bundles_to_single_packet` in
-    // `world_data/tests/player_creation.rs`.
+    // pinned by [`tests::on_client_ready_burst_bundles_to_single_packet`]
+    // in this file.
     //
     // `speaker` resolution mirrors the pre-bundle path: prefer the session's
     // `player_name`, fall back to "Server" (a real DEFAULT_CHAT_CHANNELS
@@ -571,16 +574,36 @@ async fn resend_appearance_after_cinematic(
     };
 
     // Bundle the BeingAppearance + onEntityTint pair into one fragment.
-    // Both methods target the player's own entity (long since created in
-    // map_loaded's bundle), so the transaction-state rule allows combining
-    // them — see [docs/architecture/mercury-bundle.md] for the safe-combine
-    // catalogue. Called per-iteration of the cinematic-guard spam loop
-    // (every 100 ms for up to 20 s), so the per-iter packet-count halving
-    // compounds across the spam window.
-    let mut bundle = ChannelBundle::new(true);
-    bundle.append_entity_method(method_idx::BEING_APPEARANCE, entity_id, &appearance_args);
-    bundle.append_entity_method(method_idx::ON_ENTITY_TINT, entity_id, &tint_args);
+    // Built via the shared helper so the burst-shape regression guard
+    // [`tests::appearance_resend_bundle_collapses_to_single_packet`]
+    // pins the same composition the production path emits.
+    let bundle = build_appearance_resend_bundle(entity_id, &appearance_args, &tint_args);
     send_bundle_to_witness_reliable(transport, connected, entity_to_addr, entity_id, bundle).await;
+}
+
+/// Compose the BeingAppearance + onEntityTint resend pair into one bundle.
+///
+/// Both methods target the player's own entity (long since created in
+/// `handle_map_loaded`'s bundle), so the transaction-state rule allows
+/// combining them — see the safe-combine catalogue in
+/// `docs/architecture/mercury-bundle.md` and the two-bundle split comment in
+/// [`crate::base::world_entry::map_loaded`] for the rationale.
+///
+/// Called per-iteration of the cinematic-guard spam loop (every 100 ms for
+/// up to 20 s) and also from `handle_cancel_movie` on real client
+/// `cancelMovie`. Extracted as a pure builder so
+/// [`tests::appearance_resend_bundle_collapses_to_single_packet`] can pin
+/// `num_messages == 2` and `estimated_packet_count() == 1` against the same
+/// composition the resend path actually emits.
+fn build_appearance_resend_bundle(
+    entity_id: u32,
+    appearance_args: &[u8],
+    tint_args: &[u8],
+) -> ChannelBundle {
+    let mut bundle = ChannelBundle::new(true);
+    bundle.append_entity_method(method_idx::BEING_APPEARANCE, entity_id, appearance_args);
+    bundle.append_entity_method(method_idx::ON_ENTITY_TINT, entity_id, tint_args);
+    bundle
 }
 
 /// Handle the client's `cancelMovie` (exposed cell method index 108): the
@@ -715,7 +738,7 @@ mod tests {
         assert_eq!(tint, SKIN_TINTS[0]);
     }
 
-    /// **Burst-shape regression guard for the issue #360 onClientReady
+    /// **Burst-shape regression guard for the `handle_on_client_ready`
     /// bundle migration.**
     ///
     /// Before the migration, `handle_on_client_ready` emitted 11 reliable
@@ -800,6 +823,62 @@ mod tests {
             1,
             "post-bundle burst must collapse to a single reliable packet \
              (was 11 pre-bundle)"
+        );
+    }
+
+    /// **Burst-shape regression guard for the `resend_appearance_after_cinematic`
+    /// 2-packet collapse.**
+    ///
+    /// The cinematic-guard spam loop in `send_cinematic` invokes
+    /// `resend_appearance_after_cinematic` every 100 ms for up to 20 s
+    /// (200 iterations max), each iteration emitting BeingAppearance +
+    /// onEntityTint. Pre-bundle that was 2 reliable packets per iteration
+    /// (400 TX-window slots over the worst-case spam window); post-bundle
+    /// each iteration emits exactly 1 packet (200 slots).
+    ///
+    /// `handle_cancel_movie` also calls the same resend path on real
+    /// client `cancelMovie` — single-shot 2 → 1.
+    ///
+    /// Pin two invariants:
+    ///   - `num_messages == 2` — exactly BeingAppearance + onEntityTint,
+    ///     in order. A regression that drops one or appends a stray method
+    ///     fails here.
+    ///   - `estimated_packet_count() == 1` — the realistic appearance arg
+    ///     size (~120 B for an 8-component humanoid) plus the 12-byte tint
+    ///     fits comfortably under `FRAGMENT_BODY_SIZE`. If a future regression
+    ///     bloats the appearance args past the fragment cutoff, this assert
+    ///     forces a re-audit (a fragmented appearance resend defeats the
+    ///     spam-loop's per-iter slot savings).
+    #[test]
+    fn appearance_resend_bundle_collapses_to_single_packet() {
+        const ENTITY_ID: u32 = 12345;
+        let appearance = build_appearance_args(
+            "MaleBody",
+            &[
+                "Hair".to_string(),
+                "Head".to_string(),
+                "Torso".to_string(),
+                "Legs".to_string(),
+                "Hands".to_string(),
+                "Feet".to_string(),
+                "Belt".to_string(),
+                "Backpack".to_string(),
+            ],
+        );
+        let tint = build_tint_args(3);
+
+        let bundle = build_appearance_resend_bundle(ENTITY_ID, &appearance, &tint);
+
+        assert_eq!(
+            bundle.num_messages(),
+            2,
+            "appearance resend must be exactly BeingAppearance + onEntityTint"
+        );
+        assert_eq!(
+            bundle.estimated_packet_count(),
+            1,
+            "appearance resend must collapse to a single reliable packet \
+             (was 2 pre-bundle, called per-iter of the 100 ms × 200 spam loop)"
         );
     }
 }

--- a/crates/services/src/mercury/aoi/tests.rs
+++ b/crates/services/src/mercury/aoi/tests.rs
@@ -427,6 +427,113 @@ fn compose_create_entity_base_body_matches_build_create_entity_base_body() {
     );
 }
 
+/// **Load-bearing byte-equivalence guard for the entity-method bundle path.**
+///
+/// `ChannelBundle::append_entity_method` (in `cimmeria-mercury`) and
+/// `build_entity_method_packet`'s body (via `services::mercury::append_entity_method`)
+/// must emit byte-identical wire bytes. They live in two different crates
+/// and the encoder is duplicated for performance — the only thing keeping
+/// them in lock-step is the shared `EXTENDED_ENCODING_THRESHOLD` /
+/// `EXTENDED_ENCODING_MARKER` constants and this test.
+///
+/// Coverage:
+/// - **Direct encoding** (`method_index < 61`): pin `BEING_APPEARANCE` (26),
+///   `ON_ENTITY_TINT` (10), `ON_CHAT_JOINED` (31), `ON_PLAYER_COMMUNICATION`
+///   (28). Together these are every method in the
+///   `handle_on_client_ready` post-bundle burst — drift in any of them
+///   silently desyncs the post-onClientReady client state.
+/// - **Extended encoding** (`method_index >= 61`): pin `ON_PLAY_MOVIE` (155),
+///   the only extended-encoding emit in `world_entry_appearance.rs` (via
+///   `send_cinematic`). The encoder's `(method_index - 61) as u8` truncation
+///   path needs at least one extended-encoding witness or a future regression
+///   could land at index ≥ 317 (`u8::MAX + 61 + 1`) and silently truncate.
+///
+/// **Regression shape**: if a future refactor changes the wire layout in
+/// only one of the two encoders (a length-prefix endian flip, dropping the
+/// 0x80 direct-encoding marker, etc.), the bundle-migrated `handle_on_client_ready`
+/// path would emit different bytes than the still-per-message `send_cinematic`
+/// path, breaking the BeingAppearance/onChatJoined replay semantics. This
+/// test fires before the wire divergence reaches a real client.
+#[test]
+fn channel_bundle_append_entity_method_matches_build_entity_method_packet_body() {
+    use crate::mercury::{build_entity_method_packet, method_idx};
+    use cimmeria_mercury::channel_bundle::ChannelBundle;
+
+    const ENTITY_ID: u32 = 0xCAFE_BABE;
+
+    // Direct-encoding witnesses: every method index in the
+    // handle_on_client_ready burst.
+    let direct_cases: &[(u16, &[u8])] = &[
+        (method_idx::BEING_APPEARANCE, b"appearance-body-bytes"),
+        (method_idx::ON_ENTITY_TINT, &[0u8; 12]),
+        (method_idx::ON_CHAT_JOINED, b"chat-joined-args"),
+        (method_idx::ON_PLAYER_COMMUNICATION, b"welcome-msg-args"),
+    ];
+
+    for &(method_index, args) in direct_cases {
+        // Bundle path: append one method and grab the accumulated body.
+        let mut bundle = ChannelBundle::new(true);
+        bundle.append_entity_method(method_index, ENTITY_ID, args);
+        // body is private — finalize without acks/flags to recover the
+        // bytes. With body_len() < FRAGMENT_BODY_SIZE this emits 1 packet,
+        // and the plaintext closure is identity so we get the body back.
+        let (packets, _seqs) = bundle.finalize(0, 0, |plaintext| plaintext.to_vec());
+        assert_eq!(
+            packets.len(),
+            1,
+            "small body must be one un-fragmented packet"
+        );
+        // Bundle's finalize prepends the flags byte AND appends the seq
+        // footer (since FLAG_HAS_SEQUENCE is implied by base_seq=0 +
+        // build_fragmented_bundle's framing). Recover body == pkt[1..len-4].
+        let bundle_body = &packets[0][1..packets[0].len() - 4];
+
+        // Standalone-packet path: decrypt and strip flags+seq footer.
+        let pkt = build_entity_method_packet(&TEST_KEY, 1, &[], ENTITY_ID, method_index, args);
+        let enc = MercuryEncryption::from_session_key(TEST_KEY);
+        let pt = enc.decrypt(&pkt).unwrap();
+        let standalone_body = &pt[1..pt.len() - 4];
+
+        assert_eq!(
+            bundle_body, standalone_body,
+            "direct encoding mismatch for method_index={method_index} — \
+             ChannelBundle::append_entity_method drifted from \
+             services::mercury::append_entity_method"
+        );
+    }
+
+    // Extended-encoding witness: ON_PLAY_MOVIE (155 ≥ 61). Exercises the
+    // marker-byte + sub_index code path that direct cases don't.
+    {
+        let method_index = method_idx::ON_PLAY_MOVIE;
+        let args = b"\x10\x00\x00\x00Cine-Test.Cine\x00\x01".as_slice();
+        let mut bundle = ChannelBundle::new(true);
+        bundle.append_entity_method(method_index, ENTITY_ID, args);
+        let (packets, _seqs) = bundle.finalize(0, 0, |plaintext| plaintext.to_vec());
+        assert_eq!(packets.len(), 1);
+        let bundle_body = &packets[0][1..packets[0].len() - 4];
+
+        let pkt = build_entity_method_packet(&TEST_KEY, 1, &[], ENTITY_ID, method_index, args);
+        let enc = MercuryEncryption::from_session_key(TEST_KEY);
+        let pt = enc.decrypt(&pkt).unwrap();
+        let standalone_body = &pt[1..pt.len() - 4];
+
+        assert_eq!(
+            bundle_body, standalone_body,
+            "extended encoding mismatch for method_index={method_index} — \
+             the 0xBD marker + sub_index path drifted between bundle and \
+             standalone-packet encoders"
+        );
+        // Also pin the extended-marker first byte so a regression that
+        // accidentally encoded ON_PLAY_MOVIE as direct (255 & 0x80 → wrong
+        // method id) still fails clearly.
+        assert_eq!(
+            bundle_body[0], 0xBD,
+            "method_index >= 61 must use extended encoding marker 0xBD"
+        );
+    }
+}
+
 /// Same regression guard for the phase-2 cascade composer. Tests the
 /// `npc_data: None` shape (player phase-2, smallest cascade — class_id !=
 /// 0 → includes the SGWBeing block but skips all the npc-specific

--- a/docs/architecture/mercury-bundle.md
+++ b/docs/architecture/mercury-bundle.md
@@ -202,15 +202,24 @@ appearance / chat / welcome burst on every world entry:
 | 1 × BeingAppearance + 1 × onEntityTint + 8 × onChatJoined + 1 × welcome | 1 same-entity bundle, ~700 B body, 1 packet |
 | **11 reliable packets** | **1 reliable packet** |
 
+Plus the `resend_appearance_after_cinematic` 2-packet pair (BeingAppearance
++ onEntityTint), called both from `handle_cancel_movie` (single-shot) and
+from the cinematic-guard spam loop in `send_cinematic` (every 100 ms for up
+to 20 s — 200 iterations × 2 packets = 400 reliable packets worst-case,
+now 200 packets). For a first-login cinematic that runs the full spam
+window (e.g. SGWLogo intro at 13.10 s natural end + 7 s safety buffer),
+that's a ~50% reduction in cinematic-guard TX-window pressure.
+
 Safe per the transaction-state rule because the player entity was created
 in `handle_map_loaded`'s prior bundle and its transaction released at the
 prior bundle's end-of-frame; this bundle is exclusively post-transaction
 property/method updates. Regression-guarded by
-`on_client_ready_burst_bundles_to_single_packet` in
-[base/world_entry_appearance.rs](../../crates/services/src/base/world_entry_appearance.rs)
-(pins `num_messages = 2 + DEFAULT_CHAT_CHANNELS.len() + 1` and
-`estimated_packet_count() == 1`) and by the new entity-method byte-
-equivalence guard at
+`on_client_ready_burst_bundles_to_single_packet` (pins `num_messages =
+2 + DEFAULT_CHAT_CHANNELS.len() + 1` and `estimated_packet_count() == 1`)
+and `appearance_resend_bundle_collapses_to_single_packet` (pins
+`num_messages == 2` and `estimated_packet_count() == 1`) — both in
+[base/world_entry_appearance.rs](../../crates/services/src/base/world_entry_appearance.rs).
+Plus the entity-method byte-equivalence guard at
 [mercury/aoi/tests.rs](../../crates/services/src/mercury/aoi/tests.rs)
 (`channel_bundle_append_entity_method_matches_build_entity_method_packet_body` —
 covers both direct and extended encodings via ON_PLAY_MOVIE = 155).

--- a/docs/architecture/mercury-bundle.md
+++ b/docs/architecture/mercury-bundle.md
@@ -1,6 +1,6 @@
 # Mercury Bundle abstraction
 
-> **Last updated**: 2026-05-23
+> **Last updated**: 2026-05-24
 > **Audience**: Engineers touching Mercury send paths, AoI fanout, world-entry
 > bursts, or anything that calls `send_to_witness_reliable`
 > **Type**: Architecture decision + reference for callers
@@ -42,11 +42,22 @@ decision sits with the caller, not with a per-channel auto-accumulator.
   (was 56 pre-bundle). ✅
 - **Layer C**: regression guards in place (compose↔build byte-equivalence,
   28-NPC burst budget). ✅
+- **#360 follow-up — world_entry_appearance migration**: the
+  `handle_on_client_ready` 11-packet burst (1 BeingAppearance + 1 onEntityTint
+  + 8 onChatJoined + 1 onPlayerCommunication welcome) and the
+  `resend_appearance_after_cinematic` 2-packet pair now ride a single
+  `ChannelBundle` each. Safe per the rule below: every message in both
+  bursts targets the player's own entity_id, which was created in
+  `handle_map_loaded`'s prior bundle, so the CREATE_BASE_PLAYER transaction
+  released between bundles. Pinned by
+  `on_client_ready_burst_bundles_to_single_packet` (11 → 1 packet) and a
+  new compose↔build byte-equivalence guard for the entity-method bundle
+  path covering both direct and extended encodings. ✅
 - **Deferred to follow-up [#360](https://github.com/SandboxServers/Cimmeria/issues/360)**:
-  per-handler migrations across world-entry, world-entry-appearance,
-  inventory/vendor/mail, progression, teleport, and the remaining AoI
-  handlers. Each has its own transaction-state surface to audit and
-  warrants a separate, reviewable PR.
+  remaining per-handler migrations across world-data/phases.rs, inventory/
+  vendor/mail, progression, teleport, and the remaining AoI handlers. Each
+  has its own transaction-state surface to audit and warrants a separate,
+  reviewable PR.
 
 ## The transaction-state rule
 
@@ -182,6 +193,27 @@ Regression-guarded at "≤ 15 packets" in
 [base/world_entry/cell_dispatch/tests.rs](../../crates/services/src/base/world_entry/cell_dispatch/tests.rs)
 (`flush_deferred_aoi_bundles_28_npc_burst_under_packet_budget`) with
 comfortable headroom for cascade-payload growth.
+
+The #360 follow-up extends the same shape to the post-`onClientReady`
+appearance / chat / welcome burst on every world entry:
+
+| Pre-bundle | Post-bundle |
+|---:|---:|
+| 1 × BeingAppearance + 1 × onEntityTint + 8 × onChatJoined + 1 × welcome | 1 same-entity bundle, ~700 B body, 1 packet |
+| **11 reliable packets** | **1 reliable packet** |
+
+Safe per the transaction-state rule because the player entity was created
+in `handle_map_loaded`'s prior bundle and its transaction released at the
+prior bundle's end-of-frame; this bundle is exclusively post-transaction
+property/method updates. Regression-guarded by
+`on_client_ready_burst_bundles_to_single_packet` in
+[base/world_entry_appearance.rs](../../crates/services/src/base/world_entry_appearance.rs)
+(pins `num_messages = 2 + DEFAULT_CHAT_CHANNELS.len() + 1` and
+`estimated_packet_count() == 1`) and by the new entity-method byte-
+equivalence guard at
+[mercury/aoi/tests.rs](../../crates/services/src/mercury/aoi/tests.rs)
+(`channel_bundle_append_entity_method_matches_build_entity_method_packet_body` —
+covers both direct and extended encodings via ON_PLAY_MOVIE = 155).
 
 ## Migration playbook for follow-up call families
 


### PR DESCRIPTION
## Summary

Migrates two reliable bursts in [crates/services/src/base/world_entry_appearance.rs](crates/services/src/base/world_entry_appearance.rs) from per-message `send_to_witness_reliable` to `ChannelBundle` via `send_bundle_to_witness_reliable`. First slice of [#360](https://github.com/SandboxServers/Cimmeria/issues/360), follow-up to [#356](https://github.com/SandboxServers/Cimmeria/pull/361).

- `handle_on_client_ready` — **11 reliable packets → 1** (BeingAppearance + onEntityTint + 8× onChatJoined + welcome).
- `resend_appearance_after_cinematic` — **2 → 1**, called per-iteration of the cinematic-guard spam loop (every 100 ms for up to 20 s).

`send_cinematic`'s standalone `onPlayMovie` stays on the per-message path (single send, no bundling benefit).

## Transaction-state audit

Every message in both migrated bundles targets the player's own `entity_id`, which was created in `handle_map_loaded`'s **prior** bundle. The `CREATE_BASE_PLAYER` transaction released at that prior bundle's end-of-frame, so same-entity messages here are exclusively post-transaction property/method updates — the canonical "safe to combine" case per [docs/architecture/mercury-bundle.md](docs/architecture/mercury-bundle.md). No CREATE_ENTITY / CELL_PLAYER fires inside the migrated handlers.

**Ghidra evidence** for the client-side gate: `GameAppearanceManager::scheduleAppearanceJob` at `0x00e69150` carries the debug string `"HOLD FOR TRANSACTION"` ([address-map.md line 885](docs/reverse-engineering/address-map.md)). This is the function the `BeingAppearance` records land in; it gates on transaction state, so post-transaction sends pass through cleanly.

## Test plan

- [x] **Byte-equivalence guard** (`channel_bundle_append_entity_method_matches_build_entity_method_packet_body` in [crates/services/src/mercury/aoi/tests.rs](crates/services/src/mercury/aoi/tests.rs)) — pins that `ChannelBundle::append_entity_method` (in `cimmeria-mercury`) and `services::mercury::append_entity_method` emit byte-identical wire bytes. Covers every method in the onClientReady burst (direct encoding: BEING_APPEARANCE=26, ON_ENTITY_TINT=10, ON_CHAT_JOINED=31, ON_PLAYER_COMMUNICATION=28) AND extended encoding via ON_PLAY_MOVIE=155.
- [x] **Burst-shape regression guard** (`on_client_ready_burst_bundles_to_single_packet` in [crates/services/src/base/world_entry_appearance.rs](crates/services/src/base/world_entry_appearance.rs)) — pins `num_messages = 2 + DEFAULT_CHAT_CHANNELS.len() + 1` and `estimated_packet_count() == 1` via a shared `build_on_client_ready_burst_bundle` helper the handler and test both call (handler and test cannot drift).
- [x] **Adversarial reversal check** — temporarily skipping the first DEFAULT_CHAT_CHANNELS entry in the helper fired the `num_messages == 11` assertion. Reverted before commit.
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --exclude {GUI crates} --all-targets -- -D warnings`
- [x] `cargo build --workspace --exclude {GUI crates} --all-targets`
- [x] `cargo test --workspace --exclude {GUI crates} --lib --no-fail-fast` — 1373 lib tests passed, 0 failed.

## Doc updates

[docs/architecture/mercury-bundle.md](docs/architecture/mercury-bundle.md) status + observed-win sections updated to reflect this slice.

## Closes / tracking

Ticks the `world_entry_appearance.rs` checkbox on [#360](https://github.com/SandboxServers/Cimmeria/issues/360). Issue stays open for the remaining families (world_data/phases.rs, mail, vendor, inventory, progression, teleport, minigame, AoI tail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)