### PR TITLE
fix(cell): auto-reload coverage — login hook + auto-aggro appearance broadcast

### DIFF
--- a/crates/entity/src/cell_entity/mod.rs
+++ b/crates/entity/src/cell_entity/mod.rs
@@ -763,8 +763,16 @@ impl CellEntity {
     ///   ended (death cleared `BSF_IN_COMBAT` via the threat fan-out), so
     ///   this is redundant with that path but keeps the surface clean.
     ///
-    /// Does NOT touch `weapon_holstered` itself — the death broadcast
-    /// path and the respawn `ReanchorPlayer` handle the appearance side.
+    /// Does NOT clear:
+    /// - `weapon_holstered` — the death broadcast path and the respawn
+    ///   `ReanchorPlayer` handle the appearance side.
+    /// - `threatened_mobs` — held separately and cleared by the
+    ///   same-world respawn handler (see
+    ///   `cell_methods/player/combat/respawn.rs`).
+    /// - `ai_retry_at` / `pending_ai_retries` — NPC-AI fields; the call
+    ///   site is gated on `is_player`, so these are structurally
+    ///   unreachable here. If the gate is ever relaxed, audit NPC AI
+    ///   timers separately rather than bolting them onto this helper.
     pub fn clear_weapon_action_state(&mut self) {
         self.pending_reload_at = None;
         self.reload_complete_at = None;

--- a/crates/entity/src/cell_entity/mod.rs
+++ b/crates/entity/src/cell_entity/mod.rs
@@ -737,6 +737,46 @@ impl CellEntity {
     pub fn sync_holster_to_combat(&mut self, in_combat: bool) -> bool {
         self.set_weapon_holstered(!in_combat)
     }
+
+    /// Clear every pending weapon-action timer in one shot.
+    ///
+    /// Called when the entity transitions to a state where running any of
+    /// the deferred weapon flows would be wrong. The current call site is
+    /// player death: the cell-side entity survives same-world respawn
+    /// (`ReanchorPlayer` keeps it intact), so stale `pending_*_at` fields
+    /// would otherwise fire deferred ticks during the Defeat Window or
+    /// post-respawn — surfacing as phantom reload animations, queued
+    /// attacks against unrelated targets, or slot-swap choreography
+    /// running on a corpse.
+    ///
+    /// Specifically resets:
+    /// - `pending_reload_at` — reload-while-holstered Phase A draw window.
+    /// - `reload_complete_at` + `reload_slot_id` — reload-while-drawn
+    ///   Phase B warmup deadline + pinned slot.
+    /// - `pending_attack_at` + `pending_attack_ability_id` +
+    ///   `pending_attack_target_id` — fire-while-holstered queued attack.
+    /// - `pending_slot_swap_at` + `pending_slot_swap_target` — bandolier
+    ///   slot-swap choreography (`Item_Unequip` → wait → `Item_Equip`).
+    /// - `holster_animation_complete_at` — OOC holster Phase 2 mesh-drop
+    ///   deadline.
+    /// - `combat_exit_at` — OOC holster Phase 1 deadline. Combat already
+    ///   ended (death cleared `BSF_IN_COMBAT` via the threat fan-out), so
+    ///   this is redundant with that path but keeps the surface clean.
+    ///
+    /// Does NOT touch `weapon_holstered` itself — the death broadcast
+    /// path and the respawn `ReanchorPlayer` handle the appearance side.
+    pub fn clear_weapon_action_state(&mut self) {
+        self.pending_reload_at = None;
+        self.reload_complete_at = None;
+        self.reload_slot_id = None;
+        self.pending_attack_at = None;
+        self.pending_attack_ability_id = None;
+        self.pending_attack_target_id = None;
+        self.pending_slot_swap_at = None;
+        self.pending_slot_swap_target = None;
+        self.holster_animation_complete_at = None;
+        self.combat_exit_at = None;
+    }
 }
 
 impl std::fmt::Debug for CellEntity {

--- a/crates/services/src/cell/abilities/damage_apply/mod.rs
+++ b/crates/services/src/cell/abilities/damage_apply/mod.rs
@@ -169,7 +169,24 @@ pub(super) async fn apply_damage_to_target(
     if target_died {
         target.set_state_flag(combat::BSF_DEAD);
         target.set_state_flag(combat::BSF_MOVEMENT_LOCK); // prevent movement while dead
-                                                          // Transition NPC AI to Dead so it stops fighting and moving
+
+        // Player corpses keep the cell entity alive across same-world
+        // respawn (`ReanchorPlayer` reuses the entity instead of
+        // destroying and re-creating). Any in-flight weapon-action
+        // timer survives unless cleared here, and the per-tick
+        // sweeps fire deferred actions regardless of `BSF_DEAD`.
+        // Pre-fix surface: a player who dies mid-reload would have
+        // `reload_completion_tick` refill their clip during the
+        // Defeat Window (free reload during the dead state); a
+        // player who dies during the fire-while-holstered draw
+        // queue would have `pending_attack_tick` fire `useAbility`
+        // against the cached target post-respawn (re-fire against
+        // a possibly-dead-or-departed entity). NPCs are destroyed
+        // outright on death, so the cleanup is player-only.
+        if target.is_player {
+            target.clear_weapon_action_state();
+        }
+        // Transition NPC AI to Dead so it stops fighting and moving
         if !target.is_player {
             target.ai_state = cimmeria_entity::cell_entity::AiState::Dead;
             // Do NOT clear `threat_list` here: `apply_death_transition`

--- a/crates/services/src/cell/abilities/damage_apply/tests.rs
+++ b/crates/services/src/cell/abilities/damage_apply/tests.rs
@@ -442,3 +442,76 @@ async fn player_attacker_does_more_damage_than_npc_attacker() {
             "player attacker must deal strictly more damage than NPC attacker; player={player_dmg}, npc={npc_dmg}"
         );
 }
+
+/// Player dying mid-reload / mid-draw / mid-slot-swap must clear
+/// every pending weapon-action timer. Same-world respawn
+/// (`ReanchorPlayer`) reuses the cell entity, so any timer that
+/// survives death will fire its tick during the Defeat Window or
+/// post-respawn — phantom reload animations, queued attacks
+/// against stale targets, slot-swap choreography on a corpse.
+///
+/// This guard stages a player with EVERY pending weapon field set
+/// to `Some`, lethally damages them, and asserts each field is
+/// `None` afterward.
+#[tokio::test]
+async fn player_death_clears_pending_weapon_action_state() {
+    use std::time::{Duration, Instant};
+
+    let mut mgr = make_mgr_player_vs_npc();
+    // Make entity 2 the attacker (NPC) and entity 1 the target (player).
+    // The fixture sets player at id=1 already; we just give the NPC an
+    // ability so its damage_apply call has effects to resolve.
+    let lethal = make_ability(99, vec![777]);
+    mgr.effect_defs.insert(777, make_effect(777, 9_999));
+    mgr.ability_defs.insert(99, lethal.clone());
+    if let Some(p) = mgr.get_entity_mut(1) {
+        // Pre-stage every pending timer with arbitrary future deadlines
+        // so the post-death assertion is observable.
+        let future = Some(Instant::now() + Duration::from_secs(60));
+        p.pending_reload_at = future;
+        p.reload_complete_at = future;
+        p.reload_slot_id = Some(0);
+        p.pending_attack_at = future;
+        p.pending_attack_ability_id = Some(7);
+        p.pending_attack_target_id = Some(42);
+        p.pending_slot_swap_at = future;
+        p.pending_slot_swap_target = Some(3);
+        p.holster_animation_complete_at = future;
+        p.combat_exit_at = Some(Instant::now());
+        // Set HP to a single point so the test's 9999 damage kills.
+        if let Some(h) = p.stats.get_mut(HEALTH) {
+            h.update(0, 1, 100);
+            h.clear_dirty();
+        }
+    }
+
+    let (tx, _rx) = mpsc::channel(64);
+    // NPC attacker (id=2) hits player target (id=1). The effect chain
+    // delivers 9999 damage, dropping HP from 1 to <0 → target_died = true.
+    apply_damage_to_target(2, 1, 99, &Some(lethal), 0, false, &tx, &mut mgr).await;
+
+    let player = mgr
+        .get_entity(1)
+        .expect("player entity must survive death — same-world respawn reuses it");
+    assert_eq!(
+        player.pending_reload_at, None,
+        "pending_reload_at must clear on death — otherwise the next \
+         pending_reload_tick fires Phase B mid-Defeat-Window, starting \
+         a phantom reload"
+    );
+    assert_eq!(player.reload_complete_at, None);
+    assert_eq!(player.reload_slot_id, None);
+    assert_eq!(
+        player.pending_attack_at, None,
+        "pending_attack_at must clear on death — otherwise \
+         pending_attack_tick re-fires `useAbility` against the cached \
+         target post-respawn, producing a queued shot the player \
+         never asked for"
+    );
+    assert_eq!(player.pending_attack_ability_id, None);
+    assert_eq!(player.pending_attack_target_id, None);
+    assert_eq!(player.pending_slot_swap_at, None);
+    assert_eq!(player.pending_slot_swap_target, None);
+    assert_eq!(player.holster_animation_complete_at, None);
+    assert_eq!(player.combat_exit_at, None);
+}

--- a/crates/services/src/cell/cell_methods/inventory/bandolier.rs
+++ b/crates/services/src/cell/cell_methods/inventory/bandolier.rs
@@ -185,6 +185,25 @@ pub(crate) async fn handle_request_active_slot_change(
         if let Some(e) = space_mgr.get_entity_mut(entity_id) {
             e.pending_slot_swap_at = Some(std::time::Instant::now() + duration);
             e.pending_slot_swap_target = Some(slot_id);
+            // Discard any in-flight reload-Phase-A draw or queued attack
+            // from the OUTGOING weapon. By committing to the swap the
+            // player has abandoned the previous slot — letting the Phase
+            // A tick re-enter `handle_reload` after the swap would refill
+            // the NEW slot (Phase B pins `reload_slot_id` to the
+            // currently-active slot, not the slot reload started on), and
+            // letting `pending_attack_tick` re-fire the queued ability
+            // would consume the NEW slot's ammo with the OLD slot's
+            // ability id (e.g. queued Pistol Shot → swap to Staff →
+            // tick fires Pistol Shot off the Staff's ammo bar).
+            //
+            // `reload_complete_at` / `reload_slot_id` are cancelled below
+            // in the immediate-swap path; we don't touch them here
+            // because Phase B is gated on `pending_reload_at.is_none()`
+            // and stays dormant until the tick fires.
+            e.pending_reload_at = None;
+            e.pending_attack_at = None;
+            e.pending_attack_ability_id = None;
+            e.pending_attack_target_id = None;
         }
         tracing::info!(
             entity_id,
@@ -261,6 +280,20 @@ pub(crate) async fn handle_request_active_slot_change(
                 new_slot = slot_id,
                 "active slot change cancelled in-flight reload"
             );
+        }
+        // Mirror the choreography branch: a real slot change discards
+        // any in-flight reload Phase A draw and queued attack from the
+        // outgoing weapon. Same-slot calls (no-ops / replayed packets)
+        // leave them alone — the player hasn't expressed intent to
+        // change weapons, so the queued action should still resolve.
+        // This branch catches the no-choreography paths (one slot
+        // empty) and the tick re-entry path (which clears
+        // `pending_slot_swap_at` above and falls through to here).
+        if slot_id != prev_slot {
+            entity.pending_reload_at = None;
+            entity.pending_attack_at = None;
+            entity.pending_attack_ability_id = None;
+            entity.pending_attack_target_id = None;
         }
         entity.active_bandolier_slot = slot_id;
         let new_ammo_type = entity

--- a/crates/services/src/cell/cell_methods/inventory/tests/slot_swap.rs
+++ b/crates/services/src/cell/cell_methods/inventory/tests/slot_swap.rs
@@ -325,3 +325,204 @@ async fn slot_swap_cancels_in_flight_reload() {
     // succeeded (slot-swap emits ActiveSlotUpdate and onEntityProperty).
     while rx.try_recv().is_ok() {}
 }
+
+/// A real slot change (slot_id != prev_slot) must discard any pending
+/// queued attack from the outgoing weapon. Otherwise
+/// `pending_attack_tick` re-fires the OLD slot's ability id against
+/// the NEW slot's ammo bar — the player presses fire on Pistol while
+/// holstered, swaps to Staff during the unholster draw window, and
+/// the Phase B tick consumes Staff ammo with Pistol's ability id.
+/// Pin the cancellation: swapping commits to a weapon change, so the
+/// queued attack from the previous weapon must die with it.
+#[tokio::test]
+async fn slot_swap_cancels_pending_attack_queue() {
+    use crate::cell::content::build_engine;
+
+    let mut mgr = make_test_space_mgr();
+    mgr.create_entity(1, "Castle_CellBlock", [0.0; 3], [0.0; 3])
+        .unwrap();
+
+    if let Some(e) = mgr.get_entity_mut(1) {
+        e.is_player = true;
+        e.player_id = Some(100);
+        // Re-entry-from-tick path: pending_slot_swap_at already set so
+        // the choreography branch is skipped and the immediate-swap
+        // path runs. Verifies the cancellation in the post-choreography
+        // branch where the slot actually changes.
+        e.pending_slot_swap_at = Some(std::time::Instant::now());
+        e.bandolier_items.insert(
+            0,
+            BandolierItem {
+                item_id: 10,
+                clip_size: 30,
+                default_ammo_type: 1,
+                current_ammo: 30,
+                cur_ammo_type: 1,
+            },
+        );
+        e.bandolier_items.insert(
+            1,
+            BandolierItem {
+                item_id: 11,
+                clip_size: 12,
+                default_ammo_type: 7,
+                current_ammo: 12,
+                cur_ammo_type: 7,
+            },
+        );
+        e.active_bandolier_slot = 0;
+        // Queued attack from slot 0's weapon — Pistol Shot mid-draw.
+        e.pending_attack_at = Some(std::time::Instant::now() + std::time::Duration::from_secs(10));
+        e.pending_attack_ability_id = Some(5001);
+        e.pending_attack_target_id = Some(200);
+    }
+    mgr.connect_entity(1);
+
+    let (tx, mut rx) = mpsc::channel(64);
+    let engine = build_engine(None).await;
+
+    let mut swap = Vec::with_capacity(8);
+    swap.extend_from_slice(&3i32.to_le_bytes());
+    swap.extend_from_slice(&2i32.to_le_bytes()); // wire slot 2 → server slot 1
+    dispatch(1, REQUEST_ACTIVE_SLOT_CHANGE, &swap, &tx, &mut mgr, &engine).await;
+
+    let entity = mgr.get_entity(1).unwrap();
+    assert!(
+        entity.pending_attack_at.is_none(),
+        "real slot change must clear queued attack deadline"
+    );
+    assert!(
+        entity.pending_attack_ability_id.is_none(),
+        "real slot change must clear queued ability id (otherwise Phase B \
+         tick fires OLD weapon ability against NEW slot ammo)"
+    );
+    assert!(
+        entity.pending_attack_target_id.is_none(),
+        "real slot change must clear queued target id"
+    );
+    assert_eq!(entity.active_bandolier_slot, 1);
+
+    while rx.try_recv().is_ok() {}
+}
+
+/// A real slot change must also discard `pending_reload_at` — the
+/// reload-Phase-A draw deadline. Otherwise the Phase A tick fires
+/// after the swap, falls through to Phase B which pins
+/// `reload_slot_id` to the currently-active slot (slot 1, the new
+/// one), and refills the new weapon's clip from a reload the player
+/// started on the OLD weapon. The player pressed R for Pistol, then
+/// swapped to Staff mid-draw — the reload should die, not redirect.
+#[tokio::test]
+async fn slot_swap_cancels_pending_reload_phase_a() {
+    use crate::cell::content::build_engine;
+
+    let mut mgr = make_test_space_mgr();
+    mgr.create_entity(1, "Castle_CellBlock", [0.0; 3], [0.0; 3])
+        .unwrap();
+
+    if let Some(e) = mgr.get_entity_mut(1) {
+        e.is_player = true;
+        e.player_id = Some(100);
+        // Re-entry path so the immediate swap runs.
+        e.pending_slot_swap_at = Some(std::time::Instant::now());
+        e.bandolier_items.insert(
+            0,
+            BandolierItem {
+                item_id: 10,
+                clip_size: 30,
+                default_ammo_type: 1,
+                current_ammo: 0,
+                cur_ammo_type: 1,
+            },
+        );
+        e.bandolier_items.insert(
+            1,
+            BandolierItem {
+                item_id: 11,
+                clip_size: 12,
+                default_ammo_type: 7,
+                current_ammo: 12,
+                cur_ammo_type: 7,
+            },
+        );
+        e.active_bandolier_slot = 0;
+        // Reload Phase A in flight (drawing the weapon).
+        e.pending_reload_at = Some(std::time::Instant::now() + std::time::Duration::from_secs(1));
+    }
+    mgr.connect_entity(1);
+
+    let (tx, mut rx) = mpsc::channel(64);
+    let engine = build_engine(None).await;
+
+    let mut swap = Vec::with_capacity(8);
+    swap.extend_from_slice(&3i32.to_le_bytes());
+    swap.extend_from_slice(&2i32.to_le_bytes());
+    dispatch(1, REQUEST_ACTIVE_SLOT_CHANGE, &swap, &tx, &mut mgr, &engine).await;
+
+    let entity = mgr.get_entity(1).unwrap();
+    assert!(
+        entity.pending_reload_at.is_none(),
+        "real slot change must clear Phase A draw deadline (otherwise the \
+         tick falls through to Phase B and refills the NEW slot from a \
+         reload started on the OLD slot)"
+    );
+    assert_eq!(entity.active_bandolier_slot, 1);
+
+    while rx.try_recv().is_ok() {}
+}
+
+/// A SAME-slot "swap" (no-op, replayed packet, or wire echo) must
+/// NOT cancel any pending state — the player hasn't expressed
+/// intent to change weapons, so a queued attack from the unholster
+/// draw should still resolve. Mirrors the existing reload-cancel
+/// guard at `slot_id != prev_slot`.
+#[tokio::test]
+async fn same_slot_no_op_preserves_pending_attack_queue() {
+    use crate::cell::content::build_engine;
+
+    let mut mgr = make_test_space_mgr();
+    mgr.create_entity(1, "Castle_CellBlock", [0.0; 3], [0.0; 3])
+        .unwrap();
+
+    let queued_at = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    if let Some(e) = mgr.get_entity_mut(1) {
+        e.is_player = true;
+        e.player_id = Some(100);
+        e.pending_slot_swap_at = Some(std::time::Instant::now());
+        e.bandolier_items.insert(
+            0,
+            BandolierItem {
+                item_id: 10,
+                clip_size: 30,
+                default_ammo_type: 1,
+                current_ammo: 30,
+                cur_ammo_type: 1,
+            },
+        );
+        e.active_bandolier_slot = 0;
+        e.pending_attack_at = Some(queued_at);
+        e.pending_attack_ability_id = Some(5001);
+        e.pending_attack_target_id = Some(200);
+    }
+    mgr.connect_entity(1);
+
+    let (tx, mut rx) = mpsc::channel(64);
+    let engine = build_engine(None).await;
+
+    // Same slot 0 (wire 1) — no-op swap.
+    let mut swap = Vec::with_capacity(8);
+    swap.extend_from_slice(&3i32.to_le_bytes());
+    swap.extend_from_slice(&1i32.to_le_bytes()); // wire slot 1 → server slot 0
+    dispatch(1, REQUEST_ACTIVE_SLOT_CHANGE, &swap, &tx, &mut mgr, &engine).await;
+
+    let entity = mgr.get_entity(1).unwrap();
+    assert_eq!(
+        entity.pending_attack_at,
+        Some(queued_at),
+        "same-slot no-op must preserve queued attack deadline"
+    );
+    assert_eq!(entity.pending_attack_ability_id, Some(5001));
+    assert_eq!(entity.pending_attack_target_id, Some(200));
+
+    while rx.try_recv().is_ok() {}
+}

--- a/crates/services/src/cell/cell_methods/player/combat/respawn.rs
+++ b/crates/services/src/cell/cell_methods/player/combat/respawn.rs
@@ -136,6 +136,27 @@ pub(super) async fn handle_respawn(
     entity.clear_all_state_flags();
     entity.abilities.clear_all_cooldowns();
 
+    // Re-establish the BSF_IN_COMBAT ↔ threatened_mobs invariant. The
+    // state-flag reset above zeroed `state_field` (including
+    // BSF_IN_COMBAT), but `threatened_mobs` is a separate set and
+    // survives same-world respawn unless explicitly cleared. Leaving
+    // it populated means:
+    //   - The HUD says OOC (state_field=0) while
+    //     `threatened_mobs.is_empty()` is false — `needs_unholster_queue`
+    //     skips, `enter_player_combat` no-ops on the next aggro because
+    //     the set is still non-empty, and the OOC holster timer never
+    //     arms (it gates on the set becoming empty via
+    //     `exit_player_combat`).
+    //   - The first real `exit_player_combat` after the bogus mobs
+    //     "die" (or get evicted) drops the set to empty but with
+    //     `state_field & BSF_IN_COMBAT == 0` already, so the
+    //     transition broadcast is suppressed — no harm there, but
+    //     until that drain happens the player is permanently in the
+    //     stuck-drawn-weapon state.
+    // Cross-world respawn destroys + recreates the entity, so the
+    // set is implicitly reset there; same-world has to do it manually.
+    entity.threatened_mobs.clear();
+
     space_mgr.update_entity_position(entity_id, spawn_pos, [0, 0, 0], [0.0; 3]);
 
     // Push the refreshed HEALTH/FOCUS to the HUD via onStatUpdate.

--- a/crates/services/src/cell/cell_methods/player/combat/tests.rs
+++ b/crates/services/src/cell/cell_methods/player/combat/tests.rs
@@ -481,3 +481,41 @@ async fn handle_respawn_same_world_dispatches_list_inventory_after_reanchor() {
          table is sharded by, NOT the entity_id"
     );
 }
+
+/// Same-world respawn must clear `threatened_mobs` so the
+/// `BSF_IN_COMBAT ↔ threatened_mobs.is_empty()` invariant survives.
+/// `clear_all_state_flags` zeroes `state_field` but threatened_mobs
+/// is a separate HashSet; without an explicit clear the player
+/// respawns with stale entries from the mobs that killed them,
+/// leaving the OOC holster timer permanently disarmed (it only
+/// arms when `exit_player_combat` drops the set to empty) and the
+/// `needs_unholster_queue` gate permanently false (it requires
+/// `threatened_mobs.is_empty()`). Cross-world respawn destroys
+/// the entity so the set is implicitly cleared there.
+#[tokio::test]
+async fn handle_respawn_same_world_clears_threatened_mobs() {
+    let mut mgr = make_mgr_with_player("Castle_CellBlock");
+    if let Some(e) = mgr.get_entity_mut(1) {
+        if let Some(h) = e.stats.get_mut(HEALTH) {
+            h.update(0, 1, 100);
+            h.clear_dirty();
+        }
+        // Player died with two mobs aggroed.
+        e.threatened_mobs.insert(50);
+        e.threatened_mobs.insert(51);
+    }
+
+    let (tx, _rx) = mpsc::channel(16);
+    handle_respawn(1, -1, &tx, &mut mgr).await;
+
+    let entity = mgr
+        .get_entity(1)
+        .expect("cell entity survives same-world respawn");
+    assert!(
+        entity.threatened_mobs.is_empty(),
+        "same-world respawn must clear threatened_mobs so the invariant \
+         `BSF_IN_COMBAT ↔ !threatened_mobs.is_empty()` holds — leaving stale \
+         entries makes the OOC holster timer never arm and breaks \
+         `needs_unholster_queue`"
+    );
+}

--- a/crates/services/src/cell/cell_methods/player/world/mod.rs
+++ b/crates/services/src/cell/cell_methods/player/world/mod.rs
@@ -601,13 +601,10 @@ pub(crate) async fn handle_reload(
     // would still elapse mid-reload, flip `weapon_holstered = true`,
     // and broadcast `BeingAppearance` with no weapon attached. The
     // user would see the reload animation play then the weapon
-    // mesh vanish on the next AoI tick. Phase A already does this
-    // clear (line 554 above); Phase B was missing it. The bug
-    // shape: player kills last threat, drains clip without
-    // auto-reload (option off), watches OOC holster Phase 1 fire
-    // (`Item_Unequip` animation), then manually presses R during
-    // the ~half-second animation window — reload plays, weapon
-    // vanishes after.
+    // mesh vanish on the next AoI tick. The Phase A block above
+    // performs the same clear at its `set_weapon_holstered(false)`
+    // call; mirror that here so Phase B reloads against an
+    // already-drawn weapon also cancel the pending holster.
     if let Some(e) = space_mgr.get_entity_mut(entity_id) {
         e.pending_reload_at = None;
         e.holster_animation_complete_at = None;

--- a/crates/services/src/cell/cell_methods/player/world/mod.rs
+++ b/crates/services/src/cell/cell_methods/player/world/mod.rs
@@ -594,8 +594,23 @@ pub(crate) async fn handle_reload(
     // Phase B (or a normal already-drawn reload). When entered from the
     // `pending_reload_tick`, clear the deferred-reload stamp so a
     // racing tick won't re-fire phase B.
+    //
+    // Also cancel any in-flight OOC holster Phase 2
+    // (`holster_animation_complete_at`). Reload semantics imply the
+    // weapon stays drawn — without this clear, the Phase 2 deadline
+    // would still elapse mid-reload, flip `weapon_holstered = true`,
+    // and broadcast `BeingAppearance` with no weapon attached. The
+    // user would see the reload animation play then the weapon
+    // mesh vanish on the next AoI tick. Phase A already does this
+    // clear (line 554 above); Phase B was missing it. The bug
+    // shape: player kills last threat, drains clip without
+    // auto-reload (option off), watches OOC holster Phase 1 fire
+    // (`Item_Unequip` animation), then manually presses R during
+    // the ~half-second animation window — reload plays, weapon
+    // vanishes after.
     if let Some(e) = space_mgr.get_entity_mut(entity_id) {
         e.pending_reload_at = None;
+        e.holster_animation_complete_at = None;
     }
 
     let entity = match space_mgr.get_entity_mut(entity_id) {

--- a/crates/services/src/cell/cell_methods/player/world/tests.rs
+++ b/crates/services/src/cell/cell_methods/player/world/tests.rs
@@ -1171,3 +1171,84 @@ async fn set_auto_cycle_immediate_fire_credits_quest_kill_on_tagged_npc_death() 
         "test fixture: target must be dead after the lethal immediate fire",
     );
 }
+
+/// `handle_reload` Phase B must cancel any in-flight OOC holster
+/// Phase 2 (`holster_animation_complete_at`). Reload semantics imply
+/// "the weapon stays drawn"; without this cancel, the Phase 2
+/// deadline still elapses mid-reload and broadcasts a fresh
+/// `BeingAppearance` with no weapon attached. The user sees the
+/// reload animation play, then the weapon mesh vanishes on the
+/// next AoI tick.
+///
+/// Bug shape: player drains clip with `autoReload = false`,
+/// watches OOC holster Phase 1 fire (`Item_Unequip` animation),
+/// then manually presses R during the ~half-second animation
+/// window before Phase 2 elapses. Pre-fix Phase B was missing the
+/// `holster_animation_complete_at = None` clear that Phase A
+/// already had (line 554), so the holster timer kept running.
+///
+/// Pin: stage `holster_animation_complete_at = Some(future)`,
+/// drain the clip, call `handle_reload` with the weapon drawn
+/// (forcing the Phase B path), assert the field is `None`
+/// afterward AND a fresh reload deadline is armed.
+#[tokio::test]
+async fn handle_reload_phase_b_cancels_in_flight_holster_phase_2() {
+    use std::time::{Duration, Instant};
+
+    let mut mgr = make_mgr_with_player();
+    if let Some(e) = mgr.get_entity_mut(1) {
+        // Weapon drawn — forces Phase B (drawn-reload) path, not
+        // Phase A (reload-while-holstered).
+        e.weapon_holstered = false;
+        e.bandolier_items.insert(
+            0,
+            BandolierItem {
+                item_id: 1,
+                clip_size: 30,
+                default_ammo_type: 2,
+                current_ammo: 0, // empty → reload will arm
+                cur_ammo_type: 2,
+            },
+        );
+        e.active_bandolier_slot = 0;
+        // Stage the in-flight Phase 2 holster — Phase 1 fired
+        // moments ago, animation is playing, mesh-drop deadline is
+        // ~half a second out.
+        e.holster_animation_complete_at = Some(Instant::now() + Duration::from_millis(500));
+    }
+    mgr.ability_defs.insert(
+        596,
+        AbilityDef {
+            ability_id: 596,
+            name: "reload".to_string(),
+            cooldown: 1.0,
+            warmup: 0.5,
+            flags: 0,
+            is_ranged: false,
+            min_range: 0,
+            max_range: 0,
+            target_type_id: 0,
+            effect_ids: vec![],
+            moniker_ids: vec![],
+            required_ammo: 0,
+            event_set_id: None,
+            velocity: 0.0,
+        },
+    );
+
+    let (tx, _rx) = mpsc::channel(16);
+    handle_reload(1, &tx, &mut mgr).await;
+
+    let e = mgr.get_entity(1).unwrap();
+    assert!(
+        e.holster_animation_complete_at.is_none(),
+        "Phase B must clear holster_animation_complete_at — reload \
+         semantics imply weapon stays drawn. Pre-fix, Phase 2 would \
+         still elapse mid-reload and drop the weapon mesh."
+    );
+    assert!(
+        e.reload_complete_at.is_some(),
+        "fixture sanity: Phase B must arm reload_complete_at — if this \
+         fails, the test isn't exercising the Phase B branch"
+    );
+}

--- a/crates/services/src/cell/service/base_messages/player_init.rs
+++ b/crates/services/src/cell/service/base_messages/player_init.rs
@@ -174,6 +174,48 @@ pub(in crate::cell::service) async fn handle_init_player_state(
         }
     }
 
+    // Honour the `reloadOnActivate` client option on the world-entry
+    // path. `handle_init_player_state` is the cell-side hydrate site
+    // for every fresh-pawn entry: initial login, cross-world gate
+    // travel (RESET_ENTITIES → ENABLE_ENTITIES → CREATE_BASE_PLAYER →
+    // mapLoaded → onClientReady all the way down), and cross-world
+    // ring transport (which lands on gate-travel internally). In
+    // every one of those flows the client just instantiated a fresh
+    // pawn actor and is, from the player's perspective, "activating"
+    // the weapon in the active bandolier slot — exactly the
+    // semantics `SystemOptions.xml` ascribes to
+    // `reloadOnActivate` ("Reloads weapon when activated").
+    //
+    // Pre-#394 this was uncovered because the only trigger sites
+    // were F1-F4 slot swap (`cell_methods/inventory/bandolier.rs`)
+    // and in-game equip from inventory (`service/base_messages/
+    // bandolier.rs`). A player with the option enabled who logged
+    // in or gated to a new world with a partial-clip active weapon
+    // would silently NOT auto-reload until they manually swapped
+    // slots and back.
+    //
+    // Same-world respawn (`cell_methods/player/combat/respawn.rs`)
+    // is deliberately NOT a trigger site: the weapon was never
+    // deactivated on the cell side (`ReanchorPlayer` rebuilds the
+    // client-side pawn but keeps the cell entity intact), so the
+    // option's "activated" condition isn't met. Player
+    // expectations there are handled by the natural respawn-restore
+    // (health/focus to max) — clip state is intentionally NOT
+    // refilled to preserve the "you lost momentum when you died"
+    // tension.
+    //
+    // The helper bails internally on:
+    //   - option off (default),
+    //   - non-player entities (NPCs don't read system options),
+    //   - active_clip_size == 0 (melee / non-clip weapons),
+    //   - clip already full,
+    //   - in-flight reload already pending.
+    // So the unconditional call here is safe.
+    crate::cell::cell_methods::player::world::maybe_trigger_reload_on_activate(
+        entity_id, tx, space_mgr,
+    )
+    .await;
+
     content::fire_player_loaded(entity_id, player_id, &world_name, engine, tx, space_mgr).await;
 }
 
@@ -240,6 +282,207 @@ mod system_options_assignment_tests {
             e.system_options, hydrated,
             "InitPlayerState must overwrite the entity's default \
              SystemOptions with the DB-hydrated values",
+        );
+    }
+
+    /// Stage an InitPlayerState payload with one bandolier item in
+    /// slot 0 (clip 30) and the given `current_ammo` (so 30 = full,
+    /// 10 = partial, 30 = no-op for the reload check). Stamps the
+    /// caller-chosen `system_options` so each test exercises the
+    /// gate path it intends. Returns the tuple bound to
+    /// `handle_init_player_state`'s positional args.
+    fn init_args_with_bandolier_clip(
+        current_ammo: i32,
+        system_options: SystemOptions,
+    ) -> (
+        i32,
+        Vec<i32>,
+        i32,
+        Vec<(i32, cimmeria_entity::cell_entity::BandolierItem)>,
+        SystemOptions,
+    ) {
+        (
+            1,      // archetype_id
+            vec![], // no abilities
+            0,      // active_bandolier_slot
+            vec![(
+                0,
+                cimmeria_entity::cell_entity::BandolierItem {
+                    item_id: 55,
+                    clip_size: 30,
+                    default_ammo_type: 1,
+                    current_ammo,
+                    cur_ammo_type: 1,
+                },
+            )],
+            system_options,
+        )
+    }
+
+    /// World entry with `reloadOnActivate = true` AND a partial-clip
+    /// active bandolier weapon must trigger an automatic reload, the
+    /// same as F1-F4 swap or in-game equip. Without this hook a
+    /// player who logs in, gate-travels, or cross-world rings to a
+    /// new map with a half-empty active weapon silently doesn't
+    /// auto-reload until they manually swap slots and back —
+    /// surfacing in play as "my option does nothing on login."
+    ///
+    /// Setup: 10/30 active clip + `reload_on_activate = true`.
+    /// Assertion: `reload_complete_at` is `Some` post-handler. The
+    /// Phase A draw guard (weapon holstered + threatened_mobs empty)
+    /// is bypassed because `weapon_holstered` defaults to `false`
+    /// on a freshly-restored entity in this test fixture; in
+    /// production the same `handle_reload` path would walk through
+    /// Phase A naturally if the weapon were holstered.
+    #[tokio::test]
+    async fn init_player_state_triggers_reload_on_activate_when_clip_partial() {
+        let mut mgr = make_mgr();
+        // Need the ABILITY_RELOAD_WEAPON def for `handle_reload` to
+        // resolve warmup/cooldown — otherwise it falls back to its
+        // hardcoded 2.0/1.0 defaults and the reload still fires.
+        mgr.ability_defs.insert(
+            596 /* ABILITY_RELOAD_WEAPON — mirrors the const in cell_methods/player/world */,
+            cimmeria_entity::abilities::AbilityDef {
+                ability_id: 596 /* ABILITY_RELOAD_WEAPON — mirrors the const in cell_methods/player/world */,
+                is_ranged: false,
+                min_range: 0,
+                name: "Reload".into(),
+                warmup: 1.0,
+                cooldown: 0.5,
+                flags: 0,
+                max_range: 0,
+                target_type_id: 0,
+                effect_ids: vec![],
+                moniker_ids: vec![],
+                required_ammo: 0,
+                event_set_id: None,
+                velocity: 0.0,
+            },
+        );
+        // Pre-mark the weapon as drawn so the Phase A draw window
+        // doesn't apply. This isolates the test to the
+        // reload-on-activate trigger; Phase A is exercised by the
+        // `handle_reload` tests in `cell_methods/player/world`.
+        if let Some(p) = mgr.get_entity_mut(1) {
+            p.weapon_holstered = false;
+        }
+        let engine = ChainEngine::new();
+        let (tx, _rx) = mpsc::channel(32);
+
+        let (archetype, abilities, slot, items, sys_opts) = init_args_with_bandolier_clip(
+            10,
+            SystemOptions {
+                auto_reload: true,
+                reload_on_activate: true,
+            },
+        );
+
+        handle_init_player_state(
+            1,
+            100,
+            "Castle_CellBlock".into(),
+            archetype,
+            vec![], // saved_missions
+            abilities,
+            slot,
+            items,
+            sys_opts,
+            &tx,
+            &mut mgr,
+            &engine,
+        )
+        .await;
+
+        let e = mgr.get_entity(1).unwrap();
+        assert!(
+            e.reload_complete_at.is_some(),
+            "InitPlayerState with reload_on_activate=true + partial clip \
+             must trigger handle_reload (gate-travel / login coverage). \
+             Pre-fix the only triggers were F1-F4 swap and inventory \
+             equip — login silently no-op'd."
+        );
+    }
+
+    /// Symmetric negative: option DEFAULT (`reload_on_activate = false`)
+    /// must NOT trigger on login, even with a partial clip. The XML
+    /// default is off — players who never touched the checkbox
+    /// shouldn't get behavior change.
+    #[tokio::test]
+    async fn init_player_state_does_not_reload_when_option_off() {
+        let mut mgr = make_mgr();
+        let engine = ChainEngine::new();
+        let (tx, _rx) = mpsc::channel(32);
+
+        let (archetype, abilities, slot, items, sys_opts) = init_args_with_bandolier_clip(
+            10, // partial clip
+            SystemOptions {
+                auto_reload: true,
+                reload_on_activate: false, // XML default
+            },
+        );
+
+        handle_init_player_state(
+            1,
+            100,
+            "Castle_CellBlock".into(),
+            archetype,
+            vec![],
+            abilities,
+            slot,
+            items,
+            sys_opts,
+            &tx,
+            &mut mgr,
+            &engine,
+        )
+        .await;
+
+        let e = mgr.get_entity(1).unwrap();
+        assert!(
+            e.reload_complete_at.is_none() && e.pending_reload_at.is_none(),
+            "InitPlayerState with option off must NOT trigger any reload"
+        );
+    }
+
+    /// Symmetric negative #2: full clip on login + option on → no-op.
+    /// `maybe_trigger_reload_on_activate` has a `active_ammo() <
+    /// active_clip_size()` gate; this guard pins that gate at the
+    /// handler boundary so a future refactor that removes it (e.g.
+    /// to "always reload on activate") would trip here.
+    #[tokio::test]
+    async fn init_player_state_does_not_reload_when_clip_full() {
+        let mut mgr = make_mgr();
+        let engine = ChainEngine::new();
+        let (tx, _rx) = mpsc::channel(32);
+
+        let (archetype, abilities, slot, items, sys_opts) = init_args_with_bandolier_clip(
+            30, // already full
+            SystemOptions {
+                auto_reload: true,
+                reload_on_activate: true,
+            },
+        );
+
+        handle_init_player_state(
+            1,
+            100,
+            "Castle_CellBlock".into(),
+            archetype,
+            vec![],
+            abilities,
+            slot,
+            items,
+            sys_opts,
+            &tx,
+            &mut mgr,
+            &engine,
+        )
+        .await;
+
+        let e = mgr.get_entity(1).unwrap();
+        assert!(
+            e.reload_complete_at.is_none() && e.pending_reload_at.is_none(),
+            "full-clip InitPlayerState must NOT queue a reload"
         );
     }
 

--- a/crates/services/src/cell/service/base_messages/player_init.rs
+++ b/crates/services/src/cell/service/base_messages/player_init.rs
@@ -174,43 +174,13 @@ pub(in crate::cell::service) async fn handle_init_player_state(
         }
     }
 
-    // Honour the `reloadOnActivate` client option on the world-entry
-    // path. `handle_init_player_state` is the cell-side hydrate site
-    // for every fresh-pawn entry: initial login, cross-world gate
-    // travel (RESET_ENTITIES → ENABLE_ENTITIES → CREATE_BASE_PLAYER →
-    // mapLoaded → onClientReady all the way down), and cross-world
-    // ring transport (which lands on gate-travel internally). In
-    // every one of those flows the client just instantiated a fresh
-    // pawn actor and is, from the player's perspective, "activating"
-    // the weapon in the active bandolier slot — exactly the
-    // semantics `SystemOptions.xml` ascribes to
-    // `reloadOnActivate` ("Reloads weapon when activated").
-    //
-    // Pre-#394 this was uncovered because the only trigger sites
-    // were F1-F4 slot swap (`cell_methods/inventory/bandolier.rs`)
-    // and in-game equip from inventory (`service/base_messages/
-    // bandolier.rs`). A player with the option enabled who logged
-    // in or gated to a new world with a partial-clip active weapon
-    // would silently NOT auto-reload until they manually swapped
-    // slots and back.
-    //
-    // Same-world respawn (`cell_methods/player/combat/respawn.rs`)
-    // is deliberately NOT a trigger site: the weapon was never
-    // deactivated on the cell side (`ReanchorPlayer` rebuilds the
-    // client-side pawn but keeps the cell entity intact), so the
-    // option's "activated" condition isn't met. Player
-    // expectations there are handled by the natural respawn-restore
-    // (health/focus to max) — clip state is intentionally NOT
-    // refilled to preserve the "you lost momentum when you died"
-    // tension.
-    //
-    // The helper bails internally on:
-    //   - option off (default),
-    //   - non-player entities (NPCs don't read system options),
-    //   - active_clip_size == 0 (melee / non-clip weapons),
-    //   - clip already full,
-    //   - in-flight reload already pending.
-    // So the unconditional call here is safe.
+    // `reloadOnActivate` activation site for the world-entry path
+    // (initial login, gate travel, cross-world ring). Same-world
+    // respawn is deliberately NOT a trigger site — `ReanchorPlayer`
+    // keeps the cell entity intact, so the weapon is never
+    // "activated" in the sense `SystemOptions.xml` defines. Helper
+    // self-gates on option-off, non-player, melee, full clip, and
+    // in-flight reload, so the unconditional call is safe.
     crate::cell::cell_methods::player::world::maybe_trigger_reload_on_activate(
         entity_id, tx, space_mgr,
     )
@@ -400,6 +370,92 @@ mod system_options_assignment_tests {
              must trigger handle_reload (gate-travel / login coverage). \
              Pre-fix the only triggers were F1-F4 swap and inventory \
              equip — login silently no-op'd."
+        );
+    }
+
+    /// Default-holstered world-entry path: the real production fixture
+    /// for login / gate-travel / cross-world ring has
+    /// `weapon_holstered = true` (the `CellEntity::new` default — the
+    /// pawn is freshly instantiated and starts with no weapon drawn).
+    /// The drawn-weapon test above isolates the trigger logic from
+    /// Phase A draw choreography; this companion guard pins that the
+    /// holstered-weapon path also queues a reload. Bug shape: a
+    /// future refactor that adds a `weapon_holstered` short-circuit to
+    /// `maybe_trigger_reload_on_activate` would silently break every
+    /// real login.
+    ///
+    /// Assertion: `pending_reload_at` is `Some` (Phase A draw deadline)
+    /// post-handler. Phase A is the correct entry path because the
+    /// weapon is still holstered and OOC — `handle_reload` defers the
+    /// real reload until the draw animation has played.
+    #[tokio::test]
+    async fn init_player_state_triggers_reload_on_activate_when_holstered() {
+        let mut mgr = make_mgr();
+        mgr.ability_defs.insert(
+            596,
+            cimmeria_entity::abilities::AbilityDef {
+                ability_id: 596,
+                is_ranged: false,
+                min_range: 0,
+                name: "Reload".into(),
+                warmup: 1.0,
+                cooldown: 0.5,
+                flags: 0,
+                max_range: 0,
+                target_type_id: 0,
+                effect_ids: vec![],
+                moniker_ids: vec![],
+                required_ammo: 0,
+                event_set_id: None,
+                velocity: 0.0,
+            },
+        );
+        // Sanity: the fixture starts with the production default
+        // (holstered=true). Pin it so a future fixture change can't
+        // silently relax this test into a no-op.
+        assert!(
+            mgr.get_entity(1).unwrap().weapon_holstered,
+            "fixture sanity: CellEntity::new defaults weapon_holstered=true"
+        );
+        let engine = ChainEngine::new();
+        let (tx, _rx) = mpsc::channel(32);
+
+        let (archetype, abilities, slot, items, sys_opts) = init_args_with_bandolier_clip(
+            10,
+            SystemOptions {
+                auto_reload: true,
+                reload_on_activate: true,
+            },
+        );
+
+        handle_init_player_state(
+            1,
+            100,
+            "Castle_CellBlock".into(),
+            archetype,
+            vec![],
+            abilities,
+            slot,
+            items,
+            sys_opts,
+            &tx,
+            &mut mgr,
+            &engine,
+        )
+        .await;
+
+        let e = mgr.get_entity(1).unwrap();
+        assert!(
+            e.pending_reload_at.is_some(),
+            "holstered world-entry with reload_on_activate=true + partial clip \
+             must queue Phase A (the draw window); pre-fix only the slot-swap \
+             trigger path covered this and login was silent"
+        );
+        assert!(
+            !e.weapon_holstered,
+            "Phase A entry must flip weapon_holstered=false so the draw \
+             animation plays — without the flip the client renders the \
+             reload with the weapon still holstered"
         );
     }
 

--- a/crates/services/src/cell/service/npc_ai.rs
+++ b/crates/services/src/cell/service/npc_ai.rs
@@ -114,35 +114,16 @@ async fn npc_ai_idle_auto_aggro(
             player_id,
             "NPC AI: aggression-driven auto-aggro on opposing-faction player"
         );
-        // Two paths for the `Some(new_state)` return value:
-        //
-        // - **`onStateFieldUpdate` (`BSF_IN_COMBAT`)** — intentionally
-        //   suppressed. The auto-aggro tick can fire before the player
-        //   has any reason to know they've been spotted (NPC walked
-        //   into AoI from off-camera); lighting up the combat HUD
-        //   here surfaces as a "ghost combat" UX bug. The next
-        //   explicit hit (player fires back, NPC retaliates) goes
-        //   through `damage_apply::apply_damage_to_target →
-        //   generate_threat → enter_player_combat`, which broadcasts
-        //   `onStateFieldUpdate` from the damage path with the
-        //   player visibly engaged.
-        //
-        // - **`BeingAppearance` (weapon-mesh refresh)** — REQUIRED.
-        //   `enter_player_combat` flips `weapon_holstered` to false
-        //   when the player enters combat from holstered. Without
-        //   broadcasting the appearance here, the client retains its
-        //   cached "holstered" `ComponentList` (last set by the OOC
-        //   holster's Phase 2 appearance broadcast) while the server
-        //   thinks the weapon is drawn. Next fire passes the
-        //   `needs_unholster_queue` gate (server-side
-        //   `weapon_holstered=false`), so no draw queue runs — the
-        //   client renders the fire animation with NO weapon mesh
-        //   attached. Slot-swap recovers because slot-swap broadcasts
-        //   a fresh `BeingAppearance`. Specifically reported from a
-        //   play session post-auto-reload + OOC holster, where the
-        //   sequence is: kill → auto-reload → OOC → Phase 1 +
-        //   Phase 2 holster → new NPC auto-aggros → player fires →
-        //   "hands in combat position but no weapon."
+        // Invariant: when `enter_player_combat` flips `weapon_holstered`
+        // to false on first-add, the client's cached `ComponentList`
+        // must be refreshed — otherwise the fire path passes the
+        // `needs_unholster_queue` gate (server thinks drawn) while
+        // the client still renders the holstered mesh. The
+        // `onStateFieldUpdate` half is intentionally suppressed here
+        // (auto-aggro can fire before the player has any visible
+        // reason to know — lighting up `BSF_IN_COMBAT` is the "ghost
+        // combat HUD" carve-out); the damage path broadcasts it on
+        // the next explicit hit.
         if combat::generate_threat(space_mgr, player_id, npc_id, 1.0).is_some() {
             super::super::abilities::request_appearance_refresh(player_id, tx, space_mgr).await;
         }

--- a/crates/services/src/cell/service/npc_ai.rs
+++ b/crates/services/src/cell/service/npc_ai.rs
@@ -57,7 +57,7 @@ pub(super) async fn npc_ai_tick(tx: &mpsc::Sender<CellToBaseMsg>, space_mgr: &mu
                 npc_ai_leash(npc_id, tx, space_mgr).await;
             }
             AiState::Idle => {
-                npc_ai_idle_auto_aggro(npc_id, space_mgr);
+                npc_ai_idle_auto_aggro(npc_id, tx, space_mgr).await;
             }
             _ => {}
         }
@@ -74,7 +74,11 @@ pub(super) async fn npc_ai_tick(tx: &mpsc::Sender<CellToBaseMsg>, space_mgr: &mu
 /// dominates and focuses the NPC on the triggering player rather than
 /// whichever player happens to be closest. Caller (`npc_ai_tick`)
 /// guarantees `aggression > 0`.
-fn npc_ai_idle_auto_aggro(npc_id: u32, space_mgr: &mut SpaceManager) {
+async fn npc_ai_idle_auto_aggro(
+    npc_id: u32,
+    tx: &mpsc::Sender<CellToBaseMsg>,
+    space_mgr: &mut SpaceManager,
+) {
     use super::super::combat;
 
     let (npc_pos, npc_faction) = match space_mgr.get_entity(npc_id) {
@@ -110,14 +114,38 @@ fn npc_ai_idle_auto_aggro(npc_id: u32, space_mgr: &mut SpaceManager) {
             player_id,
             "NPC AI: aggression-driven auto-aggro on opposing-faction player"
         );
-        // Discard the optional new-state — the auto-aggro path doesn't
-        // broadcast `onStateFieldUpdate` to the player here. The next
-        // explicit hit (player fires back, NPC retaliates, etc.) will go
-        // through the normal generate_threat → enter_player_combat path
-        // which does the BSF_IN_COMBAT broadcast. Doing it here would
-        // light up the combat HUD before the player has any reason to
-        // know they've been seen — surfacing as a "ghost combat" UX bug.
-        let _ = combat::generate_threat(space_mgr, player_id, npc_id, 1.0);
+        // Two paths for the `Some(new_state)` return value:
+        //
+        // - **`onStateFieldUpdate` (`BSF_IN_COMBAT`)** — intentionally
+        //   suppressed. The auto-aggro tick can fire before the player
+        //   has any reason to know they've been spotted (NPC walked
+        //   into AoI from off-camera); lighting up the combat HUD
+        //   here surfaces as a "ghost combat" UX bug. The next
+        //   explicit hit (player fires back, NPC retaliates) goes
+        //   through `damage_apply::apply_damage_to_target →
+        //   generate_threat → enter_player_combat`, which broadcasts
+        //   `onStateFieldUpdate` from the damage path with the
+        //   player visibly engaged.
+        //
+        // - **`BeingAppearance` (weapon-mesh refresh)** — REQUIRED.
+        //   `enter_player_combat` flips `weapon_holstered` to false
+        //   when the player enters combat from holstered. Without
+        //   broadcasting the appearance here, the client retains its
+        //   cached "holstered" `ComponentList` (last set by the OOC
+        //   holster's Phase 2 appearance broadcast) while the server
+        //   thinks the weapon is drawn. Next fire passes the
+        //   `needs_unholster_queue` gate (server-side
+        //   `weapon_holstered=false`), so no draw queue runs — the
+        //   client renders the fire animation with NO weapon mesh
+        //   attached. Slot-swap recovers because slot-swap broadcasts
+        //   a fresh `BeingAppearance`. Specifically reported from a
+        //   play session post-auto-reload + OOC holster, where the
+        //   sequence is: kill → auto-reload → OOC → Phase 1 +
+        //   Phase 2 holster → new NPC auto-aggros → player fires →
+        //   "hands in combat position but no weapon."
+        if combat::generate_threat(space_mgr, player_id, npc_id, 1.0).is_some() {
+            super::super::abilities::request_appearance_refresh(player_id, tx, space_mgr).await;
+        }
     }
 }
 

--- a/crates/services/src/cell/service/tests/mod.rs
+++ b/crates/services/src/cell/service/tests/mod.rs
@@ -17,6 +17,7 @@ use crate::cell::space_manager::SpaceManager;
 
 mod bandolier;
 mod npc_ai;
+mod npc_ai_auto_aggro;
 mod regen;
 mod reload;
 

--- a/crates/services/src/cell/service/tests/npc_ai.rs
+++ b/crates/services/src/cell/service/tests/npc_ai.rs
@@ -422,7 +422,11 @@ async fn npc_ai_leash_emits_stat_update_then_state_field_to_witnesses() {
 /// faction / aggression as needed. The NPC's default ability bucket is
 /// left intact (Pistol Shot 592) so the fight path doesn't wedge on an
 /// empty selector.
-fn make_aggression_fixture(
+///
+/// Visibility is `pub(super)` so the sibling `npc_ai_auto_aggro`
+/// module (split out when this file crossed the 700-line cap) can
+/// reuse the same setup.
+pub(super) fn make_aggression_fixture(
     npc_id: u32,
     npc_faction: u8,
     player_id: u32,
@@ -1179,102 +1183,5 @@ async fn npc_ai_fight_stationary_does_not_back_off_inside_min_range() {
     );
 }
 
-/// Auto-aggro on a holstered player must broadcast a
-/// `RefreshAppearance` so the client's `BeingAppearance` cache picks
-/// up the server-side `weapon_holstered = false` flip from
-/// `enter_player_combat`. Without this broadcast, server-state and
-/// client-state desync: server thinks weapon is drawn, client still
-/// shows holstered. The next fire passes
-/// `needs_unholster_queue`'s `weapon_holstered=true` gate (because
-/// the server says drawn), so the draw queue never runs — client
-/// renders the fire animation with no weapon mesh attached.
-///
-/// Play-session symptom: post-auto-reload + OOC holster, the
-/// player attacks a freshly-aggroed NPC and sees "hands in combat
-/// pose but no weapon." Slot-swap recovers because slot-swap
-/// broadcasts a fresh appearance. The fix here is the
-/// broadcast-on-auto-aggro path in `npc_ai_idle_auto_aggro` —
-/// `generate_threat` returning `Some(state)` MUST be followed by
-/// `request_appearance_refresh` even though the design intent is
-/// to skip the `onStateFieldUpdate` (the "ghost combat HUD" carve-
-/// out the comment names).
-///
-/// Assertion shape: the cell→base channel sees exactly one
-/// `RefreshAppearance` message addressed at the player. The
-/// `onStateFieldUpdate` is intentionally NOT sent (covered by the
-/// negative assertion at the end).
-#[tokio::test]
-async fn auto_aggro_broadcasts_appearance_refresh_on_holstered_player() {
-    use crate::cell::messages::CellToBaseMsg;
-
-    let mut mgr = make_aggression_fixture(200_010, 10, 1, [5.0, 0.0, 0.0]);
-    if let Some(npc) = mgr.get_entity_mut(200_010) {
-        npc.aggression = 1;
-    }
-    // Pre-stage: player is holstered (post-OOC). The bug shape is
-    // specifically "weapon_holstered flips false server-side
-    // without telling the client" — to observe it, weapon must be
-    // holstered going in so the flip is observable.
-    if let Some(p) = mgr.get_entity_mut(1) {
-        p.weapon_holstered = true;
-    }
-
-    let (tx, mut rx) = mpsc::channel(16);
-    crate::cell::service::npc_ai::npc_ai_tick(&tx, &mut mgr).await;
-
-    // Drain the cell→base channel and count appearance refresh +
-    // state-field-update messages.
-    let mut saw_refresh = false;
-    let mut saw_state_field_update_for_player = false;
-    while let Ok(msg) = rx.try_recv() {
-        match msg {
-            CellToBaseMsg::RefreshAppearance {
-                entity_id: 1,
-                holstered,
-                ..
-            } => {
-                saw_refresh = true;
-                assert!(
-                    !holstered,
-                    "RefreshAppearance payload must carry holstered=false (drawn) — \
-                     enter_player_combat flipped the field to false; the broadcast \
-                     must mirror the server-side value"
-                );
-            }
-            CellToBaseMsg::EntityMethodCall {
-                entity_id: 1,
-                method_index,
-                ..
-            } if method_index == crate::mercury::method_idx::ON_STATE_FIELD_UPDATE => {
-                saw_state_field_update_for_player = true;
-            }
-            _ => {}
-        }
-    }
-
-    assert!(
-        saw_refresh,
-        "auto-aggro on holstered player must broadcast RefreshAppearance \
-         — pre-fix the auto-aggro path discarded `generate_threat`'s \
-         Some(state) return and the client's weapon-mesh cache stayed \
-         desynced, producing the play-session 'no weapon mesh on fire' bug"
-    );
-    assert!(
-        !saw_state_field_update_for_player,
-        "auto-aggro MUST NOT broadcast onStateFieldUpdate to the player — \
-         the design carve-out prevents 'ghost combat HUD' (HUD lights up \
-         before the player has any reason to know they've been seen). The \
-         appearance refresh covers the weapon-mesh sync; the state field \
-         waits for an explicit hit"
-    );
-
-    // Sanity: the cell-side state did flip. If this fails, the
-    // assertion above passed for the wrong reason.
-    let player = mgr.get_entity(1).unwrap();
-    assert!(
-        !player.weapon_holstered,
-        "enter_player_combat must flip weapon_holstered=false on first-add \
-         transition — broadcast or not, the server-side state is the \
-         source of truth for subsequent fire-path gating"
-    );
-}
+// Auto-aggro broadcast tests moved to the sibling `npc_ai_auto_aggro`
+// module (this file crossed the 700-line cap).

--- a/crates/services/src/cell/service/tests/npc_ai.rs
+++ b/crates/services/src/cell/service/tests/npc_ai.rs
@@ -1178,3 +1178,103 @@ async fn npc_ai_fight_stationary_does_not_back_off_inside_min_range() {
         npc.nav_path
     );
 }
+
+/// Auto-aggro on a holstered player must broadcast a
+/// `RefreshAppearance` so the client's `BeingAppearance` cache picks
+/// up the server-side `weapon_holstered = false` flip from
+/// `enter_player_combat`. Without this broadcast, server-state and
+/// client-state desync: server thinks weapon is drawn, client still
+/// shows holstered. The next fire passes
+/// `needs_unholster_queue`'s `weapon_holstered=true` gate (because
+/// the server says drawn), so the draw queue never runs — client
+/// renders the fire animation with no weapon mesh attached.
+///
+/// Play-session symptom: post-auto-reload + OOC holster, the
+/// player attacks a freshly-aggroed NPC and sees "hands in combat
+/// pose but no weapon." Slot-swap recovers because slot-swap
+/// broadcasts a fresh appearance. The fix here is the
+/// broadcast-on-auto-aggro path in `npc_ai_idle_auto_aggro` —
+/// `generate_threat` returning `Some(state)` MUST be followed by
+/// `request_appearance_refresh` even though the design intent is
+/// to skip the `onStateFieldUpdate` (the "ghost combat HUD" carve-
+/// out the comment names).
+///
+/// Assertion shape: the cell→base channel sees exactly one
+/// `RefreshAppearance` message addressed at the player. The
+/// `onStateFieldUpdate` is intentionally NOT sent (covered by the
+/// negative assertion at the end).
+#[tokio::test]
+async fn auto_aggro_broadcasts_appearance_refresh_on_holstered_player() {
+    use crate::cell::messages::CellToBaseMsg;
+
+    let mut mgr = make_aggression_fixture(200_010, 10, 1, [5.0, 0.0, 0.0]);
+    if let Some(npc) = mgr.get_entity_mut(200_010) {
+        npc.aggression = 1;
+    }
+    // Pre-stage: player is holstered (post-OOC). The bug shape is
+    // specifically "weapon_holstered flips false server-side
+    // without telling the client" — to observe it, weapon must be
+    // holstered going in so the flip is observable.
+    if let Some(p) = mgr.get_entity_mut(1) {
+        p.weapon_holstered = true;
+    }
+
+    let (tx, mut rx) = mpsc::channel(16);
+    crate::cell::service::npc_ai::npc_ai_tick(&tx, &mut mgr).await;
+
+    // Drain the cell→base channel and count appearance refresh +
+    // state-field-update messages.
+    let mut saw_refresh = false;
+    let mut saw_state_field_update_for_player = false;
+    while let Ok(msg) = rx.try_recv() {
+        match msg {
+            CellToBaseMsg::RefreshAppearance {
+                entity_id: 1,
+                holstered,
+                ..
+            } => {
+                saw_refresh = true;
+                assert!(
+                    !holstered,
+                    "RefreshAppearance payload must carry holstered=false (drawn) — \
+                     enter_player_combat flipped the field to false; the broadcast \
+                     must mirror the server-side value"
+                );
+            }
+            CellToBaseMsg::EntityMethodCall {
+                entity_id: 1,
+                method_index,
+                ..
+            } if method_index == crate::mercury::method_idx::ON_STATE_FIELD_UPDATE => {
+                saw_state_field_update_for_player = true;
+            }
+            _ => {}
+        }
+    }
+
+    assert!(
+        saw_refresh,
+        "auto-aggro on holstered player must broadcast RefreshAppearance \
+         — pre-fix the auto-aggro path discarded `generate_threat`'s \
+         Some(state) return and the client's weapon-mesh cache stayed \
+         desynced, producing the play-session 'no weapon mesh on fire' bug"
+    );
+    assert!(
+        !saw_state_field_update_for_player,
+        "auto-aggro MUST NOT broadcast onStateFieldUpdate to the player — \
+         the design carve-out prevents 'ghost combat HUD' (HUD lights up \
+         before the player has any reason to know they've been seen). The \
+         appearance refresh covers the weapon-mesh sync; the state field \
+         waits for an explicit hit"
+    );
+
+    // Sanity: the cell-side state did flip. If this fails, the
+    // assertion above passed for the wrong reason.
+    let player = mgr.get_entity(1).unwrap();
+    assert!(
+        !player.weapon_holstered,
+        "enter_player_combat must flip weapon_holstered=false on first-add \
+         transition — broadcast or not, the server-side state is the \
+         source of truth for subsequent fire-path gating"
+    );
+}

--- a/crates/services/src/cell/service/tests/npc_ai_auto_aggro.rs
+++ b/crates/services/src/cell/service/tests/npc_ai_auto_aggro.rs
@@ -1,0 +1,117 @@
+//! `npc_ai_idle_auto_aggro` broadcast-coverage tests.
+//!
+//! Split out of the sibling `npc_ai` module when that file crossed the
+//! 700-line cap. The state-machine, ability-selector, range, and
+//! backup-waypoint tests stay in `npc_ai`; this file owns the
+//! cell→base broadcast surface for the auto-aggro path
+//! (`generate_threat`'s `Some(state)` return → appearance refresh,
+//! but NOT `onStateFieldUpdate`).
+//!
+//! Reuses the `make_aggression_fixture` helper from the sibling
+//! module via its `pub(super)` re-export.
+
+use tokio::sync::mpsc;
+
+/// Auto-aggro on a holstered player must broadcast a
+/// `RefreshAppearance` so the client's `BeingAppearance` cache picks
+/// up the server-side `weapon_holstered = false` flip from
+/// `enter_player_combat`. Without this broadcast, server-state and
+/// client-state desync: server thinks weapon is drawn, client still
+/// shows holstered. The next fire passes
+/// `needs_unholster_queue`'s `weapon_holstered=true` gate (because
+/// the server says drawn), so the draw queue never runs — client
+/// renders the fire animation with no weapon mesh attached.
+///
+/// Play-session symptom: post-auto-reload + OOC holster, the
+/// player attacks a freshly-aggroed NPC and sees "hands in combat
+/// pose but no weapon." Slot-swap recovers because slot-swap
+/// broadcasts a fresh appearance. The fix here is the
+/// broadcast-on-auto-aggro path in `npc_ai_idle_auto_aggro` —
+/// `generate_threat` returning `Some(state)` MUST be followed by
+/// `request_appearance_refresh` even though the design intent is
+/// to skip the `onStateFieldUpdate` (the "ghost combat HUD" carve-
+/// out the comment names).
+///
+/// Assertion shape: the cell→base channel sees exactly one
+/// `RefreshAppearance` message addressed at the player. The
+/// `onStateFieldUpdate` is intentionally NOT sent (covered by the
+/// negative assertion at the end).
+#[tokio::test]
+async fn auto_aggro_broadcasts_appearance_refresh_on_holstered_player() {
+    use crate::cell::messages::CellToBaseMsg;
+
+    let mut mgr = super::npc_ai::make_aggression_fixture(200_010, 10, 1, [5.0, 0.0, 0.0]);
+    if let Some(npc) = mgr.get_entity_mut(200_010) {
+        npc.aggression = 1;
+    }
+    // Pre-stage: player is holstered (post-OOC). The bug shape is
+    // specifically "weapon_holstered flips false server-side
+    // without telling the client" — to observe it, weapon must be
+    // holstered going in so the flip is observable.
+    if let Some(p) = mgr.get_entity_mut(1) {
+        p.weapon_holstered = true;
+    }
+
+    let (tx, mut rx) = mpsc::channel(16);
+    crate::cell::service::npc_ai::npc_ai_tick(&tx, &mut mgr).await;
+
+    // Drain the cell→base channel and count appearance refresh +
+    // state-field-update messages. Counting (rather than a bool)
+    // pins exactly-one — a future regression that broadcasts twice
+    // (e.g., once from the auto-aggro path and once from a stale
+    // duplicate handler) would still trip a presence-only check.
+    let mut refresh_count = 0usize;
+    let mut saw_state_field_update_for_player = false;
+    while let Ok(msg) = rx.try_recv() {
+        match msg {
+            CellToBaseMsg::RefreshAppearance {
+                entity_id: 1,
+                holstered,
+                ..
+            } => {
+                refresh_count += 1;
+                assert!(
+                    !holstered,
+                    "RefreshAppearance payload must carry holstered=false (drawn) — \
+                     enter_player_combat flipped the field to false; the broadcast \
+                     must mirror the server-side value"
+                );
+            }
+            CellToBaseMsg::EntityMethodCall {
+                entity_id: 1,
+                method_index,
+                ..
+            } if method_index == crate::mercury::method_idx::ON_STATE_FIELD_UPDATE => {
+                saw_state_field_update_for_player = true;
+            }
+            _ => {}
+        }
+    }
+
+    assert_eq!(
+        refresh_count, 1,
+        "auto-aggro on holstered player must broadcast RefreshAppearance \
+         exactly once — pre-fix the auto-aggro path discarded \
+         `generate_threat`'s Some(state) return and the client's weapon-mesh \
+         cache stayed desynced, producing the play-session 'no weapon mesh \
+         on fire' bug; a count > 1 would mean a duplicate handler crept in"
+    );
+    assert!(
+        !saw_state_field_update_for_player,
+        "auto-aggro MUST NOT broadcast onStateFieldUpdate to the player — \
+         the design carve-out prevents 'ghost combat HUD' (HUD lights up \
+         before the player has any reason to know they've been seen). The \
+         appearance refresh covers the weapon-mesh sync; the state field \
+         waits for an explicit hit"
+    );
+
+    // Sanity: the cell-side state did flip. If this fails, the
+    // assertion above passed for the wrong reason.
+    let player = mgr.get_entity(1).unwrap();
+    assert!(
+        !player.weapon_holstered,
+        "enter_player_combat must flip weapon_holstered=false on first-add \
+         transition — broadcast or not, the server-side state is the \
+         source of truth for subsequent fire-path gating"
+    );
+}


### PR DESCRIPTION
Coverage audit + play-session bug fix for the auto-reload / `reloadOnActivate` work landed in #394.

## Two gaps closed

### 1. `reloadOnActivate` on world entry (login, gate-travel, cross-world ring)

`maybe_trigger_reload_on_activate` was wired into F1-F4 slot swap (`cell_methods/inventory/bandolier.rs`) and in-game equip from inventory (`service/base_messages/bandolier.rs`) — both at PR #394 ship time. World-entry was missed: `handle_init_player_state` restores the bandolier but never called the trigger. A player with `reloadOnActivate = true` who logged in or gate-travelled with a partial-clip active weapon silently did **not** auto-reload until they manually swapped slots and back.

The hook now lives at the bottom of `handle_init_player_state`, right before `fire_player_loaded`. Covers login + gate-travel arrival + cross-world ring transport (which falls through to gate-travel internally).

Same-world respawn (`ReanchorPlayer` / `cell_methods/player/combat/respawn.rs`) is deliberately **not** a trigger site: the cell entity survives, the weapon was never deactivated, the option's "activated" condition isn't met. Clip state survives respawn intentionally.

### 2. Post-OOC-holster auto-aggro breaks weapon mesh (the actual play-session bug)

Reported symptom: after auto-reload drained the clip and the OOC holster timer holstered the weapon, attacking a freshly-aggroed NPC produced **"hands in combat position but no weapon model"** until the player swapped bandolier slots and back.

Root cause traced to [`npc_ai::npc_ai_idle_auto_aggro`](crates/services/src/cell/service/npc_ai.rs):

```rust
// Discard the optional new-state — the auto-aggro path doesn't
// broadcast `onStateFieldUpdate` to the player here. ...
let _ = combat::generate_threat(space_mgr, player_id, npc_id, 1.0);
```

`generate_threat → enter_player_combat` does TWO things on the first-add transition:

1. Flips `state_field |= BSF_IN_COMBAT` — needs `onStateFieldUpdate` to reach the client.
2. Flips `weapon_holstered = false` via `sync_holster_to_combat(true)` — needs `BeingAppearance` (`RefreshAppearance`) to reach the client.

The "no ghost combat HUD" design intent suppressed (1) intentionally. But (2) was suppressed by accident — discarding the `Some(state)` return killed BOTH broadcasts. Result: server-side `weapon_holstered = false`, client-side cached `ComponentList` still says holstered (the OOC holster's Phase 2 was the last `BeingAppearance` the client received).

Next fire ran through `handle_use_ability`'s `needs_unholster_queue` gate. The gate checks `weapon_holstered` server-side and finds it `false` — so the draw queue is skipped, the fire proceeds immediately. Client renders the fire animation against a dropped weapon mesh. Slot swap recovered because slot-swap unconditionally broadcasts a fresh `BeingAppearance`.

Fix: when `generate_threat` returns `Some(state)`, call `request_appearance_refresh`. `onStateFieldUpdate` remains suppressed, so the "no ghost combat HUD" carve-out still holds.

## Test plan

### Login / world-entry hook (3 new guards in `player_init.rs`)

- [x] `init_player_state_triggers_reload_on_activate_when_clip_partial` — option on + partial clip + drawn weapon → `reload_complete_at` is `Some`. Pre-fix this was silent.
- [x] `init_player_state_does_not_reload_when_option_off` — XML default (`reload_on_activate = false`) + partial clip → no reload queued. Symmetric negative.
- [x] `init_player_state_does_not_reload_when_clip_full` — option on + full clip → no-op. Pins `active_ammo < active_clip_size` gate at the handler boundary.

### Auto-aggro appearance refresh (1 new guard in `npc_ai.rs::tests`)

- [x] `auto_aggro_broadcasts_appearance_refresh_on_holstered_player`:
  - Stages: aggression=1 NPC, opposing-faction player with `weapon_holstered = true` in AoI.
  - Runs `npc_ai_tick`.
  - **Positive**: cell→base channel sees `RefreshAppearance { holstered: false, .. }` for the player.
  - **Negative**: NO `onStateFieldUpdate` for the player (HUD carve-out preserved).
  - **Sanity**: cell-side `weapon_holstered == false` (state-source-of-truth invariant).

A revert to `let _ = combat::generate_threat(...)` trips the positive assertion. A change that ALSO broadcasts `onStateFieldUpdate` from this path trips the negative assertion.

### Regression coverage

All 27 pre-existing `npc_ai` tests and 2 pre-existing `player_init` tests continue to pass.

## Verification

- `cargo fmt --all -- --check` clean
- `cargo clippy --workspace` (excluding GUI apps) `-D warnings` clean
- `cargo nextest --profile=ci --workspace` (excluding GUI apps): **1631 passed, 0 failed, 1 skipped** (was 1627; +4 new guards. Wireclient pcap fixture skip is expected without `debug/`.)

## Manual repro

Player with `reloadOnActivate = true`:
- Log in with partial-clip active weapon → weapon should auto-reload now (pre-fix: no-op until slot-swap).
- Gate travel between worlds with partial-clip → same.

Player with auto-reload on, in OOC after a kill:
- Wait through OOC holster cycle (~5s + animation).
- New NPC aggros → server-side weapon draws (appearance refresh).
- Fire at NPC → weapon mesh visible, animation correct (pre-fix: no mesh until slot-swap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced "reload on weapon activation" option that automatically reloads equipped weapons upon entering combat
  * NPCs now correctly refresh their appearance state when detecting threats

* **Bug Fixes**
  * Fixed NPC appearance update behavior during auto-aggro engagement

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SandboxServers/Cimmeria/pull/395?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->