### PR TITLE
fix(bandolier): emit AmmoTypeId on in-game equip + chain-grant (#372)

### DIFF
--- a/crates/services/src/cell/cell_methods/inventory/constants.rs
+++ b/crates/services/src/cell/cell_methods/inventory/constants.rs
@@ -10,16 +10,18 @@ pub const REQUEST_AMMO_CHANGE: u16 = 42;
 
 /// `GENERICPROPERTY_AmmoTypeId` from `entities/defs/enumerations.xml`. Used as
 /// the property-id arg for `onEntityProperty` ammo-type indicator updates.
-/// Widened from `pub(super)` so the cell-side base-message handlers in
+/// Visibility is `pub(crate)` so the cell-side base-message handlers in
 /// [`crate::cell::service::base_messages::bandolier`] can emit it on the
-/// equip paths (issue #372 — right-click equip skipped the AmmoTypeId
-/// update, leaving the client unable to play the fire animation).
+/// equip paths (right-click / drag-in-game equip and chain-engine grant
+/// both need to push the active weapon's ammo subtype to the client —
+/// otherwise the fire-animation gate stays closed at the previous
+/// slot's value, typically `0` = no ammo).
 pub(crate) const GENERICPROPERTY_AMMO_TYPE_ID: i32 = 3;
 
 /// Build the `onEntityProperty(propId, value)` arg payload (8 bytes LE).
-/// Visibility widened alongside [`GENERICPROPERTY_AMMO_TYPE_ID`] above so
-/// the base-message handlers can call it directly instead of duplicating
-/// the 8-byte LE pack.
+/// Visibility is `pub(crate)` alongside [`GENERICPROPERTY_AMMO_TYPE_ID`]
+/// above so the base-message handlers can call it directly instead of
+/// duplicating the 8-byte LE pack.
 pub(crate) fn build_entity_property_args(prop_id: i32, value: i32) -> Vec<u8> {
     let mut args = Vec::with_capacity(8);
     args.extend_from_slice(&prop_id.to_le_bytes());

--- a/crates/services/src/cell/cell_methods/inventory/constants.rs
+++ b/crates/services/src/cell/cell_methods/inventory/constants.rs
@@ -10,10 +10,17 @@ pub const REQUEST_AMMO_CHANGE: u16 = 42;
 
 /// `GENERICPROPERTY_AmmoTypeId` from `entities/defs/enumerations.xml`. Used as
 /// the property-id arg for `onEntityProperty` ammo-type indicator updates.
-pub(super) const GENERICPROPERTY_AMMO_TYPE_ID: i32 = 3;
+/// Widened from `pub(super)` so the cell-side base-message handlers in
+/// [`crate::cell::service::base_messages::bandolier`] can emit it on the
+/// equip paths (issue #372 — right-click equip skipped the AmmoTypeId
+/// update, leaving the client unable to play the fire animation).
+pub(crate) const GENERICPROPERTY_AMMO_TYPE_ID: i32 = 3;
 
 /// Build the `onEntityProperty(propId, value)` arg payload (8 bytes LE).
-pub(super) fn build_entity_property_args(prop_id: i32, value: i32) -> Vec<u8> {
+/// Visibility widened alongside [`GENERICPROPERTY_AMMO_TYPE_ID`] above so
+/// the base-message handlers can call it directly instead of duplicating
+/// the 8-byte LE pack.
+pub(crate) fn build_entity_property_args(prop_id: i32, value: i32) -> Vec<u8> {
     let mut args = Vec::with_capacity(8);
     args.extend_from_slice(&prop_id.to_le_bytes());
     args.extend_from_slice(&value.to_le_bytes());

--- a/crates/services/src/cell/service/base_messages/bandolier.rs
+++ b/crates/services/src/cell/service/base_messages/bandolier.rs
@@ -4,9 +4,42 @@
 
 use tokio::sync::mpsc;
 
+use crate::cell::cell_methods::inventory::{
+    build_entity_property_args, GENERICPROPERTY_AMMO_TYPE_ID,
+};
 use crate::cell::messages::CellToBaseMsg;
 use crate::cell::space_manager::SpaceManager;
 use cimmeria_entity::cell_entity::BandolierItem;
+
+/// Push `onEntityProperty(AmmoTypeId, ammo_type)` to the client so its
+/// bandolier UI / fire-animation gate sees the correct ammo subtype for
+/// the now-active slot. Pass `0` when the active slot has no item
+/// (mirrors python `SGWPlayer.py:522`'s `activeItem.ammoType if
+/// activeItem else 0`).
+///
+/// The manual slot-swap handler
+/// ([`crate::cell::cell_methods::inventory::bandolier::handle_request_active_slot_change`])
+/// already emits this property on every swap; the in-game equip paths
+/// here (`UpdateBandolierItem`, `SyncBandolierItems`) used to skip it,
+/// which surfaced as "the fire animation doesn't play until I swap
+/// bandolier slots and back" — the client kept stale `AmmoTypeId=0`
+/// (no ammo) until the swap forced a refresh.
+async fn emit_active_ammo_type(
+    entity_id: u32,
+    ammo_type: i32,
+    tx: &mpsc::Sender<CellToBaseMsg>,
+    space_mgr: &SpaceManager,
+) {
+    let args = build_entity_property_args(GENERICPROPERTY_AMMO_TYPE_ID, ammo_type);
+    crate::cell::abilities::send_entity_method(
+        entity_id,
+        crate::cell::client_methods::spawnable_entity::ON_ENTITY_PROPERTY,
+        args,
+        tx,
+        space_mgr,
+    )
+    .await;
+}
 
 /// Processes a `UpdateBandolierItem` message — inserts the weapon into the
 /// bandolier, optionally draws it, arms the OOC holster timer, and fires
@@ -32,6 +65,10 @@ pub(in crate::cell::service) async fn handle_update_bandolier_item(
     // when the fight ends). We skip the timer arming here to
     // avoid stamping a timer while threatened_mobs is non-empty,
     // which the holster scan doesn't (yet) gate on combat state.
+    // Capture cur_ammo_type from the inserted item so the helper below
+    // can push the AmmoTypeId update to the client when this slot is
+    // (or becomes) the active one. `item` is consumed by the insert.
+    let inserted_ammo_type = item.cur_ammo_type;
     let (play_equip_anim, drew_weapon, was_in_combat, entity_state, anim_path) =
         if let Some(entity) = space_mgr.get_entity_mut(entity_id) {
             entity.bandolier_items.insert(slot_id, item);
@@ -114,6 +151,13 @@ pub(in crate::cell::service) async fn handle_update_bandolier_item(
             space_mgr,
         )
         .await;
+        // Push AmmoTypeId so the client knows which ammo subtype the
+        // newly-equipped weapon uses. Without this the client retains
+        // AmmoTypeId=0 (no ammo) and the fire animation gate never
+        // opens until the player manually swaps bandolier slots and
+        // back (the slot-swap handler is the only other path that
+        // emits this property — issue #372).
+        emit_active_ammo_type(entity_id, inserted_ammo_type, tx, space_mgr).await;
     }
 }
 
@@ -298,5 +342,46 @@ pub(in crate::cell::service) async fn handle_sync_bandolier_items(
             space_mgr,
         )
         .await;
+    }
+
+    // Push AmmoTypeId whenever the active slot's contents changed —
+    // either the slot just gained a weapon (drag-equip / right-click
+    // equip / vendor-buy into bandolier) or just lost one (drag-
+    // unequip / sell). The manual slot-swap handler already does
+    // this on every swap; without the equivalent here, the in-game
+    // equip path stranded the client at the previous slot's
+    // AmmoTypeId — symptom was "fire animation doesn't play until I
+    // swap slots and back" because the swap forced a refresh
+    // (issue #372).
+    //
+    // Empty active slot → emit 0 to mirror the legacy "no weapon
+    // equipped" payload (`SGWPlayer.py:522`). Active-slot-unchanged
+    // syncs (the `"active slot unchanged — skip"` branch above) don't
+    // reach this point because both `active_slot_gained_weapon` and
+    // `active_slot_lost_weapon` are false there.
+    // Push AmmoTypeId whenever the active slot's contents changed —
+    // either the slot just gained a weapon (drag-equip / right-click
+    // equip / vendor-buy into bandolier) or just lost one (drag-
+    // unequip / sell). The manual slot-swap handler already does
+    // this on every swap; without the equivalent here, the in-game
+    // equip path stranded the client at the previous slot's
+    // AmmoTypeId — symptom was "fire animation doesn't play until I
+    // swap slots and back" because the swap forced a refresh.
+    //
+    // Empty active slot → emit 0 to mirror the legacy "no weapon
+    // equipped" payload (`SGWPlayer.py:522`). Active-slot-unchanged
+    // syncs (the `"active slot unchanged — skip"` branch above) don't
+    // reach this point because both `active_slot_gained_weapon` and
+    // `active_slot_lost_weapon` are false there.
+    if active_slot_gained_weapon || active_slot_lost_weapon {
+        let new_ammo_type = if let Some(entity) = space_mgr.get_entity(entity_id) {
+            entity
+                .bandolier_items
+                .get(&active_bandolier_slot)
+                .map_or(0, |item| item.cur_ammo_type)
+        } else {
+            0
+        };
+        emit_active_ammo_type(entity_id, new_ammo_type, tx, space_mgr).await;
     }
 }

--- a/crates/services/src/cell/service/base_messages/bandolier.rs
+++ b/crates/services/src/cell/service/base_messages/bandolier.rs
@@ -156,7 +156,7 @@ pub(in crate::cell::service) async fn handle_update_bandolier_item(
         // AmmoTypeId=0 (no ammo) and the fire animation gate never
         // opens until the player manually swaps bandolier slots and
         // back (the slot-swap handler is the only other path that
-        // emits this property — issue #372).
+        // emits this property).
         emit_active_ammo_type(entity_id, inserted_ammo_type, tx, space_mgr).await;
     }
 }
@@ -344,21 +344,6 @@ pub(in crate::cell::service) async fn handle_sync_bandolier_items(
         .await;
     }
 
-    // Push AmmoTypeId whenever the active slot's contents changed —
-    // either the slot just gained a weapon (drag-equip / right-click
-    // equip / vendor-buy into bandolier) or just lost one (drag-
-    // unequip / sell). The manual slot-swap handler already does
-    // this on every swap; without the equivalent here, the in-game
-    // equip path stranded the client at the previous slot's
-    // AmmoTypeId — symptom was "fire animation doesn't play until I
-    // swap slots and back" because the swap forced a refresh
-    // (issue #372).
-    //
-    // Empty active slot → emit 0 to mirror the legacy "no weapon
-    // equipped" payload (`SGWPlayer.py:522`). Active-slot-unchanged
-    // syncs (the `"active slot unchanged — skip"` branch above) don't
-    // reach this point because both `active_slot_gained_weapon` and
-    // `active_slot_lost_weapon` are false there.
     // Push AmmoTypeId whenever the active slot's contents changed —
     // either the slot just gained a weapon (drag-equip / right-click
     // equip / vendor-buy into bandolier) or just lost one (drag-

--- a/crates/services/src/cell/service/base_messages/tests/bandolier_sync.rs
+++ b/crates/services/src/cell/service/base_messages/tests/bandolier_sync.rs
@@ -312,14 +312,14 @@ async fn sync_bandolier_items_active_slot_unchanged_does_not_re_animate() {
     }
 }
 
-/// **Regression guard for issue #372** — right-click / drag equip into
-/// the bandolier must emit `onEntityProperty(AmmoTypeId, cur_ammo_type)`
-/// so the client's fire-animation gate opens immediately. Without this
-/// the client retains `AmmoTypeId=0` (no ammo) and the weapon-shot
-/// ability plays no animation until the player manually swaps to
-/// another bandolier slot and back (which fires
-/// `handle_request_active_slot_change`, the path that already emits
-/// AmmoTypeId).
+/// **Regression guard: in-game equip must emit AmmoTypeId.**
+/// Right-click / drag equip into the bandolier must emit
+/// `onEntityProperty(AmmoTypeId, cur_ammo_type)` so the client's
+/// fire-animation gate opens immediately. Without this the client
+/// retains `AmmoTypeId=0` (no ammo) and the weapon-shot ability plays
+/// no animation until the player manually swaps to another bandolier
+/// slot and back (which fires `handle_request_active_slot_change`, the
+/// path that already emits AmmoTypeId).
 ///
 /// Pinned via the wire packet: collect every `onEntityProperty` emit
 /// from the sync, find the one carrying `prop_id == 3`

--- a/crates/services/src/cell/service/base_messages/tests/bandolier_sync.rs
+++ b/crates/services/src/cell/service/base_messages/tests/bandolier_sync.rs
@@ -311,3 +311,267 @@ async fn sync_bandolier_items_active_slot_unchanged_does_not_re_animate() {
         }
     }
 }
+
+/// **Regression guard for issue #372** — right-click / drag equip into
+/// the bandolier must emit `onEntityProperty(AmmoTypeId, cur_ammo_type)`
+/// so the client's fire-animation gate opens immediately. Without this
+/// the client retains `AmmoTypeId=0` (no ammo) and the weapon-shot
+/// ability plays no animation until the player manually swaps to
+/// another bandolier slot and back (which fires
+/// `handle_request_active_slot_change`, the path that already emits
+/// AmmoTypeId).
+///
+/// Pinned via the wire packet: collect every `onEntityProperty` emit
+/// from the sync, find the one carrying `prop_id == 3`
+/// (`GENERICPROPERTY_AmmoTypeId`), assert the value matches the
+/// equipped weapon's `cur_ammo_type`. Reverting the emit in
+/// `handle_sync_bandolier_items` (the `active_slot_gained_weapon`
+/// branch) makes this assertion fail.
+#[tokio::test]
+async fn sync_bandolier_items_active_slot_gained_weapon_emits_ammo_type_id() {
+    use crate::cell::cell_methods::inventory::GENERICPROPERTY_AMMO_TYPE_ID;
+
+    const AMMO_TYPE: i32 = 2;
+
+    let mut mgr = SpaceManager::new(1);
+    let xml = r#"<?xml version="1.0"?><Spaces><Space WorldName="Castle_CellBlock" Instanced="true" MinX="-800" MaxX="800" MinY="-800" MaxY="800" /></Spaces>"#;
+    mgr.parse_spaces_xml(xml).unwrap();
+    mgr.create_startup_spaces(r#"<?xml version="1.0"?><Spaces></Spaces>"#)
+        .unwrap();
+    mgr.create_entity(1, "Castle_CellBlock", [0.0; 3], [0.0; 3])
+        .unwrap();
+    if let Some(e) = mgr.get_entity_mut(1) {
+        e.is_player = true;
+        e.player_id = Some(100);
+        e.archetype_id = Some(1);
+        e.weapon_visual = Some("WP-Human.WP_Pistol_1A".into());
+        e.weapon_holstered = true;
+        e.active_bandolier_slot = 0;
+        e.bandolier_items.clear();
+    }
+    mgr.connect_entity(1);
+    mgr.sequence_map
+        .insert((804, crate::cell::spawner::EVENT_ITEM_EQUIP), 1872);
+
+    let item = BandolierItem {
+        item_id: 55,
+        clip_size: 15,
+        default_ammo_type: AMMO_TYPE,
+        current_ammo: 0,
+        cur_ammo_type: AMMO_TYPE,
+    };
+
+    let (tx, mut rx) = mpsc::channel(16);
+    let engine = ChainEngine::new();
+
+    handle_base_message(
+        BaseToCellMsg::SyncBandolierItems {
+            entity_id: 1,
+            active_bandolier_slot: 0,
+            bandolier_items: vec![(0, item)],
+        },
+        &tx,
+        &mut mgr,
+        &engine,
+        &[],
+    )
+    .await;
+
+    // Scan for the AmmoTypeId entity-property emit. The wire payload
+    // is 8 bytes: [prop_id: i32 LE][value: i32 LE]. Pin both the
+    // packet and its content — a refactor that emits the right
+    // method but wrong prop_id (or right prop_id but wrong value)
+    // would still let the bug surface in playtest.
+    let mut saw_ammo_type_id = false;
+    while let Ok(msg) = rx.try_recv() {
+        if let CellToBaseMsg::EntityMethodCall {
+            method_index, args, ..
+        } = msg
+        {
+            if method_index == crate::cell::client_methods::spawnable_entity::ON_ENTITY_PROPERTY
+                && args.len() == 8
+            {
+                let prop_id = i32::from_le_bytes(args[0..4].try_into().unwrap());
+                let value = i32::from_le_bytes(args[4..8].try_into().unwrap());
+                if prop_id == GENERICPROPERTY_AMMO_TYPE_ID {
+                    assert_eq!(
+                        value, AMMO_TYPE,
+                        "AmmoTypeId emit must carry the equipped weapon's cur_ammo_type"
+                    );
+                    saw_ammo_type_id = true;
+                }
+            }
+        }
+    }
+    assert!(
+        saw_ammo_type_id,
+        "in-game equip into bandolier must emit onEntityProperty(AmmoTypeId, cur_ammo_type) — \
+         without this the client's fire-animation gate stays closed (AmmoTypeId=0 = no ammo) \
+         until the player manually swaps bandolier slots and back",
+    );
+}
+
+/// Parallel guard for the **unequip** path of `SyncBandolierItems` —
+/// when the active slot loses its weapon, the client's AmmoTypeId
+/// must reset to 0 (mirrors python `SGWPlayer.py:522`'s
+/// `activeItem.ammoType if activeItem else 0`). Without this, the
+/// client keeps the just-removed weapon's ammo type, which surfaces
+/// as a stale ammo-bar indicator after unequip.
+#[tokio::test]
+async fn sync_bandolier_items_active_slot_lost_weapon_emits_ammo_type_id_zero() {
+    use crate::cell::cell_methods::inventory::GENERICPROPERTY_AMMO_TYPE_ID;
+
+    let mut mgr = SpaceManager::new(1);
+    let xml = r#"<?xml version="1.0"?><Spaces><Space WorldName="Castle_CellBlock" Instanced="true" MinX="-800" MaxX="800" MinY="-800" MaxY="800" /></Spaces>"#;
+    mgr.parse_spaces_xml(xml).unwrap();
+    mgr.create_startup_spaces(r#"<?xml version="1.0"?><Spaces></Spaces>"#)
+        .unwrap();
+    mgr.create_entity(1, "Castle_CellBlock", [0.0; 3], [0.0; 3])
+        .unwrap();
+    if let Some(e) = mgr.get_entity_mut(1) {
+        e.is_player = true;
+        e.player_id = Some(100);
+        e.archetype_id = Some(1);
+        e.weapon_visual = Some("WP-Human.WP_Pistol_1A".into());
+        e.weapon_holstered = false;
+        e.active_bandolier_slot = 0;
+        e.bandolier_items.insert(
+            0,
+            BandolierItem {
+                item_id: 55,
+                clip_size: 15,
+                default_ammo_type: 2,
+                current_ammo: 7,
+                cur_ammo_type: 2,
+            },
+        );
+        e.combat_exit_at = Some(std::time::Instant::now());
+    }
+    mgr.connect_entity(1);
+    mgr.sequence_map
+        .insert((804, crate::cell::spawner::EVENT_ITEM_UNEQUIP), 1873);
+
+    let (tx, mut rx) = mpsc::channel(16);
+    let engine = ChainEngine::new();
+
+    handle_base_message(
+        BaseToCellMsg::SyncBandolierItems {
+            entity_id: 1,
+            active_bandolier_slot: 0,
+            bandolier_items: vec![],
+        },
+        &tx,
+        &mut mgr,
+        &engine,
+        &[],
+    )
+    .await;
+
+    let mut saw_zero_ammo_type = false;
+    while let Ok(msg) = rx.try_recv() {
+        if let CellToBaseMsg::EntityMethodCall {
+            method_index, args, ..
+        } = msg
+        {
+            if method_index == crate::cell::client_methods::spawnable_entity::ON_ENTITY_PROPERTY
+                && args.len() == 8
+            {
+                let prop_id = i32::from_le_bytes(args[0..4].try_into().unwrap());
+                let value = i32::from_le_bytes(args[4..8].try_into().unwrap());
+                if prop_id == GENERICPROPERTY_AMMO_TYPE_ID {
+                    assert_eq!(
+                        value, 0,
+                        "unequip must emit AmmoTypeId=0 (no weapon equipped) — \
+                         keeping the prior weapon's ammo type leaves a stale \
+                         ammo-bar indicator on the client"
+                    );
+                    saw_zero_ammo_type = true;
+                }
+            }
+        }
+    }
+    assert!(
+        saw_zero_ammo_type,
+        "unequip from active bandolier slot must emit onEntityProperty(AmmoTypeId, 0)",
+    );
+}
+
+/// Negative case: a resync where the active slot's item is unchanged
+/// must NOT emit AmmoTypeId. Without this guard, every stash-slot
+/// shuffle would re-send AmmoTypeId — wire spam, and (worse) could
+/// stomp a `requestAmmoChange` that the player issued in the same
+/// tick window.
+#[tokio::test]
+async fn sync_bandolier_items_active_slot_unchanged_does_not_emit_ammo_type_id() {
+    use crate::cell::cell_methods::inventory::GENERICPROPERTY_AMMO_TYPE_ID;
+
+    let mut mgr = SpaceManager::new(1);
+    let xml = r#"<?xml version="1.0"?><Spaces><Space WorldName="Castle_CellBlock" Instanced="true" MinX="-800" MaxX="800" MinY="-800" MaxY="800" /></Spaces>"#;
+    mgr.parse_spaces_xml(xml).unwrap();
+    mgr.create_startup_spaces(r#"<?xml version="1.0"?><Spaces></Spaces>"#)
+        .unwrap();
+    mgr.create_entity(1, "Castle_CellBlock", [0.0; 3], [0.0; 3])
+        .unwrap();
+    if let Some(e) = mgr.get_entity_mut(1) {
+        e.is_player = true;
+        e.player_id = Some(100);
+        e.weapon_holstered = false;
+        e.active_bandolier_slot = 0;
+        e.bandolier_items.insert(
+            0,
+            BandolierItem {
+                item_id: 55,
+                clip_size: 15,
+                default_ammo_type: 2,
+                current_ammo: 7,
+                cur_ammo_type: 2,
+            },
+        );
+    }
+    mgr.connect_entity(1);
+
+    let (tx, mut rx) = mpsc::channel(16);
+    let engine = ChainEngine::new();
+
+    handle_base_message(
+        BaseToCellMsg::SyncBandolierItems {
+            entity_id: 1,
+            active_bandolier_slot: 0,
+            bandolier_items: vec![(
+                0,
+                BandolierItem {
+                    item_id: 55,
+                    clip_size: 15,
+                    default_ammo_type: 2,
+                    current_ammo: 7,
+                    cur_ammo_type: 2,
+                },
+            )],
+        },
+        &tx,
+        &mut mgr,
+        &engine,
+        &[],
+    )
+    .await;
+
+    while let Ok(msg) = rx.try_recv() {
+        if let CellToBaseMsg::EntityMethodCall {
+            method_index, args, ..
+        } = msg
+        {
+            if method_index == crate::cell::client_methods::spawnable_entity::ON_ENTITY_PROPERTY
+                && args.len() == 8
+            {
+                let prop_id = i32::from_le_bytes(args[0..4].try_into().unwrap());
+                assert_ne!(
+                    prop_id, GENERICPROPERTY_AMMO_TYPE_ID,
+                    "active-slot-unchanged resync must NOT emit AmmoTypeId — \
+                     stash-slot shuffles shouldn't re-broadcast the active weapon's \
+                     ammo subtype, and emitting unconditionally could stomp an \
+                     in-flight requestAmmoChange",
+                );
+            }
+        }
+    }
+}

--- a/crates/services/src/cell/service/base_messages/tests/bandolier_update.rs
+++ b/crates/services/src/cell/service/base_messages/tests/bandolier_update.rs
@@ -397,3 +397,94 @@ async fn update_bandolier_item_in_combat_does_not_arm_holster_timer() {
          this on combat exit naturally.",
     );
 }
+
+/// **Regression guard for issue #372 (chain-engine grant path)** —
+/// `UpdateBandolierItem` lands a weapon directly into the bandolier
+/// (e.g. mission reward that grants a weapon into a still-empty
+/// active slot). The client needs `onEntityProperty(AmmoTypeId,
+/// cur_ammo_type)` to open its fire-animation gate; without it the
+/// just-granted weapon can't be fired until the player swaps
+/// bandolier slots and back.
+///
+/// Parallel coverage to `sync_bandolier_items_active_slot_gained_weapon_emits_ammo_type_id`
+/// in `bandolier_sync.rs`. Both the player-driven move path
+/// (`SyncBandolierItems`) and the chain-engine grant path
+/// (`UpdateBandolierItem`) must emit AmmoTypeId on equip.
+#[tokio::test]
+async fn update_bandolier_item_active_emits_ammo_type_id() {
+    use crate::cell::cell_methods::inventory::GENERICPROPERTY_AMMO_TYPE_ID;
+
+    const AMMO_TYPE: i32 = 3;
+
+    let mut mgr = SpaceManager::new(1);
+    let xml = r#"<?xml version="1.0"?><Spaces><Space WorldName="Castle_CellBlock" Instanced="true" MinX="-800" MaxX="800" MinY="-800" MaxY="800" /></Spaces>"#;
+    mgr.parse_spaces_xml(xml).unwrap();
+    mgr.create_startup_spaces(r#"<?xml version="1.0"?><Spaces></Spaces>"#)
+        .unwrap();
+    mgr.create_entity(1, "Castle_CellBlock", [0.0; 3], [0.0; 3])
+        .unwrap();
+    if let Some(e) = mgr.get_entity_mut(1) {
+        e.is_player = true;
+        e.player_id = Some(100);
+        e.archetype_id = Some(1);
+        e.weapon_visual = Some("WP-Human.WP_Pistol_1A".into());
+        e.weapon_holstered = true;
+        e.combat_exit_at = None;
+    }
+    mgr.connect_entity(1);
+    mgr.sequence_map
+        .insert((804, crate::cell::spawner::EVENT_ITEM_EQUIP), 1872);
+
+    let item = BandolierItem {
+        item_id: 77,
+        clip_size: 30,
+        default_ammo_type: AMMO_TYPE,
+        current_ammo: 30,
+        cur_ammo_type: AMMO_TYPE,
+    };
+
+    let (tx, mut rx) = mpsc::channel(16);
+    let engine = ChainEngine::new();
+
+    handle_base_message(
+        BaseToCellMsg::UpdateBandolierItem {
+            entity_id: 1,
+            slot_id: 0,
+            item,
+            make_active: true,
+        },
+        &tx,
+        &mut mgr,
+        &engine,
+        &[],
+    )
+    .await;
+
+    let mut saw_ammo_type_id = false;
+    while let Ok(msg) = rx.try_recv() {
+        if let CellToBaseMsg::EntityMethodCall {
+            method_index, args, ..
+        } = msg
+        {
+            if method_index == crate::cell::client_methods::spawnable_entity::ON_ENTITY_PROPERTY
+                && args.len() == 8
+            {
+                let prop_id = i32::from_le_bytes(args[0..4].try_into().unwrap());
+                let value = i32::from_le_bytes(args[4..8].try_into().unwrap());
+                if prop_id == GENERICPROPERTY_AMMO_TYPE_ID {
+                    assert_eq!(
+                        value, AMMO_TYPE,
+                        "AmmoTypeId emit must carry the granted weapon's cur_ammo_type"
+                    );
+                    saw_ammo_type_id = true;
+                }
+            }
+        }
+    }
+    assert!(
+        saw_ammo_type_id,
+        "chain-engine grant into active bandolier slot must emit \
+         onEntityProperty(AmmoTypeId, cur_ammo_type) — without this the \
+         client's fire-animation gate stays closed until the player swaps slots",
+    );
+}

--- a/crates/services/src/cell/service/base_messages/tests/bandolier_update.rs
+++ b/crates/services/src/cell/service/base_messages/tests/bandolier_update.rs
@@ -320,6 +320,13 @@ async fn update_bandolier_item_make_active_false_into_non_active_slot_does_not_d
         "stash-slot grant must NOT arm the OOC holster timer",
     );
 
+    // Also pin the AmmoTypeId negative case (Clara G5 on PR #373):
+    // the equip-display branch is gated on `slot_is_active`, so a
+    // stash-slot grant must not stomp the player's existing
+    // AmmoTypeId. If a future refactor moves the AmmoTypeId emit
+    // outside the `play_equip_anim` gate, this panic fires before
+    // the wire-side regression reaches the client.
+    use crate::cell::cell_methods::inventory::GENERICPROPERTY_AMMO_TYPE_ID;
     while let Ok(msg) = rx.try_recv() {
         match msg {
             CellToBaseMsg::RefreshAppearance { .. } => {
@@ -328,10 +335,22 @@ async fn update_bandolier_item_make_active_false_into_non_active_slot_does_not_d
                      the active slot's appearance is unchanged",
                 );
             }
-            CellToBaseMsg::EntityMethodCall { method_index, .. }
-                if method_index == crate::cell::client_methods::spawnable_entity::ON_SEQUENCE =>
-            {
-                panic!("stash-slot grant must NOT fire Item_Equip");
+            CellToBaseMsg::EntityMethodCall {
+                method_index, args, ..
+            } => {
+                if method_index == crate::cell::client_methods::spawnable_entity::ON_SEQUENCE {
+                    panic!("stash-slot grant must NOT fire Item_Equip");
+                }
+                if method_index == crate::cell::client_methods::spawnable_entity::ON_ENTITY_PROPERTY
+                    && args.len() == 8
+                {
+                    let prop_id = i32::from_le_bytes(args[0..4].try_into().unwrap());
+                    assert_ne!(
+                        prop_id, GENERICPROPERTY_AMMO_TYPE_ID,
+                        "stash-slot grant must NOT emit AmmoTypeId — would stomp \
+                         the player's existing active-slot ammo subtype",
+                    );
+                }
             }
             _ => {}
         }
@@ -398,7 +417,7 @@ async fn update_bandolier_item_in_combat_does_not_arm_holster_timer() {
     );
 }
 
-/// **Regression guard for issue #372 (chain-engine grant path)** —
+/// **Regression guard: chain-engine grant must emit AmmoTypeId.**
 /// `UpdateBandolierItem` lands a weapon directly into the bandolier
 /// (e.g. mission reward that grants a weapon into a still-empty
 /// active slot). The client needs `onEntityProperty(AmmoTypeId,


### PR DESCRIPTION
## Summary

Right-clicking a weapon in the main bag to auto-equip it into the bandolier puts the weapon in the right slot, fires the equip animation, and refreshes the appearance — but **skipped the `onEntityProperty(AmmoTypeId, cur_ammo_type)` emit**. The client's fire-animation gate keys off AmmoTypeId; without the update it retains the previous slot's value (typically 0 = "no ammo"), and the pistol-shot ability plays no animation until the player swaps bandolier slots and back. The slot-swap handler is the only other server-side site that emits this property, so the swap-and-swap-back forces a refresh that papers over the bug.

Closes #372.

## Root cause

Pre-fix, only **three** server-side sites emitted `GENERICPROPERTY_AmmoTypeId` (prop_id=3):

1. [`handle_request_active_slot_change`](https://github.com/SandboxServers/Cimmeria/blob/main/crates/services/src/cell/cell_methods/inventory/bandolier.rs#L348) — manual slot swap (the workaround)
2. [`handle_request_ammo_change`](https://github.com/SandboxServers/Cimmeria/blob/main/crates/services/src/cell/cell_methods/inventory/bandolier.rs#L558) — player toggles ammo subtype
3. [`mercury/world_data/map_loaded.rs`](https://github.com/SandboxServers/Cimmeria/blob/main/crates/services/src/mercury/world_data/map_loaded.rs#L325) — world-entry mapLoaded burst

**Missing from** `handle_sync_bandolier_items` (in-game right-click / drag equip) AND `handle_update_bandolier_item` (chain-engine grant). Both equip paths land in these handlers.

## Why the two equip paths diverged

| Equip path | AmmoTypeId emit | Outcome |
|---|---|---|
| Drag on character summary screen | ✅ — next world entry's `map_loaded` emits it | Fire works on first shot |
| In-game right-click / drag main → bandolier | ❌ — skipped by `handle_sync_bandolier_items` | **Broken** until slot swap |
| Chain-engine grant into bandolier | ❌ — skipped by `handle_update_bandolier_item` | **Broken** until slot swap |
| Manual bandolier slot swap (workaround) | ✅ — `handle_request_active_slot_change` emits | Fixes it |

## Fix shape

Added a small `emit_active_ammo_type` helper in `cell/service/base_messages/bandolier.rs` that mirrors what the slot-swap handler does (`onEntityProperty(AmmoTypeId=3, cur_ammo_type)`). Wired into both equip-display branches; widened the existing `GENERICPROPERTY_AMMO_TYPE_ID` constant + `build_entity_property_args` helper from `pub(super)` to `pub(crate)` so the base-message handler can use them directly.

Empty active slot → emit `0` (mirrors python `SGWPlayer.py:522`'s `activeItem.ammoType if activeItem else 0`).

## Test plan

- [x] **`sync_bandolier_items_active_slot_gained_weapon_emits_ammo_type_id`** — the reported bug shape. Empty bandolier → SyncBandolierItems → asserts AmmoTypeId emit carries the weapon's `cur_ammo_type`.
- [x] **`sync_bandolier_items_active_slot_lost_weapon_emits_ammo_type_id_zero`** — unequip path. Active slot loses weapon → asserts AmmoTypeId=0 so the client's ammo-bar indicator clears.
- [x] **`sync_bandolier_items_active_slot_unchanged_does_not_emit_ammo_type_id`** — negative case. Resync where active slot's item is unchanged (stash-slot shuffle) must NOT re-emit AmmoTypeId. Prevents wire spam and prevents stomping an in-flight `requestAmmoChange`.
- [x] **`update_bandolier_item_active_emits_ammo_type_id`** — parallel coverage for the chain-engine grant path (`BaseToCellMsg::UpdateBandolierItem`).
- [x] **Adversarial reversal**: confirmed the three positive guards fail when the emit is removed from each handler; the negative-case guard correctly continues to pass.
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --exclude {GUI crates} --all-targets -- -D warnings`
- [x] `cargo test --workspace --exclude {GUI crates} --lib --no-fail-fast` — **862 services + 149 mercury + 1398 lib tests total**, all green (+4 new guards from the previous 858 baseline).

## Acceptance

- Right-click pistol → empty bandolier → press pistol-shot → fire animation plays immediately ✅
- Same for in-game drag main → bandolier slot ✅
- Same for chain-engine grant into empty bandolier ✅
- Manual slot swap remains a working escape hatch (no behavior change there) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)