### PR TITLE
feat(mercury): bundle progression + teleport + close remaining #360 families

### DIFF
--- a/crates/services/src/base/world_entry/methods/progression/mod.rs
+++ b/crates/services/src/base/world_entry/methods/progression/mod.rs
@@ -2,12 +2,13 @@ use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
 
+use cimmeria_mercury::channel_bundle::ChannelBundle;
 use cimmeria_mercury::transport::Transport;
 use sqlx::PgPool;
 
 use cimmeria_game::player::{MAX_LEVEL, TRAINING_POINTS_PER_LEVEL};
 
-use super::super::super::helpers::send_to_witness_reliable;
+use super::super::super::helpers::{send_bundle_to_witness_reliable, send_to_witness_reliable};
 use super::super::super::ConnectedClientState;
 use crate::mercury::{build_entity_method_packet, method_idx};
 
@@ -175,109 +176,98 @@ pub async fn handle_grant_xp(
         "GrantXP processed"
     );
 
-    send_to_witness_reliable(
-        transport,
-        connected,
-        entity_to_addr,
+    // Bundle the post-grant notifications into a single Mercury frame.
+    //
+    // **Transaction-state audit**: every message in this bundle targets the
+    // player's own `entity_id`, created in `handle_map_loaded`'s prior bundle
+    // (the CREATE_BASE_PLAYER transaction released between bundles). No
+    // CREATE_ENTITY / CELL_PLAYER fires here; the bundle is exclusively
+    // post-transaction property/method updates — canonical "safe to combine"
+    // per [docs/architecture/mercury-bundle.md].
+    //
+    // Pre-bundle burst-shape: 1 (always) + 2 × levels_gained.len() (per-level
+    // pair) + 2 (if any level gained) = 1..2N+3 packets where N = number of
+    // levels gained. Typical small grant: 1 packet. Worst case (max-level
+    // catch-up): 2N+3 packets. Post-bundle: 1 packet (body fits one fragment
+    // for any realistic N — each per-level pair is ~30 B and MAX_LEVEL=20
+    // caps the per-grant level delta, so the body stays well under
+    // FRAGMENT_BODY_SIZE = 1300 B). Pinned by
+    // `grant_xp_max_level_burst_bundles_to_single_packet`.
+    let bundle = build_grant_xp_bundle(
         entity_id,
-        |key, seq, acks| {
-            build_entity_method_packet(
-                key,
-                seq,
-                acks,
-                entity_id,
-                method_idx::ON_EXP_UPDATE,
-                // Wire format is i32; saturate so a u64 total exceeding 2^31-1
-                // doesn't wrap negative on the client display.
-                &(total_xp.min(i32::MAX as u64) as i32).to_le_bytes(),
-            )
-        },
-    )
-    .await;
+        total_xp,
+        new_level,
+        training_points,
+        &levels_gained,
+    );
+    send_bundle_to_witness_reliable(transport, connected, entity_to_addr, entity_id, bundle).await;
+}
 
-    for &lvl in &levels_gained {
-        send_to_witness_reliable(
-            transport,
-            connected,
-            entity_to_addr,
+/// Compose the post-grant_xp notification burst into a single Mercury bundle.
+///
+/// Order matches the pre-bundle dispatch sequence so a regression that
+/// reorders two entries is caught by the order-sensitive
+/// `grant_xp_*` burst-shape regression guards in
+/// [`mod tests`]:
+///   1. `onExpUpdate`                 (always)
+///   2. per level gained, in order:
+///      a. `GIVE_XP_FOR_LEVEL`
+///      b. `onMaxExpUpdate`
+///   3. `onLevelUpdate`               (only if any level gained)
+///   4. `onEntityProperty(TRAINING_POINTS)` (only if any level gained)
+///
+/// Extracted as a pure builder so the burst-shape regression guard can pin
+/// `num_messages` and `estimated_packet_count()` against the same composition
+/// the handler emits (call-site duplication would let the test and the
+/// handler drift).
+fn build_grant_xp_bundle(
+    entity_id: u32,
+    total_xp: u64,
+    new_level: u32,
+    training_points: u32,
+    levels_gained: &[u32],
+) -> ChannelBundle {
+    let mut bundle = ChannelBundle::new(true);
+    bundle.append_entity_method(
+        method_idx::ON_EXP_UPDATE,
+        entity_id,
+        // Wire format is i32; saturate so a u64 total exceeding 2^31-1
+        // doesn't wrap negative on the client display.
+        &(total_xp.min(i32::MAX as u64) as i32).to_le_bytes(),
+    );
+
+    for &lvl in levels_gained {
+        bundle.append_entity_method(
+            method_idx::GIVE_XP_FOR_LEVEL,
             entity_id,
-            |key, seq, acks| {
-                build_entity_method_packet(
-                    key,
-                    seq,
-                    acks,
-                    entity_id,
-                    method_idx::GIVE_XP_FOR_LEVEL,
-                    &(lvl as i32).to_le_bytes(),
-                )
-            },
-        )
-        .await;
-
+            &(lvl as i32).to_le_bytes(),
+        );
         let next_threshold = if lvl >= MAX_LEVEL {
             LEVEL_XP[MAX_LEVEL as usize] as i32
         } else {
             LEVEL_XP[lvl as usize] as i32
         };
-        send_to_witness_reliable(
-            transport,
-            connected,
-            entity_to_addr,
+        bundle.append_entity_method(
+            method_idx::ON_MAX_EXP_UPDATE,
             entity_id,
-            |key, seq, acks| {
-                build_entity_method_packet(
-                    key,
-                    seq,
-                    acks,
-                    entity_id,
-                    method_idx::ON_MAX_EXP_UPDATE,
-                    &next_threshold.to_le_bytes(),
-                )
-            },
-        )
-        .await;
+            &next_threshold.to_le_bytes(),
+        );
     }
 
     if !levels_gained.is_empty() {
-        send_to_witness_reliable(
-            transport,
-            connected,
-            entity_to_addr,
+        bundle.append_entity_method(
+            method_idx::ON_LEVEL_UPDATE,
             entity_id,
-            |key, seq, acks| {
-                build_entity_method_packet(
-                    key,
-                    seq,
-                    acks,
-                    entity_id,
-                    method_idx::ON_LEVEL_UPDATE,
-                    &(new_level as i32).to_le_bytes(),
-                )
-            },
-        )
-        .await;
+            &(new_level as i32).to_le_bytes(),
+        );
 
         let mut tp_args = Vec::with_capacity(8);
         tp_args.extend_from_slice(&GENERICPROPERTY_TRAINING_POINTS.to_le_bytes());
         tp_args.extend_from_slice(&(training_points as i32).to_le_bytes());
-        send_to_witness_reliable(
-            transport,
-            connected,
-            entity_to_addr,
-            entity_id,
-            |key, seq, acks| {
-                build_entity_method_packet(
-                    key,
-                    seq,
-                    acks,
-                    entity_id,
-                    method_idx::ON_ENTITY_PROPERTY,
-                    &tp_args,
-                )
-            },
-        )
-        .await;
+        bundle.append_entity_method(method_idx::ON_ENTITY_PROPERTY, entity_id, &tp_args);
     }
+
+    bundle
 }
 
 /// Handle cash grant from CellService -- update DB and send client notification.

--- a/crates/services/src/base/world_entry/methods/progression/tests.rs
+++ b/crates/services/src/base/world_entry/methods/progression/tests.rs
@@ -1,12 +1,14 @@
-//! Live-DB integration tests for `handle_grant_cash`.
+//! Live-DB integration tests for `handle_grant_cash` plus pure burst-shape
+//! regression guards for `handle_grant_xp`'s post-grant bundle.
 //!
-//! Skip cleanly when `DATABASE_URL` is unset; against the bundled local
-//! Postgres they pin the WHERE-by-player_id contract that prevents
-//! multi-character accounts from leaking grants between siblings.
+//! Live-DB tests skip cleanly when `DATABASE_URL` is unset; against the
+//! bundled local Postgres they pin the WHERE-by-player_id contract that
+//! prevents multi-character accounts from leaking grants between siblings.
 
 use super::*;
 use crate::test_support::require_db_or_skip;
 use crate::test_support::TestTransport;
+use cimmeria_mercury::packet::FRAGMENT_BODY_SIZE;
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
@@ -186,4 +188,103 @@ async fn does_not_credit_when_player_row_missing() {
     assert_eq!(nonexistent_count, 0, "missing-row branch must not INSERT");
 
     cleanup(&pool, account_id).await;
+}
+
+// ── Burst-shape regression guards for the handle_grant_xp bundle migration ──
+//
+// Pure assertions against `build_grant_xp_bundle` — no DB, no transport.
+// The handler builds via this same helper, so a regression that drifts
+// the bundle composition (drops a record, reorders the per-level pair,
+// or skips the level-up tail) fails here before the wire desync reaches
+// the client.
+
+/// Zero-level (steady-state) grant: only `onExpUpdate` lands in the bundle.
+/// Pre-bundle this was 1 packet → 1 packet (no wire saving), but the bundle
+/// path still atomically drains pending ACKs onto the same fragment so the
+/// reliable-stream behavior matches the multi-level path uniformly.
+#[test]
+fn grant_xp_no_level_bundle_is_single_message() {
+    let bundle = build_grant_xp_bundle(42, 500, 1, 0, &[]);
+    assert_eq!(
+        bundle.num_messages(),
+        1,
+        "zero-level grant emits exactly onExpUpdate"
+    );
+    assert_eq!(
+        bundle.estimated_packet_count(),
+        1,
+        "single message must fit one packet"
+    );
+}
+
+/// Single-level grant burst: pre-bundle was 5 packets (onExpUpdate +
+/// GIVE_XP_FOR_LEVEL + onMaxExpUpdate + onLevelUpdate + onEntityProperty).
+/// Post-bundle: 1 packet.
+#[test]
+fn grant_xp_single_level_burst_bundles_to_single_packet() {
+    let bundle = build_grant_xp_bundle(42, 2_500, 7, 8, &[7]);
+    assert_eq!(
+        bundle.num_messages(),
+        5,
+        "single-level grant must contain: onExpUpdate + GIVE_XP_FOR_LEVEL + \
+         onMaxExpUpdate + onLevelUpdate + onEntityProperty(TRAINING_POINTS)"
+    );
+    assert_eq!(
+        bundle.estimated_packet_count(),
+        1,
+        "single-level grant bundle must collapse to 1 reliable packet \
+         (was 5 pre-bundle)"
+    );
+}
+
+/// Max-level catch-up burst: simulates a grant that vaults a level-1
+/// character to MAX_LEVEL (19 levels gained). Pre-bundle that was
+/// `1 + 2*19 + 2 = 41` reliable packets — a single content-engine call
+/// would chew up a quarter of the 32-slot reliable TX window before any
+/// other state-change traffic. Post-bundle: 1 packet.
+///
+/// Pin the upper bound at `num_messages == 41` and assert the body still
+/// fits one fragment so a regression that bloats per-message wire payloads
+/// past the per-fragment cutoff is caught here.
+#[test]
+fn grant_xp_max_level_burst_bundles_to_single_packet() {
+    use cimmeria_game::player::MAX_LEVEL;
+
+    let levels_gained: Vec<u32> = (1..=MAX_LEVEL).collect();
+    assert_eq!(
+        levels_gained.len() as u32,
+        MAX_LEVEL,
+        "test invariant: covers every level transition up to MAX_LEVEL"
+    );
+
+    let bundle = build_grant_xp_bundle(
+        42, // entity_id
+        LEVEL_XP[MAX_LEVEL as usize],
+        MAX_LEVEL,
+        TRAINING_POINTS_PER_LEVEL * MAX_LEVEL,
+        &levels_gained,
+    );
+
+    let expected = 1 + 2 * levels_gained.len() + 2;
+    assert_eq!(
+        bundle.num_messages(),
+        expected,
+        "max-level grant must contain onExpUpdate + 2 per level gained + \
+         onLevelUpdate + onEntityProperty(TRAINING_POINTS) = {expected}"
+    );
+    assert!(
+        bundle.body_len() < FRAGMENT_BODY_SIZE,
+        "max-level grant body ({} B) must fit one fragment (limit {} B) — \
+         a regression here means per-message wire payloads grew, and the \
+         bundle's single-packet shape needs a re-audit",
+        bundle.body_len(),
+        FRAGMENT_BODY_SIZE
+    );
+    assert_eq!(
+        bundle.estimated_packet_count(),
+        1,
+        "max-level grant bundle must collapse to 1 reliable packet \
+         (was {} pre-bundle — would consume a quarter of the 32-slot TX window)",
+        expected
+    );
 }

--- a/crates/services/src/base/world_entry/teleport.rs
+++ b/crates/services/src/base/world_entry/teleport.rs
@@ -11,12 +11,13 @@ use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
 
+use cimmeria_mercury::channel_bundle::ChannelBundle;
 use cimmeria_mercury::transport::Transport;
 use sqlx::PgPool;
 
-use crate::mercury::{build_entity_method_packet, build_forced_position};
+use crate::mercury::compose_forced_position_body;
 
-use super::super::helpers::send_to_witness_reliable;
+use super::super::helpers::send_bundle_to_witness_reliable;
 use super::super::ConnectedClientState;
 
 /// Authoritative same-world teleport: snap the player's avatar to `position`.
@@ -68,44 +69,22 @@ pub(super) async fn handle_teleport_player(
         "TeleportPlayer: snapping avatar"
     );
 
-    // 1. Engine-level snap. `prev_pos` is the entity's last-known position
-    //    before the teleport — see `build_forced_position` and
-    //    `spec.protocol.mercury` §1.10.6 for why this is not zero.
-    send_to_witness_reliable(
-        transport,
-        connected,
-        entity_to_addr,
-        entity_id,
-        |key, seq, acks| {
-            build_forced_position(key, seq, acks, entity_id, space_id, position, prev_pos)
-        },
-    )
-    .await;
-
-    // 2. Streaming-load waiting flag (method 116). Direction is zeroed —
-    //    we don't currently rotate the avatar on ring travel.
-    let mut args = Vec::with_capacity(24);
-    for &c in &position {
-        args.extend_from_slice(&c.to_le_bytes());
-    }
-    args.extend_from_slice(&[0u8; 12]); // direction = 0,0,0
-    send_to_witness_reliable(
-        transport,
-        connected,
-        entity_to_addr,
-        entity_id,
-        |key, seq, acks| {
-            build_entity_method_packet(
-                key,
-                seq,
-                acks,
-                entity_id,
-                crate::cell::client_methods::player::ON_PLAYER_TELEPORT,
-                &args,
-            )
-        },
-    )
-    .await;
+    // Bundle the engine-level snap + streaming-load hint into one frame.
+    //
+    // **Transaction-state audit**: both messages target the player's own
+    // entity, long since created. `FORCED_POSITION` (0x31) is a property-
+    // update on an already-live entity — NOT a creation — so it doesn't
+    // enter a CREATE_ENTITY transaction. Same-entity `onPlayerTeleport`
+    // (method 116) following it in the same bundle binds to the already-
+    // live entity and is NOT HOLD-FOR-TRANSACTION dropped. See
+    // [docs/architecture/mercury-bundle.md] safe-combine catalogue.
+    //
+    // Pre-bundle: 2 reliable packets (FORCED_POSITION snap + onPlayerTeleport
+    // hint). Post-bundle: 1 reliable packet (~70 B body, well under
+    // FRAGMENT_BODY_SIZE=1300). Pinned by
+    // `teleport_bundles_forced_position_and_player_teleport_to_single_packet`.
+    let bundle = build_teleport_bundle(entity_id, space_id, position, prev_pos);
+    send_bundle_to_witness_reliable(transport, connected, entity_to_addr, entity_id, bundle).await;
 
     // 3. Persist. Mirrors gate_travel's fail-closed on missing active_player_id.
     if let Some(pool) = db_pool {
@@ -147,6 +126,46 @@ pub(super) async fn handle_teleport_player(
             }
         }
     }
+}
+
+/// Compose the teleport handshake into a single Mercury bundle.
+///
+/// Order matches the pre-bundle dispatch sequence:
+///   1. `FORCED_POSITION (0x31)` — engine-level snap; the avatar moves here.
+///   2. `onPlayerTeleport (method 116)` — streaming-load waiting flag;
+///      kicks the client into terrain-chunk loading at the new position.
+///
+/// `FORCED_POSITION` is appended via [`ChannelBundle::append_raw_message`]
+/// because it's a Mercury base message (0x31), not an entity-method call.
+/// The 50-byte body is composed by [`compose_forced_position_body`].
+///
+/// Extracted as a pure builder so the burst-shape regression guard
+/// [`tests::teleport_bundles_forced_position_and_player_teleport_to_single_packet`]
+/// pins the same composition the handler actually emits.
+fn build_teleport_bundle(
+    entity_id: u32,
+    space_id: u32,
+    position: [f32; 3],
+    prev_pos: [f32; 3],
+) -> ChannelBundle {
+    let mut bundle = ChannelBundle::new(true);
+    bundle.append_raw_message(&compose_forced_position_body(
+        entity_id, space_id, position, prev_pos,
+    ));
+    // Direction is zeroed — we don't currently rotate the avatar on ring
+    // travel. The wire args are 24 bytes: 12 for position, 12 for the
+    // zero direction.
+    let mut args = Vec::with_capacity(24);
+    for &c in &position {
+        args.extend_from_slice(&c.to_le_bytes());
+    }
+    args.extend_from_slice(&[0u8; 12]);
+    bundle.append_entity_method(
+        crate::cell::client_methods::player::ON_PLAYER_TELEPORT,
+        entity_id,
+        &args,
+    );
+    bundle
 }
 
 #[cfg(test)]
@@ -213,11 +232,14 @@ mod tests {
     }
 
     /// Domain B (fan-out byte test): a valid same-world teleport snaps the
-    /// player by emitting exactly two packets to the player's own addr, in
-    /// order — `FORCED_POSITION` (seq 0) then `onPlayerTeleport` (seq 1) —
-    /// byte-exact, with **zero** witness fan-out (teleport is owner-only).
-    /// Catches a regression that drops the engine-level snap, reorders the
-    /// burst, or leaks the snap to other clients.
+    /// player by emitting **one bundled packet** to the player's own addr —
+    /// FORCED_POSITION + onPlayerTeleport concatenated into a single Mercury
+    /// frame — with **zero** witness fan-out (teleport is owner-only).
+    ///
+    /// Pre-bundle this fired 2 reliable packets; after the issue #360
+    /// migration the same two records land in one fragment. The fan-out
+    /// shape (owner-only routing) and message ordering inside the bundle
+    /// are preserved.
     #[tokio::test]
     async fn teleport_emits_forced_position_then_player_teleport_to_owner_only() {
         let transport = Arc::new(TestTransport::new());
@@ -253,38 +275,74 @@ mod tests {
         let sent = transport.drain();
         assert_eq!(
             sent.len(),
-            2,
-            "exactly FORCED_POSITION + onPlayerTeleport, no witness fan-out"
+            1,
+            "post-bundle: FORCED_POSITION + onPlayerTeleport ride one Mercury \
+             frame to the owner addr (was 2 packets pre-bundle)"
         );
-        assert_eq!(sent[0].0, player_addr, "snap goes to the player's own addr");
         assert_eq!(
-            sent[1].0, player_addr,
-            "teleport hint goes to the same addr"
+            sent[0].0, player_addr,
+            "bundled teleport handshake goes to the player's own addr only"
         );
 
-        // test_default_connected_client_state starts next_seq at 0, key all-zero.
+        // The bundled packet's decrypted body must equal the concatenation of
+        // the standalone FORCED_POSITION body and the standalone
+        // onPlayerTeleport entity-method body — the two records the client
+        // processes after fragment reassembly. Decrypting the full packet
+        // and inspecting body bytes lets the test fire on any wire-format
+        // drift inside either composer.
+        use cimmeria_mercury::encryption::MercuryEncryption;
         let key = [0u8; 32];
-        assert_eq!(
-            sent[0].1,
-            build_forced_position(&key, 0, &[], entity_id, space_id, position, prev_pos),
-            "FORCED_POSITION wire bytes (seq 0)"
-        );
+        let enc = MercuryEncryption::from_session_key(key);
+        let pt = enc.decrypt(&sent[0].1).expect("decrypt bundled packet");
+        // pt[0] = flags byte; body starts at pt[1]; suffix is the seq footer
+        // (4 bytes for FLAG_HAS_SEQUENCE-bearing packets).
+        let bundled_body = &pt[1..pt.len() - 4];
+
+        let expected_forced = compose_forced_position_body(entity_id, space_id, position, prev_pos);
+        let mut expected_method = Vec::new();
         let mut args = Vec::with_capacity(24);
         for &c in &position {
             args.extend_from_slice(&c.to_le_bytes());
         }
-        args.extend_from_slice(&[0u8; 12]); // direction = 0,0,0
+        args.extend_from_slice(&[0u8; 12]);
+        crate::mercury::append_entity_method(
+            &mut expected_method,
+            crate::cell::client_methods::player::ON_PLAYER_TELEPORT,
+            entity_id,
+            &args,
+        );
+        let mut expected_body = Vec::new();
+        expected_body.extend_from_slice(&expected_forced);
+        expected_body.extend_from_slice(&expected_method);
+
         assert_eq!(
-            sent[1].1,
-            build_entity_method_packet(
-                &key,
-                1,
-                &[],
-                entity_id,
-                crate::cell::client_methods::player::ON_PLAYER_TELEPORT,
-                &args,
-            ),
-            "onPlayerTeleport wire bytes (seq 1)"
+            bundled_body,
+            expected_body.as_slice(),
+            "bundled body must equal FORCED_POSITION body || onPlayerTeleport body \
+             — a regression here means either compose_forced_position_body or \
+             append_entity_method drifted on the bundle path"
+        );
+    }
+
+    /// Burst-shape regression guard for the issue #360 teleport bundle
+    /// migration. Pin two invariants the migration depends on:
+    ///   - `num_messages == 2` — exactly FORCED_POSITION + onPlayerTeleport.
+    ///   - `estimated_packet_count() == 1` — both messages comfortably fit
+    ///     one fragment (~70 B total body). A regression that grows either
+    ///     composer past the fragment cutoff fires here.
+    #[test]
+    fn teleport_bundles_forced_position_and_player_teleport_to_single_packet() {
+        let bundle = build_teleport_bundle(0xDEAD, 5, [10.0, 20.0, 30.0], [1.0, 2.0, 3.0]);
+        assert_eq!(
+            bundle.num_messages(),
+            2,
+            "teleport handshake must contain exactly FORCED_POSITION + onPlayerTeleport"
+        );
+        assert_eq!(
+            bundle.estimated_packet_count(),
+            1,
+            "teleport handshake bundle must collapse to 1 reliable packet \
+             (was 2 pre-bundle)"
         );
     }
 }

--- a/crates/services/src/mercury/aoi/mod.rs
+++ b/crates/services/src/mercury/aoi/mod.rs
@@ -26,6 +26,7 @@ pub use create::{build_create_entity_base, build_create_entity_cascade};
 pub(crate) use create::{compose_create_entity_base_body, compose_create_entity_cascade_body};
 pub use leave::{build_entity_invisible, build_entity_leave};
 pub use method::build_entity_method_packet;
+pub(crate) use update::compose_forced_position_body;
 pub use update::{build_avatar_update, build_forced_position};
 
 /// `BASEMSG_CREATE_ENTITY` — create a ghost (non-player) entity on the client (0x09).

--- a/crates/services/src/mercury/aoi/tests.rs
+++ b/crates/services/src/mercury/aoi/tests.rs
@@ -557,3 +557,51 @@ fn compose_create_entity_cascade_body_matches_build_create_entity_cascade_body()
          the wire format between bundle-migrated and un-migrated call sites"
     );
 }
+
+/// **Byte-equivalence guard for the FORCED_POSITION bundle migration
+/// (issue #360 teleport family).**
+///
+/// `compose_forced_position_body` is appended via
+/// [`cimmeria_mercury::channel_bundle::ChannelBundle::append_raw_message`]
+/// inside [`crate::base::world_entry::teleport::build_teleport_bundle`].
+/// The bundled wire bytes for that raw message MUST equal the body
+/// portion of the standalone [`build_forced_position`] packet. Divergence
+/// would split the wire format between the bundle-migrated teleport path
+/// and the standalone-packet `build_forced_position` callers (none today
+/// other than tests, but the cross-path guard prevents drift if a future
+/// caller resurrects the standalone path).
+///
+/// Verifies: decrypted standalone packet body == compose() output.
+#[test]
+fn compose_forced_position_body_matches_build_forced_position_body() {
+    use crate::mercury::compose_forced_position_body;
+
+    const ENTITY_ID: u32 = 0xDEAD_BEEF;
+    const SPACE_ID: u32 = 0x0001_0010;
+    const POS: [f32; 3] = [10.0, 20.0, 30.0];
+    const PREV_POS: [f32; 3] = [9.0, 19.0, 29.0];
+
+    let composed = compose_forced_position_body(ENTITY_ID, SPACE_ID, POS, PREV_POS);
+
+    let pkt = build_forced_position(&TEST_KEY, 1, &[], ENTITY_ID, SPACE_ID, POS, PREV_POS);
+    let enc = MercuryEncryption::from_session_key(TEST_KEY);
+    let pt = enc.decrypt(&pkt).unwrap();
+    let standalone_body = &pt[1..pt.len() - 4];
+
+    assert_eq!(
+        composed.as_slice(),
+        standalone_body,
+        "compose_forced_position_body must produce byte-identical output to \
+         build_forced_position's pre-framing body — divergence would split \
+         the wire format between bundle-migrated and standalone-packet paths"
+    );
+    // Length pin: catches a regression that adds/drops a field. The
+    // offset-based forced_position_wire_layout test pins the layout, but
+    // a length-drift hits this assertion more directly.
+    assert_eq!(
+        composed.len(),
+        50,
+        "FORCED_POSITION body is exactly 50 bytes: msg_id(1) + entity_id(4) + \
+         space_id(4) + vehicleID(4) + pos(12) + prev_pos(12) + rot(12) + flags(1)"
+    );
+}

--- a/crates/services/src/mercury/aoi/update.rs
+++ b/crates/services/src/mercury/aoi/update.rs
@@ -79,6 +79,37 @@ pub fn build_forced_position(
     position: [f32; 3],
     prev_pos: [f32; 3],
 ) -> Vec<u8> {
+    let body = compose_forced_position_body(entity_id, space_id, position, prev_pos);
+    // Reliable — the spawn snap is one-shot state; losing it leaves the
+    // pawn at the wrong position until something else corrects (a
+    // mistimed `forced_position` is what causes the camera-clip artifact
+    // documented in the world-entry spawn-glitch findings). Channel
+    // retransmit covers loss-in-flight.
+    let flags = REPLY_FLAGS_RELIABLE | if acks.is_empty() { 0 } else { FLAG_HAS_ACKS };
+    let plaintext = build_outgoing(flags, &body, Some(seq_id), acks, None);
+    encrypt_packet(&plaintext, key)
+}
+
+/// Compose the wire body for `FORCED_POSITION (0x31)` WITHOUT packet
+/// framing or encryption.
+///
+/// Same byte layout the standalone-packet [`build_forced_position`]
+/// produces; extracted so callers can append the body to a
+/// [`cimmeria_mercury::channel_bundle::ChannelBundle`] alongside other
+/// post-create messages for the same entity (the teleport handshake
+/// `FORCED_POSITION + onPlayerTeleport` pair is the canonical use case).
+///
+/// **Transaction-state contract** (see `channel_bundle` module doc):
+/// `FORCED_POSITION` does NOT enter a creation transaction the way
+/// `CREATE_ENTITY` does — it's a property-update on an already-existing
+/// entity. Safe to combine with same-entity entity-method calls in the
+/// same bundle.
+pub(crate) fn compose_forced_position_body(
+    entity_id: u32,
+    space_id: u32,
+    position: [f32; 3],
+    prev_pos: [f32; 3],
+) -> Vec<u8> {
     let mut body = Vec::with_capacity(50);
     body.push(BASEMSG_FORCED_POSITION);
     body.extend_from_slice(&entity_id.to_le_bytes());
@@ -92,13 +123,5 @@ pub fn build_forced_position(
     }
     body.extend_from_slice(&[0u8; 12]); // rotation = 0,0,0 (yaw/pitch/roll)
     body.push(0x01); // flags
-
-    // Reliable — the spawn snap is one-shot state; losing it leaves the
-    // pawn at the wrong position until something else corrects (a
-    // mistimed `forced_position` is what causes the camera-clip artifact
-    // documented in the world-entry spawn-glitch findings). Channel
-    // retransmit covers loss-in-flight.
-    let flags = REPLY_FLAGS_RELIABLE | if acks.is_empty() { 0 } else { FLAG_HAS_ACKS };
-    let plaintext = build_outgoing(flags, &body, Some(seq_id), acks, None);
-    encrypt_packet(&plaintext, key)
+    body
 }

--- a/crates/services/src/mercury/mod.rs
+++ b/crates/services/src/mercury/mod.rs
@@ -41,7 +41,10 @@ pub use aoi::{
     build_avatar_update, build_create_entity_base, build_create_entity_cascade,
     build_entity_invisible, build_entity_leave, build_entity_method_packet, build_forced_position,
 };
-pub(crate) use aoi::{compose_create_entity_base_body, compose_create_entity_cascade_body};
+pub(crate) use aoi::{
+    compose_create_entity_base_body, compose_create_entity_cascade_body,
+    compose_forced_position_body,
+};
 
 pub use world_data::{
     archetype_ability_tree, archetype_stats, build_create_player, build_enter_world,

--- a/docs/architecture/mercury-bundle.md
+++ b/docs/architecture/mercury-bundle.md
@@ -1,6 +1,6 @@
 # Mercury Bundle abstraction
 
-> **Last updated**: 2026-05-24
+> **Last updated**: 2026-05-25
 > **Audience**: Engineers touching Mercury send paths, AoI fanout, world-entry
 > bursts, or anything that calls `send_to_witness_reliable`
 > **Type**: Architecture decision + reference for callers
@@ -53,11 +53,52 @@ decision sits with the caller, not with a per-channel auto-accumulator.
   `on_client_ready_burst_bundles_to_single_packet` (11 → 1 packet) and a
   new compose↔build byte-equivalence guard for the entity-method bundle
   path covering both direct and extended encodings. ✅
-- **Deferred to follow-up [#360](https://github.com/SandboxServers/Cimmeria/issues/360)**:
-  remaining per-handler migrations across world-data/phases.rs, inventory/
-  vendor/mail, progression, teleport, and the remaining AoI handlers. Each
-  has its own transaction-state surface to audit and warrants a separate,
-  reviewable PR.
+- **#360 follow-up — progression + teleport migrations**:
+  - `handle_grant_xp` post-grant burst (1..2N+3 packets where N = levels
+    gained) now rides one `ChannelBundle`. Player's own entity, no CREATE
+    in-handler. Pinned by `grant_xp_max_level_burst_bundles_to_single_packet`
+    + `grant_xp_single_level_burst_bundles_to_single_packet`. ✅
+  - `handle_teleport_player` `FORCED_POSITION + onPlayerTeleport` handshake
+    (2 → 1 packet). Pinned by
+    `teleport_bundles_forced_position_and_player_teleport_to_single_packet`
+    + a new `compose_forced_position_body_matches_build_forced_position_body`
+    byte-equivalence guard for the raw-message bundle path. ✅
+- **#360 follow-up — closed unmigrated (rationale, no code change)**: every
+  remaining checkbox on issue #360 falls into one of three "no benefit"
+  buckets:
+  - **Already a single bundle** — `mercury/world_data/map_loaded.rs` is
+    already two deliberate bundles via manual `build_fragmented_bundle`.
+    Output is byte-identical to `ChannelBundle::finalize`. The caller in
+    `base/world_entry/map_loaded.rs` can't use `send_bundle_to_witness_reliable`
+    because `entity_to_addr` isn't populated until after the send (the
+    write-ordering is deliberate — see the inline comment at line 170).
+  - **No send sites** — `mercury/world_data/phases.rs` contains body
+    builders (`build_create_player`, `build_enter_world_body`, etc.), not
+    senders. The `append_entity_method` occurrences are inside body
+    composition, not wire emits. Issue text counted body ops as sends.
+  - **Single send per handler call** — these handlers each emit exactly 1
+    packet per call: `mail/mod.rs` (1 per match arm), `vendor/store.rs`,
+    `vendor/helpers.rs`, `inventory/core/mod.rs`, `inventory/grant/mod.rs`,
+    `inventory/appearance.rs`, `cell_dispatch/minigame.rs`. Bundling a
+    single send emits exactly 1 packet — no wire saving, no TX-window
+    relief. The "grant + appearance recomposite" or "vendor open + price
+    update" caller-level bursts WOULD benefit, but bundling them needs a
+    helper-return-type refactor (compose into shared bundle rather than
+    self-send), which is a separate concern.
+  - **Utility builder** — `mercury/aoi/method.rs::build_entity_method_packet`
+    is a single-packet wire builder; bundling is the caller's job, not the
+    builder's. The byte-equivalence guard added in #363
+    (`channel_bundle_append_entity_method_matches_build_entity_method_packet_body`)
+    already pins that the bundle path and standalone path produce identical
+    bytes, so caller-side migrations can swap freely.
+  - **Needs batching layer** — `cell_dispatch/aoi.rs` `EntityMethodCall`
+    fanout (per [Cadacious's scope-clarification comment on #360]) needs
+    cross-message batching at the cell→base channel drain pass, not
+    per-handler. Tracked separately; not a per-handler migration. The
+    "EnteredAoI(X) followed by EntityMethodCall(X) for same X in the same
+    drain pass" interleave requires the audit-and-split logic the
+    `flush_deferred_aoi` path already implements; lifting that pattern to
+    every drain-pass send is a separate, larger refactor.
 
 ## The transaction-state rule
 
@@ -209,6 +250,21 @@ to 20 s — 200 iterations × 2 packets = 400 reliable packets worst-case,
 now 200 packets). For a first-login cinematic that runs the full spam
 window (e.g. SGWLogo intro at 13.10 s natural end + 7 s safety buffer),
 that's a ~50% reduction in cinematic-guard TX-window pressure.
+
+Progression (`handle_grant_xp`) collapses every grant into one packet:
+
+| Grant shape | Pre-bundle | Post-bundle |
+|---|---:|---:|
+| No-level grant (steady-state XP) | 1 | 1 |
+| Single-level grant | 5 | 1 |
+| Max-level catch-up (19 levels) | 41 | 1 |
+
+Teleport (`handle_teleport_player`) collapses the engine-snap + load-hint
+handshake:
+
+| Pre-bundle | Post-bundle |
+|---:|---:|
+| FORCED_POSITION + onPlayerTeleport (2 packets) | 1 packet |
 
 Safe per the transaction-state rule because the player entity was created
 in `handle_map_loaded`'s prior bundle and its transaction released at the


### PR DESCRIPTION
## Summary

Closes #360 by addressing every remaining checkbox: **2 real bundle migrations** + **8 closures-with-rationale** where the existing code shape already produces bundle-equivalent wire output or no bundling benefit exists. Follow-up to #363 (which closed the `world_entry_appearance.rs` checkbox).

## Migrations (real wire saving)

### `progression/mod.rs handle_grant_xp` — 1..2N+3 packets → 1
Bundles every post-grant notification (`onExpUpdate` + per-level pair + `onLevelUpdate` + `onEntityProperty(TRAINING_POINTS)`) into one `ChannelBundle`. Worst case (level-1 → MAX_LEVEL=20 catch-up): **41 reliable packets → 1**.

### `teleport.rs handle_teleport_player` — 2 packets → 1
Bundles `FORCED_POSITION (0x31)` (raw base message via `append_raw_message`) + `onPlayerTeleport (method 116)` (entity-method) into one frame. Extracted `compose_forced_position_body` from `build_forced_position` per the migration playbook.

## Transaction-state audit

| Bundle | Safe? | Why |
|---|---|---|
| progression XP burst | ✅ | All messages target the player's own entity (created in `handle_map_loaded`'s prior bundle, transaction released). No CREATE in-handler. |
| teleport handshake | ✅ | `FORCED_POSITION` is a property update on an already-live entity, not a creation. Does not enter a CREATE_ENTITY transaction. |

Both safe per the canonical "post-create property update" rule in [docs/architecture/mercury-bundle.md](docs/architecture/mercury-bundle.md).

## Closures-with-rationale (no code change)

Per #360's acceptance criteria — every checkbox addressed:

| Family | Reason | Resolution |
|---|---|---|
| `mercury/world_data/map_loaded.rs` | Already 2 deliberate bundles via manual `build_fragmented_bundle`; byte-identical to `ChannelBundle::finalize`. Caller can't use `send_bundle_to_witness_reliable` because `entity_to_addr` isn't populated until after the send (deliberate write-ordering). | Closed unmigrated |
| `mercury/world_data/phases.rs` | No send sites; the file is body builders consumed by `map_loaded`. Issue text counted body ops as sends. | Closed unmigrated |
| `mail/mod.rs` | 1 send per match arm. No burst within a single call. | Closed unmigrated |
| `vendor/store.rs`, `vendor/helpers.rs` | Single-send helpers. | Closed unmigrated |
| `inventory/{core,grant,appearance}` | Single-send helpers. Caller-level bursts (grant + appearance recomposite) would need helper-return-type refactor — separate concern. | Closed unmigrated |
| `cell_dispatch/minigame.rs` | 1 send per handler call. | Closed unmigrated |
| `mercury/aoi/method.rs` | Utility builder for one packet. Bundle/standalone byte-equivalence is already pinned by #363's guard. | Closed unmigrated |
| `cell_dispatch/aoi.rs EntityMethodCall` | Per Cadacious's scope-clarification comment: needs batching at the cell→base channel drain pass, not per-handler. Same shape as `flush_deferred_aoi`'s `EnteredAoI` path; lifting it to every drain-pass send is a separate refactor. | Tracked separately |

## Test plan

- [x] **3 progression burst-shape guards** (`grant_xp_no_level_*`, `grant_xp_single_level_*`, `grant_xp_max_level_*`) — pin `num_messages` AND `estimated_packet_count() == 1` for steady-state / single-level / max-level cases.
- [x] **1 teleport burst-shape guard** (`teleport_bundles_forced_position_and_player_teleport_to_single_packet`) — pins 2 messages → 1 packet.
- [x] **1 forced-position byte-equivalence guard** (`compose_forced_position_body_matches_build_forced_position_body`) — pins bundle path vs standalone-packet builder bytes match, plus the 50-byte body length.
- [x] **Updated** `teleport_emits_forced_position_then_player_teleport_to_owner_only` — asserts the new 1-packet shape AND decrypts the bundled body to verify `compose_forced_position_body || append_entity_method` bytes exactly.
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --exclude {GUI crates} --all-targets -- -D warnings`
- [x] `cargo build --workspace --exclude {GUI crates} --all-targets`
- [x] `cargo test --workspace --exclude {GUI crates} --lib --no-fail-fast` — **843 services tests + 149 mercury tests + 1373 lib tests total**, all green.

## Doc updates

[docs/architecture/mercury-bundle.md](docs/architecture/mercury-bundle.md) status + observed-win sections updated with both migrations and the full closure rationale catalogue. New observed-win tables for progression (No-level / Single-level / Max-level) and teleport.

## Closes

#360 — every checkbox addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized XP grant notifications to send as a single bundled packet instead of multiple sequential packets.
  * Optimized player teleport handshakes to send as a single bundled packet instead of two separate packets.

* **Tests**
  * Added regression tests to verify bundled packet format and structure for XP grants and teleport operations.

* **Documentation**
  * Updated architecture documentation with bundling migration details and observed network efficiency gains.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SandboxServers/Cimmeria/pull/365?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->