### PR TITLE
fix(observability): record mercury.packet from UdpTransport, not Channel

### DIFF
--- a/crates/mercury/src/instrumentation.rs
+++ b/crates/mercury/src/instrumentation.rs
@@ -39,6 +39,23 @@
 //! attached, the event is queued onto the batch exporter's channel —
 //! the actual OTLP send happens on a background tokio task. Net cost
 //! on the hot send/receive path: a handful of nanoseconds.
+//!
+//! # Where these helpers actually fire
+//!
+//! `record_udp_packet` is called from [`crate::channel::Channel::send_packet`]
+//! and [`crate::channel::Channel::receive_packet`]. **In production
+//! those Channel methods are unused** — the hot wire path bypasses
+//! Channel and calls `UdpTransport::send_to` / `BidirectionalTransport::recv_from`
+//! directly. The production `mercury.packet` events are emitted
+//! *inline* in the transport impl (see [`crate::transport`]) rather
+//! than through this helper, because the transport layer doesn't
+//! have `seq`/`flags` to pass — those live inside the encrypted
+//! packet body.
+//!
+//! Keeping these helpers for the Channel-side fire is intentional:
+//! the test suite exercises Channel directly, and if a future
+//! refactor routes production traffic through Channel (e.g. to
+//! instrument retransmit ordering), the recording is already there.
 
 /// Direction of a packet relative to the server.
 #[derive(Copy, Clone, Debug)]

--- a/crates/mercury/src/transport.rs
+++ b/crates/mercury/src/transport.rs
@@ -61,7 +61,23 @@ impl UdpTransport {
 #[async_trait]
 impl Transport for UdpTransport {
     async fn send_to(&self, bytes: &[u8], addr: SocketAddr) -> io::Result<usize> {
-        self.socket.send_to(bytes, addr).await
+        let result = self.socket.send_to(bytes, addr).await;
+        // mercury.packet recording lives here (the actual production
+        // hot path) rather than in `Channel::send_packet`. The richer
+        // recording in Channel records `seq`/`flags` but Channel
+        // isn't called in production — only in tests. Without this
+        // helper at the transport layer, the entire `mercury.packet`
+        // log stream is empty in SigNoz.
+        tracing::info!(
+            target: "mercury.packet",
+            dir = "out",
+            transport = "udp",
+            len = bytes.len(),
+            peer = %addr,
+            ok = result.is_ok(),
+            "mercury_packet"
+        );
+        result
     }
 
     fn local_addr(&self) -> io::Result<SocketAddr> {
@@ -90,7 +106,19 @@ pub trait BidirectionalTransport: Transport {
 #[async_trait]
 impl BidirectionalTransport for UdpTransport {
     async fn recv_from(&self, buf: &mut [u8]) -> io::Result<(usize, SocketAddr)> {
-        self.socket.recv_from(buf).await
+        let result = self.socket.recv_from(buf).await;
+        if let Ok((len, addr)) = &result {
+            // See the send_to comment above — production hot path.
+            tracing::info!(
+                target: "mercury.packet",
+                dir = "in",
+                transport = "udp",
+                len = *len,
+                peer = %addr,
+                "mercury_packet"
+            );
+        }
+        result
     }
 }
 


### PR DESCRIPTION
## Summary

`mercury.packet` log events were not reaching SigNoz despite the OTLP plumbing being healthy and Mercury traffic being active. Confirmed via live SigNoz queries:

- Traces side: 2,118 \`base.datagram\` spans in a 15-min window (datagrams definitely flowing)
- Logs side: **zero** \`mercury.packet\` events in the last hour
- The OTLP log appender was otherwise working — boot logs + \`sqlx::query\` (~718/hr) all visible

## Root cause

The \`record_udp_packet\` helper was wired into \`Channel::send_packet\` and \`Channel::receive_packet\`. \`grep\` confirmed those methods have **zero production call sites** — they're called only from the Mercury test suite. The actual production hot wire path bypasses Channel and calls \`UdpTransport::send_to\` / \`BidirectionalTransport::recv_from\` directly.

So the instrumentation hooks in PR #396 (the original SigNoz integration) landed in the wrong layer. They've been dead code in production since they were written.

## Fix

Moved the recording to the actual hot path:

- \`UdpTransport::send_to\` — emits \`mercury.packet\` info event on every outbound datagram with \`dir=\"out\"\`, \`transport=\"udp\"\`, \`len\`, \`peer\`, \`ok\`.
- \`UdpTransport::recv_from\` — emits the same on every successful inbound datagram.

Fewer fields than the Channel-side recording (no \`seq\`/\`flags\`) because the transport layer doesn't have access to those — they live inside the encrypted packet body and are only decoded by later stages. Still enough to answer \"is this peer sending traffic?\" and \"what's our packet rate?\" in SigNoz.

The Channel-side helpers are kept in place (no harm — they no-op when no subscriber is active) so the test suite continues to exercise them, and so a future refactor that routes production traffic through Channel can immediately benefit from richer recording. The dual-site convention is documented in [\`crates/mercury/src/instrumentation.rs\`](crates/mercury/src/instrumentation.rs).

## Test plan

- [x] \`cargo check -p cimmeria-server\` ✅
- [x] \`cargo clippy -p cimmeria-mercury --all-targets -- -D warnings\` ✅
- [x] 230/230 mercury tests pass ✅
- [ ] After deploy, verify \`scope_name = \"mercury.packet\"\` filter in SigNoz Logs returns events at a rate roughly matching \`base.datagram\` trace count × 2 (one event per direction per packet)

## Why this is a separate small PR

This was discovered while reviewing the PR #400 work end-to-end — the diagnostic loop the new spans enable surfaced this PR #396 latent bug. Since #400 has already merged, this is a small, focused fix that should land independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced instrumentation module documentation clarifying helper invocation patterns across different execution paths.

* **Chores**
  * Added UDP packet event logging tracking inbound and outbound transmissions with directional metadata, transport identifier, payload size, peer address, and operation outcome.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SandboxServers/Cimmeria/pull/402?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->