### PR TITLE
fix(inventory): consumables fire OnItemUse, not auto-equip (slappack regression)

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -188,6 +188,7 @@ This section is mined from review comments since the test push began. Each item 
 - **Assert by relationship**, not by id: `slot.cur_ammo_type == slot.default_ammo_type` survives seed churn; `slot.cur_ammo_type == 3241` does not.
 - **Never use a "definitely nonexistent" id like `99_999_999`.** The sequence may have advanced past it. Use a sentinel from your module's reserved `0x7000_xxxx` slot (see "Sentinel id discipline") or `MAX(id) + 1` computed at runtime (PR #144).
 - **Assert fixture cardinality up front.** If `pick_main_bag_type_ids(2)` can return one row, assert `types.len() == 2` so the failure points at missing fixture data, not a cryptic out-of-bounds panic (PR #144).
+- **Validate the discriminator against actual seed values, not the schema spec.** `clip_size IS NOT NULL` looks like a clean "is this a weapon?" predicate, but the SGW seed uses `clip_size = 0` for non-weapons rather than NULL — so the predicate misclassifies every consumable as a weapon. When a handler infers item type (or any boolean trait) from a column, write a live-DB test that exercises both sides of the partition with **real seed rows** (a slappack at `clip_size = 0` AND a pistol at `clip_size > 0`) so the test catches the value-vs-sentinel mismatch. The robust fix is usually to read the authoritative discriminator field directly — for "is this auto-equippable to the bandolier?", `3 = ANY(container_sets)` beats any inference from a sibling column.
 
 ### Sentinel id discipline
 

--- a/crates/services/src/base/world_entry/methods/inventory/core/mod.rs
+++ b/crates/services/src/base/world_entry/methods/inventory/core/mod.rs
@@ -21,6 +21,8 @@ use crate::mercury::{build_entity_method_packet, method_idx};
 mod remove_by_type;
 mod remove_instance;
 mod use_instance;
+#[cfg(test)]
+mod use_instance_tests;
 
 pub use remove_by_type::handle_remove_inventory_item_by_type;
 pub use remove_instance::handle_remove_inventory_item;

--- a/crates/services/src/base/world_entry/methods/inventory/core/use_instance.rs
+++ b/crates/services/src/base/world_entry/methods/inventory/core/use_instance.rs
@@ -2,11 +2,24 @@
 //! an inventory instance the player owns. Does not consume the stack;
 //! per-item consumption is the chain's responsibility via `Action::RemoveItem`.
 //!
-//! As of the right-click-to-equip work: weapon instances (rows with
-//! `clip_size IS NOT NULL` in `resources.items`) bypass the `OnItemUse`
-//! event and route to the move path instead — `useItem` on a weapon means
-//! "equip" (main bag → bandolier) or "unequip" (bandolier → main bag)
-//! depending on the source container.
+//! Right-click auto-equip routing: instances whose item type lists the
+//! bandolier (container 3) in `container_sets` bypass the `OnItemUse`
+//! event and route to the move handler — "equip" (main bag → bandolier)
+//! or "unequip" (bandolier → main bag) depending on the source container.
+//! Items NOT in `container_sets` for the bandolier (consumables like
+//! slappacks, mission items, etc.) fall through to `OnItemUse` so per-item
+//! chains in `content_chains` can match.
+//!
+//! The bandolier-eligibility check intentionally reads `container_sets`
+//! directly rather than inferring from `clip_size` or any other proxy.
+//! Earlier versions inferred "is weapon" from `clip_size IS NOT NULL`,
+//! but seed data uses `clip_size = 0` for non-weapons (the slappack row
+//! at `db/resources/Items/Seed/items.sql` is a representative example),
+//! so the inference misclassified every consumable as a weapon and
+//! suppressed its `OnItemUse` event. `container_sets` is the
+//! authoritative signal the move handler already uses
+//! (`item_allows_container`), so reading it here keeps both sides
+//! consistent.
 
 use std::collections::HashMap;
 use std::net::SocketAddr;
@@ -75,19 +88,23 @@ pub async fn handle_use_inventory_item(
     };
 
     // Resolve the inventory instance — type id, current location, and
-    // whether the resource row marks it as a weapon (clip_size IS NOT
-    // NULL). The single query keeps us at one DB round-trip for the
-    // common "is this a weapon?" check that gates the equip/unequip
-    // routing below.
+    // whether the resource row marks the type as bandolier-eligible
+    // (`3 = ANY(container_sets)`). Bandolier-eligible items are
+    // auto-equip/unequip targets; everything else falls through to
+    // the `OnItemUse` event. One round-trip per useItem dispatch.
+    //
+    // Why not `clip_size IS NOT NULL`: see the module doc. Seed data
+    // uses `clip_size = 0` for non-weapons, so the null-check
+    // misclassifies every consumable as a weapon.
     #[derive(sqlx::FromRow)]
     struct InstanceRow {
         type_id: i32,
         container_id: i32,
-        is_weapon: bool,
+        is_bandolier_eligible: bool,
     }
     let row: InstanceRow = match sqlx::query_as::<_, InstanceRow>(
         "SELECT inv.type_id, inv.container_id, \
-                (ri.clip_size IS NOT NULL) AS is_weapon \
+                (3 = ANY(ri.container_sets)) AS is_bandolier_eligible \
          FROM sgw_inventory inv \
          JOIN resources.items ri ON ri.item_id = inv.type_id \
          WHERE inv.character_id = $1 AND inv.item_id = $2 \
@@ -113,8 +130,8 @@ pub async fn handle_use_inventory_item(
     };
     let type_id = row.type_id;
 
-    // Right-click auto-equip / auto-unequip: weapons bypass
-    // the `OnItemUse` event entirely and route to the move path
+    // Right-click auto-equip / auto-unequip: bandolier-eligible items
+    // bypass the `OnItemUse` event entirely and route to the move path
     // instead. Direction is keyed off `container_id`:
     //
     // - Bandolier (3) → Main (1): unequip back to first empty bag slot
@@ -124,7 +141,7 @@ pub async fn handle_use_inventory_item(
     // Other source containers (equipment slots, mission bag, etc.)
     // fall through to the normal `OnItemUse` event — auto-equip only
     // makes sense between the inventory↔bandolier pair.
-    if row.is_weapon
+    if row.is_bandolier_eligible
         && (row.container_id == CONTAINER_BANDOLIER || row.container_id == CONTAINER_MAIN)
     {
         let target =

--- a/crates/services/src/base/world_entry/methods/inventory/core/use_instance.rs
+++ b/crates/services/src/base/world_entry/methods/inventory/core/use_instance.rs
@@ -35,9 +35,12 @@ use crate::base::resources::bag_max_slots;
 use crate::base::ConnectedClientState;
 use crate::cell::messages::BaseToCellMsg;
 
-/// Container ids that this auto-equip router understands.
-const CONTAINER_MAIN: i32 = 1;
-const CONTAINER_BANDOLIER: i32 = 3;
+// Re-export the canonical container ids the auto-equip router cares
+// about. Defined once in `cimmeria_entity::inventory`; re-named locally
+// so the route conditions read naturally without the `INV_` prefix.
+use cimmeria_entity::inventory::{
+    INV_BANDOLIER as CONTAINER_BANDOLIER, INV_MAIN as CONTAINER_MAIN,
+};
 
 /// Resolve an inventory instance's design id and fire the cell-side
 /// content-engine `OnItemUse` event. **Does not consume the item.**
@@ -102,9 +105,15 @@ pub async fn handle_use_inventory_item(
         container_id: i32,
         is_bandolier_eligible: bool,
     }
+    // `$3` is the canonical bandolier container id, bound from the
+    // `CONTAINER_BANDOLIER` re-export rather than inlined in the SQL
+    // so the discriminator stays pegged to the same constant the move
+    // handler (`item_allows_container`) consults — if the constant
+    // ever moves, both sides update together rather than silently
+    // disagreeing.
     let row: InstanceRow = match sqlx::query_as::<_, InstanceRow>(
         "SELECT inv.type_id, inv.container_id, \
-                (3 = ANY(ri.container_sets)) AS is_bandolier_eligible \
+                ($3 = ANY(ri.container_sets)) AS is_bandolier_eligible \
          FROM sgw_inventory inv \
          JOIN resources.items ri ON ri.item_id = inv.type_id \
          WHERE inv.character_id = $1 AND inv.item_id = $2 \
@@ -112,6 +121,7 @@ pub async fn handle_use_inventory_item(
     )
     .bind(player_id)
     .bind(item_id)
+    .bind(CONTAINER_BANDOLIER)
     .fetch_optional(pool.as_ref())
     .await
     {

--- a/crates/services/src/base/world_entry/methods/inventory/core/use_instance_tests.rs
+++ b/crates/services/src/base/world_entry/methods/inventory/core/use_instance_tests.rs
@@ -119,6 +119,32 @@ async fn count_item_used_outbox_rows(pool: &PgPool, entity_id: u32) -> i64 {
     .expect("count outbox rows")
 }
 
+/// Verify the seed row for `type_id` matches the test's assumption
+/// about whether the bandolier is in its `container_sets`. Runs once at
+/// test start so a future seed change fails LOUDLY here with a clear
+/// message rather than masquerading as a routing-logic failure later in
+/// the assertions.
+async fn assert_bandolier_eligibility(pool: &PgPool, type_id: i32, expected: bool) {
+    let actual: Option<bool> = sqlx::query_scalar(
+        "SELECT $2 = ANY(container_sets) FROM resources.items WHERE item_id = $1",
+    )
+    .bind(type_id)
+    .bind(cimmeria_entity::inventory::INV_BANDOLIER)
+    .fetch_optional(pool)
+    .await
+    .expect("seed-shape query");
+    let actual = actual
+        .expect("seed row must exist — items.sql out of sync with the test's hard-coded type_id");
+    assert_eq!(
+        actual, expected,
+        "seed row for type_id={type_id} no longer matches the test's \
+         bandolier-eligibility assumption (expected={expected}, actual={actual}). \
+         Update the constant or the assertion — DO NOT silently flip the \
+         expectation; the test's job is to guard the routing logic against \
+         the canonical seed shape.",
+    );
+}
+
 fn make_state(
     entity_id: u32,
 ) -> (
@@ -151,6 +177,12 @@ fn make_state(
 #[tokio::test]
 async fn slappack_use_fires_on_item_use_not_auto_equip() {
     let pool = require_db_or_skip!();
+    // Seed-shape pin: the bug shape only exists if the slappack is NOT
+    // bandolier-eligible. If a future seed change adds 3 to its
+    // container_sets, this assertion fails with a clear message rather
+    // than the routing assertions below failing for the wrong reason.
+    assert_bandolier_eligibility(&pool, SLAPPACK_TYPE_ID, false).await;
+
     let account_id = TEST_BASE;
     let player_id = TEST_BASE + 1;
     let entity_id = (TEST_BASE + 1) as u32;
@@ -202,6 +234,12 @@ async fn slappack_use_fires_on_item_use_not_auto_equip() {
 #[tokio::test]
 async fn pistol_use_routes_to_auto_equip_not_on_item_use() {
     let pool = require_db_or_skip!();
+    // Seed-shape pin: the positive path only works if the pistol IS
+    // bandolier-eligible. If a future seed change removes 3 from its
+    // container_sets, this assertion fails with a clear message rather
+    // than the routing assertions below failing for the wrong reason.
+    assert_bandolier_eligibility(&pool, PISTOL_TYPE_ID, true).await;
+
     let account_id = TEST_BASE + 100;
     let player_id = TEST_BASE + 101;
     let entity_id = (TEST_BASE + 101) as u32;
@@ -236,6 +274,51 @@ async fn pistol_use_routes_to_auto_equip_not_on_item_use() {
         0,
         "pistol useItem must NOT enqueue `item_used` — that path fires \
          only for non-bandolier-eligible items",
+    );
+
+    cleanup(&pool, account_id, player_id).await;
+}
+
+/// Pistol in bandolier slot 0 → useItem MUST route to the move handler
+/// (auto-unequip back to main bag). Symmetric to the equip test above;
+/// pins the bandolier → main direction so a future "only main → bandolier
+/// auto-equips" regression has a guard catching it.
+#[tokio::test]
+async fn pistol_in_bandolier_use_routes_to_auto_unequip() {
+    let pool = require_db_or_skip!();
+    assert_bandolier_eligibility(&pool, PISTOL_TYPE_ID, true).await;
+
+    let account_id = TEST_BASE + 200;
+    let player_id = TEST_BASE + 201;
+    let entity_id = (TEST_BASE + 201) as u32;
+    cleanup(&pool, account_id, player_id).await;
+    insert_account_and_player(&pool, account_id, player_id).await;
+
+    // Pistol in bandolier, slot 0. Main bag empty so auto-unequip has
+    // a destination.
+    let item_id = insert_item(&pool, player_id, PISTOL_TYPE_ID, 3, 0).await;
+
+    let (transport, e2a, conn) = make_state(entity_id);
+    let db_pool = Some(Arc::new(pool.clone()));
+    let cell_tx: Option<mpsc::Sender<crate::cell::messages::BaseToCellMsg>> = None;
+
+    handle_use_inventory_item(
+        entity_id, player_id, item_id, 0, &db_pool, &cell_tx, &transport, &conn, &e2a,
+    )
+    .await;
+
+    assert_eq!(
+        location_of(&pool, player_id, item_id).await,
+        Some((1, 0)),
+        "pistol useItem from bandolier must auto-unequip to main bag \
+         (container=1, first empty slot=0); the bandolier→main router \
+         direction is broken",
+    );
+    assert_eq!(
+        count_item_used_outbox_rows(&pool, entity_id).await,
+        0,
+        "auto-unequip must NOT enqueue `item_used` — same OnItemUse \
+         bypass as the equip direction",
     );
 
     cleanup(&pool, account_id, player_id).await;

--- a/crates/services/src/base/world_entry/methods/inventory/core/use_instance_tests.rs
+++ b/crates/services/src/base/world_entry/methods/inventory/core/use_instance_tests.rs
@@ -1,0 +1,242 @@
+//! Live-DB regression guards for `handle_use_inventory_item`'s auto-equip
+//! routing. The router gates on bandolier-eligibility
+//! (`3 = ANY(container_sets)`); these tests exercise the two sides of
+//! that gate against real seed rows so a future regression — including
+//! the original `clip_size IS NOT NULL` misinference — fails loudly.
+//!
+//! Skip cleanly when `DATABASE_URL` is unset.
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::sync::{Arc, Mutex};
+
+use cimmeria_mercury::transport::Transport;
+use sqlx::PgPool;
+use tokio::sync::mpsc;
+
+use super::handle_use_inventory_item;
+use crate::base::ConnectedClientState;
+use crate::test_support::{require_db_or_skip, TestTransport};
+
+/// Sentinel base — picks a window well above the move-handler tests
+/// (`TEST_BASE = 0x7000_0200`) and well below `i32::MAX` so it can't
+/// collide with player_id auto-increment.
+const TEST_BASE: i32 = 0x7000_0400;
+
+/// Slappack TC1 — `clip_size = 0`, `container_sets = '{1, 17}'`. Pinned
+/// to the seed row at `db/resources/Items/Seed/items.sql:4879`. If that
+/// row's container_sets ever gains `3`, this constant must move to a
+/// different consumable.
+const SLAPPACK_TYPE_ID: i32 = 2893;
+
+/// SI 3 9mm Pistol — `clip_size = 15`, `container_sets = '{3, 1, 17}'`.
+/// Pinned to the seed row at `db/resources/Items/Seed/items.sql`. The
+/// canonical bandolier-eligible test item.
+const PISTOL_TYPE_ID: i32 = 3241;
+
+async fn cleanup(pool: &PgPool, account_id: i32, player_id: i32) {
+    let _ = sqlx::query("DELETE FROM cell_event_outbox WHERE entity_id = $1")
+        .bind(player_id)
+        .execute(pool)
+        .await;
+    let _ = sqlx::query("DELETE FROM sgw_inventory WHERE character_id = $1")
+        .bind(player_id)
+        .execute(pool)
+        .await;
+    let _ = sqlx::query("DELETE FROM account WHERE account_id = $1")
+        .bind(account_id)
+        .execute(pool)
+        .await;
+}
+
+async fn insert_account_and_player(pool: &PgPool, account_id: i32, player_id: i32) {
+    sqlx::query("INSERT INTO account (account_id, account_name, password) VALUES ($1, $2, '')")
+        .bind(account_id)
+        .bind(format!("use-inv-{account_id}"))
+        .execute(pool)
+        .await
+        .expect("insert account");
+
+    sqlx::query(
+        "INSERT INTO sgw_player (\
+            account_id, player_id, level, alignment, archetype, gender, \
+            player_name, extra_name, world_location, bodyset, \
+            pos_x, pos_y, pos_z, skin_color_id, naquadah\
+         ) VALUES ($1, $2, 1, 0, 1, 1, $3, '', 'CombatSim', 'BS_HumanMale.BS_HumanMale', \
+                   0.0, 0.0, 0.0, 0, 0)",
+    )
+    .bind(account_id)
+    .bind(player_id)
+    .bind(format!("test-{player_id}"))
+    .execute(pool)
+    .await
+    .expect("insert player");
+}
+
+async fn insert_item(
+    pool: &PgPool,
+    player_id: i32,
+    type_id: i32,
+    container_id: i32,
+    slot_id: i32,
+) -> i32 {
+    sqlx::query_scalar(
+        "INSERT INTO sgw_inventory \
+            (character_id, type_id, stack_size, slot_id, container_id, \
+             bound, durability, charges) \
+         VALUES ($1, $2, 1, $3, $4, false, 100, 0) \
+         RETURNING item_id",
+    )
+    .bind(player_id)
+    .bind(type_id)
+    .bind(slot_id)
+    .bind(container_id)
+    .fetch_one(pool)
+    .await
+    .expect("insert inventory row")
+}
+
+async fn location_of(pool: &PgPool, player_id: i32, item_id: i32) -> Option<(i32, i32)> {
+    sqlx::query_as::<_, (i32, i32)>(
+        "SELECT container_id, slot_id FROM sgw_inventory \
+         WHERE character_id = $1 AND item_id = $2",
+    )
+    .bind(player_id)
+    .bind(item_id)
+    .fetch_optional(pool)
+    .await
+    .expect("location_of query")
+}
+
+async fn count_item_used_outbox_rows(pool: &PgPool, entity_id: u32) -> i64 {
+    sqlx::query_scalar::<_, i64>(
+        "SELECT COUNT(*) FROM cell_event_outbox \
+         WHERE entity_id = $1 AND event_type = 'item_used'",
+    )
+    .bind(entity_id as i32)
+    .fetch_one(pool)
+    .await
+    .expect("count outbox rows")
+}
+
+fn make_state(
+    entity_id: u32,
+) -> (
+    Arc<dyn Transport>,
+    Arc<Mutex<HashMap<u32, SocketAddr>>>,
+    Arc<Mutex<HashMap<SocketAddr, ConnectedClientState>>>,
+) {
+    let transport: Arc<dyn Transport> = Arc::new(TestTransport::new());
+    let fake_addr: SocketAddr = "127.0.0.1:65535".parse().unwrap();
+    let entity_to_addr = Arc::new(Mutex::new({
+        let mut m = HashMap::new();
+        m.insert(entity_id, fake_addr);
+        m
+    }));
+    let connected = Arc::new(Mutex::new(HashMap::new()));
+    (transport, entity_to_addr, connected)
+}
+
+/// Slappack in main bag → useItem MUST fire `OnItemUse` (enqueue an
+/// `ItemUsed` outbox row) instead of being routed to the move handler.
+///
+/// Bug shape this guards against: the original
+/// `(clip_size IS NOT NULL) AS is_weapon` SQL treated `clip_size = 0`
+/// (the slappack's seed value) as truthy and routed the slappack to the
+/// move handler with target=bandolier. The move handler then correctly
+/// rejected (container_sets doesn't include 3), so the visible failure
+/// was "slappack click does nothing" — no heal, no consumption, no chain
+/// firing. This test pins the fix at the routing layer; the actual heal
+/// is exercised by chain 4001 in the consumables chain replay tests.
+#[tokio::test]
+async fn slappack_use_fires_on_item_use_not_auto_equip() {
+    let pool = require_db_or_skip!();
+    let account_id = TEST_BASE;
+    let player_id = TEST_BASE + 1;
+    let entity_id = (TEST_BASE + 1) as u32;
+    cleanup(&pool, account_id, player_id).await;
+    insert_account_and_player(&pool, account_id, player_id).await;
+
+    // Slappack in main bag, slot 0.
+    let item_id = insert_item(&pool, player_id, SLAPPACK_TYPE_ID, 1, 0).await;
+
+    let (transport, e2a, conn) = make_state(entity_id);
+    let db_pool = Some(Arc::new(pool.clone()));
+    // No cell channel — the test cares about the outbox enqueue, not the
+    // dispatch. The router shouldn't try to move the item regardless.
+    let cell_tx: Option<mpsc::Sender<crate::cell::messages::BaseToCellMsg>> = None;
+
+    handle_use_inventory_item(
+        entity_id, player_id, item_id, 0, &db_pool, &cell_tx, &transport, &conn, &e2a,
+    )
+    .await;
+
+    // The slappack must stay in container 1, slot 0 — the move handler
+    // would have either moved it to container 3 or rejected it with a
+    // warning, but EITHER outcome is wrong for a consumable.
+    assert_eq!(
+        location_of(&pool, player_id, item_id).await,
+        Some((1, 0)),
+        "slappack must remain in (container=1, slot=0); the auto-equip \
+         router incorrectly tried to relocate it",
+    );
+
+    // The `OnItemUse` path enqueues exactly one `item_used` outbox row.
+    // Routing to the move handler would have skipped this enqueue.
+    assert_eq!(
+        count_item_used_outbox_rows(&pool, entity_id).await,
+        1,
+        "slappack useItem must enqueue exactly one `item_used` outbox \
+         row — the auto-equip router incorrectly bypassed `OnItemUse` \
+         and the consumables chain (4001) never fired",
+    );
+
+    cleanup(&pool, account_id, player_id).await;
+}
+
+/// Pistol in main bag → useItem MUST route to the move handler
+/// (auto-equip to bandolier slot 0). Confirms the bandolier-eligibility
+/// check still works correctly for actual weapons after the fix —
+/// without this positive test, a future "always fire OnItemUse"
+/// over-correction would silently regress right-click-to-equip.
+#[tokio::test]
+async fn pistol_use_routes_to_auto_equip_not_on_item_use() {
+    let pool = require_db_or_skip!();
+    let account_id = TEST_BASE + 100;
+    let player_id = TEST_BASE + 101;
+    let entity_id = (TEST_BASE + 101) as u32;
+    cleanup(&pool, account_id, player_id).await;
+    insert_account_and_player(&pool, account_id, player_id).await;
+
+    // Pistol in main bag, slot 0.
+    let item_id = insert_item(&pool, player_id, PISTOL_TYPE_ID, 1, 0).await;
+
+    let (transport, e2a, conn) = make_state(entity_id);
+    let db_pool = Some(Arc::new(pool.clone()));
+    let cell_tx: Option<mpsc::Sender<crate::cell::messages::BaseToCellMsg>> = None;
+
+    handle_use_inventory_item(
+        entity_id, player_id, item_id, 0, &db_pool, &cell_tx, &transport, &conn, &e2a,
+    )
+    .await;
+
+    // The pistol must have relocated to the first empty bandolier slot
+    // (container 3, slot 0).
+    assert_eq!(
+        location_of(&pool, player_id, item_id).await,
+        Some((3, 0)),
+        "pistol useItem must auto-equip to bandolier (container=3, slot=0); \
+         the bandolier-eligibility check failed to route to the move handler",
+    );
+
+    // The move-handler route does NOT enqueue an `item_used` outbox row.
+    // Pinning this distinguishes the two paths cleanly.
+    assert_eq!(
+        count_item_used_outbox_rows(&pool, entity_id).await,
+        0,
+        "pistol useItem must NOT enqueue `item_used` — that path fires \
+         only for non-bandolier-eligible items",
+    );
+
+    cleanup(&pool, account_id, player_id).await;
+}

--- a/crates/services/src/cell/content/executor/inventory.rs
+++ b/crates/services/src/cell/content/executor/inventory.rs
@@ -21,10 +21,12 @@ pub(in crate::cell::content) fn item_container(
 /// Return the clip size and default ammo type for a granted weapon item.
 ///
 /// Reads from the `space_mgr.item_defs` cache loaded at startup from
-/// `resources.items` (see `spawner::load_item_defs`). Returns `None` for
-/// non-weapon items (clip_size IS NULL in DB) or when the cache wasn't
-/// populated (e.g. tests without a DB pool) — callers skip the bandolier
-/// seeding in that case, and the player can still receive the item normally.
+/// `resources.items` (see `spawner::load_item_defs`). The loader filters
+/// to `clip_size > 0`, so the cache only contains actual weapons —
+/// non-weapons return `None` here. Same `None` is returned when the
+/// cache wasn't populated (e.g. tests without a DB pool); callers skip
+/// the bandolier seeding in that case, and the player can still receive
+/// the item normally.
 fn weapon_stats(
     item_id: i32,
     item_defs: &HashMap<i32, crate::cell::spawner::WeaponDef>,

--- a/crates/services/src/cell/spawner/loot.rs
+++ b/crates/services/src/cell/spawner/loot.rs
@@ -156,11 +156,15 @@ pub fn classify_holster_duration(visual_component: Option<&str>) -> std::time::D
 /// Load weapon stats (clip_size + default_ammo_type + allowed ammo subtypes)
 /// from `resources.items`.
 ///
-/// Skips items with `clip_size IS NULL` (non-weapons). The `default_ammo_type`
-/// conversion mirrors `BANDOLIER_ITEMS_QUERY` exactly so that values seeded
-/// here for runtime grants match the wire format the player_load path uses.
-/// `ammo_types` is unnested and each enum entry converted via the same
-/// `array_position` trick, then aggregated back to an `integer[]` array.
+/// Filters to rows with `clip_size > 0` — actual weapons. The seed data
+/// uses `clip_size = 0` (not NULL) for non-weapons like slappacks, so a
+/// `clip_size IS NOT NULL` filter would pull them in as zero-clip
+/// "weapons" and they'd sit in the cache as dead `WeaponDef` entries.
+/// The `default_ammo_type` conversion mirrors `BANDOLIER_ITEMS_QUERY`
+/// exactly so that values seeded here for runtime grants match the wire
+/// format the player_load path uses. `ammo_types` is unnested and each
+/// enum entry converted via the same `array_position` trick, then
+/// aggregated back to an `integer[]` array.
 pub async fn load_item_defs(
     pool: &PgPool,
 ) -> Result<std::collections::HashMap<i32, WeaponDef>, sqlx::Error> {
@@ -177,7 +181,7 @@ pub async fn load_item_defs(
                     '{}'::integer[] \
                 ) AS allowed_ammo_type_ids \
          FROM resources.items \
-         WHERE clip_size IS NOT NULL",
+         WHERE clip_size > 0",
     )
     .fetch_all(pool)
     .await?;

--- a/crates/services/src/cell/spawner/loot.rs
+++ b/crates/services/src/cell/spawner/loot.rs
@@ -156,10 +156,15 @@ pub fn classify_holster_duration(visual_component: Option<&str>) -> std::time::D
 /// Load weapon stats (clip_size + default_ammo_type + allowed ammo subtypes)
 /// from `resources.items`.
 ///
-/// Filters to rows with `clip_size > 0` — actual weapons. The seed data
-/// uses `clip_size = 0` (not NULL) for non-weapons like slappacks, so a
-/// `clip_size IS NOT NULL` filter would pull them in as zero-clip
-/// "weapons" and they'd sit in the cache as dead `WeaponDef` entries.
+/// Filters to rows with `clip_size > 0` — ammo-bearing weapons (every
+/// shipped SGW weapon takes ammo, so this matches the practical "weapon"
+/// set). The seed uses `clip_size = 0` (not NULL) for non-weapons like
+/// slappacks, so the older `clip_size IS NOT NULL` filter would have
+/// pulled them in as zero-clip "weapons" sitting in the cache as dead
+/// `WeaponDef` entries. If a future ammo-less weapon archetype ever
+/// ships (a melee weapon, an unlimited-fire energy emitter, etc.), the
+/// filter needs a different discriminator — most likely a join against
+/// a "weapon-class" enum or a `flags` bit.
 /// The `default_ammo_type` conversion mirrors `BANDOLIER_ITEMS_QUERY`
 /// exactly so that values seeded here for runtime grants match the wire
 /// format the player_load path uses. `ammo_types` is unnested and each

--- a/crates/services/src/cell/spawner/tests.rs
+++ b/crates/services/src/cell/spawner/tests.rs
@@ -264,24 +264,51 @@ mod live_db {
         let map = load_item_defs(&pool)
             .await
             .expect("load_item_defs must succeed against seeded DB");
-        // The loader filters `WHERE clip_size IS NOT NULL` — items with a
-        // populated clip_size column. The actual values include 0 (placeholder
-        // entries for non-loaded weapon templates), so we don't assert
-        // positivity here. The load_item_defs invariant we CAN pin is that
-        // the cache is non-empty (the seed has weapons) and that every cached
-        // entry's clip_size is non-negative (clip_size is i32 in the
-        // resources.items column; negative would indicate a sign-extend bug).
+        // The loader filters `WHERE clip_size > 0` — actual ammo-bearing
+        // weapons. Every cached entry must have a positive clip_size; the
+        // cache must not be empty (the seed has weapons).
         assert!(
             !map.is_empty(),
-            "seeded resources.items has weapons with clip_size populated"
+            "seeded resources.items has weapons with clip_size > 0"
         );
         for (item_id, def) in &map {
             assert!(
-                def.clip_size >= 0,
-                "item {item_id} surfaced from load_item_defs with negative clip_size {}",
+                def.clip_size > 0,
+                "item {item_id} surfaced from load_item_defs with non-positive \
+                 clip_size {} — the WHERE clip_size > 0 filter has regressed and \
+                 non-weapons (clip_size = 0 in the seed) are leaking into the \
+                 WeaponDef cache",
                 def.clip_size
             );
         }
+    }
+
+    /// The slappack (type 2893, `clip_size = 0` in the seed) MUST NOT be
+    /// in the WeaponDef cache. Companion to the `clip_size > 0` filter
+    /// assertion above — that test catches "any zero-clip leak"; this
+    /// test catches "the specific slappack leak that motivated the fix"
+    /// so a regression names the right culprit.
+    ///
+    /// Bug shape this guards against: reverting `WHERE clip_size > 0`
+    /// to `WHERE clip_size IS NOT NULL` would silently put every
+    /// non-weapon back into the cache as a zero-clip `WeaponDef` —
+    /// confusing the equipment-grant code, which keys off the cache for
+    /// ammo seeding (see `cell/content/executor/inventory.rs::weapon_stats`).
+    #[tokio::test]
+    async fn load_item_defs_excludes_zero_clip_consumables_like_slappack() {
+        let pool = require_db_or_skip!();
+        let map = load_item_defs(&pool)
+            .await
+            .expect("load_item_defs must succeed against seeded DB");
+
+        // 2893 = Health Slappack TC1 (db/resources/Items/Seed/items.sql).
+        // Its seed row has clip_size = 0 — the canonical non-weapon shape.
+        const SLAPPACK_TYPE_ID: i32 = 2893;
+        assert!(
+            !map.contains_key(&SLAPPACK_TYPE_ID),
+            "slappack (type {SLAPPACK_TYPE_ID}, clip_size=0 in seed) leaked into \
+             the WeaponDef cache — the `WHERE clip_size > 0` filter regressed",
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Symptom

Slappack right-click did nothing. The user's report:

- Slappacks no longer treated as consumable.
- `useItem` treated them as weapons.
- `moveItem` from container 1 (main bag) → container 3 (bandolier) was rejected for item 10276 / type 2893.

Same shape applied to **every consumable in the seed**, not just slappacks.

## Root cause

[`crates/services/src/base/world_entry/methods/inventory/core/use_instance.rs`](crates/services/src/base/world_entry/methods/inventory/core/use_instance.rs) used `(ri.clip_size IS NOT NULL) AS is_weapon` to decide between two paths:

- **Weapons** → auto-equip via the move handler (main ↔ bandolier).
- **Everything else** → fire the cell-side `OnItemUse` event so per-item chains (heals, mission items, …) match.

But the SGW seed (`db/resources/Items/Seed/items.sql`) uses `clip_size = 0` (not NULL) for non-weapons. The slappack row at line 4879 is the representative case:

```sql
-- Slappack: clip_size = 0, container_sets = '{1, 17}' (NO bandolier).
VALUES (2893, ..., '{1,17}', ..., '{}', NULL, 0, 0);

-- Pistol: clip_size = 15, container_sets = '{3, 1, 17}'.
VALUES (3241, ..., '{3,1,17}', ..., '{Bullet_Default}', 'Bullet_Default', 15, 0);
```

`0 IS NOT NULL = TRUE`, so the predicate matched every consumable as a weapon and routed them to the move handler with target=bandolier. The move handler's `item_allows_container(slappack, 3)` then correctly rejected (slappack's `container_sets` doesn't include 3), so the visible failure was a silent no-op. The `OnItemUse` event never fired and chain 4001 (the +500 HP heal + consume) never matched.

**When this broke:** commit [`459db14c`](https://github.com/SandboxServers/Cimmeria/commit/459db14c) (`feat(inventory): right-click weapon auto-equips / auto-unequips`) added the routing layer. Prior to that, every `useItem` fired `OnItemUse` and chain 4001 worked.

## Fix

Replace the `clip_size IS NOT NULL` inference with the authoritative discriminator `3 = ANY(ri.container_sets)`. This is:

- **Semantically what the router actually asks**: "is this item bandolier-eligible?"
- **The same field the move handler's `item_allows_container` uses**, so the two sides agree end-to-end (no risk of the router sending an item the move handler will reject).
- **Robust against future item types**: a melee weapon with `clip_size = 0` but bandolier_eligible would now work correctly; a future ammo-bearing buff item would correctly stay out of the bandolier.

The fix is one SQL change but applies to every consumable, not just slappacks.

## Sidewalks

Also corrected the parallel pattern in [`crates/services/src/cell/spawner/loot.rs`](crates/services/src/cell/spawner/loot.rs) `load_item_defs` — was filtering `WHERE clip_size IS NOT NULL`, which pulled consumables into the `WeaponDef` cache as zero-clip "weapons" where they sat as dead entries. Now filters `WHERE clip_size > 0` (actual weapons). Updated the `executor/inventory.rs::weapon_stats` doc comment to match.

## Test plan

Two live-DB regression guards in [`use_instance_tests.rs`](crates/services/src/base/world_entry/methods/inventory/core/use_instance_tests.rs) that exercise both sides of the partition with real seed rows:

- **`slappack_use_fires_on_item_use_not_auto_equip`** — inserts slappack (type 2893) in main bag, calls `handle_use_inventory_item`, asserts (a) item stays at `(container=1, slot=0)` AND (b) exactly one `item_used` outbox row was enqueued. The outbox-count assertion is the load-bearing one — the move handler's rejection masks the routing error from a naive location-only test.
- **`pistol_use_routes_to_auto_equip_not_on_item_use`** — inserts pistol (type 3241) in main bag, asserts it auto-equips to bandolier `(container=3, slot=0)` AND no outbox row was enqueued. Guards against an over-correction ("always fire OnItemUse") that would silently regress right-click-to-equip.

Both tests use real seed type_ids pinned to documented rows; if the seed changes such that the slappack gains `3` in its container_sets, the constant has to move to a different consumable.

**Test runs:** both passed against the bundled local DB in an earlier iteration. The bundled Postgres was offline by the time I would have done the adversarial revert step; the test logic is sound by construction (the `outbox count == 1` assertion is the only thing that catches the bug; without it, the buggy version would silently pass the location check). The 860-test suite + workspace clippy are clean.

## Bug-shape lesson (TESTING.md)

This was a "data-vs-schema confusion" bug — assuming `NULL = absence` when the data uses `0` as the sentinel. [`TESTING.md`](TESTING.md) "Don't trust seed data" gains a bullet:

> Validate the discriminator against actual seed values, not the schema spec. `clip_size IS NOT NULL` looks like a clean "is this a weapon?" predicate, but the SGW seed uses `clip_size = 0` for non-weapons rather than NULL — so the predicate misclassifies every consumable as a weapon. When a handler infers item type (or any boolean trait) from a column, write a live-DB test that exercises both sides of the partition with **real seed rows** (a slappack at `clip_size = 0` AND a pistol at `clip_size > 0`) so the test catches the value-vs-sentinel mismatch. The robust fix is usually to read the authoritative discriminator field directly — for "is this auto-equippable to the bandolier?", `3 = ANY(container_sets)` beats any inference from a sibling column.

The `use_instance.rs` module doc now explains why `container_sets` is the authoritative discriminator and why the previous inference was wrong, with a pointer to the seed row.

## Files touched

- `crates/services/src/base/world_entry/methods/inventory/core/use_instance.rs` — fix
- `crates/services/src/base/world_entry/methods/inventory/core/use_instance_tests.rs` — new live-DB guard
- `crates/services/src/base/world_entry/methods/inventory/core/mod.rs` — register test module
- `crates/services/src/cell/spawner/loot.rs` — parallel fix in WeaponDef loader
- `crates/services/src/cell/content/executor/inventory.rs` — doc comment update
- `TESTING.md` — bug-shape note