### PR TITLE
fix(mercury): per-entity idbase for entity-method sub-slot threshold (closes #315)

### DIFF
--- a/crates/mercury/src/channel_bundle.rs
+++ b/crates/mercury/src/channel_bundle.rs
@@ -79,26 +79,70 @@
 
 use crate::packet::FRAGMENT_BODY_SIZE;
 
-/// Method-index boundary between direct and extended entity-method
-/// encoding. Indices `< 61` use direct encoding (msg_id = index | 0x80),
-/// indices `>= 61` use extended encoding (msg_id = 0xBD, sub_index byte
-/// after entity_id).
+/// Per-entity sub-slot threshold (`idBase`) for SGWPlayer.
 ///
-/// **Single source of truth** for the entity-method encoding boundary —
-/// both `ChannelBundle::append_entity_method` and the services-layer
-/// `crates/services/src/mercury/mod.rs::append_entity_method` import
-/// this constant so they cannot silently drift. A divergence between
-/// the two encoders would split the wire format between bundle-migrated
-/// and un-migrated call sites (pinned by the byte-equivalence tests
-/// `compose_create_entity_*_body_matches_*` in
-/// `crates/services/src/mercury/aoi/tests.rs`, but the shared constant
-/// removes the failure mode entirely).
-pub const EXTENDED_ENCODING_THRESHOLD: u16 = 61;
+/// SGWPlayer exposes 157 client methods, which plugged into the formula
+/// [`idbase_from_exposed_method_count`] gives `idBase = 61`. Every
+/// server→player method call uses this value: indices `0..61` direct-
+/// encode (msg_id = `index | 0x80`), indices `61..157` extended-encode
+/// (marker `0xBD`, then sub_index byte = `index - 61`).
+///
+/// **The threshold is per-entity-type, NOT a global constant.** Different
+/// entity types have different exposed-method counts and therefore
+/// different idbases. Pass the correct idbase for the target entity to
+/// every encoder call. For entities with `nExposedCount <= 62`, idbase
+/// is `62` — see [`idbase_from_exposed_method_count`] for the formula
+/// (`EntityDescription_AssignClientMethodIds @
+/// ghidra://SGW.exe@0x01590df0`).
+///
+/// Spec: [docs/drafts/spec/entity-property-sync.md §1.4][1] §1.17 S1,
+/// §1.18 R2.
+///
+/// [1]: ../../../../docs/drafts/spec/entity-property-sync.md
+pub const IDBASE_SGW_PLAYER: u8 = 61;
 
-/// Extended-encoding marker byte. Cannot be used as a direct msg_id.
-/// Shared with `services` for the same anti-drift reason as
-/// [`EXTENDED_ENCODING_THRESHOLD`].
+/// Per-entity sub-slot threshold for SGW non-player entities (SGWMob,
+/// SGWPet, SGWBeing-derived NPCs, etc.). Every such entity type in the
+/// current SGW schema exposes ≤62 client methods, so the formula
+/// [`idbase_from_exposed_method_count`] returns `62` (the maximum). Use
+/// this for any method call targeting a non-player entity until a
+/// per-class lookup is wired up.
+pub const IDBASE_NPC_DEFAULT: u8 = 62;
+
+/// Extended-encoding marker byte. Cannot be used as a direct msg_id for
+/// SGWPlayer (whose `idbase = 61`) because the direct range stops at
+/// `0xBC = 60 | 0x80`. For entities with a higher idbase the byte `0xBD`
+/// can mean "direct method 61" rather than "extended marker" — the
+/// client decoder distinguishes by knowing the receiving entity's idbase.
 pub const EXTENDED_ENCODING_MARKER: u8 = 0xBD;
+
+/// Compute the per-entity sub-slot threshold (`idBase`) from the entity
+/// type's exposed-client-method count, per `EntityDescription_AssignClient
+/// MethodIds @ ghidra://SGW.exe@0x01590df0`:
+///
+/// ```text
+///   idBase = 0x3E - (nExposedCount + 0xC0) / 0xFF
+/// ```
+///
+/// Method indices `0..idbase` use single-byte direct encoding (wire byte
+/// `(index | 0x80)`). Method indices `idbase..` use the two-byte extended
+/// encoding (marker `0xBD` + sub_index byte = `index - idbase`).
+///
+/// - `nExposedCount = 157` (SGWPlayer) → `idBase = 61`. The constant
+///   [`IDBASE_SGW_PLAYER`] pre-computes this for the common case.
+/// - `nExposedCount <= 62` → `idBase = 62`. The whole namespace fits in
+///   single-byte direct encoding; the wildcard `0xBD` byte is then a
+///   valid direct msg_id for method 61 on that entity rather than the
+///   extended marker.
+/// - `nExposedCount = 318` → `idBase = 60`. Method 60 starts extended-
+///   encoding territory.
+///
+/// Spec: `docs/drafts/spec/entity-property-sync.md` §1.4, §1.17 S1,
+/// §1.18 R2.
+pub const fn idbase_from_exposed_method_count(n_exposed_count: usize) -> u8 {
+    let i_var2 = (n_exposed_count + 0xC0) / 0xFF;
+    (0x3E - i_var2) as u8
+}
 
 /// Accumulator for one logical bundle of application-level messages.
 ///
@@ -159,6 +203,13 @@ impl ChannelBundle {
 
     /// Append a server→client entity-method call to the bundle body.
     ///
+    /// `idbase` is the per-entity-type sub-slot threshold for the target
+    /// entity — see [`idbase_from_exposed_method_count`]. For methods
+    /// targeting SGWPlayer pass [`IDBASE_SGW_PLAYER`] (`61`). For entities
+    /// with ≤62 exposed methods, pass `62`. The threshold is **not** a
+    /// global constant; encoding with the wrong idbase produces a wire
+    /// byte the client decodes as a different method.
+    ///
     /// Wire format matches
     /// [`crates/services/src/mercury/mod.rs`]'s `append_entity_method`
     /// byte-for-byte — see the module doc for the encoding.
@@ -169,19 +220,25 @@ impl ChannelBundle {
     ///
     /// **Field-width contract:** panics on inputs the Mercury wire format
     /// cannot represent:
-    /// - `method_index >= EXTENDED_ENCODING_THRESHOLD + 256` (extended
-    ///   sub-index byte overflow — max representable extended index is
-    ///   `61 + 255 = 316`)
+    /// - `method_index >= idbase + 256` (extended sub-index byte
+    ///   overflow — for SGWPlayer's `idbase = 61` that's `61 + 255 = 316`)
     /// - `args.len()` such that the per-message length field would exceed
     ///   `u16::MAX` (~65 KB body)
     ///
     /// A panic is preferable to a silent narrowing cast: the latter would
     /// emit a packet with a corrupt method/length field that the client
     /// parses incorrectly, producing a hard-to-diagnose downstream bug.
-    pub fn append_entity_method(&mut self, method_index: u16, entity_id: u32, args: &[u8]) {
-        if method_index >= EXTENDED_ENCODING_THRESHOLD {
-            let sub_index = u8::try_from(method_index - EXTENDED_ENCODING_THRESHOLD).expect(
-                "method_index exceeds Mercury extended-encoding range (max 61 + 255 = 316)",
+    pub fn append_entity_method(
+        &mut self,
+        method_index: u16,
+        idbase: u8,
+        entity_id: u32,
+        args: &[u8],
+    ) {
+        let threshold = u16::from(idbase);
+        if method_index >= threshold {
+            let sub_index = u8::try_from(method_index - threshold).expect(
+                "method_index exceeds Mercury extended-encoding range (idbase + 255 = max)",
             );
             let payload_len = u16::try_from(4 + 1 + args.len())
                 .expect("entity-method payload exceeds Mercury u16 length field (~65 KB max)");
@@ -192,9 +249,9 @@ impl ChannelBundle {
         } else {
             let payload_len = u16::try_from(4 + args.len())
                 .expect("entity-method payload exceeds Mercury u16 length field (~65 KB max)");
-            // Safe: method_index < 61 < 128 < u8::MAX, so `as u8` cannot
-            // truncate. The high bit is then set via `| 0x80` as the
-            // direct-encoding marker.
+            // Safe: method_index < idbase <= 62 < u8::MAX, so `as u8`
+            // cannot truncate. The high bit is then set via `| 0x80` as
+            // the direct-encoding marker.
             self.body.push((method_index as u8) | 0x80);
             self.body.extend_from_slice(&payload_len.to_le_bytes());
             self.body.extend_from_slice(&entity_id.to_le_bytes());
@@ -328,6 +385,148 @@ mod tests {
         parse_incoming, FLAG_FRAGMENTED, FLAG_HAS_ACKS, FLAG_HAS_SEQUENCE, FLAG_RELIABLE,
     };
 
+    // ── idbase formula tests (issue #315) ───────────────────────────────
+
+    /// SGWPlayer exposes 157 client methods; formula must reduce to the
+    /// observed wire idbase of 61. Audit Appendix C.6 wire-captured 35
+    /// `0xBD` sub-slot bytes for SGWPlayer-targeted methods — those only
+    /// align if the threshold is 61.
+    #[test]
+    fn idbase_formula_sgw_player_157_methods() {
+        assert_eq!(idbase_from_exposed_method_count(157), 61);
+        // Constant must match the formula for the documented input — drift
+        // would mean the SGWPlayer-targeted wire encoder uses a different
+        // boundary than the formula advertises.
+        assert_eq!(IDBASE_SGW_PLAYER, idbase_from_exposed_method_count(157));
+    }
+
+    /// Entities with ≤62 exposed methods all land on `idbase = 62` (the
+    /// maximum). Covers the integer-division corner: `iVar2 = (n + 0xC0) /
+    /// 0xFF` is 0 for `n ≤ 62` because `n + 192 ≤ 254 < 255`.
+    #[test]
+    fn idbase_formula_small_method_count_is_62() {
+        for n in 0..=62 {
+            assert_eq!(
+                idbase_from_exposed_method_count(n),
+                62,
+                "n={n} expected idbase=62, formula returned otherwise"
+            );
+        }
+        // Sanity-check the documented `IDBASE_NPC_DEFAULT` matches.
+        assert_eq!(IDBASE_NPC_DEFAULT, 62);
+    }
+
+    /// The boundary lives between 62 and 63 exposed methods: `n = 63`
+    /// already drops idbase to 61 because `(63 + 192) / 255 = 1`.
+    #[test]
+    fn idbase_formula_drops_to_61_at_63_methods() {
+        assert_eq!(idbase_from_exposed_method_count(62), 62);
+        assert_eq!(idbase_from_exposed_method_count(63), 61);
+    }
+
+    /// Step at every multiple of 255 exposed methods + 63. Documents the
+    /// staircase shape of the formula — each step subtracts 1 from idbase.
+    #[test]
+    fn idbase_formula_staircase_at_each_255_step() {
+        // (n+192)/255 transitions: at n=63 → 1, at n=318 → 2, at n=573 → 3.
+        assert_eq!(idbase_from_exposed_method_count(317), 61); // (317+192)/255 = 509/255 = 1
+        assert_eq!(idbase_from_exposed_method_count(318), 60); // (318+192)/255 = 510/255 = 2
+        assert_eq!(idbase_from_exposed_method_count(572), 60); // (572+192)/255 = 764/255 = 2
+        assert_eq!(idbase_from_exposed_method_count(573), 59); // (573+192)/255 = 765/255 = 3
+    }
+
+    // ── Per-idbase encoder pins (issue #315) ────────────────────────────
+
+    /// Method index 60 always lands in direct encoding regardless of
+    /// idbase — well below both SGWPlayer's 61 and any NPC's 62.
+    #[test]
+    fn encoder_method_60_direct_for_both_idbases() {
+        for &idbase in &[IDBASE_SGW_PLAYER, IDBASE_NPC_DEFAULT] {
+            let mut bundle = ChannelBundle::new(true);
+            bundle.append_entity_method(60, idbase, 1, &[]);
+            let (packets, _) = bundle.finalize(0, 0, passthrough);
+            // First byte after the flags is the msg_id.
+            assert_eq!(
+                packets[0][1],
+                0x80 | 60,
+                "method 60 must direct-encode (msg_id = 0xBC) for idbase {idbase}",
+            );
+        }
+    }
+
+    /// Method index 61 for SGWPlayer extended-encodes (marker `0xBD`,
+    /// sub_index 0) — issue #315 worked example.
+    #[test]
+    fn encoder_method_61_extended_for_sgw_player() {
+        let mut bundle = ChannelBundle::new(true);
+        bundle.append_entity_method(61, IDBASE_SGW_PLAYER, 7, &[]);
+        let (packets, _) = bundle.finalize(0, 0, passthrough);
+        assert_eq!(
+            packets[0][1], EXTENDED_ENCODING_MARKER,
+            "method 61 must extended-encode under SGWPlayer's idbase=61"
+        );
+        // Wire after marker: u16 word_len = 5, u32 entity_id = 7, u8 sub_index = 0.
+        assert_eq!(u16::from_le_bytes([packets[0][2], packets[0][3]]), 5);
+        assert_eq!(
+            u32::from_le_bytes([packets[0][4], packets[0][5], packets[0][6], packets[0][7]]),
+            7
+        );
+        assert_eq!(packets[0][8], 0, "sub_index = 61 - 61 = 0");
+    }
+
+    /// Method index 61 for an NPC (idbase=62) takes the DIRECT path — the
+    /// wire byte is `0xBD` (same byte as the SGWPlayer extended marker)
+    /// but as a direct msg_id, NOT a sub-slot trigger. This is the
+    /// per-entity divergence issue #315 makes visible. If encoded with
+    /// the wrong idbase the client would dispatch to a different method.
+    #[test]
+    fn encoder_method_61_direct_for_npc_default_idbase() {
+        let mut bundle = ChannelBundle::new(true);
+        bundle.append_entity_method(61, IDBASE_NPC_DEFAULT, 7, &[]);
+        let (packets, _) = bundle.finalize(0, 0, passthrough);
+        // Same wire byte (0xBD), DIFFERENT semantics: direct, not marker.
+        // Body has NO sub_index byte — payload is just the entity_id.
+        assert_eq!(
+            packets[0][1],
+            0x80 | 61,
+            "method 61 must direct-encode under NPC idbase=62 — wire byte is 0xBD as a direct msg_id"
+        );
+        assert_eq!(
+            u16::from_le_bytes([packets[0][2], packets[0][3]]),
+            4,
+            "direct encoding payload is entity_id only (4 bytes)"
+        );
+        assert_eq!(
+            u32::from_le_bytes([packets[0][4], packets[0][5], packets[0][6], packets[0][7]]),
+            7,
+            "entity_id immediately follows the length prefix — no sub_index"
+        );
+    }
+
+    /// SGWPlayer method 156 (one below the 157-method cap; near the top
+    /// of the range) extended-encodes with sub_index = 156 - 61 = 95.
+    /// Issue #315 specifically asks for this case.
+    #[test]
+    fn encoder_method_156_extended_sub_index_95_for_sgw_player() {
+        let mut bundle = ChannelBundle::new(true);
+        bundle.append_entity_method(156, IDBASE_SGW_PLAYER, 1, &[]);
+        let (packets, _) = bundle.finalize(0, 0, passthrough);
+        assert_eq!(packets[0][1], EXTENDED_ENCODING_MARKER);
+        assert_eq!(packets[0][8], 95, "sub_index = 156 - 61 = 95");
+    }
+
+    /// setupWorldParameters (SGWPlayer method 122) — audit Appendix C.6
+    /// wire-capture confirms this encodes as [0xBD][len][entity_id][61].
+    /// Issue #315 names this as the canary.
+    #[test]
+    fn encoder_setup_world_parameters_122_extended_sub_index_61() {
+        let mut bundle = ChannelBundle::new(true);
+        bundle.append_entity_method(122, IDBASE_SGW_PLAYER, 1, &[]);
+        let (packets, _) = bundle.finalize(0, 0, passthrough);
+        assert_eq!(packets[0][1], EXTENDED_ENCODING_MARKER);
+        assert_eq!(packets[0][8], 61, "sub_index = 122 - 61 = 61");
+    }
+
     /// Identity encrypt for tests — packet bytes pass through unmodified
     /// so `parse_incoming` can verify the wire layout without needing
     /// session-key plumbing.
@@ -346,7 +545,7 @@ mod tests {
     #[test]
     fn append_entity_method_direct_encoding_matches_services_layer_byte_for_byte() {
         let mut bundle = ChannelBundle::new(true);
-        bundle.append_entity_method(12, 0xDEAD_BEEF, &[0xAA, 0xBB]);
+        bundle.append_entity_method(12, IDBASE_SGW_PLAYER, 0xDEAD_BEEF, &[0xAA, 0xBB]);
 
         // Body should be exactly the bytes the services-layer
         // append_entity_method would emit for the same inputs.
@@ -368,7 +567,7 @@ mod tests {
     #[test]
     fn append_entity_method_extended_encoding_matches_services_layer_byte_for_byte() {
         let mut bundle = ChannelBundle::new(true);
-        bundle.append_entity_method(122, 1, &[]);
+        bundle.append_entity_method(122, IDBASE_SGW_PLAYER, 1, &[]);
 
         let expected: &[u8] = &[
             0xBD, // extended marker
@@ -389,7 +588,7 @@ mod tests {
     #[test]
     fn append_entity_method_boundary_between_direct_and_extended_encoding() {
         let mut direct = ChannelBundle::new(false);
-        direct.append_entity_method(60, 1, &[]);
+        direct.append_entity_method(60, IDBASE_SGW_PLAYER, 1, &[]);
         assert_eq!(
             direct.body[0],
             60 | 0x80,
@@ -397,7 +596,7 @@ mod tests {
         );
 
         let mut extended = ChannelBundle::new(false);
-        extended.append_entity_method(61, 1, &[]);
+        extended.append_entity_method(61, IDBASE_SGW_PLAYER, 1, &[]);
         assert_eq!(
             extended.body[0], EXTENDED_ENCODING_MARKER,
             "index 61 must flip to extended encoding"
@@ -413,7 +612,7 @@ mod tests {
     fn bundle_packs_multiple_cross_entity_messages_into_one_packet() {
         let mut bundle = ChannelBundle::new(true);
         for (i, entity_id) in [10u32, 20, 30, 40, 50].iter().enumerate() {
-            bundle.append_entity_method(12, *entity_id, &[i as u8]);
+            bundle.append_entity_method(12, IDBASE_SGW_PLAYER, *entity_id, &[i as u8]);
         }
         assert_eq!(bundle.num_messages(), 5);
         assert!(
@@ -459,7 +658,7 @@ mod tests {
         // 30 appends ≈ 3210 bytes → 3 fragments (1300 + 1300 + 610).
         let args = [0xAB; 100];
         for entity_id in 0u32..30 {
-            bundle.append_entity_method(12, entity_id, &args);
+            bundle.append_entity_method(12, IDBASE_SGW_PLAYER, entity_id, &args);
         }
         assert!(
             bundle.body_len() > 2 * FRAGMENT_BODY_SIZE,
@@ -511,7 +710,7 @@ mod tests {
         // Force fragmentation so we have multiple packets to inspect.
         let args = [0xCD; 100];
         for entity_id in 0u32..30 {
-            bundle.append_entity_method(12, entity_id, &args);
+            bundle.append_entity_method(12, IDBASE_SGW_PLAYER, entity_id, &args);
         }
 
         let (packets, _) = bundle.finalize(FLAG_RELIABLE, 500, passthrough);
@@ -591,8 +790,8 @@ mod tests {
     fn bundle_body_byte_exact_against_manual_construction() {
         // Bundle path
         let mut bundle = ChannelBundle::new(true);
-        bundle.append_entity_method(12, 0x0000_0042, &[0x11, 0x22, 0x33]);
-        bundle.append_entity_method(141, 0x0000_0099, &[0xFE, 0xED]);
+        bundle.append_entity_method(12, IDBASE_SGW_PLAYER, 0x0000_0042, &[0x11, 0x22, 0x33]);
+        bundle.append_entity_method(141, IDBASE_SGW_PLAYER, 0x0000_0099, &[0xFE, 0xED]);
         let bundle_body = bundle.body.clone();
 
         // Manual path — same wire format the services-layer builders use.
@@ -765,7 +964,12 @@ mod tests {
     #[should_panic(expected = "extended-encoding range")]
     fn append_entity_method_panics_on_extended_sub_index_overflow() {
         let mut bundle = ChannelBundle::new(true);
-        bundle.append_entity_method(EXTENDED_ENCODING_THRESHOLD + 256, 1, &[]);
+        bundle.append_entity_method(
+            u16::from(IDBASE_SGW_PLAYER) + 256,
+            IDBASE_SGW_PLAYER,
+            1,
+            &[],
+        );
     }
 
     /// Field-width contract: payload_len overflow MUST panic. A 65_536-byte
@@ -777,6 +981,6 @@ mod tests {
     fn append_entity_method_panics_on_payload_length_overflow() {
         let mut bundle = ChannelBundle::new(true);
         let huge_args = vec![0u8; u16::MAX as usize - 3]; // 4 + (u16::MAX - 3) > u16::MAX
-        bundle.append_entity_method(12, 1, &huge_args);
+        bundle.append_entity_method(12, IDBASE_SGW_PLAYER, 1, &huge_args);
     }
 }

--- a/crates/mercury/src/channel_bundle.rs
+++ b/crates/mercury/src/channel_bundle.rs
@@ -137,11 +137,26 @@ pub const EXTENDED_ENCODING_MARKER: u8 = 0xBD;
 /// - `nExposedCount = 318` → `idBase = 60`. Method 60 starts extended-
 ///   encoding territory.
 ///
+/// # Input range
+///
+/// `n_exposed_count` is the count of `<Exposed/>` client methods on a
+/// flattened entity type — realistically 0–500. The formula's domain is
+/// `0..=15_807`: above that, `(n + 0xC0) / 0xFF > 62` and the subtraction
+/// would underflow. Out-of-range inputs **saturate to 0** rather than
+/// wrap. Such a count would imply ~12_500 method indices in the extended
+/// range alone, which exceeds the sub-index byte (`u8`, max 255) — so an
+/// entity that large cannot actually be encoded by this wire format and
+/// the saturated `0` is a defensive sentinel, not a usable idbase.
+///
 /// Spec: `docs/drafts/spec/entity-property-sync.md` §1.4, §1.17 S1,
 /// §1.18 R2.
 pub const fn idbase_from_exposed_method_count(n_exposed_count: usize) -> u8 {
     let i_var2 = (n_exposed_count + 0xC0) / 0xFF;
-    (0x3E - i_var2) as u8
+    if i_var2 > 0x3E {
+        0
+    } else {
+        (0x3E - i_var2) as u8
+    }
 }
 
 /// Accumulator for one logical bundle of application-level messages.
@@ -385,7 +400,7 @@ mod tests {
         parse_incoming, FLAG_FRAGMENTED, FLAG_HAS_ACKS, FLAG_HAS_SEQUENCE, FLAG_RELIABLE,
     };
 
-    // ── idbase formula tests (issue #315) ───────────────────────────────
+    // ── idbase formula tests ────────────────────────────────────────────
 
     /// SGWPlayer exposes 157 client methods; formula must reduce to the
     /// observed wire idbase of 61. Audit Appendix C.6 wire-captured 35
@@ -435,7 +450,23 @@ mod tests {
         assert_eq!(idbase_from_exposed_method_count(573), 59); // (573+192)/255 = 765/255 = 3
     }
 
-    // ── Per-idbase encoder pins (issue #315) ────────────────────────────
+    /// Out-of-domain inputs saturate to `0` rather than wrapping. The
+    /// formula's domain is `0..=15_807`; above that, `(n+0xC0)/0xFF`
+    /// exceeds `0x3E` and the subtraction would underflow. The guard
+    /// returns `0` as a defensive sentinel — `idbase = 0` means every
+    /// method index uses extended encoding, which the sub_index byte
+    /// can only address up to method 255, so an entity that hits this
+    /// branch is unencodable anyway. The point of the test is to pin
+    /// the no-panic / no-wrap behaviour on out-of-range input.
+    #[test]
+    fn idbase_formula_saturates_to_zero_on_overflow() {
+        assert_eq!(idbase_from_exposed_method_count(15_807), 0);
+        assert_eq!(idbase_from_exposed_method_count(16_000), 0);
+        assert_eq!(idbase_from_exposed_method_count(usize::MAX / 2), 0);
+        assert_eq!(idbase_from_exposed_method_count(usize::MAX - 0xC0), 0);
+    }
+
+    // ── Per-idbase encoder pins ─────────────────────────────────────────
 
     /// Method index 60 always lands in direct encoding regardless of
     /// idbase — well below both SGWPlayer's 61 and any NPC's 62.
@@ -477,8 +508,9 @@ mod tests {
     /// Method index 61 for an NPC (idbase=62) takes the DIRECT path — the
     /// wire byte is `0xBD` (same byte as the SGWPlayer extended marker)
     /// but as a direct msg_id, NOT a sub-slot trigger. This is the
-    /// per-entity divergence issue #315 makes visible. If encoded with
-    /// the wrong idbase the client would dispatch to a different method.
+    /// per-entity divergence the threshold parameterisation makes visible.
+    /// If encoded with the wrong idbase the client would dispatch to a
+    /// different method.
     #[test]
     fn encoder_method_61_direct_for_npc_default_idbase() {
         let mut bundle = ChannelBundle::new(true);
@@ -505,7 +537,6 @@ mod tests {
 
     /// SGWPlayer method 156 (one below the 157-method cap; near the top
     /// of the range) extended-encodes with sub_index = 156 - 61 = 95.
-    /// Issue #315 specifically asks for this case.
     #[test]
     fn encoder_method_156_extended_sub_index_95_for_sgw_player() {
         let mut bundle = ChannelBundle::new(true);
@@ -517,7 +548,8 @@ mod tests {
 
     /// setupWorldParameters (SGWPlayer method 122) — audit Appendix C.6
     /// wire-capture confirms this encodes as [0xBD][len][entity_id][61].
-    /// Issue #315 names this as the canary.
+    /// Named landmark method (its method-index 122 == idbase 61 + sub_index
+    /// 61, the only such alignment in the SGWPlayer schema).
     #[test]
     fn encoder_setup_world_parameters_122_extended_sub_index_61() {
         let mut bundle = ChannelBundle::new(true);

--- a/crates/services/src/base/world_entry/cell_dispatch/aoi.rs
+++ b/crates/services/src/base/world_entry/cell_dispatch/aoi.rs
@@ -6,9 +6,8 @@ use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
 
+use cimmeria_mercury::channel_bundle::{ChannelBundle, IDBASE_NPC_DEFAULT, IDBASE_SGW_PLAYER};
 use cimmeria_mercury::transport::Transport;
-
-use cimmeria_mercury::channel_bundle::ChannelBundle;
 
 use crate::cell::messages::NpcAoIData;
 use crate::mercury::{
@@ -300,12 +299,26 @@ pub(super) async fn entity_method_call(
     // RELIABLE — entity method calls are state-change traffic (interaction
     // triggers, quest updates, mission state, dialog opens, content engine
     // events). Loss = permanent damage.
+    //
+    // `entity_id` here is the entity the cell wants to address and is also
+    // the routing key in `entity_to_addr` — that map only holds player
+    // entries, so `entity_id` is always a SGWPlayer. Use that idbase.
     send_to_witness_reliable(
         transport,
         connected,
         entity_to_addr,
         entity_id,
-        |key, seq, acks| build_entity_method_packet(key, seq, acks, entity_id, method_index, &args),
+        |key, seq, acks| {
+            build_entity_method_packet(
+                key,
+                seq,
+                acks,
+                entity_id,
+                method_index,
+                IDBASE_SGW_PLAYER,
+                &args,
+            )
+        },
     )
     .await;
 }
@@ -329,12 +342,29 @@ pub(super) async fn witness_entity_method(
     );
     // RELIABLE — witness-broadcast entity methods are state-change traffic,
     // same shape as the owning-client `entity_method_call` above.
+    //
+    // `entity_id` here is the *target* (ghost) entity in the witness's AoI,
+    // NOT the witness itself. Targets are NPCs (or rarely other player
+    // ghosts) — use `IDBASE_NPC_DEFAULT` since the current schema's NPC
+    // types all have ≤62 exposed methods. The wire-byte difference vs
+    // `IDBASE_SGW_PLAYER` only matters for method indices ≥61; today's
+    // witness methods (InteractionType, etc.) are all far below that.
     send_to_witness_reliable(
         transport,
         connected,
         entity_to_addr,
         witness_id,
-        |key, seq, acks| build_entity_method_packet(key, seq, acks, entity_id, method_index, &args),
+        |key, seq, acks| {
+            build_entity_method_packet(
+                key,
+                seq,
+                acks,
+                entity_id,
+                method_index,
+                IDBASE_NPC_DEFAULT,
+                &args,
+            )
+        },
     )
     .await;
 }

--- a/crates/services/src/base/world_entry/cell_dispatch/minigame.rs
+++ b/crates/services/src/base/world_entry/cell_dispatch/minigame.rs
@@ -10,7 +10,7 @@ use cimmeria_mercury::transport::Transport;
 use tokio::sync::mpsc;
 
 use crate::cell::messages::BaseToCellMsg;
-use crate::mercury::build_entity_method_packet;
+use crate::mercury::build_player_entity_method_packet;
 
 use super::super::super::helpers::send_to_witness_reliable;
 use super::super::super::ConnectedClientState;
@@ -72,7 +72,7 @@ pub(super) async fn start_minigame(
                 entity_to_addr,
                 entity_id,
                 |key, seq, acks| {
-                    build_entity_method_packet(key, seq, acks, entity_id, method, &args)
+                    build_player_entity_method_packet(key, seq, acks, entity_id, method, &args)
                 },
             )
             .await;
@@ -104,7 +104,7 @@ pub(super) async fn minigame_result(
         connected,
         entity_to_addr,
         entity_id,
-        |key, seq, acks| build_entity_method_packet(key, seq, acks, entity_id, method, &[]),
+        |key, seq, acks| build_player_entity_method_packet(key, seq, acks, entity_id, method, &[]),
     )
     .await;
     // Forward to CellApp for victory chain processing

--- a/crates/services/src/base/world_entry/cell_dispatch/tests.rs
+++ b/crates/services/src/base/world_entry/cell_dispatch/tests.rs
@@ -317,7 +317,12 @@ async fn send_bundle_to_witness_reliable_is_noop_for_unknown_witness() {
     let entity_to_addr = Arc::new(Mutex::new(HashMap::new()));
 
     let mut bundle = ChannelBundle::new(true);
-    bundle.append_entity_method(12, 1, &[0xAA]);
+    bundle.append_entity_method(
+        12,
+        cimmeria_mercury::channel_bundle::IDBASE_SGW_PLAYER,
+        1,
+        &[0xAA],
+    );
     send_bundle_to_witness_reliable(&transport, &connected, &entity_to_addr, 999, bundle).await;
 
     let clients = connected.lock().unwrap();

--- a/crates/services/src/base/world_entry/methods/inventory/appearance.rs
+++ b/crates/services/src/base/world_entry/methods/inventory/appearance.rs
@@ -25,7 +25,7 @@ use sqlx::PgPool;
 
 use super::super::player_load::core::query_player_load_data;
 use crate::base::{helpers, world_entry_appearance, ConnectedClientState};
-use crate::mercury::{build_entity_method_packet, method_idx};
+use crate::mercury::{build_player_entity_method_packet, method_idx};
 
 /// Re-run the player's appearance assembly and broadcast `BEING_APPEARANCE`.
 ///
@@ -100,7 +100,7 @@ pub async fn refresh_player_appearance(
         entity_to_addr,
         entity_id,
         |key, seq, acks| {
-            build_entity_method_packet(
+            build_player_entity_method_packet(
                 key,
                 seq,
                 acks,

--- a/crates/services/src/base/world_entry/methods/inventory/core/mod.rs
+++ b/crates/services/src/base/world_entry/methods/inventory/core/mod.rs
@@ -16,7 +16,7 @@ use sqlx::PgPool;
 
 use super::super::super::super::helpers::send_to_witness_reliable;
 use super::super::super::super::ConnectedClientState;
-use crate::mercury::{build_entity_method_packet, method_idx};
+use crate::mercury::{build_player_entity_method_packet, method_idx};
 
 mod remove_by_type;
 mod remove_instance;
@@ -131,7 +131,14 @@ pub async fn send_full_inventory_update(
         entity_to_addr,
         entity_id,
         |key, seq, acks| {
-            build_entity_method_packet(key, seq, acks, entity_id, method_idx::ON_UPDATE_ITEM, &args)
+            build_player_entity_method_packet(
+                key,
+                seq,
+                acks,
+                entity_id,
+                method_idx::ON_UPDATE_ITEM,
+                &args,
+            )
         },
     )
     .await;
@@ -165,7 +172,14 @@ pub(super) async fn send_on_remove_item(
         entity_to_addr,
         entity_id,
         |key, seq, acks| {
-            build_entity_method_packet(key, seq, acks, entity_id, method_idx::ON_REMOVE_ITEM, &args)
+            build_player_entity_method_packet(
+                key,
+                seq,
+                acks,
+                entity_id,
+                method_idx::ON_REMOVE_ITEM,
+                &args,
+            )
         },
     )
     .await;

--- a/crates/services/src/base/world_entry/methods/inventory/grant/mod.rs
+++ b/crates/services/src/base/world_entry/methods/inventory/grant/mod.rs
@@ -12,7 +12,7 @@ use super::core::send_full_inventory_update;
 use crate::base::outbox::{self, CellOutboxPayload};
 use crate::base::{helpers, ConnectedClientState};
 use crate::cell::messages::BaseToCellMsg;
-use crate::mercury::{build_entity_method_packet, method_idx};
+use crate::mercury::{build_player_entity_method_packet, method_idx};
 
 #[cfg(test)]
 mod tests;
@@ -328,7 +328,7 @@ pub async fn handle_grant_item(
                 entity_to_addr,
                 entity_id,
                 |key, seq, acks| {
-                    build_entity_method_packet(
+                    build_player_entity_method_packet(
                         key,
                         seq,
                         acks,

--- a/crates/services/src/base/world_entry/methods/mail/mod.rs
+++ b/crates/services/src/base/world_entry/methods/mail/mod.rs
@@ -9,7 +9,7 @@ use super::super::super::helpers::send_to_witness_reliable;
 use super::super::super::ConnectedClientState;
 use crate::cell::mail;
 use crate::cell::messages::MailOp;
-use crate::mercury::{build_entity_method_packet, method_idx};
+use crate::mercury::{build_player_entity_method_packet, method_idx};
 
 #[cfg(test)]
 mod tests;
@@ -125,7 +125,7 @@ pub async fn handle_mail_request(
                 entity_to_addr,
                 entity_id,
                 |key, seq, acks| {
-                    build_entity_method_packet(
+                    build_player_entity_method_packet(
                         key,
                         seq,
                         acks,
@@ -207,7 +207,7 @@ pub async fn handle_mail_request(
                 entity_to_addr,
                 entity_id,
                 |key, seq, acks| {
-                    build_entity_method_packet(
+                    build_player_entity_method_packet(
                         key,
                         seq,
                         acks,
@@ -250,7 +250,7 @@ pub async fn handle_mail_request(
                 entity_to_addr,
                 entity_id,
                 |key, seq, acks| {
-                    build_entity_method_packet(
+                    build_player_entity_method_packet(
                         key,
                         seq,
                         acks,
@@ -290,7 +290,7 @@ pub async fn handle_mail_request(
                 entity_to_addr,
                 entity_id,
                 |key, seq, acks| {
-                    build_entity_method_packet(
+                    build_player_entity_method_packet(
                         key,
                         seq,
                         acks,

--- a/crates/services/src/base/world_entry/methods/progression/mod.rs
+++ b/crates/services/src/base/world_entry/methods/progression/mod.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
 
-use cimmeria_mercury::channel_bundle::ChannelBundle;
+use cimmeria_mercury::channel_bundle::{ChannelBundle, IDBASE_SGW_PLAYER};
 use cimmeria_mercury::transport::Transport;
 use sqlx::PgPool;
 
@@ -10,7 +10,7 @@ use cimmeria_game::player::{MAX_LEVEL, TRAINING_POINTS_PER_LEVEL};
 
 use super::super::super::helpers::{send_bundle_to_witness_reliable, send_to_witness_reliable};
 use super::super::super::ConnectedClientState;
-use crate::mercury::{build_entity_method_packet, method_idx};
+use crate::mercury::{build_player_entity_method_packet, method_idx};
 
 const LEVEL_XP: [u64; 21] = [
     0, 100, 200, 300, 600, 1_000, 1_600, 2_500, 4_000, 6_000, 9_000, 14_000, 18_000, 25_000,
@@ -230,6 +230,7 @@ fn build_grant_xp_bundle(
     let mut bundle = ChannelBundle::new(true);
     bundle.append_entity_method(
         method_idx::ON_EXP_UPDATE,
+        IDBASE_SGW_PLAYER,
         entity_id,
         // Wire format is i32; saturate so a u64 total exceeding 2^31-1
         // doesn't wrap negative on the client display.
@@ -239,6 +240,7 @@ fn build_grant_xp_bundle(
     for &lvl in levels_gained {
         bundle.append_entity_method(
             method_idx::GIVE_XP_FOR_LEVEL,
+            IDBASE_SGW_PLAYER,
             entity_id,
             &(lvl as i32).to_le_bytes(),
         );
@@ -249,6 +251,7 @@ fn build_grant_xp_bundle(
         };
         bundle.append_entity_method(
             method_idx::ON_MAX_EXP_UPDATE,
+            IDBASE_SGW_PLAYER,
             entity_id,
             &next_threshold.to_le_bytes(),
         );
@@ -257,6 +260,7 @@ fn build_grant_xp_bundle(
     if !levels_gained.is_empty() {
         bundle.append_entity_method(
             method_idx::ON_LEVEL_UPDATE,
+            IDBASE_SGW_PLAYER,
             entity_id,
             &(new_level as i32).to_le_bytes(),
         );
@@ -264,7 +268,12 @@ fn build_grant_xp_bundle(
         let mut tp_args = Vec::with_capacity(8);
         tp_args.extend_from_slice(&GENERICPROPERTY_TRAINING_POINTS.to_le_bytes());
         tp_args.extend_from_slice(&(training_points as i32).to_le_bytes());
-        bundle.append_entity_method(method_idx::ON_ENTITY_PROPERTY, entity_id, &tp_args);
+        bundle.append_entity_method(
+            method_idx::ON_ENTITY_PROPERTY,
+            IDBASE_SGW_PLAYER,
+            entity_id,
+            &tp_args,
+        );
     }
 
     bundle
@@ -332,7 +341,7 @@ pub async fn handle_grant_cash(
             entity_to_addr,
             entity_id,
             |key, seq, acks| {
-                build_entity_method_packet(
+                build_player_entity_method_packet(
                     key,
                     seq,
                     acks,

--- a/crates/services/src/base/world_entry/methods/vendor/helpers.rs
+++ b/crates/services/src/base/world_entry/methods/vendor/helpers.rs
@@ -9,7 +9,7 @@ use tokio::sync::mpsc;
 use super::super::player_load::meta::query_bandolier_items_tx;
 use crate::base::{helpers, ConnectedClientState};
 use crate::cell::messages::BaseToCellMsg;
-use crate::mercury::{build_entity_method_packet, method_idx};
+use crate::mercury::{build_player_entity_method_packet, method_idx};
 
 pub async fn send_cash_changed_to_client(
     entity_id: u32,
@@ -24,7 +24,7 @@ pub async fn send_cash_changed_to_client(
         entity_to_addr,
         entity_id,
         |key, seq, acks| {
-            build_entity_method_packet(
+            build_player_entity_method_packet(
                 key,
                 seq,
                 acks,
@@ -236,7 +236,7 @@ pub async fn sync_bandolier_after_inventory_change_with_options(
             entity_to_addr,
             entity_id,
             |key, seq, acks| {
-                build_entity_method_packet(
+                build_player_entity_method_packet(
                     key,
                     seq,
                     acks,

--- a/crates/services/src/base/world_entry/methods/vendor/store.rs
+++ b/crates/services/src/base/world_entry/methods/vendor/store.rs
@@ -14,7 +14,7 @@ use super::data::{
 use super::serializers::{
     serialize_empty_store_open, serialize_store_open, serialize_store_update, StoreItemCostUpdate,
 };
-use crate::mercury::{build_entity_method_packet, method_idx};
+use crate::mercury::{build_player_entity_method_packet, method_idx};
 
 #[derive(sqlx::FromRow)]
 pub struct VendorTemplateLists {
@@ -156,7 +156,14 @@ pub async fn send_store_open_to_client(
         entity_to_addr,
         entity_id,
         |key, seq, acks| {
-            build_entity_method_packet(key, seq, acks, entity_id, method_idx::ON_STORE_OPEN, &args)
+            build_player_entity_method_packet(
+                key,
+                seq,
+                acks,
+                entity_id,
+                method_idx::ON_STORE_OPEN,
+                &args,
+            )
         },
     )
     .await;
@@ -182,7 +189,7 @@ pub async fn send_store_update_to_client(
         entity_to_addr,
         entity_id,
         |key, seq, acks| {
-            build_entity_method_packet(
+            build_player_entity_method_packet(
                 key,
                 seq,
                 acks,

--- a/crates/services/src/base/world_entry/reanchor_player.rs
+++ b/crates/services/src/base/world_entry/reanchor_player.rs
@@ -39,8 +39,8 @@ use cimmeria_mercury::packet::{build_outgoing, FLAG_HAS_ACKS};
 use cimmeria_mercury::transport::Transport;
 
 use crate::mercury::{
-    build_enter_world_body, build_entity_method_packet, encrypt_packet, method_idx, WorldEntryInfo,
-    BASEMSG_CREATE_BASE_PLAYER, REPLY_FLAGS, SGWPLAYER_CLASS_ID,
+    build_enter_world_body, build_player_entity_method_packet, encrypt_packet, method_idx,
+    WorldEntryInfo, BASEMSG_CREATE_BASE_PLAYER, REPLY_FLAGS, SGWPLAYER_CLASS_ID,
 };
 
 use super::super::ConnectedClientState;
@@ -96,7 +96,7 @@ fn build_reanchor_packets(
     // Both must be cached. A partial replay would re-create the pawn with
     // body geometry but no skin tint (or vice versa), worse than no replay.
     if let (Some(appearance), Some(tint)) = (appearance_args, tint_args) {
-        packets.push(build_entity_method_packet(
+        packets.push(build_player_entity_method_packet(
             key,
             base_seq + 1,
             &[],
@@ -104,7 +104,7 @@ fn build_reanchor_packets(
             method_idx::BEING_APPEARANCE,
             appearance,
         ));
-        packets.push(build_entity_method_packet(
+        packets.push(build_player_entity_method_packet(
             key,
             base_seq + 2,
             &[],
@@ -407,7 +407,7 @@ mod tests {
     /// that increments by the wrong stride.
     #[test]
     fn build_reanchor_packets_uses_consecutive_seqs() {
-        use crate::mercury::{build_entity_method_packet, method_idx};
+        use crate::mercury::{build_player_entity_method_packet, method_idx};
 
         let info = sample_info(0x1234);
         let appearance = vec![0xAA, 0xBB];
@@ -424,7 +424,7 @@ mod tests {
             &[],
         );
 
-        let expected_appearance = build_entity_method_packet(
+        let expected_appearance = build_player_entity_method_packet(
             &TEST_KEY,
             base_seq + 1,
             &[],
@@ -432,7 +432,7 @@ mod tests {
             method_idx::BEING_APPEARANCE,
             &appearance,
         );
-        let expected_tint = build_entity_method_packet(
+        let expected_tint = build_player_entity_method_packet(
             &TEST_KEY,
             base_seq + 2,
             &[],

--- a/crates/services/src/base/world_entry/teleport.rs
+++ b/crates/services/src/base/world_entry/teleport.rs
@@ -11,7 +11,7 @@ use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
 
-use cimmeria_mercury::channel_bundle::ChannelBundle;
+use cimmeria_mercury::channel_bundle::{ChannelBundle, IDBASE_SGW_PLAYER};
 use cimmeria_mercury::transport::Transport;
 use sqlx::PgPool;
 
@@ -162,6 +162,7 @@ fn build_teleport_bundle(
     args.extend_from_slice(&[0u8; 12]);
     bundle.append_entity_method(
         crate::cell::client_methods::player::ON_PLAYER_TELEPORT,
+        IDBASE_SGW_PLAYER,
         entity_id,
         &args,
     );
@@ -308,6 +309,7 @@ mod tests {
         crate::mercury::append_entity_method(
             &mut expected_method,
             crate::cell::client_methods::player::ON_PLAYER_TELEPORT,
+            IDBASE_SGW_PLAYER,
             entity_id,
             &args,
         );

--- a/crates/services/src/base/world_entry_appearance.rs
+++ b/crates/services/src/base/world_entry_appearance.rs
@@ -8,12 +8,12 @@ use std::net::SocketAddr;
 use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex};
 
-use cimmeria_mercury::channel_bundle::ChannelBundle;
+use cimmeria_mercury::channel_bundle::{ChannelBundle, IDBASE_SGW_PLAYER};
 use cimmeria_mercury::transport::Transport;
 use tokio::sync::mpsc;
 
 use crate::cell::messages::BaseToCellMsg;
-use crate::mercury::{build_entity_method_packet, method_idx, write_wstring, SKIN_TINTS};
+use crate::mercury::{build_player_entity_method_packet, method_idx, write_wstring, SKIN_TINTS};
 
 use super::helpers::{send_bundle_to_witness_reliable, send_to_witness_reliable};
 use super::world_entry::handle_map_loaded;
@@ -80,13 +80,33 @@ fn build_on_client_ready_burst_bundle(
     welcome_args: &[u8],
 ) -> ChannelBundle {
     let mut bundle = ChannelBundle::new(true);
-    bundle.append_entity_method(method_idx::BEING_APPEARANCE, entity_id, appearance_args);
-    bundle.append_entity_method(method_idx::ON_ENTITY_TINT, entity_id, tint_args);
+    bundle.append_entity_method(
+        method_idx::BEING_APPEARANCE,
+        IDBASE_SGW_PLAYER,
+        entity_id,
+        appearance_args,
+    );
+    bundle.append_entity_method(
+        method_idx::ON_ENTITY_TINT,
+        IDBASE_SGW_PLAYER,
+        entity_id,
+        tint_args,
+    );
     for &(channel_name, channel_id) in DEFAULT_CHAT_CHANNELS {
         let args = build_chat_joined_args(channel_name, channel_id);
-        bundle.append_entity_method(method_idx::ON_CHAT_JOINED, entity_id, &args);
+        bundle.append_entity_method(
+            method_idx::ON_CHAT_JOINED,
+            IDBASE_SGW_PLAYER,
+            entity_id,
+            &args,
+        );
     }
-    bundle.append_entity_method(method_idx::ON_PLAYER_COMMUNICATION, entity_id, welcome_args);
+    bundle.append_entity_method(
+        method_idx::ON_PLAYER_COMMUNICATION,
+        IDBASE_SGW_PLAYER,
+        entity_id,
+        welcome_args,
+    );
     bundle
 }
 
@@ -503,7 +523,7 @@ pub(crate) async fn send_cinematic(
         entity_to_addr,
         entity_id,
         |key, seq, acks| {
-            build_entity_method_packet(
+            build_player_entity_method_packet(
                 key,
                 seq,
                 acks,
@@ -647,8 +667,18 @@ fn build_appearance_resend_bundle(
     tint_args: &[u8],
 ) -> ChannelBundle {
     let mut bundle = ChannelBundle::new(true);
-    bundle.append_entity_method(method_idx::BEING_APPEARANCE, entity_id, appearance_args);
-    bundle.append_entity_method(method_idx::ON_ENTITY_TINT, entity_id, tint_args);
+    bundle.append_entity_method(
+        method_idx::BEING_APPEARANCE,
+        IDBASE_SGW_PLAYER,
+        entity_id,
+        appearance_args,
+    );
+    bundle.append_entity_method(
+        method_idx::ON_ENTITY_TINT,
+        IDBASE_SGW_PLAYER,
+        entity_id,
+        tint_args,
+    );
     bundle
 }
 

--- a/crates/services/src/mercury/aoi/create.rs
+++ b/crates/services/src/mercury/aoi/create.rs
@@ -2,12 +2,24 @@
 //! and Phase 2 (`createOnClient()` property cascade), plus the cascade's
 //! NPC stat and appearance helpers.
 
+use cimmeria_mercury::channel_bundle::{IDBASE_NPC_DEFAULT, IDBASE_SGW_PLAYER};
 use cimmeria_mercury::packet::{build_outgoing, FLAG_HAS_ACKS};
 
 use crate::cell::messages::NpcAoIData;
 use crate::mercury::{
     append_entity_method, encrypt_packet, method_idx, write_wstring, REPLY_FLAGS,
 };
+
+/// Select per-target idbase for the AoI cascade. The cascade target is
+/// the entity entering the witness's AoI: an NPC when `npc_data` is
+/// `Some(_)`, otherwise another player ghost.
+fn cascade_idbase(npc_data: Option<&NpcAoIData>) -> u8 {
+    if npc_data.is_some() {
+        IDBASE_NPC_DEFAULT
+    } else {
+        IDBASE_SGW_PLAYER
+    }
+}
 
 use super::{pack_angle, BASEMSG_CREATE_ENTITY, BASEMSG_UPDATE_AVATAR_NO_ALIAS_FULL_POS_YPR};
 
@@ -126,6 +138,7 @@ pub(crate) fn compose_create_entity_cascade_body(
     npc_data: Option<&NpcAoIData>,
 ) -> Vec<u8> {
     let mut body = Vec::with_capacity(128);
+    let idbase = cascade_idbase(npc_data);
 
     // Per-entity values from template data (or defaults for players)
     let entity_flags = npc_data.map_or(0u64, |d| d.entity_flags);
@@ -140,7 +153,13 @@ pub(crate) fn compose_create_entity_cascade_body(
             let mut args = Vec::with_capacity(8);
             args.extend_from_slice(&GENERICPROPERTY_DATABASE_ID.to_le_bytes());
             args.extend_from_slice(&speaker_id.to_le_bytes());
-            append_entity_method(&mut body, method_idx::ON_ENTITY_PROPERTY, entity_id, &args);
+            append_entity_method(
+                &mut body,
+                method_idx::ON_ENTITY_PROPERTY,
+                idbase,
+                entity_id,
+                &args,
+            );
         }
     }
 
@@ -151,6 +170,7 @@ pub(crate) fn compose_create_entity_cascade_body(
                 append_entity_method(
                     &mut body,
                     method_idx::ON_KISMET_EVENT_SET_UPDATE,
+                    idbase,
                     entity_id,
                     &event_set_id.to_le_bytes(),
                 );
@@ -160,7 +180,7 @@ pub(crate) fn compose_create_entity_cascade_body(
 
     // 3. createAppearanceOnClient — BeingAppearance (humanoid) OR onStaticMeshNameUpdate (prop)
     if let Some(d) = npc_data {
-        append_appearance(&mut body, entity_id, d);
+        append_appearance(&mut body, entity_id, idbase, d);
     }
 
     // 4. InteractionType(interactionType) — base flags (dynamic merged flags sent separately)
@@ -168,6 +188,7 @@ pub(crate) fn compose_create_entity_cascade_body(
         append_entity_method(
             &mut body,
             method_idx::INTERACTION_TYPE,
+            idbase,
             entity_id,
             &(d.interaction_type as u64).to_le_bytes(),
         );
@@ -180,6 +201,7 @@ pub(crate) fn compose_create_entity_cascade_body(
                 append_entity_method(
                     &mut body,
                     method_idx::ON_BEING_NAME_ID_UPDATE,
+                    idbase,
                     entity_id,
                     &name_id.to_le_bytes(),
                 );
@@ -191,12 +213,13 @@ pub(crate) fn compose_create_entity_cascade_body(
     append_entity_method(
         &mut body,
         method_idx::ON_ENTITY_FLAGS,
+        idbase,
         entity_id,
         &entity_flags.to_le_bytes(),
     );
 
     // 7. onVisible(1) — CRITICAL: registers entity with the client's viewport
-    append_entity_method(&mut body, method_idx::ON_VISIBLE, entity_id, &[1u8]);
+    append_entity_method(&mut body, method_idx::ON_VISIBLE, idbase, entity_id, &[1u8]);
 
     // ── SGWBeing.createOnClient ──
     if class_id != 0x00 {
@@ -204,6 +227,7 @@ pub(crate) fn compose_create_entity_cascade_body(
         append_entity_method(
             &mut body,
             method_idx::ON_LEVEL_UPDATE,
+            idbase,
             entity_id,
             &(level as i32).to_le_bytes(),
         );
@@ -212,6 +236,7 @@ pub(crate) fn compose_create_entity_cascade_body(
         append_entity_method(
             &mut body,
             method_idx::ON_TARGET_UPDATE,
+            idbase,
             entity_id,
             &0i32.to_le_bytes(),
         );
@@ -219,15 +244,23 @@ pub(crate) fn compose_create_entity_cascade_body(
         append_entity_method(
             &mut body,
             method_idx::ON_ALIGNMENT_UPDATE,
+            idbase,
             entity_id,
             &[align],
         );
         // 11. onFactionUpdate
-        append_entity_method(&mut body, method_idx::ON_FACTION_UPDATE, entity_id, &[fac]);
+        append_entity_method(
+            &mut body,
+            method_idx::ON_FACTION_UPDATE,
+            idbase,
+            entity_id,
+            &[fac],
+        );
         // 12. onStateFieldUpdate(0) — alive state
         append_entity_method(
             &mut body,
             method_idx::ON_STATE_FIELD_UPDATE,
+            idbase,
             entity_id,
             &0u32.to_le_bytes(),
         );
@@ -240,10 +273,17 @@ pub(crate) fn compose_create_entity_cascade_body(
         append_entity_method(
             &mut body,
             method_idx::ON_STAT_BASE_UPDATE,
+            idbase,
             entity_id,
             &stat_data,
         );
-        append_entity_method(&mut body, method_idx::ON_STAT_UPDATE, entity_id, &stat_data);
+        append_entity_method(
+            &mut body,
+            method_idx::ON_STAT_UPDATE,
+            idbase,
+            entity_id,
+            &stat_data,
+        );
     }
 
     body
@@ -286,7 +326,7 @@ fn build_default_npc_stats() -> Vec<u8> {
 /// Mirrors `SGWBeing.createAppearanceOnClient()` / `SGWSpawnableEntity.createAppearanceOnClient()`:
 /// - If bodySet + components (humanoid): `BeingAppearance(bodySet, componentList)` + `onEntityTint(0,0,0)`
 /// - Else if staticMesh + bodySet: `onStaticMeshNameUpdate(staticMesh, bodySet)`
-fn append_appearance(body: &mut Vec<u8>, entity_id: u32, d: &NpcAoIData) {
+fn append_appearance(body: &mut Vec<u8>, entity_id: u32, idbase: u8, d: &NpcAoIData) {
     if let Some(ref body_set) = d.body_set {
         if !body_set.is_empty() && !d.components.is_empty() {
             // Humanoid: BeingAppearance(bodySet: WSTRING, componentList: ARRAY<WSTRING>)
@@ -297,14 +337,20 @@ fn append_appearance(body: &mut Vec<u8>, entity_id: u32, d: &NpcAoIData) {
             for comp in &d.components {
                 write_wstring(&mut args, comp);
             }
-            append_entity_method(body, method_idx::BEING_APPEARANCE, entity_id, &args);
+            append_entity_method(body, method_idx::BEING_APPEARANCE, idbase, entity_id, &args);
 
             // onEntityTint(primaryColorId=0, secondaryColorId=0, skinTint=0)
             let mut tint_args = Vec::with_capacity(12);
             tint_args.extend_from_slice(&0u32.to_le_bytes());
             tint_args.extend_from_slice(&0u32.to_le_bytes());
             tint_args.extend_from_slice(&0u32.to_le_bytes());
-            append_entity_method(body, method_idx::ON_ENTITY_TINT, entity_id, &tint_args);
+            append_entity_method(
+                body,
+                method_idx::ON_ENTITY_TINT,
+                idbase,
+                entity_id,
+                &tint_args,
+            );
             return;
         }
     }
@@ -317,7 +363,7 @@ fn append_appearance(body: &mut Vec<u8>, entity_id: u32, d: &NpcAoIData) {
             write_wstring(&mut args, static_mesh);
             write_wstring(&mut args, body_set_str);
             // onStaticMeshNameUpdate is method index 0
-            append_entity_method(body, 0, entity_id, &args);
+            append_entity_method(body, 0, idbase, entity_id, &args);
         }
     }
 }

--- a/crates/services/src/mercury/aoi/create.rs
+++ b/crates/services/src/mercury/aoi/create.rs
@@ -13,6 +13,15 @@ use crate::mercury::{
 /// Select per-target idbase for the AoI cascade. The cascade target is
 /// the entity entering the witness's AoI: an NPC when `npc_data` is
 /// `Some(_)`, otherwise another player ghost.
+///
+/// Returns `IDBASE_NPC_DEFAULT` (62) for the NPC branch because every
+/// current schema NPC type has ≤62 exposed methods. Once any NPC type
+/// gains >62 exposed methods, this fallback becomes incorrect — the
+/// fix is to thread the entity's `class_id` through `NpcAoIData` and
+/// look up the precomputed idbase per class instead of the blanket
+/// default. The cascade today emits only methods at indices well
+/// below 61 so the value is unobservable on the wire, but the lookup
+/// is the long-term shape.
 fn cascade_idbase(npc_data: Option<&NpcAoIData>) -> u8 {
     if npc_data.is_some() {
         IDBASE_NPC_DEFAULT
@@ -365,5 +374,23 @@ fn append_appearance(body: &mut Vec<u8>, entity_id: u32, idbase: u8, d: &NpcAoID
             // onStaticMeshNameUpdate is method index 0
             append_entity_method(body, 0, idbase, entity_id, &args);
         }
+    }
+}
+
+#[cfg(test)]
+mod cascade_idbase_tests {
+    use super::*;
+
+    /// NPC cascade — `npc_data` present → NPC idbase.
+    #[test]
+    fn cascade_idbase_npc_branch_returns_npc_default() {
+        let npc = NpcAoIData::default();
+        assert_eq!(cascade_idbase(Some(&npc)), IDBASE_NPC_DEFAULT);
+    }
+
+    /// Player-ghost cascade — `npc_data` absent → SGWPlayer idbase.
+    #[test]
+    fn cascade_idbase_player_branch_returns_sgw_player() {
+        assert_eq!(cascade_idbase(None), IDBASE_SGW_PLAYER);
     }
 }

--- a/crates/services/src/mercury/aoi/method.rs
+++ b/crates/services/src/mercury/aoi/method.rs
@@ -1,15 +1,40 @@
 //! Single entity-method-call packet builder — used by CellService to push
 //! an `onTimerUpdate`, `onEffectResults`, etc. to one client.
 
+use cimmeria_mercury::channel_bundle::IDBASE_SGW_PLAYER;
 use cimmeria_mercury::packet::{build_outgoing, FLAG_HAS_ACKS};
 
 use crate::mercury::{append_entity_method, encrypt_packet, REPLY_FLAGS};
 
 /// Build and encrypt a single server→client entity method call.
 ///
-/// Used by CellService to send entity method calls (e.g., `onTimerUpdate`,
-/// `onEffectResults`) to a specific client.
+/// `idbase` is the per-entity sub-slot threshold for `entity_id`'s class —
+/// see [`cimmeria_mercury::channel_bundle::idbase_from_exposed_method_count`].
+/// Pass [`cimmeria_mercury::channel_bundle::IDBASE_SGW_PLAYER`] when the
+/// target is the connected player; pass
+/// [`cimmeria_mercury::channel_bundle::IDBASE_NPC_DEFAULT`] for any
+/// non-player entity in the current SGW schema. For the common case where
+/// the target is the connected player, prefer
+/// [`build_player_entity_method_packet`].
 pub fn build_entity_method_packet(
+    key: &[u8; 32],
+    seq: u32,
+    acks: &[u32],
+    entity_id: u32,
+    method_index: u16,
+    idbase: u8,
+    args: &[u8],
+) -> Vec<u8> {
+    let mut body = Vec::with_capacity(32 + args.len());
+    append_entity_method(&mut body, method_index, idbase, entity_id, args);
+    let flags = REPLY_FLAGS | if acks.is_empty() { 0 } else { FLAG_HAS_ACKS };
+    let plaintext = build_outgoing(flags, &body, Some(seq), acks, None);
+    encrypt_packet(&plaintext, key)
+}
+
+/// SGWPlayer-target convenience wrapper for [`build_entity_method_packet`].
+/// Equivalent to passing `IDBASE_SGW_PLAYER` (`61`).
+pub fn build_player_entity_method_packet(
     key: &[u8; 32],
     seq: u32,
     acks: &[u32],
@@ -17,9 +42,13 @@ pub fn build_entity_method_packet(
     method_index: u16,
     args: &[u8],
 ) -> Vec<u8> {
-    let mut body = Vec::with_capacity(32 + args.len());
-    append_entity_method(&mut body, method_index, entity_id, args);
-    let flags = REPLY_FLAGS | if acks.is_empty() { 0 } else { FLAG_HAS_ACKS };
-    let plaintext = build_outgoing(flags, &body, Some(seq), acks, None);
-    encrypt_packet(&plaintext, key)
+    build_entity_method_packet(
+        key,
+        seq,
+        acks,
+        entity_id,
+        method_index,
+        IDBASE_SGW_PLAYER,
+        args,
+    )
 }

--- a/crates/services/src/mercury/aoi/mod.rs
+++ b/crates/services/src/mercury/aoi/mod.rs
@@ -25,7 +25,7 @@ mod tests;
 pub use create::{build_create_entity_base, build_create_entity_cascade};
 pub(crate) use create::{compose_create_entity_base_body, compose_create_entity_cascade_body};
 pub use leave::{build_entity_invisible, build_entity_leave};
-pub use method::build_entity_method_packet;
+pub use method::{build_entity_method_packet, build_player_entity_method_packet};
 pub(crate) use update::compose_forced_position_body;
 pub use update::{build_avatar_update, build_forced_position};
 

--- a/crates/services/src/mercury/aoi/tests.rs
+++ b/crates/services/src/mercury/aoi/tests.rs
@@ -430,7 +430,7 @@ fn compose_create_entity_base_body_matches_build_create_entity_base_body() {
 /// **Load-bearing byte-equivalence guard for the entity-method bundle path.**
 ///
 /// `ChannelBundle::append_entity_method` (in `cimmeria-mercury`) and
-/// `build_entity_method_packet`'s body (via `services::mercury::append_entity_method`)
+/// `build_player_entity_method_packet`'s body (via `services::mercury::append_entity_method`)
 /// must emit byte-identical wire bytes. They live in two different crates
 /// and the encoder is duplicated for performance — the only thing keeping
 /// them in lock-step is the shared `EXTENDED_ENCODING_THRESHOLD` /
@@ -456,8 +456,8 @@ fn compose_create_entity_base_body_matches_build_create_entity_base_body() {
 /// test fires before the wire divergence reaches a real client.
 #[test]
 fn channel_bundle_append_entity_method_matches_build_entity_method_packet_body() {
-    use crate::mercury::{build_entity_method_packet, method_idx};
-    use cimmeria_mercury::channel_bundle::ChannelBundle;
+    use crate::mercury::{build_player_entity_method_packet, method_idx};
+    use cimmeria_mercury::channel_bundle::{ChannelBundle, IDBASE_SGW_PLAYER};
 
     const ENTITY_ID: u32 = 0xCAFE_BABE;
 
@@ -473,7 +473,7 @@ fn channel_bundle_append_entity_method_matches_build_entity_method_packet_body()
     for &(method_index, args) in direct_cases {
         // Bundle path: append one method and grab the accumulated body.
         let mut bundle = ChannelBundle::new(true);
-        bundle.append_entity_method(method_index, ENTITY_ID, args);
+        bundle.append_entity_method(method_index, IDBASE_SGW_PLAYER, ENTITY_ID, args);
         // body is private — finalize without acks/flags to recover the
         // bytes. With body_len() < FRAGMENT_BODY_SIZE this emits 1 packet,
         // and the plaintext closure is identity so we get the body back.
@@ -489,7 +489,8 @@ fn channel_bundle_append_entity_method_matches_build_entity_method_packet_body()
         let bundle_body = &packets[0][1..packets[0].len() - 4];
 
         // Standalone-packet path: decrypt and strip flags+seq footer.
-        let pkt = build_entity_method_packet(&TEST_KEY, 1, &[], ENTITY_ID, method_index, args);
+        let pkt =
+            build_player_entity_method_packet(&TEST_KEY, 1, &[], ENTITY_ID, method_index, args);
         let enc = MercuryEncryption::from_session_key(TEST_KEY);
         let pt = enc.decrypt(&pkt).unwrap();
         let standalone_body = &pt[1..pt.len() - 4];
@@ -508,12 +509,13 @@ fn channel_bundle_append_entity_method_matches_build_entity_method_packet_body()
         let method_index = method_idx::ON_PLAY_MOVIE;
         let args = b"\x10\x00\x00\x00Cine-Test.Cine\x00\x01".as_slice();
         let mut bundle = ChannelBundle::new(true);
-        bundle.append_entity_method(method_index, ENTITY_ID, args);
+        bundle.append_entity_method(method_index, IDBASE_SGW_PLAYER, ENTITY_ID, args);
         let (packets, _seqs) = bundle.finalize(0, 0, |plaintext| plaintext.to_vec());
         assert_eq!(packets.len(), 1);
         let bundle_body = &packets[0][1..packets[0].len() - 4];
 
-        let pkt = build_entity_method_packet(&TEST_KEY, 1, &[], ENTITY_ID, method_index, args);
+        let pkt =
+            build_player_entity_method_packet(&TEST_KEY, 1, &[], ENTITY_ID, method_index, args);
         let enc = MercuryEncryption::from_session_key(TEST_KEY);
         let pt = enc.decrypt(&pkt).unwrap();
         let standalone_body = &pt[1..pt.len() - 4];

--- a/crates/services/src/mercury/mod.rs
+++ b/crates/services/src/mercury/mod.rs
@@ -40,6 +40,7 @@ pub use protocol::{
 pub use aoi::{
     build_avatar_update, build_create_entity_base, build_create_entity_cascade,
     build_entity_invisible, build_entity_leave, build_entity_method_packet, build_forced_position,
+    build_player_entity_method_packet,
 };
 pub(crate) use aoi::{
     compose_create_entity_base_body, compose_create_entity_cascade_body,
@@ -240,28 +241,38 @@ pub mod method_idx {
 
 /// Append a server→client entity method call to a Mercury message body.
 ///
-/// Handles two encoding schemes per C++ `Bundle::beginEntityMessage()`:
-/// - **Direct** (method_index 0–127): `[(index | 0x80): u8][word_len: u16][entity_id: u32][args...]`
-/// - **Extended** (method_index >= 128): `[0xBD: u8][word_len: u16][entity_id: u32][(index - 61): u8][args...]`
+/// `idbase` is the per-entity-type sub-slot threshold for the target entity —
+/// see [`cimmeria_mercury::channel_bundle::idbase_from_exposed_method_count`].
+/// For methods targeting SGWPlayer pass
+/// [`cimmeria_mercury::channel_bundle::IDBASE_SGW_PLAYER`] (`61`); for entities
+/// with ≤62 exposed methods pass `62`. The threshold is **not** a global
+/// constant — it is computed per entity type per
+/// `EntityDescription_AssignClientMethodIds @ ghidra://SGW.exe@0x01590df0`:
+/// `idBase = 0x3E - (nExposedCount + 0xC0) / 0xFF`. Spec:
+/// [docs/drafts/spec/entity-property-sync.md §1.4][1].
 ///
-/// The C++ server conservatively uses extended at >= 61, but the client accepts
-/// direct encoding through index 127 (verified with setupWorldParameters=122
-/// and onPlayerDataLoaded=115). We use the simpler boundary at 128.
-pub fn append_entity_method(body: &mut Vec<u8>, method_index: u16, entity_id: u32, args: &[u8]) {
-    use cimmeria_mercury::channel_bundle::{EXTENDED_ENCODING_MARKER, EXTENDED_ENCODING_THRESHOLD};
+/// Wire encodings per C++ `Bundle::beginEntityMessage()`:
+/// - **Direct** (`method_index < idbase`): `[(index | 0x80): u8][word_len: u16][entity_id: u32][args...]`
+/// - **Extended** (`method_index >= idbase`): `[0xBD: u8][word_len: u16][entity_id: u32][(index - idbase): u8][args...]`
+///
+/// [1]: ../../../../docs/drafts/spec/entity-property-sync.md
+pub fn append_entity_method(
+    body: &mut Vec<u8>,
+    method_index: u16,
+    idbase: u8,
+    entity_id: u32,
+    args: &[u8],
+) {
+    use cimmeria_mercury::channel_bundle::EXTENDED_ENCODING_MARKER;
 
-    // BigWorld uses direct encoding for indices 0-60 (msg_id 0x80-0xBC) and
-    // extended encoding for indices 61+ (msg_id 0xBD with sub_index byte).
-    // 0xBD is the marker — it cannot be used as a direct msg_id.
-    // Boundary + marker imported from cimmeria-mercury so this encoder
-    // and `ChannelBundle::append_entity_method` cannot drift.
-    if method_index >= EXTENDED_ENCODING_THRESHOLD {
-        // Extended encoding: marker 0xBD
+    let threshold = u16::from(idbase);
+    if method_index >= threshold {
+        // Extended encoding: marker 0xBD + sub_index
         body.push(EXTENDED_ENCODING_MARKER);
         let payload_len = (4 + 1 + args.len()) as u16; // entity_id + sub_index + args
         body.extend_from_slice(&payload_len.to_le_bytes());
         body.extend_from_slice(&entity_id.to_le_bytes());
-        body.push((method_index - EXTENDED_ENCODING_THRESHOLD) as u8);
+        body.push((method_index - threshold) as u8);
     } else {
         // Direct encoding: msg_id = index | 0x80
         body.push((method_index as u8) | 0x80);
@@ -355,7 +366,13 @@ mod tests {
         let mut body = Vec::new();
         let args = [0xAA, 0xBB, 0xCC];
         // Pick index 12 (onTimerUpdate). 12 | 0x80 = 0x8C.
-        append_entity_method(&mut body, 12, 0xDEAD_BEEF, &args);
+        append_entity_method(
+            &mut body,
+            12,
+            cimmeria_mercury::channel_bundle::IDBASE_SGW_PLAYER,
+            0xDEAD_BEEF,
+            &args,
+        );
 
         assert_eq!(body[0], 0x8C, "msg_id must be (index | 0x80)");
         let word_len = u16::from_le_bytes([body[1], body[2]]);
@@ -375,7 +392,13 @@ mod tests {
     #[test]
     fn append_entity_method_extended_encoding_at_index_122() {
         let mut body = Vec::new();
-        append_entity_method(&mut body, 122, 1, &[]);
+        append_entity_method(
+            &mut body,
+            122,
+            cimmeria_mercury::channel_bundle::IDBASE_SGW_PLAYER,
+            1,
+            &[],
+        );
 
         assert_eq!(body[0], 0xBD);
         let word_len = u16::from_le_bytes([body[1], body[2]]);

--- a/crates/services/src/mercury/mod.rs
+++ b/crates/services/src/mercury/mod.rs
@@ -255,6 +255,17 @@ pub mod method_idx {
 /// - **Direct** (`method_index < idbase`): `[(index | 0x80): u8][word_len: u16][entity_id: u32][args...]`
 /// - **Extended** (`method_index >= idbase`): `[0xBD: u8][word_len: u16][entity_id: u32][(index - idbase): u8][args...]`
 ///
+/// # Field-width contract
+///
+/// Mirrors the panics from `ChannelBundle::append_entity_method` so the two
+/// encoders are behaviorally aligned — a silent narrowing cast here would
+/// emit corrupt wire bytes the client cannot recover from. Panics on inputs
+/// the wire format cannot represent:
+/// - `method_index - idbase >= 256` (extended sub-index byte overflow — for
+///   SGWPlayer's `idbase = 61` that's max representable `61 + 255 = 316`)
+/// - `args.len()` such that the per-message length field would exceed
+///   `u16::MAX` (~65 KB body)
+///
 /// [1]: ../../../../docs/drafts/spec/entity-property-sync.md
 pub fn append_entity_method(
     body: &mut Vec<u8>,
@@ -268,15 +279,22 @@ pub fn append_entity_method(
     let threshold = u16::from(idbase);
     if method_index >= threshold {
         // Extended encoding: marker 0xBD + sub_index
+        let sub_index = u8::try_from(method_index - threshold)
+            .expect("method_index exceeds Mercury extended-encoding range (idbase + 255 = max)");
+        let payload_len = u16::try_from(4 + 1 + args.len())
+            .expect("entity-method payload exceeds Mercury u16 length field (~65 KB max)");
         body.push(EXTENDED_ENCODING_MARKER);
-        let payload_len = (4 + 1 + args.len()) as u16; // entity_id + sub_index + args
         body.extend_from_slice(&payload_len.to_le_bytes());
         body.extend_from_slice(&entity_id.to_le_bytes());
-        body.push((method_index - threshold) as u8);
+        body.push(sub_index);
     } else {
         // Direct encoding: msg_id = index | 0x80
+        let payload_len = u16::try_from(4 + args.len())
+            .expect("entity-method payload exceeds Mercury u16 length field (~65 KB max)");
+        // Safe: method_index < idbase <= 62 < u8::MAX, so `as u8` cannot
+        // truncate. The high bit is then set via `| 0x80` as the direct-
+        // encoding marker.
         body.push((method_index as u8) | 0x80);
-        let payload_len = (4 + args.len()) as u16; // entity_id + args
         body.extend_from_slice(&payload_len.to_le_bytes());
         body.extend_from_slice(&entity_id.to_le_bytes());
     }

--- a/crates/services/src/mercury/protocol/tests.rs
+++ b/crates/services/src/mercury/protocol/tests.rs
@@ -609,9 +609,10 @@ fn logged_off_with_acks_includes_ack_flag() {
 #[test]
 fn append_entity_method_direct_index_0() {
     use super::super::append_entity_method;
+    use cimmeria_mercury::channel_bundle::IDBASE_SGW_PLAYER;
 
     let mut body = Vec::new();
-    append_entity_method(&mut body, 0, 42, &[]);
+    append_entity_method(&mut body, 0, IDBASE_SGW_PLAYER, 42, &[]);
     // msg_id = 0 | 0x80 = 0x80, word_len = 4, entity_id = 42
     assert_eq!(body[0], 0x80);
     assert_eq!(u16::from_le_bytes([body[1], body[2]]), 4);
@@ -622,10 +623,11 @@ fn append_entity_method_direct_index_0() {
 #[test]
 fn append_entity_method_direct_index_60() {
     use super::super::append_entity_method;
+    use cimmeria_mercury::channel_bundle::IDBASE_SGW_PLAYER;
 
     // Index 60 is the last direct-encoded index (msg_id 0x80-0xBC)
     let mut body = Vec::new();
-    append_entity_method(&mut body, 60, 1, &[0xAA, 0xBB]);
+    append_entity_method(&mut body, 60, IDBASE_SGW_PLAYER, 1, &[0xAA, 0xBB]);
     // msg_id = 60 | 0x80 = 0xBC, word_len = 6, entity_id = 1, args
     assert_eq!(body[0], 0xBC);
     assert_eq!(u16::from_le_bytes([body[1], body[2]]), 6);
@@ -636,10 +638,11 @@ fn append_entity_method_direct_index_60() {
 #[test]
 fn append_entity_method_extended_index_61() {
     use super::super::append_entity_method;
+    use cimmeria_mercury::channel_bundle::IDBASE_SGW_PLAYER;
 
     // Index 61 is the first extended-encoded index (0xBD marker)
     let mut body = Vec::new();
-    append_entity_method(&mut body, 61, 99, &[]);
+    append_entity_method(&mut body, 61, IDBASE_SGW_PLAYER, 99, &[]);
     // marker = 0xBD, word_len = 5 (entity_id + sub_index), entity_id = 99,
     // sub_index = 61 - 61 = 0
     assert_eq!(body[0], 0xBD);
@@ -652,9 +655,10 @@ fn append_entity_method_extended_index_61() {
 #[test]
 fn append_entity_method_extended_index_128() {
     use super::super::append_entity_method;
+    use cimmeria_mercury::channel_bundle::IDBASE_SGW_PLAYER;
 
     let mut body = Vec::new();
-    append_entity_method(&mut body, 128, 99, &[]);
+    append_entity_method(&mut body, 128, IDBASE_SGW_PLAYER, 99, &[]);
     // marker = 0xBD, word_len = 5 (entity_id + sub_index), entity_id = 99,
     // sub_index = 128 - 61 = 67 (0x43)
     assert_eq!(body[0], 0xBD);
@@ -667,11 +671,12 @@ fn append_entity_method_extended_index_128() {
 #[test]
 fn append_entity_method_extended_index_141() {
     use super::super::append_entity_method;
+    use cimmeria_mercury::channel_bundle::IDBASE_SGW_PLAYER;
 
     // onAbilityTreeInfo = 141 → sub_index = 141 - 61 = 80 (0x50)
     let mut body = Vec::new();
     let args = [0x01, 0x02, 0x03];
-    append_entity_method(&mut body, 141, 5, &args);
+    append_entity_method(&mut body, 141, IDBASE_SGW_PLAYER, 5, &args);
     assert_eq!(body[0], 0xBD);
     assert_eq!(u16::from_le_bytes([body[1], body[2]]), 8); // 4 + 1 + 3
     assert_eq!(body[7], 80); // 0x50
@@ -681,9 +686,10 @@ fn append_entity_method_extended_index_141() {
 #[test]
 fn append_entity_method_preserves_existing_body() {
     use super::super::append_entity_method;
+    use cimmeria_mercury::channel_bundle::IDBASE_SGW_PLAYER;
 
     let mut body = vec![0xDE, 0xAD];
-    append_entity_method(&mut body, 0, 1, &[]);
+    append_entity_method(&mut body, 0, IDBASE_SGW_PLAYER, 1, &[]);
     assert_eq!(&body[..2], &[0xDE, 0xAD]); // prefix preserved
     assert_eq!(body[2], 0x80); // method appended after
 }

--- a/crates/services/src/mercury/world_data/map_loaded.rs
+++ b/crates/services/src/mercury/world_data/map_loaded.rs
@@ -1,6 +1,7 @@
 //! `mapLoaded()` multi-packet builder: assembles all entity method calls for
 //! client game state initialization, then fragments into encrypted Mercury packets.
 
+use cimmeria_mercury::channel_bundle::IDBASE_SGW_PLAYER;
 use cimmeria_mercury::packet::build_fragmented_bundle;
 
 use super::stats::{archetype_stats, level_exp};
@@ -97,10 +98,12 @@ fn build_map_loaded_body_inner(
     world_entry: &WorldEntryInfo,
     stats: &super::ArchetypeStats,
 ) {
-    // Helper: append an entity method call to the body.
+    // Helper: append an entity method call to the body. Entity is the
+    // local player, so `IDBASE_SGW_PLAYER` (61) governs the sub-slot
+    // threshold for every method in this body.
     macro_rules! append_method {
         ($method_idx:expr, $args:expr) => {{
-            append_entity_method(body, $method_idx, entity_id, $args);
+            append_entity_method(body, $method_idx, IDBASE_SGW_PLAYER, entity_id, $args);
         }};
     }
 

--- a/crates/services/src/mercury/world_data/phases.rs
+++ b/crates/services/src/mercury/world_data/phases.rs
@@ -1,5 +1,6 @@
 //! World entry builders: create player, enter world, and standalone entity method packets.
 
+use cimmeria_mercury::channel_bundle::IDBASE_SGW_PLAYER;
 use cimmeria_mercury::packet::{build_outgoing, FLAG_HAS_ACKS};
 
 use super::{
@@ -69,6 +70,7 @@ pub fn build_create_player(
         append_entity_method(
             &mut body,
             method_idx::BEING_APPEARANCE,
+            IDBASE_SGW_PLAYER,
             info.player_entity_id,
             &appearance_args,
         );
@@ -85,6 +87,7 @@ pub fn build_create_player(
         append_entity_method(
             &mut body,
             method_idx::ON_ENTITY_TINT,
+            IDBASE_SGW_PLAYER,
             info.player_entity_id,
             &tint_args,
         );
@@ -112,6 +115,7 @@ pub fn build_create_player(
         append_entity_method(
             &mut body,
             method_idx::ON_CLIENT_MAP_LOAD,
+            IDBASE_SGW_PLAYER,
             info.player_entity_id,
             &args,
         );
@@ -170,6 +174,7 @@ pub fn build_enter_world_body(info: &WorldEntryInfo, load: Option<&PlayerLoadDat
         append_entity_method(
             &mut body,
             method_idx::BEING_APPEARANCE,
+            IDBASE_SGW_PLAYER,
             info.player_entity_id,
             &appearance_args,
         );
@@ -186,6 +191,7 @@ pub fn build_enter_world_body(info: &WorldEntryInfo, load: Option<&PlayerLoadDat
         append_entity_method(
             &mut body,
             method_idx::ON_ENTITY_TINT,
+            IDBASE_SGW_PLAYER,
             info.player_entity_id,
             &tint_args,
         );
@@ -267,7 +273,13 @@ pub fn build_on_player_data_loaded(
     entity_id: u32,
 ) -> Vec<u8> {
     let mut body = Vec::new();
-    append_entity_method(&mut body, method_idx::ON_PLAYER_DATA_LOADED, entity_id, &[]);
+    append_entity_method(
+        &mut body,
+        method_idx::ON_PLAYER_DATA_LOADED,
+        IDBASE_SGW_PLAYER,
+        entity_id,
+        &[],
+    );
 
     let flags = REPLY_FLAGS | if acks.is_empty() { 0 } else { FLAG_HAS_ACKS };
     let plaintext = build_outgoing(flags, &body, Some(seq), acks, None);
@@ -289,6 +301,7 @@ pub fn build_setup_world_parameters(
     append_entity_method(
         &mut body,
         method_idx::SETUP_WORLD_PARAMETERS,
+        IDBASE_SGW_PLAYER,
         entity_id,
         &args,
     );

--- a/crates/services/src/mercury/world_data/tests/entity_encoding.rs
+++ b/crates/services/src/mercury/world_data/tests/entity_encoding.rs
@@ -2,6 +2,7 @@
 //! onEntityTint) emitted as part of the world-entry packet stream.
 
 use super::super::*;
+use cimmeria_mercury::channel_bundle::IDBASE_SGW_PLAYER;
 
 /// Verify BeingAppearance wire encoding matches C++ reference:
 ///   msg_id=0x9A (index 26, direct: 26|0x80)
@@ -28,7 +29,13 @@ fn being_appearance_wire_encoding() {
     }
 
     let mut body = Vec::new();
-    append_entity_method(&mut body, method_idx::BEING_APPEARANCE, entity_id, &args);
+    append_entity_method(
+        &mut body,
+        method_idx::BEING_APPEARANCE,
+        IDBASE_SGW_PLAYER,
+        entity_id,
+        &args,
+    );
 
     // method_index=26 < 61 -> direct: msg_id = 26 | 0x80 = 0x9A
     assert_eq!(
@@ -121,7 +128,13 @@ fn entity_tint_wire_encoding() {
     args.extend_from_slice(&skin.to_le_bytes());
 
     let mut body = Vec::new();
-    append_entity_method(&mut body, method_idx::ON_ENTITY_TINT, entity_id, &args);
+    append_entity_method(
+        &mut body,
+        method_idx::ON_ENTITY_TINT,
+        IDBASE_SGW_PLAYER,
+        entity_id,
+        &args,
+    );
 
     // method_index=10 < 61 -> direct: msg_id = 10 | 0x80 = 0x8A
     assert_eq!(


### PR DESCRIPTION
Closes #315

## Summary

The entity-method sub-slot threshold (between direct `0x80..0xBC` and extended `0xBD + sub_index` encoding) is **per-entity-type**, computed from each type's exposed-client-method count. The previous code hardcoded `61` and the docstring contradicted the implementation (\"we use the simpler boundary at 128\").

Latent today because every server→client method call currently targets the player, and SGWPlayer's 157 exposed methods happen to plug into the formula and yield `61` — so the hardcoded value was correct by accident. It becomes a wire bug the first time we emit a method index near the boundary on a non-player entity.

Formula (per audit §1.4, Ghidra [`EntityDescription_AssignClientMethodIds @ 0x01590df0`](docs/audits/entity-property-sync-section2-audit-2026-05-16.md#c2)):

```text
idBase = 0x3E - (nExposedCount + 0xC0) / 0xFF
```

| Entity | nExposed | idbase | Notes |
|---|---:|---:|---|
| SGWPlayer | 157 | **61** | Hardcoded value worked by accident. |
| SGWMob / SGWPet / SGWBeing-derived NPCs | ≤62 | **62** | All current NPC types. |

## Implementation

- **`crates/mercury/src/channel_bundle.rs`**: removed `EXTENDED_ENCODING_THRESHOLD`. Added:
  - `IDBASE_SGW_PLAYER: u8 = 61`
  - `IDBASE_NPC_DEFAULT: u8 = 62`
  - `const fn idbase_from_exposed_method_count(n: usize) -> u8`
  - `ChannelBundle::append_entity_method` now takes `idbase: u8`.

- **`crates/services/src/mercury/mod.rs::append_entity_method`**: takes `idbase: u8`. Docstring rewritten — old \"boundary at 128\" / \"client accepts through 127\" claims removed; new docstring documents the per-entity formula with bible/Ghidra anchors.

- **`crates/services/src/mercury/aoi/method.rs`**: `build_entity_method_packet` takes `idbase: u8`. Added `build_player_entity_method_packet` wrapper for the common SGWPlayer-target case.

- **AoI cascade (`compose_create_entity_cascade_body`)**: picks idbase via `cascade_idbase(npc_data)` — `IDBASE_NPC_DEFAULT` for NPC cascades, `IDBASE_SGW_PLAYER` for player-ghost cascades.

- **Witness broadcast (`witness_entity_method` in `cell_dispatch/aoi.rs`)**: uses `IDBASE_NPC_DEFAULT` since the target is a ghost entity in the witness's AoI (not the witness itself, who happens to be a player).

- ~20 player-targeted callers updated. Direct `append_entity_method` callers pass `IDBASE_SGW_PLAYER`; legacy `build_entity_method_packet` callers migrate to `build_player_entity_method_packet` — same wire bytes, but the function name now documents which idbase governs.

## Tests (per issue plan)

**8 new tests** in [`crates/mercury/src/channel_bundle.rs`](crates/mercury/src/channel_bundle.rs) covering the issue's test plan:

Formula:
- `idbase_formula_sgw_player_157_methods` — 157 → 61 (issue example).
- `idbase_formula_small_method_count_is_62` — every n ∈ 0..=62 → 62.
- `idbase_formula_drops_to_61_at_63_methods` — boundary jump 62→63.
- `idbase_formula_staircase_at_each_255_step` — 318→60, 573→59 (formula corners).

Encoder:
- `encoder_method_60_direct_for_both_idbases` — sanity (no wire change at low indices).
- `encoder_method_61_extended_for_sgw_player` — sub_index = 0 (worked-example boundary).
- `encoder_method_61_direct_for_npc_default_idbase` — the per-entity divergence the issue makes visible (msg_id `0xBD` here is a direct byte, not an extended marker).
- `encoder_method_156_extended_sub_index_95_for_sgw_player` — issue's worked example.
- `encoder_setup_world_parameters_122_extended_sub_index_61` — audit Appendix C.6 wire-capture witness.

**Existing wire-format byte-equivalence tests** updated to pass the new `idbase` parameter — covers BeingAppearance / onEntityTint / setup_world_parameters byte layouts. 1569 workspace tests pass.

## Wire bytes — what does and doesn't change

For SGWPlayer-targeted methods, **no wire bytes change** — `IDBASE_SGW_PLAYER` is `61`, the same value the hardcode used. The audit Appendix C.6 wire capture (35 `0xBD` sub-slot sentinels for SGWPlayer methods, named methods at the expected sub-indices) continues to pass byte-for-byte.

For NPC-targeted methods, no current emit crosses index 61, so no current wire byte changes either. The fix is forward-looking: when we start emitting NPC method indices ≥61, they will now correctly direct-encode with the NPC's idbase=62 instead of mis-encoding as an extended marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)