### PR TITLE
fix(combat): credit quest kills from auto-cycle and other tick paths (#367)

### DIFF
--- a/crates/services/src/cell/abilities/mod.rs
+++ b/crates/services/src/cell/abilities/mod.rs
@@ -36,4 +36,4 @@ pub(crate) use messaging::{request_appearance_refresh, send_entity_method};
 // land here for #278 child PRs to adopt. They stay private to the `messaging`
 // module until the first child callsite migrates — at which point the
 // migrating PR adds the re-exports it needs.
-pub use use_ability::handle_use_ability;
+pub use use_ability::{handle_use_ability, handle_use_ability_with_kill_credit};

--- a/crates/services/src/cell/abilities/use_ability/mod.rs
+++ b/crates/services/src/cell/abilities/use_ability/mod.rs
@@ -509,20 +509,19 @@ pub async fn handle_use_ability(
 
 /// `handle_use_ability` + content-engine kill-credit hook.
 ///
-/// **Use this from every player-driven attack path.** Calls
-/// [`handle_use_ability`] to resolve the ability, then — if the attacker
-/// is a player who just transitioned a tagged NPC from alive→dead —
-/// fires the `EntityDeath` content event so mission KillCount chains
-/// (e.g., "kill 5 Hallway_Guards") progress.
+/// **Use this from every single-target player-driven path that calls
+/// [`handle_use_ability`] directly.** Calls `handle_use_ability` to
+/// resolve the ability, then — if the attacker is a player who just
+/// transitioned a tagged NPC from alive→dead — fires the `EntityDeath`
+/// content event so mission KillCount chains (e.g., "kill 5
+/// Hallway_Guards") progress.
 ///
-/// Wrap-shape extracted from the previous in-line copies at the cell-
-/// method dispatch sites in `cell_methods/player/combat/mod.rs` and
-/// `cell_methods/player/interaction.rs`. Three other player-attack
-/// paths used to call [`handle_use_ability`] directly and bypass this
-/// hook — auto-cycle's immediate-fire on toggle, the auto-cycle tick
-/// re-fire loop, and the pending-attack tick (Phase B of
-/// attack-while-holstered). All three are now routed through here,
-/// closing issue #367 ("auto-shoot kills don't credit quest objectives").
+/// **Not** for AoE / ground-target callers: those go through
+/// [`super::handle_use_ability_on_ground`], which returns the set of
+/// every NPC that died during the cast and fires per-death
+/// `fire_entity_death` at the caller layer. The AoE path is the only
+/// other single canonical kill-credit fan-out today; collapsing them
+/// would require returning a Vec<entity_id> from this helper too.
 ///
 /// Why this isn't baked into `handle_use_ability` itself: NPC AI also
 /// calls `handle_use_ability`, and NPC kills shouldn't fire

--- a/crates/services/src/cell/abilities/use_ability/mod.rs
+++ b/crates/services/src/cell/abilities/use_ability/mod.rs
@@ -8,11 +8,13 @@
 //! ordering between immutable and mutable space_manager access is delicate
 //! and a hand-rolled split here would just trade lines for `&mut` plumbing.
 
+use cimmeria_content_engine::chain::ChainEngine;
 use tokio::sync::mpsc;
 
 use cimmeria_entity::abilities::{
     serialize_timer_update, AF_DEACTIVATE_AUTO_CYCLE, TIMER_ABILITY_COOLDOWN,
 };
+use cimmeria_entity::stats::HEALTH;
 
 use super::super::combat;
 use super::super::messages::CellToBaseMsg;
@@ -503,6 +505,96 @@ pub async fn handle_use_ability(
     )
     .await;
     true
+}
+
+/// `handle_use_ability` + content-engine kill-credit hook.
+///
+/// **Use this from every player-driven attack path.** Calls
+/// [`handle_use_ability`] to resolve the ability, then — if the attacker
+/// is a player who just transitioned a tagged NPC from alive→dead —
+/// fires the `EntityDeath` content event so mission KillCount chains
+/// (e.g., "kill 5 Hallway_Guards") progress.
+///
+/// Wrap-shape extracted from the previous in-line copies at the cell-
+/// method dispatch sites in `cell_methods/player/combat/mod.rs` and
+/// `cell_methods/player/interaction.rs`. Three other player-attack
+/// paths used to call [`handle_use_ability`] directly and bypass this
+/// hook — auto-cycle's immediate-fire on toggle, the auto-cycle tick
+/// re-fire loop, and the pending-attack tick (Phase B of
+/// attack-while-holstered). All three are now routed through here,
+/// closing issue #367 ("auto-shoot kills don't credit quest objectives").
+///
+/// Why this isn't baked into `handle_use_ability` itself: NPC AI also
+/// calls `handle_use_ability`, and NPC kills shouldn't fire
+/// `EntityDeath` (the killer has no `player_id` — there's no mission to
+/// credit). Tests that exercise `handle_use_ability` mechanics also
+/// don't need to thread a `ChainEngine` through. Keeping the bare
+/// function callable from those sites preserves both invariants.
+///
+/// Mirrors the python `useAbility` → `attemptDeath` → `_doDeath` chain
+/// where the cell-side death callback was the canonical credit point.
+pub async fn handle_use_ability_with_kill_credit(
+    entity_id: u32,
+    ability_id: i32,
+    target_id: i32,
+    engine: &ChainEngine,
+    tx: &mpsc::Sender<CellToBaseMsg>,
+    space_mgr: &mut SpaceManager,
+) -> bool {
+    // Snapshot whether the target was a live NPC *before* the ability
+    // resolves. Without this, hitting an already-dead corpse would
+    // re-fire `fire_entity_death` and double-count mission progress on
+    // every post-death swing. Player targets are excluded because PvP
+    // kills don't drive mission progression today.
+    let was_alive_before = if target_id > 0 {
+        space_mgr
+            .get_entity(target_id as u32)
+            .is_some_and(|t| !t.is_player && t.stats.get(HEALTH).is_some_and(|s| s.cur > 0))
+    } else {
+        false
+    };
+
+    let committed = handle_use_ability(entity_id, ability_id, target_id, tx, space_mgr).await;
+
+    // Skip the death check when the ability was rejected pre-consume —
+    // nothing was damaged, so nothing died. Also short-circuits the
+    // common no-target paths (target_id == 0).
+    if !committed || !was_alive_before {
+        return committed;
+    }
+
+    let target_eid = target_id as u32;
+    let just_died = space_mgr
+        .get_entity(target_eid)
+        .is_some_and(|t| t.stats.get(HEALTH).is_some_and(|s| s.cur <= 0));
+    if !just_died {
+        return committed;
+    }
+
+    // Resolve the target's content-engine tag (the chain trigger key,
+    // e.g. "Hallway01_Guard") and the killer's `player_id` (the
+    // mission-context key). Either being absent is benign — a tagless
+    // NPC just doesn't progress any chain; a player_id-less killer
+    // (NPC AI shouldn't reach this helper, but be defensive) skips
+    // with a warn so the unexpected case stays visible.
+    let tag = match space_mgr.get_entity(target_eid).and_then(|t| t.tag.clone()) {
+        Some(t) => t,
+        None => return committed,
+    };
+    let player_id = match space_mgr.get_entity(entity_id).and_then(|e| e.player_id) {
+        Some(pid) => pid,
+        None => {
+            tracing::warn!(
+                entity_id, npc_tag = %tag,
+                "handle_use_ability_with_kill_credit: killer has no player_id — skipping EntityDeath event"
+            );
+            return committed;
+        }
+    };
+
+    crate::cell::content::fire_entity_death(entity_id, player_id, &tag, engine, tx, space_mgr)
+        .await;
+    committed
 }
 
 #[cfg(test)]

--- a/crates/services/src/cell/cell_methods/player/combat/mod.rs
+++ b/crates/services/src/cell/cell_methods/player/combat/mod.rs
@@ -9,7 +9,6 @@
 use crate::cell::messages::CellToBaseMsg;
 use crate::cell::space_manager::SpaceManager;
 use cimmeria_content_engine::chain::ChainEngine;
-use cimmeria_entity::stats::HEALTH;
 use tokio::sync::mpsc;
 
 use super::constants::*;
@@ -43,54 +42,14 @@ pub async fn dispatch(
                 let target_id = i32::from_le_bytes([args[4], args[5], args[6], args[7]]);
                 tracing::debug!(entity_id, ability_id, target_id, "useAbility");
 
-                // Snapshot whether the target was alive *before* the ability
-                // resolves. Without this, hitting an already-dead corpse would
-                // re-fire fire_entity_death (and stomp the AI cleanup that
-                // handle_use_ability already performed on the original kill),
-                // double-counting mission progress on every post-death swing.
-                let was_alive_before = if target_id > 0 {
-                    space_mgr.get_entity(target_id as u32).is_some_and(|t| {
-                        !t.is_player && t.stats.get(HEALTH).is_some_and(|s| s.cur > 0)
-                    })
-                } else {
-                    false
-                };
-
-                crate::cell::abilities::handle_use_ability(
-                    entity_id, ability_id, target_id, tx, space_mgr,
+                // Single canonical kill-credit path — see
+                // `handle_use_ability_with_kill_credit` for the
+                // alive→dead detection + `fire_entity_death` wrap that
+                // previously lived inline here. Issue #367.
+                crate::cell::abilities::handle_use_ability_with_kill_credit(
+                    entity_id, ability_id, target_id, engine, tx, space_mgr,
                 )
                 .await;
-
-                // Only react to alive→dead transitions caused by *this* call.
-                // handle_use_ability already handles AI/loot/XP on the kill
-                // itself; we only need to fire the content-engine death event
-                // here, since that's a separate concern wired off the killing
-                // player's player_id.
-                if was_alive_before {
-                    let target_eid = target_id as u32;
-                    let just_died = space_mgr
-                        .get_entity(target_eid)
-                        .is_some_and(|t| t.stats.get(HEALTH).is_some_and(|s| s.cur <= 0));
-                    if just_died {
-                        let tag = space_mgr.get_entity(target_eid).and_then(|t| t.tag.clone());
-                        if let Some(tag) = tag {
-                            match space_mgr.get_entity(entity_id).and_then(|e| e.player_id) {
-                                Some(player_id) => {
-                                    crate::cell::content::fire_entity_death(
-                                        entity_id, player_id, &tag, engine, tx, space_mgr,
-                                    )
-                                    .await;
-                                }
-                                None => {
-                                    tracing::warn!(
-                                        entity_id, npc_tag = %tag,
-                                        "Skipping entity_death event: killer entity has no player_id"
-                                    );
-                                }
-                            }
-                        }
-                    }
-                }
             }
             true
         }

--- a/crates/services/src/cell/cell_methods/player/combat/mod.rs
+++ b/crates/services/src/cell/cell_methods/player/combat/mod.rs
@@ -45,7 +45,7 @@ pub async fn dispatch(
                 // Single canonical kill-credit path — see
                 // `handle_use_ability_with_kill_credit` for the
                 // alive→dead detection + `fire_entity_death` wrap that
-                // previously lived inline here. Issue #367.
+                // previously lived inline here.
                 crate::cell::abilities::handle_use_ability_with_kill_credit(
                     entity_id, ability_id, target_id, engine, tx, space_mgr,
                 )

--- a/crates/services/src/cell/cell_methods/player/interaction.rs
+++ b/crates/services/src/cell/cell_methods/player/interaction.rs
@@ -72,58 +72,22 @@ pub async fn dispatch(
                         return true;
                     }
 
-                    // Snapshot alive-before so we only fire the content-engine
-                    // death event on the alive→dead transition caused by this
-                    // call. Mirrors `super::combat::dispatch`'s USE_ABILITY arm.
-                    // Without this, kills via right-click auto-attack (this path)
-                    // never fire `OnEntityDeath` chains — mission progress that
-                    // depends on tagged kills (e.g., FindAmbernol drone → step
-                    // 2144 → 2343) silently stalls.
-                    let was_alive_before =
-                        space_mgr.get_entity(target_entity_u32).is_some_and(|t| {
-                            !t.is_player
-                                && t.stats
-                                    .get(cimmeria_entity::stats::HEALTH)
-                                    .is_some_and(|s| s.cur > 0)
-                        });
-
-                    crate::cell::abilities::handle_use_ability(
+                    // Single canonical kill-credit path — see
+                    // `handle_use_ability_with_kill_credit` for the
+                    // alive→dead detection + `fire_entity_death` wrap
+                    // that previously lived inline here. Routing every
+                    // player-attack path through this helper closes
+                    // issue #367 (auto-shoot kills not crediting
+                    // quest progress).
+                    crate::cell::abilities::handle_use_ability_with_kill_credit(
                         entity_id,
                         592,
                         target_entity_id,
+                        engine,
                         tx,
                         space_mgr,
                     )
                     .await;
-
-                    if was_alive_before {
-                        let just_died = space_mgr.get_entity(target_entity_u32).is_some_and(|t| {
-                            t.stats
-                                .get(cimmeria_entity::stats::HEALTH)
-                                .is_some_and(|s| s.cur <= 0)
-                        });
-                        if just_died {
-                            let tag = space_mgr
-                                .get_entity(target_entity_u32)
-                                .and_then(|t| t.tag.clone());
-                            if let Some(tag) = tag {
-                                match space_mgr.get_entity(entity_id).and_then(|e| e.player_id) {
-                                    Some(player_id) => {
-                                        crate::cell::content::fire_entity_death(
-                                            entity_id, player_id, &tag, engine, tx, space_mgr,
-                                        )
-                                        .await;
-                                    }
-                                    None => {
-                                        tracing::warn!(
-                                            entity_id, npc_tag = %tag,
-                                            "Skipping entity_death event (interact path): killer entity has no player_id"
-                                        );
-                                    }
-                                }
-                            }
-                        }
-                    }
                     return true;
                 }
 

--- a/crates/services/src/cell/cell_methods/player/interaction.rs
+++ b/crates/services/src/cell/cell_methods/player/interaction.rs
@@ -75,10 +75,13 @@ pub async fn dispatch(
                     // Single canonical kill-credit path — see
                     // `handle_use_ability_with_kill_credit` for the
                     // alive→dead detection + `fire_entity_death` wrap
-                    // that previously lived inline here. Routing every
-                    // player-attack path through this helper closes
-                    // issue #367 (auto-shoot kills not crediting
-                    // quest progress).
+                    // that previously lived inline here. Every player-
+                    // attack path that reaches `handle_use_ability`
+                    // for a single target routes through this helper
+                    // so quest KillCount objectives advance uniformly,
+                    // regardless of which entry point fired the shot
+                    // (manual right-click, interact, auto-cycle loop,
+                    // queued attack-while-holstered).
                     crate::cell::abilities::handle_use_ability_with_kill_credit(
                         entity_id,
                         592,

--- a/crates/services/src/cell/cell_methods/player/world/mod.rs
+++ b/crates/services/src/cell/cell_methods/player/world/mod.rs
@@ -83,11 +83,12 @@ pub async fn dispatch(
                             target_id,
                             "setAutoCycle: immediate fire on enable (last_fired + current_target ready)"
                         );
-                        // Issue #367: the immediate-fire on auto-cycle
-                        // toggle ON is a player-driven kill path —
-                        // route through the kill-credit wrapper so a
-                        // tap of the auto-fire button that immediately
-                        // kills a quest target credits the mission.
+                        // The immediate-fire on auto-cycle toggle ON
+                        // is a player-driven kill path — route through
+                        // the kill-credit wrapper so a tap of the
+                        // auto-fire button that immediately kills a
+                        // quest target credits the mission, matching
+                        // the manual-right-click path.
                         let _ =
                             super::super::super::abilities::handle_use_ability_with_kill_credit(
                                 entity_id, ability_id, target_id, engine, tx, space_mgr,

--- a/crates/services/src/cell/cell_methods/player/world/mod.rs
+++ b/crates/services/src/cell/cell_methods/player/world/mod.rs
@@ -83,10 +83,16 @@ pub async fn dispatch(
                             target_id,
                             "setAutoCycle: immediate fire on enable (last_fired + current_target ready)"
                         );
-                        let _ = super::super::super::abilities::handle_use_ability(
-                            entity_id, ability_id, target_id, tx, space_mgr,
-                        )
-                        .await;
+                        // Issue #367: the immediate-fire on auto-cycle
+                        // toggle ON is a player-driven kill path —
+                        // route through the kill-credit wrapper so a
+                        // tap of the auto-fire button that immediately
+                        // kills a quest target credits the mission.
+                        let _ =
+                            super::super::super::abilities::handle_use_ability_with_kill_credit(
+                                entity_id, ability_id, target_id, engine, tx, space_mgr,
+                            )
+                            .await;
                     }
                 } else {
                     // Explicit disable: drop the stash AND clear the bit.

--- a/crates/services/src/cell/cell_methods/player/world/tests.rs
+++ b/crates/services/src/cell/cell_methods/player/world/tests.rs
@@ -980,3 +980,115 @@ async fn reload_in_isolation_does_not_flip_bsf_in_combat() {
          for the in-combat state"
     );
 }
+
+/// **Regression guard: SET_AUTO_CYCLE's immediate-fire path must
+/// credit quest kills.** When pressing the auto-fire button kills a
+/// quest-tagged NPC in the same press (immediate-fire fires the
+/// stashed ability at the current target), the EntityDeath content
+/// event must reach the chain engine so KillCount missions advance.
+///
+/// Parallel coverage to `auto_cycle_tick_credits_quest_kill_on_tagged_npc_death`
+/// in `service/ticks/auto_cycle.rs`. Both paths route through
+/// `handle_use_ability_with_kill_credit`; both tests fail when the
+/// caller is reverted to bare `handle_use_ability`.
+#[tokio::test]
+async fn set_auto_cycle_immediate_fire_credits_quest_kill_on_tagged_npc_death() {
+    use cimmeria_content_engine::actions::Action;
+    use cimmeria_content_engine::chain::Chain;
+    use cimmeria_content_engine::triggers::Trigger;
+    use cimmeria_entity::abilities::EffectDef;
+    use cimmeria_entity::stats::HEALTH;
+
+    const QUEST_TAG: &str = "QuestTargetDrone";
+    const COUNTER_NAME: &str = "drone_kills";
+
+    let mut mgr = make_mgr_with_player();
+    mgr.spawn_npc(50, "Castle_CellBlock", [3.0, 0.0, 0.0], [0.0; 3])
+        .unwrap();
+    // Pre-conditions for SET_AUTO_CYCLE's immediate-fire branch:
+    // current_target_id + last_fired_ability_id both Some. Mirror
+    // the existing `set_auto_cycle_enable_fires_immediately_*` test
+    // shape so a future regression that changes the branch
+    // conditions is caught uniformly.
+    if let Some(p) = mgr.get_entity_mut(1) {
+        p.abilities.add_ability(7);
+        p.abilities.last_fired_ability_id = Some(7);
+        p.current_target_id = Some(50);
+        p.weapon_holstered = false;
+    }
+    // Lethal effect on ability 7 so the immediate fire kills the
+    // NPC outright. Mirrors the fixture in the auto_cycle_tick test.
+    let mut params = std::collections::HashMap::new();
+    params.insert("HealthDamage".to_string(), "9999".to_string());
+    mgr.effect_defs.insert(
+        100,
+        EffectDef {
+            effect_id: 100,
+            ability_id: 7,
+            delay: 0,
+            effect_sequence: 0,
+            event_set_id: None,
+            script_name: None,
+            params,
+        },
+    );
+    mgr.ability_defs.insert(
+        7,
+        AbilityDef {
+            ability_id: 7,
+            name: "test".to_string(),
+            cooldown: 0.5,
+            warmup: 0.0,
+            flags: 0,
+            is_ranged: false,
+            min_range: 0,
+            max_range: 30,
+            target_type_id: 0,
+            effect_ids: vec![100],
+            moniker_ids: vec![],
+            required_ammo: 0,
+            event_set_id: None,
+            velocity: 0.0,
+        },
+    );
+    if let Some(npc) = mgr.get_entity_mut(50) {
+        npc.tag = Some(QUEST_TAG.to_string());
+        if let Some(stat) = npc.stats.get_mut(HEALTH) {
+            stat.update(0, 1, 100);
+            stat.clear_dirty();
+        }
+    }
+
+    let mut engine = ChainEngine::new();
+    engine.register_chain(Chain {
+        id: 999_998,
+        name: "test: SET_AUTO_CYCLE drone kill counter".to_string(),
+        enabled: true,
+        trigger: Trigger::OnEntityDeath {
+            entity_type: None,
+            entity_tag: Some(QUEST_TAG.to_string()),
+        },
+        conditions: vec![],
+        actions: vec![Action::IncrementCounter {
+            counter_name: COUNTER_NAME.to_string(),
+            amount: 1,
+        }],
+        priority: 0,
+    });
+
+    let (tx, _rx) = mpsc::channel(64);
+    let handled = dispatch(1, SET_AUTO_CYCLE, &[1], &tx, &mut mgr, &engine).await;
+    assert!(handled);
+
+    assert_eq!(
+        mgr.get_entity(1).unwrap().counters.get(COUNTER_NAME),
+        Some(&1),
+        "SET_AUTO_CYCLE's immediate-fire on enable must credit a tagged-NPC \
+         kill via fire_entity_death — reverting the immediate-fire site to \
+         bare handle_use_ability leaves this counter at None",
+    );
+    assert!(
+        crate::cell::combat::is_dead_state(mgr.get_entity(50).unwrap().state_field),
+        "test fixture: target must be dead after the lethal immediate fire",
+    );
+}

--- a/crates/services/src/cell/service/message_loop.rs
+++ b/crates/services/src/cell/service/message_loop.rs
@@ -84,9 +84,10 @@ pub(super) async fn run_cell_loop(
                 // current_target_id whenever its cooldown has cleared.
                 // Cooldown gate is the rate limiter; the eligibility
                 // filter short-circuits when nobody is auto-cycling.
-                // Engine is threaded for the kill-credit hook (issue
-                // #367): loop-driven kills against quest-tagged NPCs
-                // fire `EntityDeath` so KillCount missions advance.
+                // Engine is threaded for the kill-credit hook:
+                // loop-driven kills against quest-tagged NPCs fire
+                // `EntityDeath` so KillCount missions advance via the
+                // same content-engine path as manual right-click kills.
                 super::ticks::auto_cycle_tick(tx, &mut space_mgr, &engine).await;
 
                 // Promote queued bandolier slot swap: any player whose

--- a/crates/services/src/cell/service/message_loop.rs
+++ b/crates/services/src/cell/service/message_loop.rs
@@ -77,14 +77,17 @@ pub(super) async fn run_cell_loop(
                 // whose draw window has elapsed gets the deferred
                 // ability dispatched. Same filter shape — short-circuits
                 // when the queue is empty.
-                super::ticks::pending_attack_tick(tx, &mut space_mgr).await;
+                super::ticks::pending_attack_tick(tx, &mut space_mgr, &engine).await;
 
                 // Drive the server-side auto-cycle loop: re-fire any
                 // armed player's stashed ability against the LIVE
                 // current_target_id whenever its cooldown has cleared.
                 // Cooldown gate is the rate limiter; the eligibility
                 // filter short-circuits when nobody is auto-cycling.
-                super::ticks::auto_cycle_tick(tx, &mut space_mgr).await;
+                // Engine is threaded for the kill-credit hook (issue
+                // #367): loop-driven kills against quest-tagged NPCs
+                // fire `EntityDeath` so KillCount missions advance.
+                super::ticks::auto_cycle_tick(tx, &mut space_mgr, &engine).await;
 
                 // Promote queued bandolier slot swap: any player whose
                 // Item_Unequip animation window has elapsed gets the

--- a/crates/services/src/cell/service/ticks/auto_cycle.rs
+++ b/crates/services/src/cell/service/ticks/auto_cycle.rs
@@ -7,6 +7,7 @@
 //! cooldown gate is the rate limiter; the eligibility filter
 //! short-circuits to empty when nobody is auto-cycling.
 
+use cimmeria_content_engine::chain::ChainEngine;
 use tokio::sync::mpsc;
 
 use crate::cell::messages::CellToBaseMsg;
@@ -46,6 +47,7 @@ use crate::cell::space_manager::SpaceManager;
 pub(in crate::cell::service) async fn auto_cycle_tick(
     tx: &mpsc::Sender<CellToBaseMsg>,
     space_mgr: &mut SpaceManager,
+    engine: &ChainEngine,
 ) {
     // Snapshot armed players. Drop the borrow before re-invoking
     // `handle_use_ability` (takes `&mut space_mgr`).
@@ -143,8 +145,13 @@ pub(in crate::cell::service) async fn auto_cycle_tick(
             target_id,
             "auto_cycle_tick: re-firing"
         );
-        let _ = crate::cell::abilities::handle_use_ability(
-            entity_id, ability_id, target_id, tx, space_mgr,
+        // Issue #367: route loop-driven re-fires through the kill-credit
+        // wrapper so killing a quest-tagged NPC via auto-shoot advances
+        // the mission's KillCount objective, matching the manual
+        // right-click path. The wrapper is a no-op when the target
+        // wasn't a live tagged NPC or when no kill happened this tick.
+        let _ = crate::cell::abilities::handle_use_ability_with_kill_credit(
+            entity_id, ability_id, target_id, engine, tx, space_mgr,
         )
         .await;
         // Commit/reject is the handler's call. A rejected re-fire
@@ -158,6 +165,13 @@ pub(in crate::cell::service) async fn auto_cycle_tick(
 mod tests {
     use super::*;
     use cimmeria_entity::abilities::AbilityDef;
+
+    /// Empty chain engine for tests that don't exercise content chains.
+    /// The kill-credit hook is a no-op when the resolved-action list is
+    /// empty, so these tests don't need real chain content loaded.
+    fn empty_engine() -> ChainEngine {
+        ChainEngine::new()
+    }
 
     /// Shared fixture: one connected armed player and one target NPC,
     /// both in the same Castle space. Ability 7 is a 30-unit ranged
@@ -220,7 +234,7 @@ mod tests {
         assert!(!mgr.get_entity(1).unwrap().abilities.is_on_cooldown(7));
 
         let (tx, _rx) = mpsc::channel(64);
-        auto_cycle_tick(&tx, &mut mgr).await;
+        auto_cycle_tick(&tx, &mut mgr, &empty_engine()).await;
 
         assert!(
             mgr.get_entity(1).unwrap().abilities.is_on_cooldown(7),
@@ -241,7 +255,7 @@ mod tests {
         }
 
         let (tx, mut rx) = mpsc::channel(64);
-        auto_cycle_tick(&tx, &mut mgr).await;
+        auto_cycle_tick(&tx, &mut mgr, &empty_engine()).await;
 
         assert!(
             rx.try_recv().is_err(),
@@ -266,7 +280,7 @@ mod tests {
         }
 
         let (tx, mut rx) = mpsc::channel(64);
-        auto_cycle_tick(&tx, &mut mgr).await;
+        auto_cycle_tick(&tx, &mut mgr, &empty_engine()).await;
 
         let p = mgr.get_entity(1).unwrap();
         assert!(!p.abilities.auto_cycle, "loop must be cleared");
@@ -308,7 +322,7 @@ mod tests {
         }
 
         let (tx, _rx) = mpsc::channel(64);
-        auto_cycle_tick(&tx, &mut mgr).await;
+        auto_cycle_tick(&tx, &mut mgr, &empty_engine()).await;
 
         let p = mgr.get_entity(1).unwrap();
         assert!(!p.abilities.auto_cycle);
@@ -333,7 +347,7 @@ mod tests {
             p.position = Vector3::new(0.0, 0.0, 0.0);
         }
         let (tx, _rx) = mpsc::channel(64);
-        auto_cycle_tick(&tx, &mut mgr).await;
+        auto_cycle_tick(&tx, &mut mgr, &empty_engine()).await;
 
         let npc_b = mgr.get_entity(75).expect("NPC 75 should still exist");
         assert!(
@@ -365,7 +379,7 @@ mod tests {
         }
 
         let (tx, _rx) = mpsc::channel(64);
-        auto_cycle_tick(&tx, &mut mgr).await;
+        auto_cycle_tick(&tx, &mut mgr, &empty_engine()).await;
 
         let p = mgr.get_entity(1).unwrap();
         assert!(
@@ -387,7 +401,7 @@ mod tests {
         }
 
         let (tx, _rx) = mpsc::channel(64);
-        auto_cycle_tick(&tx, &mut mgr).await;
+        auto_cycle_tick(&tx, &mut mgr, &empty_engine()).await;
 
         let p = mgr.get_entity(1).unwrap();
         assert!(
@@ -409,7 +423,7 @@ mod tests {
         }
 
         let (tx, mut rx) = mpsc::channel(64);
-        auto_cycle_tick(&tx, &mut mgr).await;
+        auto_cycle_tick(&tx, &mut mgr, &empty_engine()).await;
 
         assert!(!mgr.get_entity(1).unwrap().abilities.is_on_cooldown(7));
         assert!(rx.try_recv().is_err());
@@ -437,7 +451,7 @@ mod tests {
         }
 
         let (tx, mut rx) = mpsc::channel(64);
-        auto_cycle_tick(&tx, &mut mgr).await;
+        auto_cycle_tick(&tx, &mut mgr, &empty_engine()).await;
 
         let p = mgr.get_entity(1).unwrap();
         assert!(
@@ -451,6 +465,134 @@ mod tests {
         assert!(
             rx.try_recv().is_err(),
             "out-of-range tick must be wire-silent — no onErrorCode, no onTimerUpdate",
+        );
+    }
+
+    /// **Regression guard for issue #367.** Auto-cycle kills against a
+    /// quest-tagged NPC must fire the content-engine `EntityDeath` event
+    /// so KillCount-style mission objectives advance, exactly the way a
+    /// manual right-click kill does.
+    ///
+    /// Bug shape this catches: the tick used to call bare
+    /// `handle_use_ability`, bypassing the kill-credit wrapper that the
+    /// cell-method `USE_ABILITY` dispatch site wired around manual
+    /// fires. Reverting the fix (changing the tick back to
+    /// `handle_use_ability`) leaves the counter at 0 and fails this
+    /// assertion.
+    ///
+    /// Pinned via an end-to-end signal: register a chain that
+    /// increments a counter on `EntityDeath(entity_tag=QuestTargetDrone)`
+    /// and assert the counter incremented on the killer entity after
+    /// the tick fires. This proves the full path — tick →
+    /// `handle_use_ability_with_kill_credit` →
+    /// `apply_damage_to_target` (kill detected) →
+    /// `fire_entity_death` → chain engine resolve + execute.
+    #[tokio::test]
+    async fn auto_cycle_tick_credits_quest_kill_on_tagged_npc_death() {
+        use cimmeria_content_engine::actions::Action;
+        use cimmeria_content_engine::chain::Chain;
+        use cimmeria_content_engine::triggers::Trigger;
+        use cimmeria_entity::abilities::EffectDef;
+        use cimmeria_entity::stats::HEALTH;
+
+        const QUEST_TAG: &str = "QuestTargetDrone";
+        const COUNTER_NAME: &str = "drone_kills";
+
+        let mut mgr = make_auto_cycle_mgr();
+
+        // Give the ability a lethal effect so the tick's re-fire
+        // actually kills the NPC. `apply_damage_to_target` reads
+        // `HealthDamage` from the ability's effect NVPs; 9999 mirrors
+        // the lethal-fixture pattern in damage_apply/tests.rs.
+        let mut params = std::collections::HashMap::new();
+        params.insert("HealthDamage".to_string(), "9999".to_string());
+        mgr.effect_defs.insert(
+            100,
+            EffectDef {
+                effect_id: 100,
+                ability_id: 7,
+                delay: 0,
+                effect_sequence: 0,
+                event_set_id: None,
+                script_name: None,
+                params,
+            },
+        );
+        if let Some(ability) = mgr.ability_defs.get_mut(&7) {
+            ability.effect_ids = vec![100];
+        }
+
+        // Tag the NPC and seed it at 1 HP so the first re-fire kills
+        // it. Without the tag, `fire_entity_death` has no `entity_tag`
+        // to match against the chain trigger — the assertion would
+        // pass even with the bug present.
+        if let Some(npc) = mgr.get_entity_mut(50) {
+            npc.tag = Some(QUEST_TAG.to_string());
+            if let Some(stat) = npc.stats.get_mut(HEALTH) {
+                stat.update(0, 1, 100);
+                stat.clear_dirty();
+            }
+        }
+
+        // Register a minimal chain that increments a counter on the
+        // tagged death. The chain's resolved actions feed directly to
+        // the executor (no DB lookup); the counter lands on the
+        // killer entity's `counters` map per the `IncrementCounter`
+        // handler at executor/counter.rs.
+        let mut engine = ChainEngine::new();
+        engine.register_chain(Chain {
+            id: 999_999,
+            name: "test: drone kill counter".to_string(),
+            enabled: true,
+            trigger: Trigger::OnEntityDeath {
+                entity_type: None,
+                entity_tag: Some(QUEST_TAG.to_string()),
+            },
+            conditions: vec![],
+            actions: vec![Action::IncrementCounter {
+                counter_name: COUNTER_NAME.to_string(),
+                amount: 1,
+            }],
+            priority: 0,
+        });
+
+        // Sanity: counter unset before the kill so the post-tick
+        // assertion is genuinely measuring the increment, not a stale
+        // value.
+        assert!(
+            !mgr.get_entity(1)
+                .unwrap()
+                .counters
+                .contains_key(COUNTER_NAME),
+            "test invariant: counter must start unset",
+        );
+
+        let (tx, _rx) = mpsc::channel(64);
+        auto_cycle_tick(&tx, &mut mgr, &engine).await;
+
+        // Primary assertion: the kill credit landed. Reverting the
+        // tick to call `handle_use_ability` directly (the pre-fix
+        // shape) leaves this at None — the chain never resolves
+        // because `fire_entity_death` is never called.
+        assert_eq!(
+            mgr.get_entity(1).unwrap().counters.get(COUNTER_NAME),
+            Some(&1),
+            "auto-cycle kill of a quest-tagged NPC must increment the kill counter \
+             via fire_entity_death — bypassing the kill-credit wrapper (issue #367) \
+             leaves this counter at None",
+        );
+
+        // Sanity: the NPC actually died (proves we exercised the kill
+        // path, not a chain that fires on non-lethal hits). The
+        // counter assertion above only fires if both (a) the kill
+        // happened AND (b) fire_entity_death ran; this second check
+        // disambiguates a future regression where the kill path
+        // broke but the counter assertion happened to pass via some
+        // other code path.
+        let target = mgr.get_entity(50).unwrap();
+        assert!(
+            crate::cell::combat::is_dead_state(target.state_field),
+            "test fixture: target must be dead after the lethal re-fire",
         );
     }
 }

--- a/crates/services/src/cell/service/ticks/auto_cycle.rs
+++ b/crates/services/src/cell/service/ticks/auto_cycle.rs
@@ -145,11 +145,11 @@ pub(in crate::cell::service) async fn auto_cycle_tick(
             target_id,
             "auto_cycle_tick: re-firing"
         );
-        // Issue #367: route loop-driven re-fires through the kill-credit
-        // wrapper so killing a quest-tagged NPC via auto-shoot advances
-        // the mission's KillCount objective, matching the manual
-        // right-click path. The wrapper is a no-op when the target
-        // wasn't a live tagged NPC or when no kill happened this tick.
+        // Route loop-driven re-fires through the kill-credit wrapper
+        // so killing a quest-tagged NPC via auto-shoot advances the
+        // mission's KillCount objective, matching the manual right-
+        // click path. The wrapper is a no-op when the target wasn't a
+        // live tagged NPC or when no kill happened this tick.
         let _ = crate::cell::abilities::handle_use_ability_with_kill_credit(
             entity_id, ability_id, target_id, engine, tx, space_mgr,
         )
@@ -468,17 +468,18 @@ mod tests {
         );
     }
 
-    /// **Regression guard for issue #367.** Auto-cycle kills against a
-    /// quest-tagged NPC must fire the content-engine `EntityDeath` event
-    /// so KillCount-style mission objectives advance, exactly the way a
-    /// manual right-click kill does.
+    /// **Regression guard: auto-cycle kills must credit quest
+    /// objectives.** Auto-cycle kills against a quest-tagged NPC must
+    /// fire the content-engine `EntityDeath` event so KillCount-style
+    /// mission objectives advance, exactly the way a manual right-
+    /// click kill does.
     ///
     /// Bug shape this catches: the tick used to call bare
-    /// `handle_use_ability`, bypassing the kill-credit wrapper that the
-    /// cell-method `USE_ABILITY` dispatch site wired around manual
-    /// fires. Reverting the fix (changing the tick back to
-    /// `handle_use_ability`) leaves the counter at 0 and fails this
-    /// assertion.
+    /// `handle_use_ability`, bypassing the kill-credit wrapper that
+    /// the cell-method `USE_ABILITY` dispatch site wired around manual
+    /// fires. Reverting the tick to `handle_use_ability` (instead of
+    /// `handle_use_ability_with_kill_credit`) leaves the counter at
+    /// `None` and fails this assertion.
     ///
     /// Pinned via an end-to-end signal: register a chain that
     /// increments a counter on `EntityDeath(entity_tag=QuestTargetDrone)`
@@ -578,8 +579,8 @@ mod tests {
             mgr.get_entity(1).unwrap().counters.get(COUNTER_NAME),
             Some(&1),
             "auto-cycle kill of a quest-tagged NPC must increment the kill counter \
-             via fire_entity_death — bypassing the kill-credit wrapper (issue #367) \
-             leaves this counter at None",
+             via fire_entity_death — bypassing the kill-credit wrapper \
+             (calling bare handle_use_ability from the tick) leaves this counter at None",
         );
 
         // Sanity: the NPC actually died (proves we exercised the kill

--- a/crates/services/src/cell/service/ticks/mod.rs
+++ b/crates/services/src/cell/service/ticks/mod.rs
@@ -1,6 +1,7 @@
 //! Per-frame tick handlers: AoI propagation, reload-completion promotion,
 //! and NPC movement along nav paths.
 
+use cimmeria_content_engine::chain::ChainEngine;
 use tokio::sync::mpsc;
 
 use super::super::messages::CellToBaseMsg;
@@ -204,6 +205,7 @@ pub(super) async fn reload_completion_tick(
 pub(super) async fn pending_attack_tick(
     tx: &mpsc::Sender<CellToBaseMsg>,
     space_mgr: &mut SpaceManager,
+    engine: &ChainEngine,
 ) {
     let now = std::time::Instant::now();
     // Snapshot the queue entries first — `handle_use_ability` takes
@@ -239,8 +241,13 @@ pub(super) async fn pending_attack_tick(
             target_id,
             "pending_attack_tick: draw window elapsed, firing queued attack"
         );
-        let _ = super::super::abilities::handle_use_ability(
-            entity_id, ability_id, target_id, tx, space_mgr,
+        // Issue #367: route Phase-B queued attacks through the kill-
+        // credit wrapper. Without this, a player who fires a weapon
+        // while holstered (the attack is deferred to Phase B until the
+        // draw window elapses) doesn't credit a quest objective if that
+        // queued shot makes the kill.
+        let _ = super::super::abilities::handle_use_ability_with_kill_credit(
+            entity_id, ability_id, target_id, engine, tx, space_mgr,
         )
         .await;
     }
@@ -579,7 +586,7 @@ mod tests {
         mgr.connect_entity(1);
 
         let (tx, _rx) = mpsc::channel(8);
-        pending_attack_tick(&tx, &mut mgr).await;
+        pending_attack_tick(&tx, &mut mgr, &ChainEngine::new()).await;
 
         let entity = mgr.get_entity(1).unwrap();
         assert!(
@@ -617,7 +624,7 @@ mod tests {
         mgr.connect_entity(1);
 
         let (tx, _rx) = mpsc::channel(8);
-        pending_attack_tick(&tx, &mut mgr).await;
+        pending_attack_tick(&tx, &mut mgr, &ChainEngine::new()).await;
 
         let entity = mgr.get_entity(1).unwrap();
         assert!(

--- a/crates/services/src/cell/service/ticks/mod.rs
+++ b/crates/services/src/cell/service/ticks/mod.rs
@@ -241,11 +241,12 @@ pub(super) async fn pending_attack_tick(
             target_id,
             "pending_attack_tick: draw window elapsed, firing queued attack"
         );
-        // Issue #367: route Phase-B queued attacks through the kill-
-        // credit wrapper. Without this, a player who fires a weapon
-        // while holstered (the attack is deferred to Phase B until the
-        // draw window elapses) doesn't credit a quest objective if that
-        // queued shot makes the kill.
+        // Route Phase-B queued attacks through the kill-credit
+        // wrapper. Without this, a player who fires a weapon while
+        // holstered (the attack is deferred to Phase B until the draw
+        // window elapses) doesn't credit a quest objective if that
+        // queued shot makes the kill — same divergence the auto-cycle
+        // tick had until both paths joined the canonical helper.
         let _ = super::super::abilities::handle_use_ability_with_kill_credit(
             entity_id, ability_id, target_id, engine, tx, space_mgr,
         )
@@ -633,6 +634,133 @@ mod tests {
         );
         assert_eq!(entity.pending_attack_ability_id, Some(42));
         assert_eq!(entity.pending_attack_target_id, Some(200));
+    }
+
+    /// **Regression guard: `pending_attack_tick` Phase B fires must
+    /// credit quest kills.** A player who fires while holstered has
+    /// the attack deferred to Phase B (after the draw window
+    /// elapses). When Phase B kills a quest-tagged NPC, the
+    /// EntityDeath content event must reach the chain engine.
+    ///
+    /// Parallel coverage to
+    /// `auto_cycle_tick_credits_quest_kill_on_tagged_npc_death` (in
+    /// `service/ticks/auto_cycle.rs`) and
+    /// `set_auto_cycle_immediate_fire_credits_quest_kill_on_tagged_npc_death`
+    /// (in `cell_methods/player/world/tests.rs`). All three player-
+    /// driven re-fire paths route through
+    /// `handle_use_ability_with_kill_credit`; all three tests fail
+    /// when the caller is reverted to bare `handle_use_ability`.
+    #[tokio::test]
+    async fn pending_attack_tick_credits_quest_kill_on_tagged_npc_death() {
+        use cimmeria_content_engine::actions::Action;
+        use cimmeria_content_engine::chain::Chain;
+        use cimmeria_content_engine::triggers::Trigger;
+        use cimmeria_entity::abilities::{AbilityDef, EffectDef};
+        use cimmeria_entity::stats::HEALTH;
+
+        const QUEST_TAG: &str = "QuestTargetDrone";
+        const COUNTER_NAME: &str = "drone_kills";
+
+        let mut mgr = SpaceManager::new(1);
+        let xml = r#"<?xml version="1.0"?><Spaces><Space WorldName="Castle" Instanced="false" MinX="-800" MaxX="800" MinY="-800" MaxY="800" /></Spaces>"#;
+        mgr.parse_spaces_xml(xml).unwrap();
+        mgr.create_startup_spaces(
+            r#"<?xml version="1.0"?><Spaces><Space WorldName="Castle" /></Spaces>"#,
+        )
+        .unwrap();
+        mgr.create_entity(1, "Castle", [0.0; 3], [0.0; 3]).unwrap();
+        mgr.spawn_npc(50, "Castle", [3.0, 0.0, 0.0], [0.0; 3])
+            .unwrap();
+        // Phase-B queue pre-conditions: stamp is in the past so the
+        // tick promotes it, and the queue carries the target+ability
+        // the deferred fire should pick up.
+        if let Some(p) = mgr.get_entity_mut(1) {
+            p.is_player = true;
+            p.player_id = Some(100);
+            p.abilities.add_ability(7);
+            p.weapon_holstered = false;
+            p.pending_attack_at =
+                Some(std::time::Instant::now() - std::time::Duration::from_millis(1));
+            p.pending_attack_ability_id = Some(7);
+            p.pending_attack_target_id = Some(50);
+        }
+        mgr.connect_entity(1);
+        let _ = mgr.compute_aoi_changes();
+
+        // Lethal effect + ability def so the deferred fire kills the
+        // NPC outright. Same fixture shape as the auto_cycle test.
+        let mut params = std::collections::HashMap::new();
+        params.insert("HealthDamage".to_string(), "9999".to_string());
+        mgr.effect_defs.insert(
+            100,
+            EffectDef {
+                effect_id: 100,
+                ability_id: 7,
+                delay: 0,
+                effect_sequence: 0,
+                event_set_id: None,
+                script_name: None,
+                params,
+            },
+        );
+        mgr.ability_defs.insert(
+            7,
+            AbilityDef {
+                ability_id: 7,
+                name: "test".to_string(),
+                cooldown: 0.5,
+                warmup: 0.0,
+                flags: 0,
+                is_ranged: false,
+                min_range: 0,
+                max_range: 30,
+                target_type_id: 0,
+                effect_ids: vec![100],
+                moniker_ids: vec![],
+                required_ammo: 0,
+                event_set_id: None,
+                velocity: 0.0,
+            },
+        );
+        if let Some(npc) = mgr.get_entity_mut(50) {
+            npc.tag = Some(QUEST_TAG.to_string());
+            if let Some(stat) = npc.stats.get_mut(HEALTH) {
+                stat.update(0, 1, 100);
+                stat.clear_dirty();
+            }
+        }
+
+        let mut engine = ChainEngine::new();
+        engine.register_chain(Chain {
+            id: 999_997,
+            name: "test: pending_attack drone kill counter".to_string(),
+            enabled: true,
+            trigger: Trigger::OnEntityDeath {
+                entity_type: None,
+                entity_tag: Some(QUEST_TAG.to_string()),
+            },
+            conditions: vec![],
+            actions: vec![Action::IncrementCounter {
+                counter_name: COUNTER_NAME.to_string(),
+                amount: 1,
+            }],
+            priority: 0,
+        });
+
+        let (tx, _rx) = mpsc::channel(64);
+        pending_attack_tick(&tx, &mut mgr, &engine).await;
+
+        assert_eq!(
+            mgr.get_entity(1).unwrap().counters.get(COUNTER_NAME),
+            Some(&1),
+            "pending_attack_tick's Phase-B fire must credit a tagged-NPC kill \
+             via fire_entity_death — reverting the tick to bare \
+             handle_use_ability leaves this counter at None",
+        );
+        assert!(
+            crate::cell::combat::is_dead_state(mgr.get_entity(50).unwrap().state_field),
+            "test fixture: target must be dead after the lethal deferred fire",
+        );
     }
 
     /// Defensive path: `reload_complete_at` set but `reload_slot_id` is None

--- a/docs/gameplay/combat-system.md
+++ b/docs/gameplay/combat-system.md
@@ -158,6 +158,48 @@ baseDamage
 | Critical | `RC_Critical` | qrRand < QR_DOUBLE_CRITICAL_HIT |
 | Double Critical | `RC_DoubleCritical` | qrRand >= QR_DOUBLE_CRITICAL_HIT |
 
+## Kill credit (quest objective progression)
+
+The cell-side ability path has **two** entry-point shapes, and the
+distinction is load-bearing for mission progression.
+
+| Caller shape | Entry point | When to use |
+|---|---|---|
+| Player-driven, single target | `handle_use_ability_with_kill_credit` | Every player-initiated single-target attack |
+| NPC AI, tests, AoE caller layer | `handle_use_ability` (bare) | NPC attacks; ability-mechanic tests; AoE primary cast (the AoE caller fires `fire_entity_death` per-death itself) |
+
+`handle_use_ability_with_kill_credit` wraps `handle_use_ability` with
+an alive→dead transition detector that fires the content-engine
+`EntityDeath` event. KillCount-style mission chains (e.g., "kill 5
+Hallway_Guards") subscribe to that event via
+`Trigger::OnEntityDeath { entity_tag }` and progress on each tagged
+kill. Skipping the wrapper makes the kill happen on the wire AND in
+the cell entity state, but the chain never fires — the player sees
+the NPC die, the corpse is lootable, XP is granted, but the
+"3 of 5" counter never moves.
+
+### Why two entry points
+
+NPC AI also calls `handle_use_ability`. NPC kills shouldn't fire
+`EntityDeath` — the killer has no `player_id`, no mission to credit.
+Baking the credit hook into `handle_use_ability` itself would either
+require an `Option<player_id>` branch inside the helper (verbose and
+easy to miss at call sites) or a separate `engine: Option<&ChainEngine>`
+parameter on every caller. Keeping the bare function callable from
+NPC AI + tests, and wrapping it explicitly at player entry points,
+keeps both invariants visible at the call site.
+
+### Every player-driven attack path routes through the wrapper
+
+Cell-method dispatch sites (`USE_ABILITY`, `INTERACT`, `SET_AUTO_CYCLE`'s
+immediate fire) and tick-driven re-fire paths (`auto_cycle_tick`,
+`pending_attack_tick`) all route through
+`handle_use_ability_with_kill_credit`. The cell-method `USE_ABILITY_ON_GROUND`
+(AoE) is the one player path that calls `handle_use_ability_on_ground`
++ fires `fire_entity_death` per-death at the caller layer, because
+the AoE flow returns a `Vec<entity_id>` of every NPC that died during
+the cast (primary + secondaries).
+
 ## Data References
 
 - **Abilities**: 1,887 defined in `db/resources.sql`


### PR DESCRIPTION
## Summary

Auto-shoot kills against quest-tagged NPCs (e.g. the med-room drone in the early-game mission) did not advance KillCount objectives. Manual right-click kills against the same target worked. This PR fixes the divergence by routing every player-driven attack path through a single canonical kill-credit helper.

Closes #367.

## Root cause

`fire_entity_death` (the content-engine `EntityDeath` trigger that KillCount chains subscribe to) was wired as an **inline wrapper** around `handle_use_ability` at three cell-method dispatch sites. **Three other player-attack paths** called `handle_use_ability` directly and bypassed it:

| Path | Status before | Status after |
|---|---|---|
| `combat/mod.rs::USE_ABILITY` (manual right-click) | ✅ fires | ✅ fires (via helper) |
| `combat/mod.rs::USE_ABILITY_ON_GROUND` (AoE) | ✅ fires | ✅ unchanged (different shape, returns Vec of deaths) |
| `interaction.rs` (right-click interact path) | ✅ fires | ✅ fires (via helper) |
| `service/ticks/auto_cycle.rs` (**reported bug**) | ❌ bypass | ✅ fires (via helper) |
| `world/mod.rs::SET_AUTO_CYCLE` (immediate fire on toggle) | ❌ bypass | ✅ fires (via helper) |
| `service/ticks/mod.rs::pending_attack_tick` (queued attack-while-holstered) | ❌ bypass | ✅ fires (via helper) |
| `service/npc_ai.rs` (NPC attacking) | ✅ correctly skips | ✅ unchanged (NPC has no player_id) |

## Fix shape

Extracted the inline wrapper into a single helper next to `handle_use_ability`:

```rust
pub async fn handle_use_ability_with_kill_credit(
    entity_id: u32, ability_id: i32, target_id: i32,
    engine: &ChainEngine,
    tx: &mpsc::Sender<CellToBaseMsg>,
    space_mgr: &mut SpaceManager,
) -> bool;
```

Snapshots the target's alive-state before the ability resolves, calls `handle_use_ability`, and fires `fire_entity_death` if a tagged-NPC alive→dead transition happened on this call.

All 5 player-driven callers now route through the helper. NPC AI keeps the bare `handle_use_ability` (correct — no player_id, nothing to credit). The two previously-inline wrappers (USE_ABILITY + interaction) collapsed into a single helper call each.

`engine: &ChainEngine` is now threaded into `auto_cycle_tick` and `pending_attack_tick`; `SET_AUTO_CYCLE` already had it in scope.

## Test plan

- [x] **End-to-end regression guard** (`auto_cycle_tick_credits_quest_kill_on_tagged_npc_death`) — registers a chain that increments a counter on `EntityDeath(entity_tag=QuestTargetDrone)`, drives one auto-cycle tick against a tagged 1-HP NPC, asserts the counter incremented on the killer entity. Drives the full path: tick → kill-credit wrapper → damage → death → `fire_entity_death` → chain resolve → counter increment.
- [x] **Adversarial reversal**: temporarily switched the tick back to bare `handle_use_ability` — counter stays at None instead of `Some(1)`. Test fires correctly on the bug shape. Reverted before commit.
- [x] Updated all 15 existing `auto_cycle_tick_*` + `pending_attack_tick_*` tests to pass the new `ChainEngine` parameter (via a shared `empty_engine()` helper for the tick-mechanics tests that don't exercise chains).
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --exclude {GUI crates} --all-targets -- -D warnings`
- [x] `cargo build --workspace --exclude {GUI crates} --all-targets`
- [x] `cargo test --workspace --exclude {GUI crates} --lib --no-fail-fast` — **844 services + 149 mercury + 1380 lib tests total**, all green.

## Risks

- **None for shipped behavior** — every kill that used to credit still credits. The change widens kill-credit to three previously-missing paths.
- **API surface**: `handle_use_ability_with_kill_credit` is a new public symbol in `cell/abilities/`. The existing `handle_use_ability` stays untouched so NPC AI and the 23 test call sites that don't need engine threading keep working.
- **Test churn**: 15 existing tests in `auto_cycle.rs::tests` and `ticks/mod.rs::tests` need the new engine parameter. Done via shared helper / inline `ChainEngine::new()` — mechanical change, no logic shifts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)