### PR TITLE
fix(respawn): push full inventory snapshot after ReanchorPlayer

### DIFF
--- a/crates/services/src/cell/cell_methods/player/combat/respawn.rs
+++ b/crates/services/src/cell/cell_methods/player/combat/respawn.rs
@@ -173,6 +173,54 @@ pub(super) async fn handle_respawn(
             rotation: [0.0; 3],
         })
         .await;
+
+    // Re-push the full inventory snapshot after the reanchor.
+    //
+    // CREATE_BASE_PLAYER above re-instantiates the client-side pawn
+    // actor, and the new pawn's `InventoryComponent` is empty — the
+    // ragdolled pawn (and its inventory cache) was just destroyed by
+    // the pawn-recreate hook. The bandolier visual survives because
+    // it's part of the cached `BeingAppearance.ComponentList`
+    // replayed above, but the actual `sgw_inventory` rows
+    // (consumables, mission items like Frost's Letter, anything in
+    // the main bag) live in a separate `onUpdateItem` snapshot that
+    // the server only pushes when the client asks via `listItems`.
+    //
+    // On initial login the client invokes `listItems` itself after
+    // pawn-creation; on respawn it doesn't (it thinks it's the same
+    // pawn identity). Without this push, the bag panel renders
+    // empty until relog AND subsequent pickups silently no-op
+    // because their incremental `onUpdateItem` lands against an
+    // empty client-side cache.
+    //
+    // Cross-world respawn (handled in the early-return branch above
+    // via GateTravel) doesn't need this because it re-runs the full
+    // world-entry handshake, during which the client invokes
+    // `listItems` of its own accord.
+    let player_id = space_mgr.get_entity(entity_id).and_then(|e| e.player_id);
+    if let Some(player_id) = player_id {
+        if let Err(e) = tx
+            .send(CellToBaseMsg::ListInventoryItems {
+                entity_id,
+                player_id,
+            })
+            .await
+        {
+            tracing::warn!(
+                entity_id,
+                player_id,
+                error = %e,
+                "respawn: ListInventoryItems send failed -- inventory will not repopulate \
+                 post-respawn (bag panel will stay empty until relog)"
+            );
+        }
+    } else {
+        tracing::warn!(
+            entity_id,
+            "respawn: entity has no player_id; skipping post-reanchor inventory snapshot \
+             (NPC respawn? this branch should be player-only)"
+        );
+    }
 }
 
 /// Resolve `(world, position)` for the respawn target.

--- a/crates/services/src/cell/cell_methods/player/combat/tests.rs
+++ b/crates/services/src/cell/cell_methods/player/combat/tests.rs
@@ -432,20 +432,16 @@ async fn handle_respawn_same_world_dispatches_list_inventory_after_reanchor() {
     let mut idx: usize = 0;
     while let Ok(m) = rx.try_recv() {
         match m {
-            CellToBaseMsg::ReanchorPlayer { entity_id: 1, .. } => {
-                if reanchor_at.is_none() {
-                    reanchor_at = Some(idx);
-                }
+            CellToBaseMsg::ReanchorPlayer { entity_id: 1, .. } if reanchor_at.is_none() => {
+                reanchor_at = Some(idx);
             }
             CellToBaseMsg::ListInventoryItems {
                 entity_id,
                 player_id,
-            } => {
-                if list_inventory_at.is_none() {
-                    list_inventory_at = Some(idx);
-                    list_inventory_entity_id = Some(entity_id);
-                    list_inventory_player_id = Some(player_id);
-                }
+            } if list_inventory_at.is_none() => {
+                list_inventory_at = Some(idx);
+                list_inventory_entity_id = Some(entity_id);
+                list_inventory_player_id = Some(player_id);
             }
             _ => {}
         }

--- a/crates/services/src/cell/cell_methods/player/combat/tests.rs
+++ b/crates/services/src/cell/cell_methods/player/combat/tests.rs
@@ -390,3 +390,98 @@ fn resolve_respawn_target_uses_in_place_for_other_worlds_without_respawners() {
         "must respawn in place, not at Castle default"
     );
 }
+
+/// Same-world respawn must dispatch `ListInventoryItems` AFTER
+/// `ReanchorPlayer` so the client's bag panel repopulates.
+///
+/// Bug shape this guards (play-session report 2026-05-25): the
+/// `CREATE_BASE_PLAYER` inside the reanchor re-instantiates the
+/// client-side pawn actor; the new pawn's `InventoryComponent` is
+/// empty. The bandolier visual survives because it's part of the
+/// cached `BeingAppearance.ComponentList` replayed alongside, but
+/// `sgw_inventory` rows (Frost's Letter, slappack, anything in the
+/// main bag) live in a separate `onUpdateItem` snapshot the server
+/// only pushes when the client asks via `listItems`. On initial
+/// login the client asks; on respawn it doesn't. Without this
+/// push the bag stays empty until relog AND subsequent pickups
+/// silently no-op against an empty cache.
+///
+/// Cross-world respawn doesn't need the push — it falls through to
+/// `GateTravel`, which re-runs the full world-entry handshake and
+/// the client invokes `listItems` of its own accord. The negative
+/// pin in `handle_respawn_cross_world_falls_back_to_gate_travel`
+/// already covers that branch.
+#[tokio::test]
+async fn handle_respawn_same_world_dispatches_list_inventory_after_reanchor() {
+    let mut mgr = make_mgr_with_player("Castle_CellBlock");
+    if let Some(e) = mgr.get_entity_mut(1) {
+        if let Some(h) = e.stats.get_mut(HEALTH) {
+            h.update(0, 1, 100);
+            h.clear_dirty();
+        }
+    }
+
+    let (tx, mut rx) = mpsc::channel(16);
+    handle_respawn(1, -1, &tx, &mut mgr).await;
+
+    let mut reanchor_at: Option<usize> = None;
+    let mut list_inventory_at: Option<usize> = None;
+    let mut list_inventory_player_id: Option<i32> = None;
+    let mut list_inventory_entity_id: Option<u32> = None;
+
+    let mut idx: usize = 0;
+    while let Ok(m) = rx.try_recv() {
+        match m {
+            CellToBaseMsg::ReanchorPlayer { entity_id: 1, .. } => {
+                if reanchor_at.is_none() {
+                    reanchor_at = Some(idx);
+                }
+            }
+            CellToBaseMsg::ListInventoryItems {
+                entity_id,
+                player_id,
+            } => {
+                if list_inventory_at.is_none() {
+                    list_inventory_at = Some(idx);
+                    list_inventory_entity_id = Some(entity_id);
+                    list_inventory_player_id = Some(player_id);
+                }
+            }
+            _ => {}
+        }
+        idx += 1;
+    }
+
+    let reanchor_idx = reanchor_at.expect(
+        "fixture sanity: same-world respawn must emit ReanchorPlayer (covered by the \
+         primary burst-shape test; this assertion is just to anchor the ordering check)",
+    );
+    let list_idx = list_inventory_at.expect(
+        "play-session regression: same-world respawn must follow ReanchorPlayer with a \
+         ListInventoryItems snapshot — without it the client's bag panel renders empty \
+         after respawn until relog (slappack / mission items / Frost's Letter vanish, \
+         subsequent pickups silently no-op against the empty cache)",
+    );
+
+    assert!(
+        reanchor_idx < list_idx,
+        "ordering: ReanchorPlayer (#{reanchor_idx}) must precede ListInventoryItems \
+         (#{list_idx}) so the client's pawn-recreate hook fires first; the inventory \
+         snapshot lands on the freshly-instantiated pawn, not the ragdoll about to be \
+         torn down"
+    );
+
+    assert_eq!(
+        list_inventory_entity_id,
+        Some(1),
+        "ListInventoryItems must carry the respawning entity's id so the base-side \
+         dispatcher routes the onUpdateItem snapshot to the right client session"
+    );
+    assert_eq!(
+        list_inventory_player_id,
+        Some(100),
+        "ListInventoryItems must carry the persistent player_id (read from \
+         space_mgr.get_entity(...).player_id) — that's the key the inventory \
+         table is sharded by, NOT the entity_id"
+    );
+}


### PR DESCRIPTION
## Symptom (from a play-session report)

> Inventory doesn't persist on death — frosts letter is no longer visible in mission inventory after respawning from death. Picking up new inventory items do not show up in player inventory, slappack does not show up in respawned player inventory. The rest of the death and respawn system seems to work. The bandolier persists state across death like it should. Just seems to be inventory related.

## Diagnosis

Same-world respawn dispatches [`CellToBaseMsg::ReanchorPlayer`](crates/services/src/cell/cell_methods/player/combat/respawn.rs), whose `handle_reanchor_player` sends:

1. `CREATE_BASE_PLAYER` + enter-world body
2. Cached `BeingAppearance` + `onEntityTint` replay

`CREATE_BASE_PLAYER` re-instantiates the client-side pawn actor. The new pawn's `InventoryComponent` is **empty** — the ragdolled pawn (and its inventory cache) was just destroyed by the pawn-recreate hook.

The bandolier visual survives because it's part of the cached `BeingAppearance.ComponentList` replayed alongside the burst. The actual `sgw_inventory` rows (Frost's Letter, slappack, anything in the main bag) live in a separate `onUpdateItem` snapshot the server only pushes when the client asks via `listItems`.

On initial login the client invokes `listItems` after pawn-creation of its own accord. On respawn it doesn't (it thinks it's the same pawn identity). Without the server pushing, the bag panel renders empty until relog AND subsequent pickups silently no-op because their incremental `onUpdateItem` lands against an empty client-side cache. That's both reported symptoms in one bug.

Cross-world respawn isn't affected — it falls through to `GateTravel`, which re-runs the full world-entry handshake and the client invokes `listItems` itself.

## Fix

After dispatching `ReanchorPlayer`, push `CellToBaseMsg::ListInventoryItems` so the base-side dispatcher's existing `send_full_inventory_update` path fires and re-broadcasts the full inventory to the client. Ordering matters at the wire level: `ReanchorPlayer` first (pawn must exist before inventory lands on it), then `ListInventoryItems`. The mpsc channel preserves order; the base-side dispatcher processes them in arrival order; both are reliable on the wire.

`player_id` lookup goes through `space_mgr.get_entity(entity_id).player_id` since that's the persistent key the `sgw_inventory` table is sharded by, NOT the entity_id.

## Regression guard

[`handle_respawn_same_world_dispatches_list_inventory_after_reanchor`](crates/services/src/cell/cell_methods/player/combat/tests.rs) pins:

1. `ListInventoryItems` is dispatched at all (without it the test panics with the play-session bug message).
2. `ReanchorPlayer` precedes `ListInventoryItems` (ordering invariant).
3. The carried `player_id` matches the persistent value (`space_mgr.get_entity.player_id`), NOT the entity_id.

A revert to the old `let _ = tx.send(ReanchorPlayer).await; }` form trips the test on assertion #1.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p cimmeria-services -D warnings` clean
- [x] `cargo nextest --profile=ci --workspace` (excluding GUI apps): **1510 passed, 0 failed, 1 skipped** (the wireclient pcap fixture, expected on environments without `debug/`)
- [x] All three respawn tests pass alongside (`handle_respawn_same_world_emits_in_place_burst_with_reanchor`, `handle_respawn_cross_world_falls_back_to_gate_travel`, plus the new one)
- [ ] **Manual repro in a play session** — die in Castle CellBlock with the slappack + Frost's Letter in inventory, respawn, confirm both visible in the bag panel without relog and that subsequent pickups appear

## Out of scope

The bandolier visual is already correct because it rides on the cached `BeingAppearance.ComponentList`. No change required there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where player inventory would appear empty after respawning in the same location. Inventory now properly refreshes immediately after respawn, ensuring items remain accessible.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SandboxServers/Cimmeria/pull/387?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->