### PR TITLE
fix(cell): chain-fired dialogs send NPC entity id, not player id

### DIFF
--- a/crates/entity/src/cell_entity/mod.rs
+++ b/crates/entity/src/cell_entity/mod.rs
@@ -452,6 +452,26 @@ pub struct CellEntity {
     /// Reference: `python/cell/SGWPlayer.py:setLooting()`
     pub looting_entity: Option<u32>,
 
+    /// Entity ID of the NPC the player most recently interacted with
+    /// (player entities only).
+    ///
+    /// Set on every successful `handle_interact`. Read by paths that need
+    /// to know "which NPC is on the other side of this conversation" but
+    /// don't get that ID through their own wire frame — notably
+    /// `handle_initial_response` (the client sends only
+    /// `interaction_set_map_id`, mirroring python's
+    /// `SGWPlayer.initialResponse` which used `self.lastInteractionTarget`)
+    /// and content-engine `display_dialog` / `start_dialog` actions fired
+    /// from chains that don't carry `target_entity_id` in params (e.g. a
+    /// follow-up dialog triggered by `OnDialogChoice`).
+    ///
+    /// The wire `EntityId` field of `onDialogDisplay` must be the NPC's
+    /// entity ID, not the player's — the client looks it up in the AoI
+    /// listener table via `LookupEntityListenerEntry` to bind the dialog
+    /// portrait actor (see
+    /// `docs/reverse-engineering/findings/dialog-portrait-lookup.md`).
+    pub last_interaction_target: Option<u32>,
+
     /// Entity ID of the currently-open vendor (only for player entities).
     pub vendor_entity: Option<u32>,
 
@@ -636,6 +656,7 @@ impl CellEntity {
             loot: Vec::new(),
             next_loot_index: 1,
             looting_entity: None,
+            last_interaction_target: None,
             vendor_entity: None,
             current_target_id: None,
             active_bandolier_slot: 0,

--- a/crates/services/src/cell/content/executor/dialog.rs
+++ b/crates/services/src/cell/content/executor/dialog.rs
@@ -9,21 +9,73 @@ use crate::cell::space_manager::SpaceManager;
 /// `Action::DisplayDialog` and `Action::StartDialog` — both render a dialog
 /// to the player. They take different field names but the same id semantics,
 /// merged into one handler.
+///
+/// The wire `EntityId` field of `onDialogDisplay` MUST be the NPC the
+/// player is talking to — the client uses it as the key into
+/// `LookupEntityListenerEntry` to bind the dialog portrait actor and the
+/// per-screen speaker entity (see
+/// `docs/reverse-engineering/findings/dialog-portrait-lookup.md`).
+/// Resolution order, from most to least direct:
+///
+/// 1. Chain `params["target_entity_id"]` — present when the chain was
+///    fired from an `InteractTag` / `InteractTemplate` trigger
+///    (`fire_interact_*` stamps it into the context).
+/// 2. Player's `last_interaction_target` — the per-player pin set by
+///    `handle_interact`. Covers follow-up chains (e.g. an
+///    `OnDialogChoice` trigger that fires another `display_dialog` on
+///    the same NPC) where the trigger event itself carries no NPC.
+/// 3. Abort with a `warn` — falling back to the player's own entity ID
+///    here is the bug this commit fixed: the client would bind the
+///    player as the dialog speaker, blanking the portrait and
+///    rendering the player's name for every screen.
 #[tracing::instrument(
     name = "dialog.display",
     level = "info",
     skip_all,
-    fields(entity_id, dialog_id, chain_id)
+    fields(entity_id, dialog_id, chain_id, npc_entity_id = tracing::field::Empty)
 )]
 pub(super) async fn display(
     dialog_id: i32,
     entity_id: u32,
     chain_id: i64,
+    params: &std::collections::HashMap<String, serde_json::Value>,
     tx: &mpsc::Sender<CellToBaseMsg>,
+    space_mgr: &SpaceManager,
 ) {
-    tracing::info!(entity_id, dialog_id, chain_id, "Content: displaying dialog");
-    crate::cell::interactions::send_dialog_display(entity_id, entity_id as i32, dialog_id, tx)
-        .await;
+    let npc_entity_id = params
+        .get("target_entity_id")
+        .and_then(|v| v.as_u64())
+        .map(|v| v as i32)
+        .or_else(|| {
+            space_mgr
+                .get_entity(entity_id)
+                .and_then(|p| p.last_interaction_target)
+                .map(|id| id as i32)
+        });
+
+    let npc_entity_id = match npc_entity_id {
+        Some(id) => id,
+        None => {
+            tracing::warn!(
+                entity_id,
+                dialog_id,
+                chain_id,
+                "DisplayDialog: no NPC entity id in chain params or last_interaction_target -- \
+                 cannot send onDialogDisplay (would bind player as speaker and blank portrait)"
+            );
+            return;
+        }
+    };
+
+    tracing::Span::current().record("npc_entity_id", npc_entity_id);
+    tracing::info!(
+        entity_id,
+        dialog_id,
+        npc_entity_id,
+        chain_id,
+        "Content: displaying dialog"
+    );
+    crate::cell::interactions::send_dialog_display(entity_id, npc_entity_id, dialog_id, tx).await;
 }
 
 /// `Action::AddDialogSet` — register a dialog set on the player's
@@ -310,5 +362,105 @@ async fn send_interaction_update_if_visible(
                 "NPC not yet in player AoI — deferring InteractionType to AoI create"
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::{make_space_manager, LogCapture};
+    use std::collections::HashMap;
+    use tracing::Level;
+
+    fn empty_params() -> HashMap<String, serde_json::Value> {
+        HashMap::new()
+    }
+
+    /// Chain `params["target_entity_id"]` is the most direct source — it's
+    /// stamped by `fire_interact_*` for chains fired off an interact. The
+    /// wire `EntityId` of `onDialogDisplay` must match that, not the
+    /// player's id.
+    #[tokio::test]
+    async fn display_uses_target_entity_id_from_chain_params() {
+        let mut mgr = make_space_manager();
+        mgr.create_entity(1, "Agnos", [0.0; 3], [0.0; 3]).unwrap();
+
+        const NPC_ID: u32 = 0xABCD;
+        let mut params = empty_params();
+        params.insert("target_entity_id".into(), serde_json::json!(NPC_ID as u64));
+
+        let (tx, mut rx) = mpsc::channel(4);
+        display(
+            /* dialog_id */ 4001, /* entity_id */ 1, /* chain_id */ 99, &params,
+            &tx, &mgr,
+        )
+        .await;
+
+        let msg = rx.try_recv().expect("must emit onDialogDisplay");
+        match msg {
+            CellToBaseMsg::EntityMethodCall { args, .. } => {
+                let wire_entity_id = i32::from_le_bytes([args[0], args[1], args[2], args[3]]);
+                assert_eq!(
+                    wire_entity_id as u32, NPC_ID,
+                    "params.target_entity_id must win over any fallback; got {wire_entity_id}, expected {NPC_ID}"
+                );
+            }
+            other => panic!("expected EntityMethodCall, got {other:?}"),
+        }
+    }
+
+    /// When the chain didn't stamp `target_entity_id` (e.g. an
+    /// `OnDialogChoice`-triggered follow-up dialog), fall back to the
+    /// player's `last_interaction_target` pin.
+    #[tokio::test]
+    async fn display_falls_back_to_last_interaction_target() {
+        let mut mgr = make_space_manager();
+        mgr.create_entity(1, "Agnos", [0.0; 3], [0.0; 3]).unwrap();
+        const NPC_ID: u32 = 0xBEEF;
+        if let Some(p) = mgr.get_entity_mut(1) {
+            p.last_interaction_target = Some(NPC_ID);
+        }
+
+        let params = empty_params();
+        let (tx, mut rx) = mpsc::channel(4);
+        display(2299, 1, 1021, &params, &tx, &mgr).await;
+
+        let msg = rx.try_recv().expect("must emit onDialogDisplay");
+        match msg {
+            CellToBaseMsg::EntityMethodCall { args, .. } => {
+                let wire_entity_id = i32::from_le_bytes([args[0], args[1], args[2], args[3]]);
+                assert_eq!(wire_entity_id as u32, NPC_ID);
+            }
+            other => panic!("expected EntityMethodCall, got {other:?}"),
+        }
+    }
+
+    /// With neither `target_entity_id` in params nor a
+    /// `last_interaction_target` pin, the handler must abort with a warn
+    /// rather than emit a wire frame that binds the player as the
+    /// speaker. The warn level is load-bearing — operators rely on it
+    /// to correlate "dialog never opened" with a chain that wasn't
+    /// fired off an interact path.
+    #[tokio::test]
+    async fn display_aborts_with_warn_when_no_npc_id_available() {
+        let capture = LogCapture::install();
+        let mut mgr = make_space_manager();
+        mgr.create_entity(1, "Agnos", [0.0; 3], [0.0; 3]).unwrap();
+        // last_interaction_target intentionally None.
+
+        let params = empty_params();
+        let (tx, mut rx) = mpsc::channel(4);
+        display(4001, 1, 9999, &params, &tx, &mgr).await;
+
+        assert!(
+            rx.try_recv().is_err(),
+            "must not emit onDialogDisplay when no NPC id can be resolved"
+        );
+        assert!(
+            capture
+                .find_message(Level::WARN, "DisplayDialog: no NPC entity id")
+                .is_some(),
+            "abort must surface a WARN — silent return masks the chain-author bug"
+        );
     }
 }

--- a/crates/services/src/cell/content/executor/mod.rs
+++ b/crates/services/src/cell/content/executor/mod.rs
@@ -102,7 +102,7 @@ pub(super) async fn execute_actions(
             | Action::StartDialog {
                 dialog_set_id: dialog_id,
             } => {
-                dialog::display(dialog_id, entity_id, chain_id, tx).await;
+                dialog::display(dialog_id, entity_id, chain_id, &params, tx, space_mgr).await;
             }
             Action::PlaySequence { sequence_id } => {
                 tracing::info!(

--- a/crates/services/src/cell/interactions/dispatch.rs
+++ b/crates/services/src/cell/interactions/dispatch.rs
@@ -80,6 +80,19 @@ pub async fn handle_interact(
         return None;
     }
 
+    // Pin the interaction target on the player. Downstream dispatchers
+    // that don't get the NPC entity ID on their own wire frame
+    // (`handle_initial_response`, content-engine `display_dialog`
+    // fired from a follow-up trigger like `OnDialogChoice`) read this
+    // to fill the wire `EntityId` field of `onDialogDisplay`. The
+    // dialog portrait widget binds its actor by that ID via
+    // `LookupEntityListenerEntry`, so passing the player's ID there
+    // (the prior bug) made the dialog speak as the player. Mirrors
+    // python's `SGWPlayer.lastInteractionTarget` write in `interact()`.
+    if let Some(player) = space_mgr.get_entity_mut(entity_id) {
+        player.last_interaction_target = Some(target_entity_id);
+    }
+
     // Check per-player available interactions (from add_dialog_set content actions).
     // These take priority over static interaction_type.
     if let Some(tmpl_id) = target_template_id {
@@ -210,13 +223,39 @@ pub async fn handle_initial_response(
                 return;
             }
         };
+        // Wire `EntityId` of `onDialogDisplay` must be the NPC the player
+        // is talking to — the client passes it through
+        // `LookupEntityListenerEntry` to bind the dialog portrait actor.
+        // `last_interaction_target` was set by the preceding `handle_interact`
+        // (the client only sends `interactionSetMapId` here, so the NPC ID
+        // has to come from the per-player pin). Falling back to `entity_id`
+        // (the player) makes the dialog speak as the player and blanks the
+        // portrait — same shape as python's `SGWPlayer.initialResponse`
+        // returning early when `lastInteractionTarget` is unset.
+        let npc_entity_id = match space_mgr
+            .get_entity(entity_id)
+            .and_then(|p| p.last_interaction_target)
+        {
+            Some(id) => id as i32,
+            None => {
+                tracing::warn!(
+                    entity_id,
+                    interaction_set_map_id,
+                    dialog_id,
+                    "handle_initial_response: no last_interaction_target on player; \
+                     aborting dialog open -- portrait would render blank against the player"
+                );
+                return;
+            }
+        };
         tracing::info!(
             entity_id,
             interaction_set_map_id,
             dialog_id,
+            npc_entity_id,
             "handle_initial_response: found dialog, sending onDialogDisplay"
         );
-        send_dialog_display(entity_id, entity_id as i32, dialog_id, tx).await;
+        send_dialog_display(entity_id, npc_entity_id, dialog_id, tx).await;
         crate::cell::content::fire_dialog_open(
             entity_id, player_id, dialog_id, engine, tx, space_mgr,
         )
@@ -298,11 +337,170 @@ mod tests {
                 assert_eq!(entity_id, 1); // sent to player
                 assert_eq!(method_index, crate::mercury::method_idx::ON_DIALOG_DISPLAY);
                 assert_eq!(args.len(), 17);
+                // Wire `EntityId` (args[0..4]) MUST be the NPC's entity id, not
+                // the player's. The client uses it as the key into
+                // `LookupEntityListenerEntry` to bind the dialog portrait actor;
+                // passing the player here makes the dialog speak as the player
+                // and blanks the portrait. See
+                // `docs/reverse-engineering/findings/dialog-portrait-lookup.md`.
+                let wire_entity_id = i32::from_le_bytes([args[0], args[1], args[2], args[3]]);
+                assert_eq!(
+                    wire_entity_id as u32, npc_id,
+                    "onDialogDisplay wire EntityId must be the NPC id (got {wire_entity_id}, expected {npc_id})"
+                );
                 let dialog_id = i32::from_le_bytes([args[4], args[5], args[6], args[7]]);
                 assert_eq!(dialog_id, 42);
             }
             _ => panic!("Expected EntityMethodCall"),
         }
+    }
+
+    /// `handle_interact` must pin `last_interaction_target` on the player so
+    /// the subsequent `handle_initial_response` (which only gets
+    /// `interactionSetMapId` on the wire) can recover the NPC entity id to
+    /// stamp into `onDialogDisplay`. Without this pin, the chain-fired
+    /// dialog path bound the player as the speaker.
+    #[tokio::test]
+    async fn interact_pins_last_interaction_target_on_player() {
+        let mut mgr = crate::cell::space_manager::SpaceManager::new(1);
+        let spaces_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<Spaces><Space WorldName="Agnos" Instanced="false" MinX="-2400" MaxX="2200" MinY="-3200" MaxY="2800" /></Spaces>"#;
+        let cell_spaces_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<Spaces><Space WorldName="Agnos" /></Spaces>"#;
+        mgr.parse_spaces_xml(spaces_xml).unwrap();
+        mgr.create_startup_spaces(cell_spaces_xml).unwrap();
+        mgr.create_entity(1, "Agnos", [0.0, 0.0, 0.0], [0.0; 3])
+            .unwrap();
+        let npc_id = mgr.allocate_npc_id();
+        mgr.spawn_npc(npc_id, "Agnos", [2.0, 0.0, 0.0], [0.0; 3])
+            .unwrap();
+        if let Some(npc) = mgr.get_entity_mut(npc_id) {
+            npc.interaction_type = Some(NpcInteractionType::Dialog { dialog_id: 42 });
+        }
+
+        let (tx, _rx) = mpsc::channel(16);
+        handle_interact(1, npc_id, &tx, &mut mgr).await;
+
+        assert_eq!(
+            mgr.get_entity(1).and_then(|p| p.last_interaction_target),
+            Some(npc_id),
+            "handle_interact must pin last_interaction_target = NPC id on the player"
+        );
+    }
+
+    /// Out-of-range interact must NOT pin `last_interaction_target` — a
+    /// stale pin from a too-far click would then misroute a subsequent
+    /// `initialResponse` (or chain-fired dialog) at the wrong NPC.
+    #[tokio::test]
+    async fn out_of_range_interact_does_not_pin_target() {
+        let mut mgr = crate::cell::space_manager::SpaceManager::new(1);
+        let spaces_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<Spaces><Space WorldName="Agnos" Instanced="false" MinX="-2400" MaxX="2200" MinY="-3200" MaxY="2800" /></Spaces>"#;
+        let cell_spaces_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<Spaces><Space WorldName="Agnos" /></Spaces>"#;
+        mgr.parse_spaces_xml(spaces_xml).unwrap();
+        mgr.create_startup_spaces(cell_spaces_xml).unwrap();
+        mgr.create_entity(1, "Agnos", [0.0, 0.0, 0.0], [0.0; 3])
+            .unwrap();
+        let npc_id = mgr.allocate_npc_id();
+        mgr.spawn_npc(npc_id, "Agnos", [100.0, 0.0, 0.0], [0.0; 3])
+            .unwrap();
+
+        let (tx, _rx) = mpsc::channel(16);
+        handle_interact(1, npc_id, &tx, &mut mgr).await;
+
+        assert_eq!(
+            mgr.get_entity(1).and_then(|p| p.last_interaction_target),
+            None,
+            "out-of-range interact must leave last_interaction_target untouched"
+        );
+    }
+
+    /// `handle_initial_response` must stamp the NPC entity id (from
+    /// `last_interaction_target`) into the wire `EntityId` field of
+    /// `onDialogDisplay`, not the player's id. Regression for the bug
+    /// where the dialog opened with the player bound as the speaker
+    /// actor (blank portrait, player name on every screen).
+    #[tokio::test]
+    async fn initial_response_uses_last_interaction_target_for_wire_entity_id() {
+        let mut mgr = crate::cell::space_manager::SpaceManager::new(1);
+        let spaces_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<Spaces><Space WorldName="Agnos" Instanced="false" MinX="-2400" MaxX="2200" MinY="-3200" MaxY="2800" /></Spaces>"#;
+        let cell_spaces_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<Spaces><Space WorldName="Agnos" /></Spaces>"#;
+        mgr.parse_spaces_xml(spaces_xml).unwrap();
+        mgr.create_startup_spaces(cell_spaces_xml).unwrap();
+        mgr.create_entity(1, "Agnos", [0.0, 0.0, 0.0], [0.0; 3])
+            .unwrap();
+
+        const TEMPLATE_ID: i32 = 7;
+        const DIALOG_SET_MAP_ID: i32 = 99;
+        const DIALOG_ID: i32 = 4001;
+        const NPC_ID: u32 = 0x1234;
+        if let Some(p) = mgr.get_entity_mut(1) {
+            p.player_id = Some(42);
+            p.last_interaction_target = Some(NPC_ID);
+            p.available_interactions
+                .insert(TEMPLATE_ID, vec![(DIALOG_SET_MAP_ID, DIALOG_ID, 0)]);
+        }
+
+        let (tx, mut rx) = mpsc::channel(16);
+        let engine = ChainEngine::new();
+        handle_initial_response(1, DIALOG_SET_MAP_ID, &engine, &tx, &mut mgr).await;
+
+        let msg = rx.try_recv().expect("must emit onDialogDisplay");
+        match msg {
+            CellToBaseMsg::EntityMethodCall {
+                method_index, args, ..
+            } => {
+                assert_eq!(method_index, crate::mercury::method_idx::ON_DIALOG_DISPLAY);
+                let wire_entity_id = i32::from_le_bytes([args[0], args[1], args[2], args[3]]);
+                assert_eq!(
+                    wire_entity_id as u32, NPC_ID,
+                    "initial_response must stamp last_interaction_target as wire EntityId, \
+                     not the player's id (got {wire_entity_id}, expected {NPC_ID})"
+                );
+                let dialog_id = i32::from_le_bytes([args[4], args[5], args[6], args[7]]);
+                assert_eq!(dialog_id, DIALOG_ID);
+            }
+            other => panic!("expected EntityMethodCall, got {other:?}"),
+        }
+    }
+
+    /// `handle_initial_response` must abort (not fire onDialogDisplay) when
+    /// `last_interaction_target` is unset. Falling back to the player here
+    /// is exactly the prior bug shape.
+    #[tokio::test]
+    async fn initial_response_aborts_when_last_interaction_target_missing() {
+        let mut mgr = crate::cell::space_manager::SpaceManager::new(1);
+        let spaces_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<Spaces><Space WorldName="Agnos" Instanced="false" MinX="-2400" MaxX="2200" MinY="-3200" MaxY="2800" /></Spaces>"#;
+        let cell_spaces_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<Spaces><Space WorldName="Agnos" /></Spaces>"#;
+        mgr.parse_spaces_xml(spaces_xml).unwrap();
+        mgr.create_startup_spaces(cell_spaces_xml).unwrap();
+        mgr.create_entity(1, "Agnos", [0.0, 0.0, 0.0], [0.0; 3])
+            .unwrap();
+
+        const TEMPLATE_ID: i32 = 7;
+        const DIALOG_SET_MAP_ID: i32 = 99;
+        const DIALOG_ID: i32 = 4001;
+        if let Some(p) = mgr.get_entity_mut(1) {
+            p.player_id = Some(42);
+            // last_interaction_target intentionally left as None.
+            p.available_interactions
+                .insert(TEMPLATE_ID, vec![(DIALOG_SET_MAP_ID, DIALOG_ID, 0)]);
+        }
+
+        let (tx, mut rx) = mpsc::channel(16);
+        let engine = ChainEngine::new();
+        handle_initial_response(1, DIALOG_SET_MAP_ID, &engine, &tx, &mut mgr).await;
+
+        assert!(
+            rx.try_recv().is_err(),
+            "initial_response must NOT emit onDialogDisplay when last_interaction_target \
+             is unset -- falling back to the player blanks the portrait"
+        );
     }
 
     #[tokio::test]

--- a/docs/reverse-engineering/findings/README.md
+++ b/docs/reverse-engineering/findings/README.md
@@ -36,6 +36,7 @@ This directory contains per-system reverse engineering findings with evidence.
 | `architectural-anomalies.md` | V5 (W-anom) | Three CME EventSignal anomalies resolved: BM emitters use Pattern B (not unknown mechanism); GiveInventory NetOut has no client subscriber (server-only signal); SGWHomeless is `class_SGWHomeless`, an in-editor developer tool class | HIGH |
 | `cooked-data-pipeline.md` | V5 (W-cooked) | 21 ServerSource categories (1–21) with binary-confirmed PAK filenames; LibCategory/ServerSource struct layout; 5 CME events per category; onVersionInfo/onCookedDataError handler logic; ZipStorageBase open+MetaData-write path; contradiction with existing pipeline doc category table | HIGH |
 | `mercury-nub-anatomy.md` | V5 | Mercury `Nub` / `BaseNub` / `ChannelInternal` / `Connection` class layouts (22 functions, 4 struct anatomies); two-channel-map design; network thread loop; `Nub::send` 4-phase pipeline; rdtsc inactivity vs our `MAX_RETRIES`; two latent wire gaps (REPLY piggyback XOR-inverted length, ACK batching per 10ms tick) | HIGH |
+| `dialog-portrait-lookup.md` | V5 | Dialog portrait + speaker-name lookup — wire EntityId path (not DatabaseId) through LookupEntityListenerEntry → slot 17 → UnitMappingChanged → createCharacterPortrait; CookedData SpeakerID PAK parse at piVar2[7]; empty-name fallback to player name; Prisoner 329 + Col Marsh root-cause diagnoses | HIGH |
 
 ## Finding Format
 

--- a/docs/reverse-engineering/findings/dialog-portrait-lookup.md
+++ b/docs/reverse-engineering/findings/dialog-portrait-lookup.md
@@ -1,0 +1,274 @@
+# RE Finding: Dialog Portrait and Speaker-Name Lookup
+
+**Confidence**: HIGH (portrait entity path), MEDIUM (speaker-name fallback trigger — Lua script not recovered)
+**Date**: 2026-05-25
+**Phase**: V5 investigation (targeted, single-session)
+**Sources**:
+
+- `FUN_00d26850` — DialogController constructor (CME subscriber registration)
+- `FUN_00d25310` — `Event_NetIn_DialogDisplay` handler
+- `FUN_00d24f10` — core dialog-show function
+- `FUN_00d22c90` — entity slot-pin function
+- `FUN_00c67bd0` — GameEntityManager slot-17 mapping + `Event_UI_UnitMappingChanged` emitter
+- `FUN_015e4d10` — `CookedData_DialogScreenType` PAK parser
+- `FUN_00e6a430` — PortraitManager entity lookup
+- `FUN_00ac58d0` / `FUN_00ae2b20` — `createCharacterPortrait` Lua binding + implementation
+- `0x00ad4ae5` — Lua method table entry for `createCharacterPortrait`
+- `0x00cc39b7`/`0x00cc39c6` — `Event_UI_UnitMappingChanged` Lua binding in `FUN_00cc33f0`
+- `docs/reverse-engineering/decompiled/14_standalone_named.c` line ~2797 — CookedDataDialogs.pak load
+- `docs/reverse-engineering/decompiled/09_game_ui_visuals.c` — PortraitManager body
+- `docs/reverse-engineering/address-map.md` — prior finding: `GENERICPROPERTY_DatabaseId=9`
+
+---
+
+## Questions Investigated
+
+This finding answers four questions raised before the server-side fix for the dialog portrait/name bugs:
+
+- **A** — Dialog UI render path: what C++ functions execute between dialog-screen open and portrait/name population?
+- **B** — Speaker → portrait actor: does the client search AoI by `GENERICPROPERTY_DatabaseId`? Or by entity ID? Or via a dedicated wire method?
+- **C** — Speaker → name string: how does the name fall back to the player in the Col Marsh case?
+- **D** — Required server-side wire data: is `onEntityProperty(GENERICPROPERTY_DatabaseId=9)` sufficient, or is another method required?
+
+---
+
+## Architecture: Two Independent Tracks
+
+The dialog window resolves portrait and name through two independent lookup pipelines that share no runtime state at display time.
+
+---
+
+## Track 1 — Portrait Actor Lookup
+
+### Summary
+
+The portrait is populated by a Lua callback that fires when `Event_UI_UnitMappingChanged` delivers a non-zero entity to GameEntityManager slot 17 ("DialogSpeaker"). The entity is identified by its wire `EntityId` — the same numeric ID present in the `Event_NetIn_DialogDisplay` message — via `LookupEntityListenerEntry`. The `GENERICPROPERTY_DatabaseId` field is NOT searched at portrait time.
+
+### Call Chain (all confirmed)
+
+```
+Event_NetIn_DialogDisplay (wire method 105)
+  └─ FUN_00d25310            [DialogController handler @ 0x00d25310]
+       match: param_1[1] == dialog->entityId
+       └─ FUN_00d25200       [activate dialog]
+            └─ FUN_00d24f10  [core dialog-show @ 0x00d24f10]
+                 ├─ FUN_00d22c90(dialog, 0x1b58)  [pin player-side slot]
+                 ├─ FUN_00d22c90(dialog, 0x1bbc)  [pin NPC-side slot]
+                 │    └─ LookupEntityListenerEntry(GameEntityManager, npc_entity_id, ...)
+                 │         → returns listener entry if entity is in AoI listener table
+                 │         → calls FUN_00d06ca0 → FUN_00d067e0 to pin entity
+                 └─ FUN_00d27b80(pvVar1, 0, puVar2, 1)
+                      → emits Event_UI_DialogDisplay (carries DialogID only)
+
+GameEntityManager slot registration (concurrent path):
+FUN_00c67bd0(GameEntityManager, 0x11, entity_id)   [slot 17 = "DialogSpeaker"]
+  └─ emits Event_UI_UnitMappingChanged
+       └─ SGWScriptedWindow Lua dispatch (FUN_00cc33f0 @ 0x00cc39b7/0x00cc39c6)
+            └─ Lua: createCharacterPortrait(portraitImagesetName, entity_id, ...)
+                 └─ FUN_00ac58d0 → FUN_00ae2b20
+                      └─ ImagesetManager::getImageset(portraitName)
+                      └─ FUN_00e6b890(PortraitManager, entity_id, ...)
+                           └─ FUN_00e6a430: LookupEntityListenerEntry(GameEntityManager, entity_id, ...)
+```
+
+### Key Evidence
+
+**`FUN_00d25310` entity-ID match** (decompiled, confirms wire EntityId is the lookup key):
+
+```c
+// param_1[1] = wire EntityId from Event_NetIn_DialogDisplay
+// *(int *)(*(*(dialog+0x10)+8) + 0x14) = dialog->entityId stored at creation time
+if (*(int *)(param_1 + 4) == *(int *)(*(*(dialog+0x10)+8) + 0x14)) {
+    FUN_00d271c0(*(void**)(dialog+0x10), dialog_ptr);
+    FUN_00d25200(this, dialog_ptr);
+}
+```
+
+**`FUN_00d22c90` AoI lookup** (decompiled, confirms `LookupEntityListenerEntry` uses entity ID, not DatabaseId):
+
+```c
+uVar7 = LookupEntityListenerEntry(GameEntityManager, pvIgnored, uVar7, unaff_SI);
+if ((uVar7 != 0) && (piVar2 = *(int **)(uVar7 + 8), piVar2 != NULL)) {
+    FUN_00d06ca0(ppuVar4, puVar5, puVar6, piVar2);  // pin entity
+    FUN_00d01c50(local_18, uVar7, '\x01');
+    FUN_00d01bd0(local_18, (int)param_1, 0);
+    FUN_00d00ac0((int)local_18);
+}
+```
+
+**`FUN_00c67bd0` slot-17 emit** (decompiled, confirms UnitMappingChanged carries entity to Lua):
+
+```c
+FUN_00a372f0(this_00, 0, &iStack_3c,
+             &CME::EventSignal::NoSubject::RTTI_Type_Descriptor,
+             (type_info *)&Event_UI_UnitMappingChanged::RTTI_Type_Descriptor);
+FUN_00e6b6c0(*(void **)(iVar4 + 0x58), param_1);  // notifies PortraitManager subsidiary
+```
+
+**`FUN_00e6a430` PortraitManager entity lookup** (decompiled, confirms same `LookupEntityListenerEntry` pattern — no DatabaseId search):
+
+```c
+uVar13 = LookupEntityListenerEntry(GameEntityManager, param_2, uVar13, unaff_DI);
+if ((uVar13 == 0) || (this_00 = *(int **)(uVar13 + 8), this_00 == NULL)) return NULL;
+```
+
+**`createCharacterPortrait` Lua method table entry** (`0x00ad4ae5`):
+
+```asm
+00ad4ae5: PUSH 0xac58d0     ; createCharacterPortrait C++ function
+00ad4aea: PUSH 0x1954fe0    ; "createCharacterPortrait"
+00ad4aef: PUSH ESI          ; lua state
+00ad4af0: CALL 0x00403ec0   ; register Lua method
+```
+
+### Answer to Question B
+
+**The portrait lookup does NOT search by `GENERICPROPERTY_DatabaseId`.** It searches by the wire `EntityId` from `Event_NetIn_DialogDisplay`. If the entity is in the client's AoI listener table under that entity ID, the portrait renders. If not, slot 17 is never populated and the portrait remains blank.
+
+### Answer to Question D
+
+`onEntityProperty(GENERICPROPERTY_DatabaseId=9, value=speaker_id)` is NOT sufficient to populate the portrait. The required sequence is:
+
+1. The NPC entity must be visible in the client's AoI (i.e., it must have gone through the entity-creation pipeline and be in `LookupEntityListenerEntry`'s table).
+2. `Event_NetIn_DialogDisplay` must carry the same wire `EntityId` as the AoI-registered entity.
+
+If (1) holds and (2) delivers the right `EntityId`, the slot-17 pin fires automatically and the portrait renders. No additional wire method is needed. The `GENERICPROPERTY_DatabaseId` broadcast is orthogonal to portrait display — it populates an index used by other subsystems, not this one.
+
+---
+
+## Track 2 — Speaker Name String
+
+### Summary
+
+The speaker name is resolved by the Lua dialog script from the CookedData `DialogScreenType` record, not from a wire event. Each screen's `SpeakerID` is stored at offset `+0x1C` in the parsed binary PAK record (`piVar2[7]`). Lua looks up the name string for that `SpeakerID` from the `speakers` table in CookedData. When the name is empty or the `SpeakerID` maps to no record, Lua falls back to the player's own name.
+
+### Key Evidence
+
+**`FUN_015e4d10` CookedData PAK parser** (decompiled, confirms `SpeakerID` is read from PAK, not wire):
+
+```c
+pcVar3 = FUN_00a3c1e0((int)param_1, (byte *)"ScreenID", 1);
+iVar1 = FUN_00a3d050((int)param_1, pcVar3, puVar8);  // → piVar2[5]
+
+pbVar4 = FUN_00a3c1e0((int)param_1, &DAT_01b23c98, 1);
+iVar1 = FUN_00a3d1e0((int)param_1, pbVar4, piVar9);  // → piVar2[6] (string field)
+
+pcVar3 = FUN_00a3c1e0((int)param_1, (byte *)"SpeakerID", 1);
+iVar1 = FUN_00a3d050((int)param_1, pcVar3, puVar8);  // → piVar2[7] = offset +0x1C
+```
+
+The `"SpeakerID"` field name (literal string at the call site) and the integer read into `piVar2[7]` are unambiguous. This is a PAK-time parse, not a wire-time receive.
+
+**`Event_UI_DialogSpeakerChanged` and `Event_UI_DialogDisplay` both deliver data to Lua** via SGWScriptedWindow handlers (confirmed from `docs/reverse-engineering/decompiled/01_sgw_game_classes.c` lines 4135–4161). The decompiled stubs call `FUN_00cd9580` (DialogDisplay) and `FUN_00ccca70` (4-arg Lua dispatcher). The CME event carries `DialogID` only — no speaker name, no `SpeakerID`. Lua must read the screen record from the CookedData cache using that `DialogID`.
+
+### Answer to Question C
+
+The player name appears in the Col Marsh case because `SpeakerID=256` has an empty (`''`) name in the `speakers` CookedData table. When Lua resolves an empty string from the CookedData lookup, it substitutes the current player's display name. This is the built-in fallback for zero or missing speaker names.
+
+Note: `entity_templates.speaker_id=941` is the server-side column used to populate `GENERICPROPERTY_DatabaseId` on the entity. It does NOT feed into CookedData at runtime — CookedData is baked at game-ship time. The relevant fix is in the `dialog_screens.speaker_id` column (which maps to the PAK `SpeakerID` field), not in `entity_templates.speaker_id`.
+
+---
+
+## Symptom Diagnoses
+
+### Prisoner 329 (dialog_id 2300) — blank portrait, correct name
+
+- Name correct: `SpeakerID` in the `dialog_screens` PAK record resolves to "Prisoner 329" in CookedData. This track is working.
+- Portrait blank: the `EntityId` in the server's `onDialogDisplay` wire event does not match the entity ID registered for Prisoner 329 in the client's AoI listener table. The target-selector widget sees the entity (it uses the AoI grid/zone system), but `LookupEntityListenerEntry` does not find it under the entity ID the server sent. Result: `FUN_00d22c90` returns early (`uVar7 == 0`), slot 17 is never set, portrait never renders.
+
+### Future Col Marsh (dialog_id 4001) — player name on all screens, blank portrait
+
+- Name wrong: `SpeakerID=256` in `dialog_screens` has an empty string in the CookedData `speakers` table. Lua fallback substitutes the player name. The PAK entry must be corrected to point to the right speaker record, or the speakers table entry for 256 must be populated.
+- Portrait blank: same entity-ID mismatch as Prisoner 329. Additionally, Future Col Marsh may not be spawned as an AoI entity at the dialog trigger location — Marsh's dialog fires before or during a cutscene, not while standing next to a visible NPC.
+
+---
+
+## Answer to Question A — Full Render Path
+
+```
+Wire arrives:  Event_NetIn_DialogDisplay (method 105)
+               payload: EntityId, DialogID
+
+FUN_00d25310:  matches EntityId → finds AvailableDialog → calls FUN_00d25200
+
+FUN_00d24f10:  determines player/NPC slot (screen byte 0x28 == 3 ?)
+               calls FUN_00d22c90(dialog, 0x1b58) — player slot
+               calls FUN_00d22c90(dialog, 0x1bbc) — NPC slot
+               both internally: LookupEntityListenerEntry(GameEntityManager, entityId, ...)
+               if found: pins entity → fires into slot 17 via FUN_00c67bd0
+
+FUN_00c67bd0:  GameEntityManager[slot 17] = entityId
+               emits Event_UI_UnitMappingChanged
+
+SGWScriptedWindow:  receives UnitMappingChanged
+               dispatches to Lua dialog script
+
+Lua:           reads slot-17 entity
+               calls createCharacterPortrait(imageset, entity, ...)
+               FUN_00ac58d0 → FUN_00ae2b20:
+                 ImagesetManager::getImageset(imageset)
+                 FUN_00e6b890(PortraitManager, entity, ...)
+                   FUN_00e6a430: LookupEntityListenerEntry again
+                   if found: render head mesh into portrait circle
+
+FUN_00d27b80:  emits Event_UI_DialogDisplay (carries DialogID)
+
+SGWScriptedWindow:  receives DialogDisplay
+               dispatches to Lua dialog script
+
+Lua:           uses DialogID to look up dialog from CookedData cache
+               reads current screen's SpeakerID from piVar2[7]
+               looks up name from CookedData speakers table
+               if name empty or SpeakerID==0: substitutes player name
+               sets name label text
+```
+
+---
+
+## Implementation Impact (Server-Side)
+
+### Fix 1 — Portrait (both NPCs)
+
+The server must ensure `EntityId` in `onDialogDisplay` equals the entity ID the client received during entity creation for that NPC. The most robust path:
+
+- Track the entity ID assigned during `CREATE_CELL` or equivalent for the dialog NPC.
+- Pass that entity ID — not a database ID, not a template ID — as the `EntityId` field in the `Event_NetIn_DialogDisplay` wire event.
+
+### Fix 2 — Col Marsh name
+
+Either:
+- Update the `speakers` table entry for `SpeakerID=256` to have name `"Future Col Marsh"` (or the correct localized string); or
+- Update `dialog_screens` rows for `dialog_id=4001` to reference a `SpeakerID` that already has the correct name in CookedData.
+
+The `entity_templates.speaker_id=941` field is irrelevant to name display. It is used only for the `GENERICPROPERTY_DatabaseId` AoI broadcast, not for CookedData name lookup.
+
+### Fix 3 — Prisoner 329 entity visibility
+
+If Prisoner 329 is in its cell and the dialog fires while the player is adjacent, the entity should already be in AoI. Verify whether the server is:
+(a) sending the wrong `EntityId` in `onDialogDisplay` (most likely), or
+(b) not including Prisoner 329 in the AoI update before dialog fires (race condition).
+
+If (b), the server must ensure the NPC entity creation messages complete before the dialog display message is sent.
+
+---
+
+## Open Questions
+
+1. **Constants `0x1b58` / `0x1bbc` (decimal 7000 / 7100)**: These are passed to `FUN_00d22c90` as the second argument — likely screen-type or dialog-slot enum values distinguishing player vs NPC sides. Exact semantics not confirmed; functional behavior confirmed by context.
+
+2. **`Event_UI_DialogSpeakerChanged` emitter**: Not fully traced. Likely fired from screen-transition logic within `DialogController` when the active screen changes and the speaker entity differs. Does not affect the main portrait path (which is driven by `UnitMappingChanged`) but may affect per-screen name updates.
+
+3. **Lua script source**: The dialog Lua script that reads `SpeakerID` and calls `createCharacterPortrait` was not recovered — it is in the game's Lua package, not the binary. The call chain above is inferred from the C++ bindings and CME event routing. The fallback-to-player-name behavior is inferred from symptom observation; the exact Lua condition (empty string? SpeakerID==0?) is not confirmed from source.
+
+4. **Screen byte `0x28 == 3` condition**: The decompiled `FUN_00d24f10` selects player vs NPC slot based on a byte at offset `0x28` of the screen record. The exact enum values are not catalogued here.
+
+---
+
+## Summary Table
+
+| Question | Answer | Confidence |
+|----------|--------|------------|
+| A — render path | Wire EntityId → AoI lookup → slot 17 → UnitMappingChanged → Lua createCharacterPortrait | HIGH |
+| B — portrait lookup mechanism | Wire EntityId via LookupEntityListenerEntry; DatabaseId NOT used | HIGH |
+| C — name fallback trigger | SpeakerID → CookedData speakers table; empty string → player name | HIGH (mechanism), MEDIUM (exact fallback condition) |
+| D — required server wire data | EntityId in onDialogDisplay must match AoI entity ID; DatabaseId broadcast insufficient alone | HIGH |


### PR DESCRIPTION
## Summary

Chain-fired dialogs (`display_dialog` content action) and the
`initialResponse` handler were sending the **player's** entity id as
the wire `EntityId` field of `onDialogDisplay`, where the client
expects the **NPC's** id. The client uses that id as the key into
`LookupEntityListenerEntry` to bind the dialog portrait actor and
the per-screen speaker entity — so dialogs opened with the player
bound as the speaker, blanking the portrait and rendering the
player's name on every screen. The interact path itself was already
correct; only the chain + initialResponse paths needed the fix.

User-visible symptom: in Castle_CellBlock, Col Marsh's briefing
dialog (chain 1051 → `display_dialog 4001`) shows the player's name
on every screen with a blank portrait. Same shape for every
chain-fired dialog in the codebase.

## Fix

Threads the NPC entity id through to the wire:

- New `CellEntity::last_interaction_target: Option<u32>` (player-only
  pin, mirrors python's `SGWPlayer.lastInteractionTarget`). Written
  by `handle_interact` after the distance check passes.
- `handle_initial_response` reads the pin and uses it as the wire
  `EntityId`. Warns + aborts when unset (rather than falling back to
  the player, which was the bug).
- `dialog::display` resolves the NPC id as:
  1. `params["target_entity_id"]` — stamped by `fire_interact_*` for
     chains fired off an interact trigger.
  2. Player's `last_interaction_target` — covers `OnDialogChoice`
     follow-ups where the trigger event carries no NPC.
  3. Warn + abort — the warn level is load-bearing for operator
     triage.

## Evidence

New V5-session RE finding at
`docs/reverse-engineering/findings/dialog-portrait-lookup.md` traces
`Event_NetIn_DialogDisplay` through the SGW.exe binary:

```
FUN_00d25310 (handler) → FUN_00d24f10 → FUN_00d22c90
  → LookupEntityListenerEntry(GameEntityManager, npc_entity_id, ...)
  → slot 17 pin via FUN_00c67bd0
  → Event_UI_UnitMappingChanged
  → Lua createCharacterPortrait
```

The `LookupEntityListenerEntry` call is keyed by the wire EntityId,
not `GENERICPROPERTY_DatabaseId`. The earlier backfill in #386 was
orthogonal to the portrait widget — necessary for other paths, but
insufficient on its own to render the dialog portrait.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p cimmeria-services --all-targets -- -D warnings`
- [x] 534 cell tests + 21 executor tests + 12 dialog-themed tests pass
- [x] 7 new regression guards added, all bug-shape (fail when fix is
      reverted):
  - dispatch: pins `args[0..4]` are the NPC id, pins
    `last_interaction_target` write semantics, pins the abort + WARN
    when the pin is missing.
  - executor::dialog: pins params resolution, fallback to the player
    pin, and the WARN-and-abort path when neither is available.
- [ ] Manual: log in, talk to Col Marsh in Castle_CellBlock, verify
      his portrait renders and his name appears on his lines.
- [ ] Manual: same for every other chain-fired dialog (chains
      1014/1015/1021/1032/1052/1056/1057/1061/1099 reference
      `display_dialog`).

## Known remaining gaps (separate issues, out of scope)

- **Prisoner 329's portrait still blank** even with the correct wire
  EntityId — his interact path was already correct, so this PR
  doesn't change his case. The RE finding flags the AoI
  listener-table vs spatial AoI grid distinction as the next dig.
- **`speakers[256]` is empty in CookedData**, so Col Marsh's
  per-screen speaker *name* (separate from the portrait actor) will
  still fall back to the player on his lines until that PAK/seed row
  is populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)