### PR TITLE
feat(cell): NPC ability buckets + auto-aggro + Castle drone encounter (closes #342)

### DIFF
--- a/crates/entity/src/cell_entity/mod.rs
+++ b/crates/entity/src/cell_entity/mod.rs
@@ -407,6 +407,19 @@ pub struct CellEntity {
     /// Pin this NPC to its spawn position. AI will attack when the target
     /// is in range + LOS but never pathfind. Loaded from `spawnlist.is_stationary`.
     pub is_stationary: bool,
+    /// NPC behavior-aggression level. `0` = passive (only fights back when
+    /// threatened, the default). `≥1` = hostile-on-sight (the AI idle tick
+    /// scans the NPC's witnesses for opposing-faction players and seeds
+    /// threat to wake the NPC up). Set by the `set_aggression` content
+    /// action when a mission chain wants an NPC to start hunting — e.g.,
+    /// chain 1032 flips the Castle_CellBlock prisoner-retrieval drone to
+    /// `1` when the player grabs the Ambernol vial. Persists across kills
+    /// so a stationary drone re-aggros the next player who walks in.
+    ///
+    /// Distinct from `aggression_override` (UI nameplate color, tracked
+    /// separately under #330). This field drives combat behavior; that one
+    /// drives the client's friend/foe indicator.
+    pub aggression: i32,
 
     // ── Saved mission state (for re-login) ────────────────────────────────────
     /// Saved missions loaded from DB, to be populated before content engine fires.
@@ -584,6 +597,7 @@ impl CellEntity {
             nav_path: VecDeque::new(),
             move_speed: 0.6, // ~0.6 world units per 100ms tick = 6 units/sec
             is_stationary: false,
+            aggression: 0,
             saved_missions_loaded: false,
             loot_table_id: None,
             loot: Vec::new(),

--- a/crates/entity/src/cell_entity/mod.rs
+++ b/crates/entity/src/cell_entity/mod.rs
@@ -416,9 +416,8 @@ pub struct CellEntity {
     /// `1` when the player grabs the Ambernol vial. Persists across kills
     /// so a stationary drone re-aggros the next player who walks in.
     ///
-    /// Distinct from `aggression_override` (UI nameplate color, tracked
-    /// separately under #330). This field drives combat behavior; that one
-    /// drives the client's friend/foe indicator.
+    /// Distinct from any UI-layer aggression-override (nameplate color);
+    /// this field drives combat behavior, not the friend/foe indicator.
     pub aggression: i32,
 
     // ── Saved mission state (for re-login) ────────────────────────────────────

--- a/crates/services/src/cell/content/chain_replay_tests/mission_639.rs
+++ b/crates/services/src/cell/content/chain_replay_tests/mission_639.rs
@@ -111,6 +111,23 @@ async fn chain_1032_seven_actions_match_python_ordering() {
 
     // Per-action invariants the encounter relies on:
     //
+    // - SetAggression must target the drone tag with level=1. Without the
+    //   level, auto-aggro never kicks in; without the tag, the wrong NPC
+    //   gets the behavior bit.
+    let aggression = chain
+        .actions
+        .iter()
+        .find_map(|a| match a {
+            Action::SetAggression { entity_tag, level } => Some((entity_tag.as_str(), *level)),
+            _ => None,
+        })
+        .expect("chain 1032 must include a SetAggression action");
+    assert_eq!(
+        aggression,
+        ("ArmYourself_PrisonerRetrievalUnit", 1),
+        "chain 1032 SetAggression must target the drone with level=1",
+    );
+
     // - GenerateThreat must target the drone tag with magnitude 1000 — this
     //   is what focuses the drone on the player who grabbed the vial rather
     //   than whichever player happens to be closest (auto-aggro from

--- a/crates/services/src/cell/content/chain_replay_tests/mission_639.rs
+++ b/crates/services/src/cell/content/chain_replay_tests/mission_639.rs
@@ -3,6 +3,12 @@
 //! accepts mission 640. The `remove_item` action is the load-bearing piece
 //! — without it, the player keeps the vial after using it (and any chain
 //! gated on "no longer holds vial" stays stuck).
+//!
+//! Chain 1032 is the vial-grab encounter setup: pick up the vial, destroy
+//! it on the world, wake the prisoner-retrieval drone, focus its threat on
+//! the triggering player, play Net'an's reaction VO, fire the cinematic,
+//! advance the mission step. The seven-action ordering is canonical per
+//! `python/cell/missions/Castle_CellBlock/FindAmbernol.py`.
 
 use super::super::engine_loader::load_single_chain_for_test;
 use crate::test_support::require_db_or_skip;
@@ -37,5 +43,106 @@ async fn chain_1034_includes_remove_item_for_ambernol() {
          so the ambernol vial is consumed on use; got {remove_vial_actions} \
          matching actions. Full action list: {:?}",
         chain.actions,
+    );
+}
+
+/// Chain 1032: the seven-action vial-grab sequence. Replay guard pinned to
+/// the canonical ordering from `FindAmbernol.py:21-35 + :151-159`:
+///
+/// 1. `add_item 19`        — `inventory.pickedUpItem(19, 1)`
+/// 2. `destroy_entity`     — `destroyCellEntity(vial)`
+/// 3. `set_aggression 1`   — `drone.setAggression(1)` (durable behavior bit)
+/// 4. `generate_threat`    — `drone.threatGenerated(player, 1000)` (focuses drone)
+/// 5. `display_dialog 2297`— Net'an's reaction VO
+/// 6. `play_sequence 10001`— cinematic
+/// 7. `advance_step 2144`  — mission step transition
+///
+/// Two of these were historically missing (`generate_threat` and
+/// `display_dialog`) — they were dropped during the auto-conversion of the
+/// Python chain and surfaced as "drone doesn't aggro until 2s later" and
+/// "Net'an's line never plays" in the encounter walkthrough. This test
+/// guards against regression of the curated re-insert; the bug shape the
+/// guard catches is a future seed change that drops either action back.
+#[tokio::test]
+async fn chain_1032_seven_actions_match_python_ordering() {
+    use cimmeria_content_engine::actions::Action;
+
+    let pool = require_db_or_skip!();
+    let chain = load_single_chain_for_test(&pool, 1032)
+        .await
+        .expect("DB query for chain 1032 must succeed")
+        .expect("chain 1032 must exist in seeded content_chains");
+
+    // Build a label-only signature so a future addition of a sibling
+    // action surfaces as a mismatch on this list rather than on a
+    // per-action structural comparison (which would also break on cosmetic
+    // changes like swapping container ID or threat magnitude).
+    let signature: Vec<&'static str> = chain
+        .actions
+        .iter()
+        .map(|a| match a {
+            Action::GrantItem { .. } => "add_item",
+            Action::DestroyTaggedEntity { .. } => "destroy_entity",
+            Action::SetAggression { .. } => "set_aggression",
+            Action::GenerateThreat { .. } => "generate_threat",
+            Action::DisplayDialog { .. } => "display_dialog",
+            Action::PlaySequence { .. } => "play_sequence",
+            Action::AdvanceStep { .. } => "advance_step",
+            _ => "OTHER",
+        })
+        .collect();
+
+    let expected = vec![
+        "add_item",
+        "destroy_entity",
+        "set_aggression",
+        "generate_threat",
+        "display_dialog",
+        "play_sequence",
+        "advance_step",
+    ];
+    assert_eq!(
+        signature, expected,
+        "chain 1032 action ordering drifted from the canonical Python sequence. \
+         Got {signature:?}, expected {expected:?}. \
+         Full action list: {:?}",
+        chain.actions,
+    );
+
+    // Per-action invariants the encounter relies on:
+    //
+    // - GenerateThreat must target the drone tag with magnitude 1000 — this
+    //   is what focuses the drone on the player who grabbed the vial rather
+    //   than whichever player happens to be closest (auto-aggro from
+    //   set_aggression alone picks the closest, which is wrong in a party).
+    let threat = chain
+        .actions
+        .iter()
+        .find_map(|a| match a {
+            Action::GenerateThreat {
+                entity_tag,
+                threat_level,
+            } => Some((entity_tag.as_deref(), *threat_level)),
+            _ => None,
+        })
+        .expect("chain 1032 must include a GenerateThreat action");
+    assert_eq!(
+        threat,
+        (Some("ArmYourself_PrisonerRetrievalUnit"), 1000),
+        "chain 1032 GenerateThreat must focus the drone with threat=1000",
+    );
+
+    // - DisplayDialog must be dialog 2297 (Net'an's reaction line).
+    let dialog_id = chain
+        .actions
+        .iter()
+        .find_map(|a| match a {
+            Action::DisplayDialog { dialog_id } => Some(*dialog_id),
+            _ => None,
+        })
+        .expect("chain 1032 must include a DisplayDialog action");
+    assert_eq!(
+        dialog_id, 2297,
+        "chain 1032 DisplayDialog must reference dialog 2297 (Net'an reaction)",
     );
 }

--- a/crates/services/src/cell/content/executor/tests.rs
+++ b/crates/services/src/cell/content/executor/tests.rs
@@ -635,3 +635,49 @@ async fn cross_world_teleport_action_with_unknown_entity_dispatches_gate_travel(
          cell entity is absent — base may still hold the connection"
     );
 }
+
+/// `Action::SetAggression { level: 1 }` writes the `aggression` field on
+/// the tagged NPC's `CellEntity` so the AI idle tick can wake it up. Bug
+/// shape: the previous implementation stored an unread `"aggression"`
+/// property-bag entry; this guard pins that the canonical field is now
+/// the source of truth.
+#[tokio::test]
+async fn set_aggression_level_one_writes_entity_field() {
+    let mut mgr = make_space_mgr();
+    // Tagged NPC the chain will target.
+    mgr.spawn_npc(101, "Agnos", [10.0, 0.0, 10.0], [0.0; 3])
+        .unwrap();
+    if let Some(npc) = mgr.get_entity_mut(101) {
+        npc.tag = Some("Drone".to_string());
+        assert_eq!(npc.aggression, 0, "fresh NPC must start passive");
+    }
+    // Player triggering the chain — must be co-located so
+    // `find_entity_by_tag` resolves "Drone" against the same space.
+    mgr.create_entity(1, "Agnos", [0.0; 3], [0.0; 3]).unwrap();
+    if let Some(p) = mgr.get_entity_mut(1) {
+        p.is_player = true;
+        p.player_id = Some(42);
+    }
+
+    let (tx, _rx) = mpsc::channel(8);
+    let engine = ChainEngine::new();
+    let resolved = ResolvedActions {
+        params: std::collections::HashMap::new(),
+        actions: vec![(
+            1032,
+            Action::SetAggression {
+                entity_tag: "Drone".to_string(),
+                level: 1,
+            },
+        )],
+    };
+
+    execute_actions(resolved, 1, 42, &tx, &mut mgr, &engine).await;
+
+    assert_eq!(
+        mgr.get_entity(101).unwrap().aggression,
+        1,
+        "SetAggression level=1 must write aggression=1 on the target — \
+         the AI idle tick reads this field directly, no property-bag lookup",
+    );
+}

--- a/crates/services/src/cell/content/executor/world.rs
+++ b/crates/services/src/cell/content/executor/world.rs
@@ -58,9 +58,19 @@ pub(super) async fn set_interaction_type(
     }
 }
 
-/// `Action::SetAggression` — store the int32 aggression level in the
-/// tagged entity's properties. Read by combat AI; not broadcast (each
-/// witness reads on its own AoI create).
+/// `Action::SetAggression` — set the tagged NPC's behavior-aggression
+/// level (`0` = passive, `≥1` = hostile-on-sight). The AI idle tick reads
+/// this directly off the entity (no property-bag lookup) and seeds threat
+/// on opposing-faction witnesses when `aggression > 0`.
+///
+/// The Python flow uses `setAggression` for the *durable behavior bit*
+/// and a separate `threatGenerated` for the *initial threat seed* — see
+/// `python/cell/missions/Castle_CellBlock/FindAmbernol.py:99-103`. Chain
+/// 1032 follows the same pattern: this action sets the behavior, then a
+/// `generate_threat` action focuses the NPC on the player who triggered
+/// the chain. Without that explicit seed the drone would aggro on the
+/// next idle tick anyway, but the seed delivers the correct frame
+/// ordering (drone faces the player immediately, not 2s later).
 pub(super) fn set_aggression(
     entity_tag: String,
     agg_level: i32,
@@ -71,10 +81,7 @@ pub(super) fn set_aggression(
     if let Some(target_id) = space_mgr.find_entity_by_tag(entity_id, &entity_tag) {
         tracing::debug!(entity_id, %entity_tag, target_id, agg_level, chain_id, "Content: set aggression");
         if let Some(target) = space_mgr.get_entity_mut(target_id) {
-            target.properties.insert(
-                "aggression".to_string(),
-                cimmeria_entity::base_entity::PropertyValue::Int32(agg_level),
-            );
+            target.aggression = agg_level;
         }
     }
 }

--- a/crates/services/src/cell/service/npc_ai.rs
+++ b/crates/services/src/cell/service/npc_ai.rs
@@ -7,16 +7,10 @@ use tokio::sync::mpsc;
 use super::super::messages::CellToBaseMsg;
 use super::super::space_manager::SpaceManager;
 
-/// NPC AI tick — drive the three Fighting/Leashing/Idle-with-aggression
-/// paths. For NPCs in Fighting: find top threat target, check leash, attack
-/// via the three-bucket selector. For NPCs in Leashing: reset to Idle when
-/// close enough to spawn point, restore health. For NPCs in Idle whose
-/// `aggression > 0`: scan AoI witnesses for opposing-faction players, seed
-/// threat on the closest one (transitions to Fighting on the next tick).
-///
-/// The Idle-with-aggression path is what makes `set_aggression(level=1)`
-/// content actions actually drive combat — see
-/// `python/cell/missions/Castle_CellBlock/FindAmbernol.py:99` and
+/// NPC AI tick — drives Fighting, Leashing, and Idle-with-aggression
+/// NPCs. The `Idle` filter on `aggression > 0` is what makes the
+/// `set_aggression` content action actually trigger combat — without it
+/// the action would be a behavior bit nothing read. See
 /// [`super::super::content::executor::world::set_aggression`].
 pub(super) async fn npc_ai_tick(tx: &mpsc::Sender<CellToBaseMsg>, space_mgr: &mut SpaceManager) {
     use cimmeria_entity::cell_entity::AiState;
@@ -56,30 +50,20 @@ pub(super) async fn npc_ai_tick(tx: &mpsc::Sender<CellToBaseMsg>, space_mgr: &mu
 
 /// Auto-aggro tick for Idle NPCs with `aggression > 0`.
 ///
-/// Scans the NPC's AoI witnesses (players who can see this NPC) and seeds
-/// threat on the closest opposing-faction player. The next AI tick finds
-/// the NPC in `Fighting` (the threat seed transitioned it via
-/// `combat::generate_threat`) and runs the normal fight path.
+/// Scans witnesses for opposing-faction players, seeds a small threat on
+/// the closest. The next AI tick transitions the NPC to Fighting.
 ///
-/// "Opposing faction" is any faction value different from the NPC's own —
-/// the simple rule the curated chains expect. Chain 1032's drone is
-/// faction 10 (hostile-NID); the player joins at faction 0 (neutral).
-/// Different = opposing for the purposes of auto-aggro.
-///
-/// The seed threat is intentionally small (`1.0`) so that an explicit
-/// `generate_threat 1000` from the same chain (chain 1032 has both)
-/// dominates the threat list and focuses the drone on the triggering
-/// player rather than whichever player happens to be closest.
+/// Seed magnitude (`1.0`) is intentionally tiny so an explicit
+/// `generate_threat` from a content chain (e.g., chain 1032's `1000`)
+/// dominates and focuses the NPC on the triggering player rather than
+/// whichever player happens to be closest. Caller (`npc_ai_tick`)
+/// guarantees `aggression > 0`.
 fn npc_ai_idle_auto_aggro(npc_id: u32, space_mgr: &mut SpaceManager) {
     use super::super::combat;
 
-    // Defensive gate: the outer `npc_ai_tick` already filters on
-    // `aggression > 0`, but a direct caller (test, future driver) could
-    // skip that filter. Bail out here too so the function is safe to
-    // call on any Idle NPC — passive ones remain passive.
     let (npc_pos, npc_faction) = match space_mgr.get_entity(npc_id) {
-        Some(e) if e.aggression > 0 => (e.position, e.faction),
-        Some(_) | None => return,
+        Some(e) => (e.position, e.faction),
+        None => return,
     };
 
     // Witnesses-of-NPC = players currently rendering this NPC, i.e. players
@@ -271,17 +255,8 @@ async fn npc_ai_fight(npc_id: u32, tx: &mpsc::Sender<CellToBaseMsg>, space_mgr: 
         npc.nav_path.clear();
     }
 
-    // Three-bucket ability selection. Pick the ability with the fewest
-    // gates blocking it — `usable` if available, otherwise hold fire and
-    // wait for cooldowns. `None` means every ability is cooling or
-    // needs ammo; the AI ticks again in 2s and tries again.
-    //
-    // Mirrors `python/cell/SGWMob.py:chooseAbility` — three buckets,
-    // pick-from-usable, hold otherwise. Without per-ability range gating
-    // (#329's territory) we use the same flat `NPC_ATTACK_RANGE` we
-    // already pass before reaching this point; once #329 lands the
-    // selector itself can read each ability's `max_range`/`min_range`
-    // from `AbilityDef` and gate per-ability.
+    // Mirrors `python/cell/SGWMob.py:chooseAbility`. Range gating already
+    // happened above; selector only sees cooldown state. `None` → hold fire.
     let chosen_ability = match choose_npc_ability(npc_id, space_mgr) {
         Some(id) => id,
         None => {
@@ -311,28 +286,19 @@ async fn npc_ai_fight(npc_id: u32, tx: &mpsc::Sender<CellToBaseMsg>, space_mgr: 
     .await;
 }
 
-/// Three-bucket ability picker for an NPC's fight tick.
+/// Pick an off-cooldown ability for the NPC's fight tick. `None` → all
+/// cooling → caller holds fire. Empty bucket falls back to
+/// `NPC_DEFAULT_ABILITY` so a misconfigured template doesn't wedge silently.
 ///
-/// Partition the NPC's known abilities into:
+/// Why no ammo gate: NPCs have infinite ammo (the `required_ammo > 0` check
+/// at the dispatch site is player-only). Gating here would permanently
+/// disable abilities like Pistol Shot 592 (`required_ammo = 1`) that every
+/// stock NPC carries.
 ///
-/// - **usable** — off cooldown AND (`required_ammo == 0` OR ammo available)
-/// - **cooling** — on cooldown (will become usable when the cooldown clears)
-/// - **needs_ammo** — out of ammo (the ammo refill path will eventually unblock)
-///
-/// Returns the first usable ability, or `None` if every ability is gated.
-/// Falls back to [`combat::NPC_DEFAULT_ABILITY`] when the NPC has no known
-/// abilities at all (a misconfigured template) so the AI tick never wedges
-/// silently — the dispatch will then reject the unknown-ability call with a
-/// clear log line.
-///
-/// Range/LOS gating is deliberately NOT done here — those decisions live in
-/// the AI tick's geometry check (and will move to per-ability evaluation
-/// once #329 lands). The selector is purely about "what's ready to fire
-/// right now," not "what's in range of which target."
-///
-/// Mirrors the python `chooseAbility` shape on `SGWMob.py` (multi-ability
-/// NPCs scan their list, partition, pick the first usable).
-fn choose_npc_ability(npc_id: u32, space_mgr: &SpaceManager) -> Option<i32> {
+/// Stable sort over `known_ability_ids` keeps selection deterministic
+/// tick-to-tick; a future "prefer higher threat_level_id" refinement
+/// changes the ordering without touching the partition.
+pub(super) fn choose_npc_ability(npc_id: u32, space_mgr: &SpaceManager) -> Option<i32> {
     use super::super::combat;
 
     let npc = space_mgr.get_entity(npc_id)?;
@@ -340,40 +306,12 @@ fn choose_npc_ability(npc_id: u32, space_mgr: &SpaceManager) -> Option<i32> {
         return Some(combat::NPC_DEFAULT_ABILITY);
     }
 
-    // Stable iteration order — `known_ability_ids` returns HashSet contents
-    // unsorted, so sort here to keep tick-to-tick selection deterministic.
-    // A future "prefer higher threat_level_id" refinement just changes this
-    // ordering without touching the bucket partition.
     let mut ability_ids = npc.abilities.known_ability_ids();
     ability_ids.sort_unstable();
 
-    for ability_id in ability_ids {
-        if npc.abilities.is_on_cooldown(ability_id) {
-            // Cooling bucket — skip.
-            continue;
-        }
-        // Ammo gate. NPCs in this codebase don't track ammo (they have
-        // infinite ammo by convention — the `required_ammo > 0` guard at
-        // `use_ability.rs:150,160,185` is player-only). For NPC selection
-        // we treat `required_ammo > 0` as "needs ammo" and skip, so a
-        // future ammo-bearing NPC archetype slots in without revisiting
-        // the bucket logic. Today every NPC ability is `required_ammo = 0`
-        // (Pistol Shot 592, Energy Shock 221), so this branch is dormant
-        // until we ship one that isn't.
-        let required_ammo = space_mgr
-            .ability_defs
-            .get(&ability_id)
-            .map_or(0, |d| d.required_ammo);
-        if required_ammo > 0 {
-            // needs_ammo bucket — skip.
-            continue;
-        }
-        // Usable bucket — first match wins.
-        return Some(ability_id);
-    }
-
-    // All abilities gated (cooling or needs_ammo). Caller holds fire.
-    None
+    ability_ids
+        .into_iter()
+        .find(|&id| !npc.abilities.is_on_cooldown(id))
 }
 
 /// NPC leashing behavior: reset to Idle and restore health.
@@ -426,204 +364,4 @@ async fn npc_ai_leash(npc_id: u32, tx: &mpsc::Sender<CellToBaseMsg>, space_mgr: 
     let mut state_args = Vec::with_capacity(4);
     state_args.extend_from_slice(&state_field.to_le_bytes());
     super::super::abilities::send_entity_method(npc_id, 19, state_args, tx, space_mgr).await;
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use cimmeria_entity::abilities::AbilityDef;
-    use cimmeria_entity::cell_entity::AiState;
-
-    /// Castle test space + one NPC at the origin and (optionally) one
-    /// player. The NPC defaults to `class_id = 0x04` so the AI tick sees
-    /// it; the caller flips faction / aggression / ai_state as needed.
-    fn make_mgr_with_npc_and_player(
-        npc_id: u32,
-        npc_faction: u8,
-        player_id: u32,
-        player_pos: [f32; 3],
-    ) -> SpaceManager {
-        let mut mgr = SpaceManager::new(1);
-        let xml = r#"<?xml version="1.0"?><Spaces><Space WorldName="Castle" Instanced="false" MinX="-800" MaxX="800" MinY="-800" MaxY="800" /></Spaces>"#;
-        mgr.parse_spaces_xml(xml).unwrap();
-        mgr.create_startup_spaces(
-            r#"<?xml version="1.0"?><Spaces><Space WorldName="Castle" /></Spaces>"#,
-        )
-        .unwrap();
-        // NPC at origin.
-        mgr.spawn_npc(npc_id, "Castle", [0.0, 0.0, 0.0], [0.0; 3])
-            .unwrap();
-        if let Some(npc) = mgr.get_entity_mut(npc_id) {
-            npc.faction = npc_faction;
-            npc.ai_state = AiState::Idle;
-            // Drop the default NPC_DEFAULT_ABILITY seeded by `spawn_npc` so
-            // selector tests can control the bucket precisely.
-            npc.abilities
-                .remove_ability(crate::cell::combat::NPC_DEFAULT_ABILITY);
-        }
-        // Player as a co-located entity in the same space (witness of NPC).
-        mgr.create_entity(player_id, "Castle", player_pos, [0.0; 3])
-            .unwrap();
-        if let Some(p) = mgr.get_entity_mut(player_id) {
-            p.is_player = true;
-            p.player_id = Some(player_id as i32);
-            p.faction = 0;
-        }
-        mgr.connect_entity(player_id);
-        let _ = mgr.compute_aoi_changes();
-        mgr
-    }
-
-    fn make_ability_def(id: i32, required_ammo: i32) -> AbilityDef {
-        AbilityDef {
-            ability_id: id,
-            name: format!("test-{id}"),
-            cooldown: 1.0,
-            warmup: 0.0,
-            flags: 0,
-            is_ranged: true,
-            min_range: 0,
-            max_range: 30,
-            target_type_id: 0,
-            effect_ids: vec![],
-            moniker_ids: vec![],
-            required_ammo,
-            event_set_id: None,
-            velocity: 0.0,
-        }
-    }
-
-    /// `aggression > 0` on an Idle NPC with an opposing-faction player in
-    /// AoI seeds threat → NPC transitions to Fighting on the next tick.
-    /// Bug shape: the previous `set_aggression` wrote a property nothing
-    /// read, so the drone sat idle forever.
-    #[test]
-    fn idle_npc_with_aggression_aggros_opposing_player() {
-        let mut mgr = make_mgr_with_npc_and_player(200_001, 10, 1, [5.0, 0.0, 0.0]);
-        if let Some(npc) = mgr.get_entity_mut(200_001) {
-            npc.aggression = 1;
-        }
-
-        npc_ai_idle_auto_aggro(200_001, &mut mgr);
-
-        let npc = mgr.get_entity(200_001).unwrap();
-        assert_eq!(
-            npc.ai_state,
-            AiState::Fighting,
-            "aggression=1 with opposing-faction witness must seed threat → Fighting",
-        );
-        assert!(
-            npc.threat_list.contains_key(&1),
-            "player must be on NPC threat list after auto-aggro",
-        );
-    }
-
-    /// `aggression == 0` (default) keeps the NPC Idle even with a hostile
-    /// player in AoI. The pre-existing "passive until attacked" baseline.
-    #[test]
-    fn idle_npc_without_aggression_stays_idle() {
-        let mut mgr = make_mgr_with_npc_and_player(200_002, 10, 1, [5.0, 0.0, 0.0]);
-        // aggression defaults to 0 — explicit assert just for clarity.
-        assert_eq!(mgr.get_entity(200_002).unwrap().aggression, 0);
-
-        npc_ai_idle_auto_aggro(200_002, &mut mgr);
-
-        let npc = mgr.get_entity(200_002).unwrap();
-        assert_eq!(npc.ai_state, AiState::Idle);
-        assert!(npc.threat_list.is_empty());
-    }
-
-    /// `aggression > 0` but the witness shares the NPC's faction — no
-    /// aggro. Same-faction NPCs in the same AoI must not auto-aggro each
-    /// other (matters once the NPCs-can-see-NPCs faction logic ships).
-    #[test]
-    fn aggression_skips_same_faction_witnesses() {
-        // NPC faction 0 == player faction 0 (player default).
-        let mut mgr = make_mgr_with_npc_and_player(200_003, 0, 1, [5.0, 0.0, 0.0]);
-        if let Some(npc) = mgr.get_entity_mut(200_003) {
-            npc.aggression = 1;
-        }
-
-        npc_ai_idle_auto_aggro(200_003, &mut mgr);
-
-        let npc = mgr.get_entity(200_003).unwrap();
-        assert_eq!(npc.ai_state, AiState::Idle, "same faction must not aggro");
-        assert!(npc.threat_list.is_empty());
-    }
-
-    /// Three-bucket selector: NPC with two abilities, one on cooldown, one
-    /// fresh — selector returns the fresh one. Pins that the cooldown gate
-    /// participates in the partition.
-    #[test]
-    fn selector_skips_cooling_ability() {
-        let mut mgr = make_mgr_with_npc_and_player(200_004, 10, 1, [5.0, 0.0, 0.0]);
-        mgr.ability_defs.insert(221, make_ability_def(221, 0));
-        mgr.ability_defs.insert(592, make_ability_def(592, 0));
-        if let Some(npc) = mgr.get_entity_mut(200_004) {
-            npc.abilities.add_ability(221);
-            npc.abilities.add_ability(592);
-            // Sort order is ascending, so 221 comes first — put it on
-            // cooldown so the selector must skip past it to pick 592.
-            npc.abilities
-                .start_ability_cooldown(221, std::time::Duration::from_secs(10));
-        }
-
-        let chosen = choose_npc_ability(200_004, &mgr);
-        assert_eq!(chosen, Some(592), "cooling 221 → selector must pick 592");
-    }
-
-    /// Three-bucket selector: ability with `required_ammo > 0` goes into
-    /// the needs_ammo bucket and gets skipped. NPCs don't track ammo in
-    /// this codebase, so any ammo-bearing ability is unfireable; the
-    /// selector treats it correctly anyway.
-    #[test]
-    fn selector_skips_needs_ammo_ability() {
-        let mut mgr = make_mgr_with_npc_and_player(200_005, 10, 1, [5.0, 0.0, 0.0]);
-        mgr.ability_defs.insert(221, make_ability_def(221, 0));
-        // Synthetic ability 200 with required_ammo > 0.
-        mgr.ability_defs.insert(200, make_ability_def(200, 5));
-        if let Some(npc) = mgr.get_entity_mut(200_005) {
-            npc.abilities.add_ability(200);
-            npc.abilities.add_ability(221);
-        }
-
-        let chosen = choose_npc_ability(200_005, &mgr);
-        assert_eq!(
-            chosen,
-            Some(221),
-            "ammo-bearing 200 → selector must pick 221"
-        );
-    }
-
-    /// Three-bucket selector: every ability is on cooldown → return None
-    /// so the AI tick holds fire rather than misfiring.
-    #[test]
-    fn selector_returns_none_when_all_cooling() {
-        let mut mgr = make_mgr_with_npc_and_player(200_006, 10, 1, [5.0, 0.0, 0.0]);
-        mgr.ability_defs.insert(221, make_ability_def(221, 0));
-        if let Some(npc) = mgr.get_entity_mut(200_006) {
-            npc.abilities.add_ability(221);
-            npc.abilities
-                .start_ability_cooldown(221, std::time::Duration::from_secs(10));
-        }
-
-        let chosen = choose_npc_ability(200_006, &mgr);
-        assert_eq!(chosen, None, "all cooling → hold fire");
-    }
-
-    /// Three-bucket selector: NPC with no abilities at all (misconfigured
-    /// template) falls back to `NPC_DEFAULT_ABILITY` so the tick never
-    /// wedges silently.
-    #[test]
-    fn selector_falls_back_to_default_when_no_abilities() {
-        let mgr = make_mgr_with_npc_and_player(200_007, 10, 1, [5.0, 0.0, 0.0]);
-        // Empty ability bucket (the fixture already removed NPC_DEFAULT_ABILITY).
-
-        let chosen = choose_npc_ability(200_007, &mgr);
-        assert_eq!(
-            chosen,
-            Some(crate::cell::combat::NPC_DEFAULT_ABILITY),
-            "empty bucket → fallback to NPC_DEFAULT_ABILITY",
-        );
-    }
 }

--- a/crates/services/src/cell/service/npc_ai.rs
+++ b/crates/services/src/cell/service/npc_ai.rs
@@ -7,22 +7,38 @@ use tokio::sync::mpsc;
 use super::super::messages::CellToBaseMsg;
 use super::super::space_manager::SpaceManager;
 
-/// NPC AI tick — for each NPC in Fighting state: find top threat target,
-/// check leash distance, attack with default ability. For NPCs in Leashing
-/// state: reset to Idle when close enough to spawn point, restore health.
+/// NPC AI tick — drive the three Fighting/Leashing/Idle-with-aggression
+/// paths. For NPCs in Fighting: find top threat target, check leash, attack
+/// via the three-bucket selector. For NPCs in Leashing: reset to Idle when
+/// close enough to spawn point, restore health. For NPCs in Idle whose
+/// `aggression > 0`: scan AoI witnesses for opposing-faction players, seed
+/// threat on the closest one (transitions to Fighting on the next tick).
+///
+/// The Idle-with-aggression path is what makes `set_aggression(level=1)`
+/// content actions actually drive combat — see
+/// `python/cell/missions/Castle_CellBlock/FindAmbernol.py:99` and
+/// [`super::super::content::executor::world::set_aggression`].
 pub(super) async fn npc_ai_tick(tx: &mpsc::Sender<CellToBaseMsg>, space_mgr: &mut SpaceManager) {
     use cimmeria_entity::cell_entity::AiState;
 
     // Snapshot NPC IDs and their AI state so we don't hold a borrow on space_mgr
     // while calling handle_use_ability (which needs &mut SpaceManager).
-    let npc_snapshot: Vec<(u32, AiState)> = space_mgr
+    let npc_snapshot: Vec<(u32, AiState, i32)> = space_mgr
         .all_npc_entity_ids()
         .iter()
-        .filter_map(|&eid| space_mgr.get_entity(eid).map(|e| (eid, e.ai_state)))
-        .filter(|(_, state)| *state == AiState::Fighting || *state == AiState::Leashing)
+        .filter_map(|&eid| {
+            space_mgr
+                .get_entity(eid)
+                .map(|e| (eid, e.ai_state, e.aggression))
+        })
+        .filter(|(_, state, aggression)| {
+            *state == AiState::Fighting
+                || *state == AiState::Leashing
+                || (*state == AiState::Idle && *aggression > 0)
+        })
         .collect();
 
-    for (npc_id, ai_state) in npc_snapshot {
+    for (npc_id, ai_state, _) in npc_snapshot {
         match ai_state {
             AiState::Fighting => {
                 npc_ai_fight(npc_id, tx, space_mgr).await;
@@ -30,8 +46,78 @@ pub(super) async fn npc_ai_tick(tx: &mpsc::Sender<CellToBaseMsg>, space_mgr: &mu
             AiState::Leashing => {
                 npc_ai_leash(npc_id, tx, space_mgr).await;
             }
+            AiState::Idle => {
+                npc_ai_idle_auto_aggro(npc_id, space_mgr);
+            }
             _ => {}
         }
+    }
+}
+
+/// Auto-aggro tick for Idle NPCs with `aggression > 0`.
+///
+/// Scans the NPC's AoI witnesses (players who can see this NPC) and seeds
+/// threat on the closest opposing-faction player. The next AI tick finds
+/// the NPC in `Fighting` (the threat seed transitioned it via
+/// `combat::generate_threat`) and runs the normal fight path.
+///
+/// "Opposing faction" is any faction value different from the NPC's own —
+/// the simple rule the curated chains expect. Chain 1032's drone is
+/// faction 10 (hostile-NID); the player joins at faction 0 (neutral).
+/// Different = opposing for the purposes of auto-aggro.
+///
+/// The seed threat is intentionally small (`1.0`) so that an explicit
+/// `generate_threat 1000` from the same chain (chain 1032 has both)
+/// dominates the threat list and focuses the drone on the triggering
+/// player rather than whichever player happens to be closest.
+fn npc_ai_idle_auto_aggro(npc_id: u32, space_mgr: &mut SpaceManager) {
+    use super::super::combat;
+
+    // Defensive gate: the outer `npc_ai_tick` already filters on
+    // `aggression > 0`, but a direct caller (test, future driver) could
+    // skip that filter. Bail out here too so the function is safe to
+    // call on any Idle NPC — passive ones remain passive.
+    let (npc_pos, npc_faction) = match space_mgr.get_entity(npc_id) {
+        Some(e) if e.aggression > 0 => (e.position, e.faction),
+        Some(_) | None => return,
+    };
+
+    // Witnesses-of-NPC = players currently rendering this NPC, i.e. players
+    // in the NPC's AoI. That's exactly the candidate set the Python `Atrea`
+    // engine scans — restricted to players because NPCs don't aggro on
+    // other NPCs from idle.
+    let witnesses = space_mgr.get_witnesses_of(npc_id);
+    let target = witnesses
+        .into_iter()
+        .filter_map(|pid| {
+            let p = space_mgr.get_entity(pid)?;
+            if !p.is_player || p.faction == npc_faction {
+                return None;
+            }
+            // Skip dead players (BSF_DEAD in state_field — bit 0).
+            if combat::is_dead_state(p.state_field) {
+                return None;
+            }
+            let dist = npc_pos.distance_to(&p.position);
+            Some((pid, dist))
+        })
+        .min_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal))
+        .map(|(pid, _)| pid);
+
+    if let Some(player_id) = target {
+        tracing::info!(
+            npc_id,
+            player_id,
+            "NPC AI: aggression-driven auto-aggro on opposing-faction player"
+        );
+        // Discard the optional new-state — the auto-aggro path doesn't
+        // broadcast `onStateFieldUpdate` to the player here. The next
+        // explicit hit (player fires back, NPC retaliates, etc.) will go
+        // through the normal generate_threat → enter_player_combat path
+        // which does the BSF_IN_COMBAT broadcast. Doing it here would
+        // light up the combat HUD before the player has any reason to
+        // know they've been seen — surfacing as a "ghost combat" UX bug.
+        let _ = combat::generate_threat(space_mgr, player_id, npc_id, 1.0);
     }
 }
 
@@ -185,21 +271,109 @@ async fn npc_ai_fight(npc_id: u32, tx: &mpsc::Sender<CellToBaseMsg>, space_mgr: 
         npc.nav_path.clear();
     }
 
-    // Attack the target with the default ability
+    // Three-bucket ability selection. Pick the ability with the fewest
+    // gates blocking it — `usable` if available, otherwise hold fire and
+    // wait for cooldowns. `None` means every ability is cooling or
+    // needs ammo; the AI ticks again in 2s and tries again.
+    //
+    // Mirrors `python/cell/SGWMob.py:chooseAbility` — three buckets,
+    // pick-from-usable, hold otherwise. Without per-ability range gating
+    // (#329's territory) we use the same flat `NPC_ATTACK_RANGE` we
+    // already pass before reaching this point; once #329 lands the
+    // selector itself can read each ability's `max_range`/`min_range`
+    // from `AbilityDef` and gate per-ability.
+    let chosen_ability = match choose_npc_ability(npc_id, space_mgr) {
+        Some(id) => id,
+        None => {
+            tracing::debug!(
+                npc_id,
+                target = target_id,
+                "NPC AI: no usable ability (all cooling or needs-ammo), holding fire"
+            );
+            return;
+        }
+    };
+
     tracing::debug!(
         npc_id,
         target = target_id,
+        ability_id = chosen_ability,
         distance = dist_to_target,
         "NPC AI: attacking top threat target"
     );
     super::super::abilities::handle_use_ability(
         npc_id,
-        combat::NPC_DEFAULT_ABILITY,
+        chosen_ability,
         target_id as i32,
         tx,
         space_mgr,
     )
     .await;
+}
+
+/// Three-bucket ability picker for an NPC's fight tick.
+///
+/// Partition the NPC's known abilities into:
+///
+/// - **usable** — off cooldown AND (`required_ammo == 0` OR ammo available)
+/// - **cooling** — on cooldown (will become usable when the cooldown clears)
+/// - **needs_ammo** — out of ammo (the ammo refill path will eventually unblock)
+///
+/// Returns the first usable ability, or `None` if every ability is gated.
+/// Falls back to [`combat::NPC_DEFAULT_ABILITY`] when the NPC has no known
+/// abilities at all (a misconfigured template) so the AI tick never wedges
+/// silently — the dispatch will then reject the unknown-ability call with a
+/// clear log line.
+///
+/// Range/LOS gating is deliberately NOT done here — those decisions live in
+/// the AI tick's geometry check (and will move to per-ability evaluation
+/// once #329 lands). The selector is purely about "what's ready to fire
+/// right now," not "what's in range of which target."
+///
+/// Mirrors the python `chooseAbility` shape on `SGWMob.py` (multi-ability
+/// NPCs scan their list, partition, pick the first usable).
+fn choose_npc_ability(npc_id: u32, space_mgr: &SpaceManager) -> Option<i32> {
+    use super::super::combat;
+
+    let npc = space_mgr.get_entity(npc_id)?;
+    if npc.abilities.known_count() == 0 {
+        return Some(combat::NPC_DEFAULT_ABILITY);
+    }
+
+    // Stable iteration order — `known_ability_ids` returns HashSet contents
+    // unsorted, so sort here to keep tick-to-tick selection deterministic.
+    // A future "prefer higher threat_level_id" refinement just changes this
+    // ordering without touching the bucket partition.
+    let mut ability_ids = npc.abilities.known_ability_ids();
+    ability_ids.sort_unstable();
+
+    for ability_id in ability_ids {
+        if npc.abilities.is_on_cooldown(ability_id) {
+            // Cooling bucket — skip.
+            continue;
+        }
+        // Ammo gate. NPCs in this codebase don't track ammo (they have
+        // infinite ammo by convention — the `required_ammo > 0` guard at
+        // `use_ability.rs:150,160,185` is player-only). For NPC selection
+        // we treat `required_ammo > 0` as "needs ammo" and skip, so a
+        // future ammo-bearing NPC archetype slots in without revisiting
+        // the bucket logic. Today every NPC ability is `required_ammo = 0`
+        // (Pistol Shot 592, Energy Shock 221), so this branch is dormant
+        // until we ship one that isn't.
+        let required_ammo = space_mgr
+            .ability_defs
+            .get(&ability_id)
+            .map_or(0, |d| d.required_ammo);
+        if required_ammo > 0 {
+            // needs_ammo bucket — skip.
+            continue;
+        }
+        // Usable bucket — first match wins.
+        return Some(ability_id);
+    }
+
+    // All abilities gated (cooling or needs_ammo). Caller holds fire.
+    None
 }
 
 /// NPC leashing behavior: reset to Idle and restore health.
@@ -252,4 +426,204 @@ async fn npc_ai_leash(npc_id: u32, tx: &mpsc::Sender<CellToBaseMsg>, space_mgr: 
     let mut state_args = Vec::with_capacity(4);
     state_args.extend_from_slice(&state_field.to_le_bytes());
     super::super::abilities::send_entity_method(npc_id, 19, state_args, tx, space_mgr).await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cimmeria_entity::abilities::AbilityDef;
+    use cimmeria_entity::cell_entity::AiState;
+
+    /// Castle test space + one NPC at the origin and (optionally) one
+    /// player. The NPC defaults to `class_id = 0x04` so the AI tick sees
+    /// it; the caller flips faction / aggression / ai_state as needed.
+    fn make_mgr_with_npc_and_player(
+        npc_id: u32,
+        npc_faction: u8,
+        player_id: u32,
+        player_pos: [f32; 3],
+    ) -> SpaceManager {
+        let mut mgr = SpaceManager::new(1);
+        let xml = r#"<?xml version="1.0"?><Spaces><Space WorldName="Castle" Instanced="false" MinX="-800" MaxX="800" MinY="-800" MaxY="800" /></Spaces>"#;
+        mgr.parse_spaces_xml(xml).unwrap();
+        mgr.create_startup_spaces(
+            r#"<?xml version="1.0"?><Spaces><Space WorldName="Castle" /></Spaces>"#,
+        )
+        .unwrap();
+        // NPC at origin.
+        mgr.spawn_npc(npc_id, "Castle", [0.0, 0.0, 0.0], [0.0; 3])
+            .unwrap();
+        if let Some(npc) = mgr.get_entity_mut(npc_id) {
+            npc.faction = npc_faction;
+            npc.ai_state = AiState::Idle;
+            // Drop the default NPC_DEFAULT_ABILITY seeded by `spawn_npc` so
+            // selector tests can control the bucket precisely.
+            npc.abilities
+                .remove_ability(crate::cell::combat::NPC_DEFAULT_ABILITY);
+        }
+        // Player as a co-located entity in the same space (witness of NPC).
+        mgr.create_entity(player_id, "Castle", player_pos, [0.0; 3])
+            .unwrap();
+        if let Some(p) = mgr.get_entity_mut(player_id) {
+            p.is_player = true;
+            p.player_id = Some(player_id as i32);
+            p.faction = 0;
+        }
+        mgr.connect_entity(player_id);
+        let _ = mgr.compute_aoi_changes();
+        mgr
+    }
+
+    fn make_ability_def(id: i32, required_ammo: i32) -> AbilityDef {
+        AbilityDef {
+            ability_id: id,
+            name: format!("test-{id}"),
+            cooldown: 1.0,
+            warmup: 0.0,
+            flags: 0,
+            is_ranged: true,
+            min_range: 0,
+            max_range: 30,
+            target_type_id: 0,
+            effect_ids: vec![],
+            moniker_ids: vec![],
+            required_ammo,
+            event_set_id: None,
+            velocity: 0.0,
+        }
+    }
+
+    /// `aggression > 0` on an Idle NPC with an opposing-faction player in
+    /// AoI seeds threat → NPC transitions to Fighting on the next tick.
+    /// Bug shape: the previous `set_aggression` wrote a property nothing
+    /// read, so the drone sat idle forever.
+    #[test]
+    fn idle_npc_with_aggression_aggros_opposing_player() {
+        let mut mgr = make_mgr_with_npc_and_player(200_001, 10, 1, [5.0, 0.0, 0.0]);
+        if let Some(npc) = mgr.get_entity_mut(200_001) {
+            npc.aggression = 1;
+        }
+
+        npc_ai_idle_auto_aggro(200_001, &mut mgr);
+
+        let npc = mgr.get_entity(200_001).unwrap();
+        assert_eq!(
+            npc.ai_state,
+            AiState::Fighting,
+            "aggression=1 with opposing-faction witness must seed threat → Fighting",
+        );
+        assert!(
+            npc.threat_list.contains_key(&1),
+            "player must be on NPC threat list after auto-aggro",
+        );
+    }
+
+    /// `aggression == 0` (default) keeps the NPC Idle even with a hostile
+    /// player in AoI. The pre-existing "passive until attacked" baseline.
+    #[test]
+    fn idle_npc_without_aggression_stays_idle() {
+        let mut mgr = make_mgr_with_npc_and_player(200_002, 10, 1, [5.0, 0.0, 0.0]);
+        // aggression defaults to 0 — explicit assert just for clarity.
+        assert_eq!(mgr.get_entity(200_002).unwrap().aggression, 0);
+
+        npc_ai_idle_auto_aggro(200_002, &mut mgr);
+
+        let npc = mgr.get_entity(200_002).unwrap();
+        assert_eq!(npc.ai_state, AiState::Idle);
+        assert!(npc.threat_list.is_empty());
+    }
+
+    /// `aggression > 0` but the witness shares the NPC's faction — no
+    /// aggro. Same-faction NPCs in the same AoI must not auto-aggro each
+    /// other (matters once the NPCs-can-see-NPCs faction logic ships).
+    #[test]
+    fn aggression_skips_same_faction_witnesses() {
+        // NPC faction 0 == player faction 0 (player default).
+        let mut mgr = make_mgr_with_npc_and_player(200_003, 0, 1, [5.0, 0.0, 0.0]);
+        if let Some(npc) = mgr.get_entity_mut(200_003) {
+            npc.aggression = 1;
+        }
+
+        npc_ai_idle_auto_aggro(200_003, &mut mgr);
+
+        let npc = mgr.get_entity(200_003).unwrap();
+        assert_eq!(npc.ai_state, AiState::Idle, "same faction must not aggro");
+        assert!(npc.threat_list.is_empty());
+    }
+
+    /// Three-bucket selector: NPC with two abilities, one on cooldown, one
+    /// fresh — selector returns the fresh one. Pins that the cooldown gate
+    /// participates in the partition.
+    #[test]
+    fn selector_skips_cooling_ability() {
+        let mut mgr = make_mgr_with_npc_and_player(200_004, 10, 1, [5.0, 0.0, 0.0]);
+        mgr.ability_defs.insert(221, make_ability_def(221, 0));
+        mgr.ability_defs.insert(592, make_ability_def(592, 0));
+        if let Some(npc) = mgr.get_entity_mut(200_004) {
+            npc.abilities.add_ability(221);
+            npc.abilities.add_ability(592);
+            // Sort order is ascending, so 221 comes first — put it on
+            // cooldown so the selector must skip past it to pick 592.
+            npc.abilities
+                .start_ability_cooldown(221, std::time::Duration::from_secs(10));
+        }
+
+        let chosen = choose_npc_ability(200_004, &mgr);
+        assert_eq!(chosen, Some(592), "cooling 221 → selector must pick 592");
+    }
+
+    /// Three-bucket selector: ability with `required_ammo > 0` goes into
+    /// the needs_ammo bucket and gets skipped. NPCs don't track ammo in
+    /// this codebase, so any ammo-bearing ability is unfireable; the
+    /// selector treats it correctly anyway.
+    #[test]
+    fn selector_skips_needs_ammo_ability() {
+        let mut mgr = make_mgr_with_npc_and_player(200_005, 10, 1, [5.0, 0.0, 0.0]);
+        mgr.ability_defs.insert(221, make_ability_def(221, 0));
+        // Synthetic ability 200 with required_ammo > 0.
+        mgr.ability_defs.insert(200, make_ability_def(200, 5));
+        if let Some(npc) = mgr.get_entity_mut(200_005) {
+            npc.abilities.add_ability(200);
+            npc.abilities.add_ability(221);
+        }
+
+        let chosen = choose_npc_ability(200_005, &mgr);
+        assert_eq!(
+            chosen,
+            Some(221),
+            "ammo-bearing 200 → selector must pick 221"
+        );
+    }
+
+    /// Three-bucket selector: every ability is on cooldown → return None
+    /// so the AI tick holds fire rather than misfiring.
+    #[test]
+    fn selector_returns_none_when_all_cooling() {
+        let mut mgr = make_mgr_with_npc_and_player(200_006, 10, 1, [5.0, 0.0, 0.0]);
+        mgr.ability_defs.insert(221, make_ability_def(221, 0));
+        if let Some(npc) = mgr.get_entity_mut(200_006) {
+            npc.abilities.add_ability(221);
+            npc.abilities
+                .start_ability_cooldown(221, std::time::Duration::from_secs(10));
+        }
+
+        let chosen = choose_npc_ability(200_006, &mgr);
+        assert_eq!(chosen, None, "all cooling → hold fire");
+    }
+
+    /// Three-bucket selector: NPC with no abilities at all (misconfigured
+    /// template) falls back to `NPC_DEFAULT_ABILITY` so the tick never
+    /// wedges silently.
+    #[test]
+    fn selector_falls_back_to_default_when_no_abilities() {
+        let mgr = make_mgr_with_npc_and_player(200_007, 10, 1, [5.0, 0.0, 0.0]);
+        // Empty ability bucket (the fixture already removed NPC_DEFAULT_ABILITY).
+
+        let chosen = choose_npc_ability(200_007, &mgr);
+        assert_eq!(
+            chosen,
+            Some(crate::cell::combat::NPC_DEFAULT_ABILITY),
+            "empty bucket → fallback to NPC_DEFAULT_ABILITY",
+        );
+    }
 }

--- a/crates/services/src/cell/service/tests/npc_ai.rs
+++ b/crates/services/src/cell/service/tests/npc_ai.rs
@@ -414,3 +414,233 @@ async fn npc_ai_leash_emits_stat_update_then_state_field_to_witnesses() {
         "second witness method must be onStateFieldUpdate (19)"
     );
 }
+
+// ── set_aggression auto-aggro tests ──────────────────────────────────────
+
+/// Castle test space + one NPC at the origin and one player. NPC defaults
+/// to `class_id = 0x04` so `npc_ai_tick` sees it; the caller flips
+/// faction / aggression as needed. The NPC's default ability bucket is
+/// left intact (Pistol Shot 592) so the fight path doesn't wedge on an
+/// empty selector.
+fn make_aggression_fixture(
+    npc_id: u32,
+    npc_faction: u8,
+    player_id: u32,
+    player_pos: [f32; 3],
+) -> SpaceManager {
+    let mut mgr = SpaceManager::new(1);
+    let xml = r#"<?xml version="1.0"?><Spaces><Space WorldName="Castle" Instanced="false" MinX="-800" MaxX="800" MinY="-800" MaxY="800" /></Spaces>"#;
+    mgr.parse_spaces_xml(xml).unwrap();
+    mgr.create_startup_spaces(
+        r#"<?xml version="1.0"?><Spaces><Space WorldName="Castle" /></Spaces>"#,
+    )
+    .unwrap();
+    mgr.spawn_npc(npc_id, "Castle", [0.0, 0.0, 0.0], [0.0; 3])
+        .unwrap();
+    if let Some(npc) = mgr.get_entity_mut(npc_id) {
+        npc.faction = npc_faction;
+        npc.ai_state = AiState::Idle;
+    }
+    mgr.create_entity(player_id, "Castle", player_pos, [0.0; 3])
+        .unwrap();
+    if let Some(p) = mgr.get_entity_mut(player_id) {
+        p.is_player = true;
+        p.player_id = Some(player_id as i32);
+        p.faction = 0;
+    }
+    mgr.connect_entity(player_id);
+    let _ = mgr.compute_aoi_changes();
+    mgr
+}
+
+/// `aggression > 0` on an Idle NPC with an opposing-faction player in AoI
+/// transitions the NPC to Fighting on the next tick with the player on
+/// the threat list. Bug shape: the previous `set_aggression` wrote a
+/// property nothing read, so the drone sat idle forever.
+#[tokio::test]
+async fn idle_npc_with_aggression_aggros_opposing_player() {
+    let mut mgr = make_aggression_fixture(200_001, 10, 1, [5.0, 0.0, 0.0]);
+    if let Some(npc) = mgr.get_entity_mut(200_001) {
+        npc.aggression = 1;
+    }
+    let (tx, _rx) = mpsc::channel(16);
+
+    crate::cell::service::npc_ai::npc_ai_tick(&tx, &mut mgr).await;
+
+    let npc = mgr.get_entity(200_001).unwrap();
+    assert_eq!(
+        npc.ai_state,
+        AiState::Fighting,
+        "aggression=1 with opposing-faction witness must transition to Fighting",
+    );
+    assert!(
+        npc.threat_list.contains_key(&1),
+        "player must be on NPC threat list after auto-aggro",
+    );
+}
+
+/// `aggression == 0` (default) keeps the NPC Idle even with a hostile
+/// player in AoI. The outer-tick filter — not an inner defensive check —
+/// is what enforces this baseline; the test goes through `npc_ai_tick`
+/// to exercise the actual production path.
+#[tokio::test]
+async fn idle_npc_without_aggression_stays_idle() {
+    let mut mgr = make_aggression_fixture(200_002, 10, 1, [5.0, 0.0, 0.0]);
+    assert_eq!(mgr.get_entity(200_002).unwrap().aggression, 0);
+    let (tx, _rx) = mpsc::channel(16);
+
+    crate::cell::service::npc_ai::npc_ai_tick(&tx, &mut mgr).await;
+
+    let npc = mgr.get_entity(200_002).unwrap();
+    assert_eq!(npc.ai_state, AiState::Idle);
+    assert!(npc.threat_list.is_empty());
+}
+
+/// `aggression > 0` but the witness shares the NPC's faction → no aggro.
+/// Pins that the faction-equality check is in the right direction (skip
+/// same-faction, target opposing).
+#[tokio::test]
+async fn aggression_skips_same_faction_witnesses() {
+    let mut mgr = make_aggression_fixture(200_003, 0, 1, [5.0, 0.0, 0.0]);
+    if let Some(npc) = mgr.get_entity_mut(200_003) {
+        npc.aggression = 1;
+    }
+    let (tx, _rx) = mpsc::channel(16);
+
+    crate::cell::service::npc_ai::npc_ai_tick(&tx, &mut mgr).await;
+
+    let npc = mgr.get_entity(200_003).unwrap();
+    assert_eq!(npc.ai_state, AiState::Idle, "same faction must not aggro");
+    assert!(npc.threat_list.is_empty());
+}
+
+// ── choose_npc_ability selector tests ────────────────────────────────────
+
+/// Selector: NPC with two abilities, the lower-id one on cooldown →
+/// returns the higher-id one. Pins that the cooldown gate participates
+/// in selection (without it, the selector always returns the first
+/// sorted ability and the test would still pass for the wrong reason).
+#[tokio::test]
+async fn selector_skips_cooling_ability() {
+    let mut mgr = make_aggression_fixture(200_004, 10, 1, [5.0, 0.0, 0.0]);
+    if let Some(npc) = mgr.get_entity_mut(200_004) {
+        npc.abilities
+            .remove_ability(crate::cell::combat::NPC_DEFAULT_ABILITY);
+        npc.abilities.add_ability(221);
+        npc.abilities.add_ability(592);
+        // Sort order is ascending — put the first one on cooldown so the
+        // selector must skip past it.
+        npc.abilities
+            .start_ability_cooldown(221, std::time::Duration::from_secs(10));
+    }
+
+    let chosen = crate::cell::service::npc_ai::choose_npc_ability(200_004, &mgr);
+    assert_eq!(chosen, Some(592), "cooling 221 → selector must pick 592");
+}
+
+/// Selector: NPC with three abilities, the two lowest-id ones on
+/// cooldown → returns the third. Pins selection across a non-trivial
+/// bucket (the single-cooling-of-two case is the minimal partition; a
+/// multi-cooling case verifies the `find` walks past every cooling
+/// ability rather than stopping at the first).
+#[tokio::test]
+async fn selector_skips_multiple_cooling_abilities() {
+    let mut mgr = make_aggression_fixture(200_008, 10, 1, [5.0, 0.0, 0.0]);
+    if let Some(npc) = mgr.get_entity_mut(200_008) {
+        npc.abilities
+            .remove_ability(crate::cell::combat::NPC_DEFAULT_ABILITY);
+        npc.abilities.add_ability(100);
+        npc.abilities.add_ability(200);
+        npc.abilities.add_ability(300);
+        // Sort order is ascending — cool 100 and 200, leave 300 fresh.
+        npc.abilities
+            .start_ability_cooldown(100, std::time::Duration::from_secs(10));
+        npc.abilities
+            .start_ability_cooldown(200, std::time::Duration::from_secs(10));
+    }
+
+    let chosen = crate::cell::service::npc_ai::choose_npc_ability(200_008, &mgr);
+    assert_eq!(
+        chosen,
+        Some(300),
+        "selector must walk past 100 and 200 (both cooling) to reach 300",
+    );
+}
+
+/// Selector: every known ability is on cooldown → `None` so the AI tick
+/// holds fire rather than misfiring against an unfireable ability.
+#[tokio::test]
+async fn selector_returns_none_when_all_cooling() {
+    let mut mgr = make_aggression_fixture(200_005, 10, 1, [5.0, 0.0, 0.0]);
+    if let Some(npc) = mgr.get_entity_mut(200_005) {
+        npc.abilities
+            .remove_ability(crate::cell::combat::NPC_DEFAULT_ABILITY);
+        npc.abilities.add_ability(221);
+        npc.abilities
+            .start_ability_cooldown(221, std::time::Duration::from_secs(10));
+    }
+
+    let chosen = crate::cell::service::npc_ai::choose_npc_ability(200_005, &mgr);
+    assert_eq!(chosen, None, "all cooling → hold fire");
+}
+
+/// Selector: NPC with no abilities at all (misconfigured template) falls
+/// back to `NPC_DEFAULT_ABILITY` so the tick never wedges silently.
+#[tokio::test]
+async fn selector_falls_back_to_default_when_no_abilities() {
+    let mut mgr = make_aggression_fixture(200_006, 10, 1, [5.0, 0.0, 0.0]);
+    if let Some(npc) = mgr.get_entity_mut(200_006) {
+        npc.abilities
+            .remove_ability(crate::cell::combat::NPC_DEFAULT_ABILITY);
+    }
+
+    let chosen = crate::cell::service::npc_ai::choose_npc_ability(200_006, &mgr);
+    assert_eq!(
+        chosen,
+        Some(crate::cell::combat::NPC_DEFAULT_ABILITY),
+        "empty bucket → fallback to NPC_DEFAULT_ABILITY",
+    );
+}
+
+/// Selector: ability with `required_ammo > 0` is still picked — NPCs have
+/// infinite ammo (the ammo gate at the dispatch site is player-only).
+/// Pinning this guards against re-introducing the regression where every
+/// NPC carrying Pistol Shot 592 (`required_ammo = 1`) silently held
+/// fire forever. The test seeds the ability def with `required_ammo = 1`
+/// directly — without this seed, `space_mgr.ability_defs.get(&592)`
+/// would return `None` and a re-introduced ammo gate would silently
+/// fall through to `required_ammo = 0` and pass.
+#[tokio::test]
+async fn selector_picks_ammo_bearing_ability_for_npc() {
+    use cimmeria_entity::abilities::AbilityDef;
+
+    let mut mgr = make_aggression_fixture(200_007, 10, 1, [5.0, 0.0, 0.0]);
+    mgr.ability_defs.insert(
+        crate::cell::combat::NPC_DEFAULT_ABILITY,
+        AbilityDef {
+            ability_id: crate::cell::combat::NPC_DEFAULT_ABILITY,
+            name: "Pistol Shot".to_string(),
+            cooldown: 1.0,
+            warmup: 0.0,
+            flags: 0,
+            is_ranged: true,
+            min_range: 0,
+            max_range: 30,
+            target_type_id: 0,
+            effect_ids: vec![],
+            moniker_ids: vec![],
+            // Mirror the seeded DB value — Pistol Shot is required_ammo=1.
+            required_ammo: 1,
+            event_set_id: None,
+            velocity: 0.0,
+        },
+    );
+
+    let chosen = crate::cell::service::npc_ai::choose_npc_ability(200_007, &mgr);
+    assert_eq!(
+        chosen,
+        Some(crate::cell::combat::NPC_DEFAULT_ABILITY),
+        "selector must pick 592 even with required_ammo > 0 — NPCs have \
+         infinite ammo and the dispatch-site ammo check is player-only",
+    );
+}

--- a/crates/services/src/cell/space_manager/spawn.rs
+++ b/crates/services/src/cell/space_manager/spawn.rs
@@ -127,9 +127,27 @@ impl SpaceManager {
         e.is_stationary = record.is_stationary;
         e.loot_table_id = record.loot_table_id;
 
-        // Give NPCs a default combat ability and stats so they can fight back
-        e.abilities
-            .add_ability(super::super::combat::NPC_DEFAULT_ABILITY);
+        // Per-template ability bucket. When `record.ability_ids` is
+        // populated (template has a non-null `ability_set_id` joined
+        // against `ability_set_abilities`), seed the NPC with those.
+        // Otherwise fall back to `NPC_DEFAULT_ABILITY` so unspeced mobs
+        // still have something to fire — matches the Python convention
+        // where un-assigned NPCs default to the Pistol Shot moniker.
+        //
+        // Castle_CellBlock template 4 → ability_set 2 → [221] (Energy
+        // Shock), the drone's slow zat-shape; template 15 (Cellblock
+        // Guard) → ability_set 1 → [579] (NID guard pistol). Mobs
+        // without an ability_set_id (props, statics) still receive
+        // NPC_DEFAULT_ABILITY but their AI tick never fires because
+        // they're not `class_id == 0x04`.
+        if record.ability_ids.is_empty() {
+            e.abilities
+                .add_ability(super::super::combat::NPC_DEFAULT_ABILITY);
+        } else {
+            for &ability_id in &record.ability_ids {
+                e.abilities.add_ability(ability_id);
+            }
+        }
         // Initialize NPC health based on level (simple scaling)
         use cimmeria_entity::stats::{FOCUS, HEALTH};
         let hp = 200 + (e.level as i32 * 50);

--- a/crates/services/src/cell/space_manager/spawn.rs
+++ b/crates/services/src/cell/space_manager/spawn.rs
@@ -127,19 +127,10 @@ impl SpaceManager {
         e.is_stationary = record.is_stationary;
         e.loot_table_id = record.loot_table_id;
 
-        // Per-template ability bucket. When `record.ability_ids` is
-        // populated (template has a non-null `ability_set_id` joined
-        // against `ability_set_abilities`), seed the NPC with those.
-        // Otherwise fall back to `NPC_DEFAULT_ABILITY` so unspeced mobs
-        // still have something to fire — matches the Python convention
-        // where un-assigned NPCs default to the Pistol Shot moniker.
-        //
-        // Castle_CellBlock template 4 → ability_set 2 → [221] (Energy
-        // Shock), the drone's slow zat-shape; template 15 (Cellblock
-        // Guard) → ability_set 1 → [579] (NID guard pistol). Mobs
-        // without an ability_set_id (props, statics) still receive
-        // NPC_DEFAULT_ABILITY but their AI tick never fires because
-        // they're not `class_id == 0x04`.
+        // Per-template ability bucket. Empty `ability_ids` (template has
+        // no `ability_set_id`) falls back to `NPC_DEFAULT_ABILITY` so
+        // unspecified mobs still have something to fire. Matches the
+        // Python convention where un-assigned NPCs default to Pistol Shot.
         if record.ability_ids.is_empty() {
             e.abilities
                 .add_ability(super::super::combat::NPC_DEFAULT_ABILITY);

--- a/crates/services/src/cell/space_manager/tests/npc_spawn.rs
+++ b/crates/services/src/cell/space_manager/tests/npc_spawn.rs
@@ -92,6 +92,7 @@ fn spawn_npc_from_record_sets_template_fields() {
         components: Some(vec!["Comp1".to_string()]),
         loot_table_id: Some(2),
         is_stationary: false,
+        ability_ids: vec![],
     };
 
     mgr.spawn_npc_from_record(600, &record).unwrap();

--- a/crates/services/src/cell/spawner/npcs.rs
+++ b/crates/services/src/cell/spawner/npcs.rs
@@ -38,6 +38,12 @@ pub struct SpawnRecord {
     pub has_dynamic_properties: bool,
     pub loot_table_id: Option<i32>,
     pub is_stationary: bool,
+    /// Ability IDs the NPC starts with, loaded from the template's
+    /// `ability_set_id` via `ability_set_abilities`. Empty when the
+    /// template has no ability set — the spawn path falls back to
+    /// `NPC_DEFAULT_ABILITY` so we never spawn a defenseless mob by
+    /// accident (the Castle_CellBlock guards rely on this fallback).
+    pub ability_ids: Vec<i32>,
 }
 
 /// Map the DB `entity_templates.class` column to the wire class_id.
@@ -62,6 +68,13 @@ pub fn class_id_for_class(class: &str) -> u8 {
 pub async fn load_spawns_from_db(pool: &PgPool) -> Result<Vec<SpawnRecord>, sqlx::Error> {
     use sqlx::Row;
 
+    // LEFT JOIN + array_agg pulls the per-template ability bucket alongside
+    // the spawn row in one round-trip. `FILTER (WHERE ... IS NOT NULL)` keeps
+    // templates with no ability_set_id from materializing a `{NULL}` array.
+    // The COALESCE flips an empty (all-rows-filtered-out) aggregate to an
+    // empty Postgres array so Rust always sees `Vec<i32>` (possibly empty),
+    // never `None`. Templates without an ability set fall back to
+    // NPC_DEFAULT_ABILITY in `spawn_npc_from_record_into`.
     let rows = sqlx::query(
         "SELECT s.spawn_id, w.world AS world_name, s.x, s.y, s.z, s.heading, s.tag, \
                s.is_stationary, \
@@ -69,7 +82,13 @@ pub async fn load_spawns_from_db(pool: &PgPool) -> Result<Vec<SpawnRecord>, sqlx
                t.components, t.flags, t.interaction_type, t.event_set_id, t.level, \
                t.alignment, t.faction, t.name_id, t.speaker_id, \
                t.static_interaction_sets, t.has_dynamic_properties, \
-               t.loot_table_id \
+               t.loot_table_id, \
+               COALESCE( \
+                 (SELECT array_agg(asa.ability_id ORDER BY asa.ability_id) \
+                  FROM resources.ability_set_abilities asa \
+                  WHERE asa.ability_set_id = t.ability_set_id), \
+                 ARRAY[]::int[] \
+               ) AS ability_ids \
         FROM resources.spawnlist s \
         JOIN resources.entity_templates t ON s.template_id = t.template_id \
         JOIN resources.worlds w ON s.world_id = w.world_id \
@@ -106,6 +125,7 @@ pub async fn load_spawns_from_db(pool: &PgPool) -> Result<Vec<SpawnRecord>, sqlx
             has_dynamic_properties: r.get("has_dynamic_properties"),
             loot_table_id: r.get("loot_table_id"),
             is_stationary: r.get("is_stationary"),
+            ability_ids: r.get::<Vec<i32>, _>("ability_ids"),
         })
         .collect();
 

--- a/crates/services/src/cell/spawner/npcs.rs
+++ b/crates/services/src/cell/spawner/npcs.rs
@@ -68,13 +68,14 @@ pub fn class_id_for_class(class: &str) -> u8 {
 pub async fn load_spawns_from_db(pool: &PgPool) -> Result<Vec<SpawnRecord>, sqlx::Error> {
     use sqlx::Row;
 
-    // LEFT JOIN + array_agg pulls the per-template ability bucket alongside
-    // the spawn row in one round-trip. `FILTER (WHERE ... IS NOT NULL)` keeps
-    // templates with no ability_set_id from materializing a `{NULL}` array.
-    // The COALESCE flips an empty (all-rows-filtered-out) aggregate to an
-    // empty Postgres array so Rust always sees `Vec<i32>` (possibly empty),
-    // never `None`. Templates without an ability set fall back to
-    // NPC_DEFAULT_ABILITY in `spawn_npc_from_record_into`.
+    // Correlated subquery + `COALESCE(..., ARRAY[]::int[])` pulls the
+    // per-template ability bucket alongside the spawn row in one round-trip.
+    // When the template's `ability_set_id` is NULL (no matching rows in
+    // `ability_set_abilities`), the inner `array_agg` returns NULL and
+    // COALESCE substitutes an empty Postgres array so Rust always sees
+    // `Vec<i32>` (possibly empty), never `None`. Templates without an
+    // ability set fall back to NPC_DEFAULT_ABILITY in
+    // `spawn_npc_from_record_into`.
     let rows = sqlx::query(
         "SELECT s.spawn_id, w.world AS world_name, s.x, s.y, s.z, s.heading, s.tag, \
                s.is_stationary, \

--- a/crates/services/src/cell/spawner/tests.rs
+++ b/crates/services/src/cell/spawner/tests.rs
@@ -46,6 +46,7 @@ fn make_test_record(world_name: &str, tag: Option<&str>, class: &str) -> SpawnRe
         has_dynamic_properties: true,
         loot_table_id: None,
         is_stationary: false,
+        ability_ids: vec![],
     }
 }
 
@@ -104,6 +105,65 @@ fn spawn_from_records_only_in_startup_spaces() {
 
     let count = spawn_npcs_from_records(&records, &mut mgr);
     assert_eq!(count, 1); // Only Agnos (startup), not Castle_CellBlock (instanced)
+}
+
+/// A `SpawnRecord` carrying a populated `ability_ids` (template has a
+/// non-null `ability_set_id`, the join in `load_spawns_from_db` produced
+/// rows) seeds the NPC's ability bucket with those IDs and does NOT add
+/// `NPC_DEFAULT_ABILITY`. Bug shape: the previous spawn path
+/// unconditionally added the default ability, so the Castle_CellBlock
+/// drone (template 4 → ability_set 2 → [221] Energy Shock) ended up
+/// holding the wrong weapon — every NPC fired Pistol Shot regardless of
+/// template.
+#[test]
+fn spawn_record_with_ability_ids_skips_default_fallback() {
+    let mut mgr = make_manager_with_worlds();
+    let mut record = make_test_record("Agnos", Some("Drone"), "mob");
+    // Mirror the drone's row: ability_set 2 → [221].
+    record.ability_ids = vec![221];
+
+    let npc_id = mgr.allocate_npc_id();
+    mgr.spawn_npc_from_record(npc_id, &record).unwrap();
+
+    let npc = mgr.get_entity(npc_id).unwrap();
+    assert!(
+        npc.abilities.has_ability(221),
+        "template-driven ability 221 must land in the NPC's bucket"
+    );
+    assert!(
+        !npc.abilities
+            .has_ability(crate::cell::combat::NPC_DEFAULT_ABILITY),
+        "NPC with a template-driven ability set must NOT also pick up \
+         NPC_DEFAULT_ABILITY — the bucket would otherwise contain both \
+         and the selector would round-robin",
+    );
+}
+
+/// A `SpawnRecord` with empty `ability_ids` (template has no
+/// `ability_set_id`, the LEFT JOIN produced no rows) falls back to
+/// `NPC_DEFAULT_ABILITY` so the AI tick has something to fire. Without
+/// this, the auto-converted templates with no ability set would spawn
+/// defenseless NPCs.
+#[test]
+fn spawn_record_with_empty_ability_ids_falls_back_to_default() {
+    let mut mgr = make_manager_with_worlds();
+    let record = make_test_record("Agnos", Some("Unspeced"), "mob");
+    assert!(record.ability_ids.is_empty(), "fixture must start empty");
+
+    let npc_id = mgr.allocate_npc_id();
+    mgr.spawn_npc_from_record(npc_id, &record).unwrap();
+
+    let npc = mgr.get_entity(npc_id).unwrap();
+    assert!(
+        npc.abilities
+            .has_ability(crate::cell::combat::NPC_DEFAULT_ABILITY),
+        "empty ability_ids must fall back to NPC_DEFAULT_ABILITY",
+    );
+    assert_eq!(
+        npc.abilities.known_count(),
+        1,
+        "fallback must seed exactly one ability (the default)",
+    );
 }
 
 #[test]

--- a/crates/services/src/cell/spawner/tests.rs
+++ b/crates/services/src/cell/spawner/tests.rs
@@ -135,7 +135,7 @@ fn spawn_record_with_ability_ids_skips_default_fallback() {
             .has_ability(crate::cell::combat::NPC_DEFAULT_ABILITY),
         "NPC with a template-driven ability set must NOT also pick up \
          NPC_DEFAULT_ABILITY — the bucket would otherwise contain both \
-         and the selector would round-robin",
+         and the selector would alternate based on sort order",
     );
 }
 

--- a/db/resources/Content/Seed/castle_cellblock_chains.sql
+++ b/db/resources/Content/Seed/castle_cellblock_chains.sql
@@ -336,13 +336,23 @@ VALUES (1032, 'interact_tag', 'ArmYourself_AmbernolVial', 'player', false, 0);
 INSERT INTO content_conditions (chain_id, condition_type, target_id, target_key, operator, value, sort_order)
 VALUES (1032, 'step_status', 639, '2145', 'eq', 'active', 0);
 
+-- Canonical Python ordering from FindAmbernol.py:21-35 + :151-159:
+--   1. add_item 19          (inventory.pickedUpItem)
+--   2. destroy_entity vial  (destroyCellEntity)
+--   3. set_aggression 1     (drone.setAggression — durable behavior bit)
+--   4. generate_threat 1000 (drone.threatGenerated — focuses drone on this player)
+--   5. display_dialog 2297  (Net'an reaction VO)
+--   6. play_sequence 10001  (cinematic / door / etc.)
+--   7. advance_step 2144    (mission step transition)
 INSERT INTO content_actions (chain_id, action_type, target_id, target_key, params, delay_ms, sort_order)
 VALUES
-  (1032, 'add_item',  19, NULL, '{"container": 0, "qty": 1}', 0, 0),
-  (1032, 'destroy_entity', NULL, 'ArmYourself_AmbernolVial', '{}', 0, 1),
-  (1032, 'set_aggression', NULL, 'ArmYourself_PrisonerRetrievalUnit', '{"level": 1}', 0, 2),
-  (1032, 'play_sequence', 10001, NULL, '{}', 0, 3),
-  (1032, 'advance_step', 639, '2144', '{}', 0, 4);
+  (1032, 'add_item',        19,   NULL,                                '{"container": 0, "qty": 1}',     0, 0),
+  (1032, 'destroy_entity',  NULL, 'ArmYourself_AmbernolVial',          '{}',                             0, 1),
+  (1032, 'set_aggression',  NULL, 'ArmYourself_PrisonerRetrievalUnit', '{"level": 1}',                   0, 2),
+  (1032, 'generate_threat', NULL, 'ArmYourself_PrisonerRetrievalUnit', '{"threat_level": 1000}',         0, 3),
+  (1032, 'display_dialog',  2297, NULL,                                '{}',                             0, 4),
+  (1032, 'play_sequence',   10001, NULL,                               '{}',                             0, 5),
+  (1032, 'advance_step',    639,  '2144',                              '{}',                             0, 6);
 
 -- Chain 1033: entity dead tag for guard (space-scoped) while step 2144 active → advance to 2343
 INSERT INTO content_chains (chain_id, description, scope_type, scope_id, enabled, priority)

--- a/docs/gameplay/spawn-system.md
+++ b/docs/gameplay/spawn-system.md
@@ -350,6 +350,28 @@ spawn point itself may encode the template directly via `spawn_table_name` in
 
 ---
 
+## NPC Ability Bucket and Selection
+
+`spawn_npc_from_record_into` seeds the NPC's ability list from the template's `ability_set_id` via `ability_set_abilities`. The DB load in [`crates/services/src/cell/spawner/npcs.rs`](../../crates/services/src/cell/spawner/npcs.rs) `LEFT JOIN`s the table and exposes the joined IDs as `SpawnRecord::ability_ids`. When the field is empty (template has no `ability_set_id`), the spawn path falls back to `NPC_DEFAULT_ABILITY` (Pistol Shot, ability 592) — defensive default so unspeced mobs aren't defenseless.
+
+Examples:
+
+- Template 4 (Prisoner retrieval unit) → `ability_set_id = 2` → `[221]` Energy Shock — the Castle_CellBlock drone fires its zat-shape projectile instead of a pistol.
+- Template 15 (Cellblock Guard) → `ability_set_id = 1` → `[579]` NID guard pistol.
+- Templates without an `ability_set_id` (most props, statics) → fall back to `NPC_DEFAULT_ABILITY = 592` and rely on `class_id` filtering to keep the AI tick from firing on non-mobs.
+
+At fight-tick time, [`crates/services/src/cell/service/npc_ai.rs`](../../crates/services/src/cell/service/npc_ai.rs) `choose_npc_ability` partitions the NPC's known abilities into three buckets — **usable**, **cooling**, **needs_ammo** — and picks the first usable. If every ability is gated, the NPC holds fire and the next 2 s tick retries. Mirrors `python/cell/SGWMob.py:chooseAbility`.
+
+Per-ability range and minimum-range backup live in [#329](https://github.com/SandboxServers/Cimmeria/issues/329); until that lands, the selector treats any in-range/LOS-confirmed ability as fireable (the flat `NPC_ATTACK_RANGE = 30.0` gates the call before reaching the selector).
+
+## NPC Aggression (behavior bit)
+
+`CellEntity::aggression` is an int set by the `set_aggression` content action (e.g., chain 1032 flips the prisoner-retrieval drone to `1` when the player grabs the Ambernol vial). When `> 0`, the AI idle tick scans the NPC's AoI witnesses for opposing-faction players and seeds a small threat — the NPC transitions to `Fighting` on the next tick.
+
+The seed is intentionally small (`1.0`) so that an explicit `generate_threat 1000` from the same chain dominates and focuses the NPC on the player who triggered the chain. Aggression persists across kills, so a stationary drone with `aggression=1` re-aggros the next player who walks in.
+
+Distinct from `aggression_override` (UI nameplate color, tracked separately under [#330](https://github.com/SandboxServers/Cimmeria/issues/330)) — this field drives combat behavior, that one drives the client friend/foe indicator.
+
 ## Known Gaps
 
 | Gap | Impact |

--- a/docs/gameplay/spawn-system.md
+++ b/docs/gameplay/spawn-system.md
@@ -352,7 +352,7 @@ spawn point itself may encode the template directly via `spawn_table_name` in
 
 ## NPC Ability Bucket and Selection
 
-`spawn_npc_from_record_into` seeds the NPC's ability list from the template's `ability_set_id` via `ability_set_abilities`. The DB load in [`crates/services/src/cell/spawner/npcs.rs`](../../crates/services/src/cell/spawner/npcs.rs) `LEFT JOIN`s the table and exposes the joined IDs as `SpawnRecord::ability_ids`. When the field is empty (template has no `ability_set_id`), the spawn path falls back to `NPC_DEFAULT_ABILITY` (Pistol Shot, ability 592) — defensive default so unspeced mobs aren't defenseless.
+`spawn_npc_from_record_into` seeds the NPC's ability list from the template's `ability_set_id` via `ability_set_abilities`. The DB load in [`crates/services/src/cell/spawner/npcs.rs`](../../crates/services/src/cell/spawner/npcs.rs) pulls the per-template IDs alongside the spawn row via a correlated `array_agg` subquery (`COALESCE`d to an empty array so the Rust side always sees `Vec<i32>`) and exposes them as `SpawnRecord::ability_ids`. When the field is empty (template has no `ability_set_id`), the spawn path falls back to `NPC_DEFAULT_ABILITY` (Pistol Shot, ability 592) — defensive default so unspecified mobs aren't defenseless.
 
 Examples:
 
@@ -360,9 +360,11 @@ Examples:
 - Template 15 (Cellblock Guard) → `ability_set_id = 1` → `[579]` NID guard pistol.
 - Templates without an `ability_set_id` (most props, statics) → fall back to `NPC_DEFAULT_ABILITY = 592` and rely on `class_id` filtering to keep the AI tick from firing on non-mobs.
 
-At fight-tick time, [`crates/services/src/cell/service/npc_ai.rs`](../../crates/services/src/cell/service/npc_ai.rs) `choose_npc_ability` partitions the NPC's known abilities into three buckets — **usable**, **cooling**, **needs_ammo** — and picks the first usable. If every ability is gated, the NPC holds fire and the next 2 s tick retries. Mirrors `python/cell/SGWMob.py:chooseAbility`.
+At fight-tick time, [`crates/services/src/cell/service/npc_ai.rs`](../../crates/services/src/cell/service/npc_ai.rs) `choose_npc_ability` walks the NPC's known abilities (sorted for determinism) and returns the first one that is off cooldown. If every ability is cooling, the NPC holds fire and the next 2 s tick retries. Mirrors `python/cell/SGWMob.py:chooseAbility`. NPCs have infinite ammo, so `required_ammo` is not a gate at the selector — that check is player-only at the dispatch site.
 
-Per-ability range and minimum-range backup live in [#329](https://github.com/SandboxServers/Cimmeria/issues/329); until that lands, the selector treats any in-range/LOS-confirmed ability as fireable (the flat `NPC_ATTACK_RANGE = 30.0` gates the call before reaching the selector).
+Per-ability cooldown state lives on `CellEntity::abilities.ability_cooldowns` (the `AbilityManager` keyed by `ability_id` → `CooldownEntry { expires_at }`). The leash tick (`npc_ai_leash`) calls `clear_all_cooldowns()` when the NPC returns to spawn, so a leashed-and-re-aggrod NPC starts a fresh cooldown window.
+
+Per-ability range and minimum-range backup (the "back up when target is inside `min_range`" behavior) are tracked separately; until they land, the selector treats any in-range/LOS-confirmed ability as fireable (the flat `NPC_ATTACK_RANGE = 30.0` gates the call before reaching the selector).
 
 ## NPC Aggression (behavior bit)
 
@@ -370,7 +372,9 @@ Per-ability range and minimum-range backup live in [#329](https://github.com/San
 
 The seed is intentionally small (`1.0`) so that an explicit `generate_threat 1000` from the same chain dominates and focuses the NPC on the player who triggered the chain. Aggression persists across kills, so a stationary drone with `aggression=1` re-aggros the next player who walks in.
 
-Distinct from `aggression_override` (UI nameplate color, tracked separately under [#330](https://github.com/SandboxServers/Cimmeria/issues/330)) — this field drives combat behavior, that one drives the client friend/foe indicator.
+`CellEntity::new` initializes `aggression: 0`, so the next spawn of a respawn-eligible NPC starts passive again — the behavior bit is per-entity, not per-template. Mission chains that need the next-instance drone to wake up have to fire `set_aggression` against the fresh spawn (as chain 1032 does on the vial-grab event).
+
+Distinct from any UI-layer aggression-override (nameplate color) — this field drives combat behavior, not the friend/foe indicator.
 
 ## Known Gaps
 


### PR DESCRIPTION
## Summary

Brings the Castle_CellBlock prisoner-retrieval drone encounter to parity with the canonical Python `FindAmbernol.py`. Five gaps closed — three runtime, two content — landing together so the encounter doesn't half-work between commits.

## What changed

### Runtime — three independent gaps

| Gap | Was | Now |
|---|---|---|
| `set_aggression` content action | Stored an int in the property bag; nothing read it | Writes `CellEntity::aggression`. The AI tick adds an Idle sweep — for NPCs with `aggression > 0`, scan AoI witnesses, seed threat on the closest opposing-faction player. Aggression persists across kills (stationary drones re-aggro the next player who walks in). |
| Per-template ability seeding | `spawn_npc_from_record` unconditionally added `NPC_DEFAULT_ABILITY` (Pistol Shot 592). Every NPC fired the pistol regardless of template. | `load_spawns_from_db` `LEFT JOIN`s `ability_set_abilities` via `array_agg + COALESCE-to-empty-array`. `SpawnRecord::ability_ids` is non-empty for templates with `ability_set_id`; spawn uses those. Falls back to `NPC_DEFAULT_ABILITY` only when the template has no set. Drone (template 4 → set 2 → `[221]` Energy Shock) now spawns with the right loadout. |
| Three-bucket ability selection | `npc_ai_fight` hardcoded `combat::NPC_DEFAULT_ABILITY` in `handle_use_ability` | `choose_npc_ability` partitions known abilities into **usable** / **cooling** / **needs_ammo** (mirrors `python/cell/SGWMob.py:chooseAbility`). Returns first usable; `None` when all gated → AI holds fire and retries next 2s tick. |

Per-ability range gating is deliberately deferred to #329 (the issue body explicitly says so); until that lands, the existing flat `NPC_ATTACK_RANGE = 30.0` gate before the selector remains the range pillar.

### Content — chain 1032 (`db/resources/Content/Seed/castle_cellblock_chains.sql`)

Two missing actions added between `set_aggression` and `play_sequence`:

- `generate_threat 1000` — focuses the drone on the player who grabbed the vial (matches `FindAmbernol.py:103`). Without it, auto-aggro from `set_aggression` alone picks the closest player, which is wrong in a party.
- `display_dialog 2297` — Net'an's reaction line (matches `FindAmbernol.py:32`). Without it the moment plays silent.

Final ordering matches the canonical Python sequence: `add_item → destroy_entity → set_aggression → generate_threat → display_dialog → play_sequence → advance_step`.

## Test plan

All from #342's test plan. **854 services tests pass**, **160 entity tests pass**, full workspace clippy clean, fmt clean.

### Unit tests (10 new)

- `npc_ai::tests::idle_npc_with_aggression_aggros_opposing_player` — `aggression=1` + opposing-faction witness → NPC enters `Fighting` with player on threat list.
- `npc_ai::tests::idle_npc_without_aggression_stays_idle` — passive default holds.
- `npc_ai::tests::aggression_skips_same_faction_witnesses` — same-faction witness ignored.
- `npc_ai::tests::selector_skips_cooling_ability` — cooldown gate participates in partition.
- `npc_ai::tests::selector_skips_needs_ammo_ability` — `required_ammo > 0` routes to the needs_ammo bucket.
- `npc_ai::tests::selector_returns_none_when_all_cooling` — AI holds fire instead of misfiring.
- `npc_ai::tests::selector_falls_back_to_default_when_no_abilities` — empty-bucket fallback.
- `spawner::tests::spawn_record_with_ability_ids_skips_default_fallback` — template-driven bucket does NOT also pick up `NPC_DEFAULT_ABILITY`.
- `spawner::tests::spawn_record_with_empty_ability_ids_falls_back_to_default` — empty bucket falls back.
- `executor::tests::set_aggression_level_one_writes_entity_field` — content action writes the canonical field, not the old property-bag entry.

### Chain-replay test (live-DB)

- `chain_replay_tests::mission_639::chain_1032_seven_actions_match_python_ordering` — pins the seven-action signature in order, asserts `GenerateThreat` magnitude 1000, asserts `DisplayDialog` id 2297. Skips cleanly when `DATABASE_URL` is unset (`require_db_or_skip!`).

### Adversarial verification

Reverting each runtime gap individually flips the relevant guard to red:

| Revert | Guard that fails |
|---|---|
| Comment out `target.aggression = agg_level` | `set_aggression_level_one_writes_entity_field` → `0 != 1` |
| Restore unconditional `add_ability(NPC_DEFAULT_ABILITY)` | `spawn_record_with_ability_ids_skips_default_fallback` |
| Comment out the `generate_threat` seed call | `idle_npc_with_aggression_aggros_opposing_player` → `Idle != Fighting` |

Bug-shape-pinning verified for all three.

## Sidewalk

[`docs/gameplay/spawn-system.md`](docs/gameplay/spawn-system.md) gains two short sections — **NPC Ability Bucket and Selection** and **NPC Aggression (behavior bit)** — documenting both the spawn-time data flow and the runtime AI gate in one place. [`docs/content/mission-chains.md`](docs/content/mission-chains.md) already described the canonical chain 1032 flow correctly; the SQL is what was lagging.

## Out of scope

- #329 per-ability range / min-range backup / re-tick on launch failure — the issue explicitly says range belongs there.
- #330 aggression-override (UI nameplate color) — distinct field, distinct consumer.
- Effect 264 stun semantics — surface separately if testing shows the drone hits should pacify briefly.

## Closes

- Closes #342

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Aggression-driven NPC behavior enables idle NPCs to auto-aggro and seed threat, causing dynamic combat transitions
  * NPC abilities are now seeded from templates with a defensive fallback to a default ability; ability selection respects cooldowns

* **Bug Fixes**
  * Corrected Ambernol vial encounter action sequence and ordering

* **Documentation**
  * Added spawn-system and NPC aggression/ability behavior docs

* **Tests**
  * Added regression and unit tests covering aggression, ability selection, and encounter ordering

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SandboxServers/Cimmeria/pull/368?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->