### PR TITLE
feat(observability): wire-log capture stream — per-message decode to SigNoz

### DIFF
--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -570,6 +570,7 @@ fn init_logging(
                 cimmeria_mercury=debug,\
                 mercury.packet=info,\
                 mercury.retransmit=info,\
+                wire.in=info,wire.out=info,\
                 aoi.entity_enter=debug,aoi.entity_leave=debug,\
                 movement.npc=debug,movement.player=debug,\
                 sqlx::query=debug,\

--- a/crates/services/src/base/connect_loop/encrypted/mod.rs
+++ b/crates/services/src/base/connect_loop/encrypted/mod.rs
@@ -179,6 +179,12 @@ pub(crate) async fn handle_encrypted_datagram(
 
         tracing::debug!(%addr, msg_id = format_args!("{:#04x}", msg_id), payload_len = payload.len(), "Client bundle message");
 
+        // wire.in capture — every inbound bundle message gets logged
+        // with its msg_name + args_hex + schema-decoded fields (when
+        // a decoder is registered). See `crate::wire_log` for the
+        // capture contract.
+        crate::wire_log::log_inbound(addr, msg_id, payload);
+
         // Dispatch message.
         //
         // The client cache methods are protocol-level messages that keep the

--- a/crates/services/src/base/connect_loop/encrypted/mod.rs
+++ b/crates/services/src/base/connect_loop/encrypted/mod.rs
@@ -179,10 +179,6 @@ pub(crate) async fn handle_encrypted_datagram(
 
         tracing::debug!(%addr, msg_id = format_args!("{:#04x}", msg_id), payload_len = payload.len(), "Client bundle message");
 
-        // wire.in capture — every inbound bundle message gets logged
-        // with its msg_name + args_hex + schema-decoded fields (when
-        // a decoder is registered). See `crate::wire_log` for the
-        // capture contract.
         crate::wire_log::log_inbound(addr, msg_id, payload);
 
         // Dispatch message.

--- a/crates/services/src/base/world_entry/cell_dispatch/mod.rs
+++ b/crates/services/src/base/world_entry/cell_dispatch/mod.rs
@@ -197,6 +197,12 @@ pub(crate) async fn handle_cell_message(
             method_index,
             args,
         } => {
+            // wire.out capture — log the method call before the
+            // deferred-buffer check so even buffered calls (pre-
+            // onClientReady) get captured. Recovery via deferred
+            // replay does NOT re-log; the original send is the wire
+            // truth.
+            crate::wire_log::log_outbound_entity_method(entity_id, entity_id, method_index, &args);
             // Gate on the TARGET entity's session — entity-method calls
             // are dispatched to the entity_id's owning client (see
             // `aoi::entity_method_call`'s lookup). If that client is
@@ -371,6 +377,11 @@ pub(crate) async fn handle_cell_message(
             method_index,
             args,
         } => {
+            // wire.out capture — AoI-fanout entity-method calls. The
+            // observer (`witness_id`) and observee (`entity_id`) differ
+            // here, so both ride on the event for "show me everything
+            // entity X broadcast to its witnesses" queries.
+            crate::wire_log::log_outbound_entity_method(witness_id, entity_id, method_index, &args);
             aoi::witness_entity_method(
                 witness_id,
                 entity_id,

--- a/crates/services/src/base/world_entry/cell_dispatch/mod.rs
+++ b/crates/services/src/base/world_entry/cell_dispatch/mod.rs
@@ -197,11 +197,9 @@ pub(crate) async fn handle_cell_message(
             method_index,
             args,
         } => {
-            // wire.out capture — log the method call before the
-            // deferred-buffer check so even buffered calls (pre-
-            // onClientReady) get captured. Recovery via deferred
-            // replay does NOT re-log; the original send is the wire
-            // truth.
+            // Logged before the deferred-buffer check so pre-
+            // onClientReady buffered calls still appear once on the
+            // wire log; deferred-replay does NOT re-emit.
             crate::wire_log::log_outbound_entity_method(entity_id, entity_id, method_index, &args);
             // Gate on the TARGET entity's session — entity-method calls
             // are dispatched to the entity_id's owning client (see
@@ -377,10 +375,9 @@ pub(crate) async fn handle_cell_message(
             method_index,
             args,
         } => {
-            // wire.out capture — AoI-fanout entity-method calls. The
-            // observer (`witness_id`) and observee (`entity_id`) differ
-            // here, so both ride on the event for "show me everything
-            // entity X broadcast to its witnesses" queries.
+            // observer (witness_id) and observee (entity_id) differ
+            // on the AoI fanout — both are recorded so SigNoz can
+            // answer "what did entity X broadcast to its witnesses?"
             crate::wire_log::log_outbound_entity_method(witness_id, entity_id, method_index, &args);
             aoi::witness_entity_method(
                 witness_id,

--- a/crates/services/src/lib.rs
+++ b/crates/services/src/lib.rs
@@ -17,6 +17,7 @@ pub mod minigame;
 pub mod orchestrator;
 mod orchestrator_postgres;
 mod orchestrator_shards;
+pub mod wire_log;
 
 #[cfg(test)]
 pub(crate) mod test_support;

--- a/crates/services/src/wire_log/client_names.rs
+++ b/crates/services/src/wire_log/client_names.rs
@@ -1,0 +1,251 @@
+//! Method-name lookup for the wire-log capture surface.
+//!
+//! Two sides:
+//!
+//! * [`outbound_method_name`] — server→client method indices (157
+//!   methods on SGWPlayer). The flat index encoding is per
+//!   `docs/protocol/client-method-dispatch-table.md`: indices 0–60
+//!   ship as direct `msg_id = 0x80 + index`; 61+ use the extended
+//!   encoding (`msg_id = 0xBD`, sub-byte = `index - 61`). The wire-log
+//!   captures at the structured-message layer where `method_index`
+//!   is the *flat* index, so this table is keyed by flat index.
+//!
+//! * [`inbound_msg_name`] — client→server message IDs. Bundled
+//!   system-message IDs (0x00–0x0D) get explicit names; entity-method
+//!   calls (0xC0+) fall through to the cell-method-name lookup at
+//!   `cell::dispatch::names::cell_method_name`, which already covers
+//!   the full set.
+
+/// Outbound (server → client) method name for the flat SGWPlayer
+/// method index. Source: `docs/protocol/client-method-dispatch-table.md`.
+/// Unknown indices return `"unknown"`.
+pub fn outbound_method_name(method_index: u16) -> &'static str {
+    match method_index {
+        0 => "onStaticMeshNameUpdate",
+        1 => "onSequence",
+        2 => "onEntityMove",
+        3 => "InteractionType",
+        4 => "onEntityFlags",
+        5 => "getInteractions",
+        6 => "toggleInteractionDebugging",
+        7 => "onEntityProperty",
+        8 => "onVisible",
+        9 => "onKismetEventSetUpdate",
+        10 => "onEntityTint",
+        11 => "onBeingNameIDUpdate",
+        12 => "onTimerUpdate",
+        13 => "onEffectUserData",
+        14 => "onEffectResults",
+        15 => "onLevelUpdate",
+        16 => "onTargetUpdate",
+        17 => "onBeingNameUpdate",
+        18 => "onTopSpeedUpdate",
+        19 => "onStateFieldUpdate",
+        20 => "onStatUpdate",
+        21 => "onStatBaseUpdate",
+        22 => "onMeleeRangeUpdate",
+        23 => "onArchetypeUpdate",
+        24 => "onAlignmentUpdate",
+        25 => "onFactionUpdate",
+        26 => "BeingAppearance",
+        27 => "onSystemCommunication",
+        28 => "onPlayerCommunication",
+        29 => "onLocalizedCommunication",
+        30 => "onTellSent",
+        31 => "onChatJoined",
+        32 => "onChatLeft",
+        33 => "onNickChanged",
+        34 => "onOrganizationInvite",
+        35 => "onOrganizationJoined",
+        36 => "onOrganizationLeft",
+        37 => "onMemberJoinedOrganization",
+        38 => "onOrganizationRosterInfo",
+        39 => "onMemberLeftOrganization",
+        40 => "onMemberRankChangedOrganization",
+        41 => "onStrikeTeamUpdate",
+        42 => "onPvPOrganizationLeaveRequest",
+        43 => "onOrganizationNameUpdate",
+        44 => "onOrganizationExperienceUpdate",
+        45 => "onOrganizationMOTDUpdate",
+        46 => "onOrganizationNoteUpdate",
+        47 => "onOrganizationOfficerNoteUpdate",
+        48 => "onOrganizationCashUpdate",
+        49 => "onOrganizationRankUpdate",
+        50 => "onOrganizationRankNameUpdate",
+        51 => "onSquadLootType",
+        52 => "onStartMinigame",
+        53 => "onStartMinigameDialog",
+        54 => "onStartMinigameDialogClose",
+        55 => "onEndMinigame",
+        56 => "onSpectateList",
+        57 => "onMinigameRegistrationPrompt",
+        58 => "minigameRegistrationInfo",
+        59 => "addOrUpdateMinigameHelper",
+        60 => "removeMinigameHelper",
+        61 => "minigameCallDisplay",
+        62 => "minigameCallResult",
+        63 => "minigameCallAbort",
+        64 => "showMinigameContact",
+        65 => "setupStargateInfo",
+        66 => "updateStargateAddress",
+        67 => "stargateRotationOverride",
+        68 => "onStargatePassage",
+        69 => "onBagInfo",
+        70 => "onActiveSlotUpdate",
+        71 => "onRemoveItem",
+        72 => "onUpdateItem",
+        73 => "onRefreshItem",
+        74 => "onClearOrgVaultInventory",
+        75 => "onCashChanged",
+        76 => "onMailHeaderInfo",
+        77 => "onMailHeaderRemove",
+        78 => "onMailRead",
+        79 => "sendMailResult",
+        80 => "onMissionUpdate",
+        81 => "onStepUpdate",
+        82 => "onObjectiveUpdate",
+        83 => "onTaskUpdate",
+        84 => "offerSharedMission",
+        85 => "onContactListUpdate",
+        86 => "onContactListDelete",
+        87 => "onContactListAddMembers",
+        88 => "onContactListRemoveMembers",
+        89 => "onContactListEvent",
+        90 => "onBMOpen",
+        91 => "onBMError",
+        92 => "onBMAuctions",
+        93 => "onBMAuctionRemove",
+        94 => "onBMAuctionUpdate",
+        95 => "onBMWatchedItemsUpdate",
+        96 => "onVersionInfo",
+        97 => "onCookedDataError",
+        98 => "onBeginAidWait",
+        99 => "onEndAidWait",
+        100 => "onDHDReply",
+        101 => "onKnownAbilitiesUpdate",
+        102 => "onTimeofDay",
+        103 => "onOverridePerfStatsRate",
+        104 => "onInitialInteraction",
+        105 => "onDialogDisplay",
+        106 => "onVaultOpen",
+        107 => "onTeamVaultOpen",
+        108 => "onCommandVaultOpen",
+        109 => "onStoreOpen",
+        110 => "onStoreUpdate",
+        111 => "onStoreClose",
+        112 => "onCraftingRespecPrompt",
+        113 => "onTrainerOpen",
+        114 => "onLootDisplay",
+        115 => "onPlayerDataLoaded",
+        116 => "onPlayerTeleport",
+        117 => "onClientMapLoad",
+        118 => "giveAbility",
+        119 => "giveXPForLevel",
+        120 => "onDisplayDHD",
+        121 => "onErrorCode",
+        122 => "setupWorldParameters",
+        123 => "onMapInfo",
+        124 => "clearClientHintedGenericRegions",
+        125 => "addClientHintedGenericRegion",
+        126 => "onResetMapInfo",
+        127 => "onMissionRewardsDisplay",
+        128 => "onMissionOfferDisplay",
+        129 => "stargateTriggerFailed",
+        130 => "onExtraNameUpdate",
+        131 => "onExpUpdate",
+        132 => "onMaxExpUpdate",
+        133 => "onRingTransporterList",
+        134 => "onOrganizationCreationResult",
+        135 => "launchOrganizationCreation",
+        136 => "onUpdateDiscipline",
+        137 => "onDisciplineRespec",
+        138 => "onUpdateRacialParadigmLevel",
+        139 => "onUpdateKnownCrafts",
+        140 => "onUpdateCraftingOptions",
+        141 => "onAbilityTreeInfo",
+        142 => "onClientChallenge",
+        143 => "onDuelChallenge",
+        144 => "onTradeState",
+        145 => "onTradeResults",
+        146 => "onSpaceQueued",
+        147 => "onSpaceQueueReady",
+        148 => "onRemoteEntityCreate",
+        149 => "onRemoteEntityMove",
+        150 => "onRemoteEntityRemove",
+        151 => "onDuelEntitiesSet",
+        152 => "onDuelEntitiesRemove",
+        153 => "onDuelEntitiesClear",
+        154 => "onThreatenedMobsUpdate",
+        155 => "onPlayMovie",
+        156 => "onCancelMovie",
+        _ => "unknown",
+    }
+}
+
+/// Inbound (client → server) message name for the bundle msg_id byte.
+///
+/// System messages 0x00–0x0D have fixed wire formats per the
+/// ClientMessageList table in `messages.cpp` (legacy reference);
+/// entity-method calls land at 0xC0+ and delegate to the existing
+/// cell-method-name lookup, which already covers the full set.
+pub fn inbound_msg_name(msg_id: u8) -> &'static str {
+    match msg_id {
+        0x00 => "loginRequest",
+        0x01 => "authenticate",
+        0x02 => "avatarUpdateImplicit",
+        0x03 => "avatarUpdateExplicit",
+        0x04 => "avatarUpdwImplicit",
+        0x05 => "avatarUpdwExplicit",
+        0x06 => "loggedOff",
+        0x07 => "requestEntityUpdate",
+        0x08 => "enableEntities",
+        0x09 => "viewportAck",
+        0x0A => "createCellPlayer",
+        0x0B => "restoreClientAck",
+        0x0C => "disconnect",
+        0x0D => "channelSetup",
+        // Entity-method calls (0xC0+) delegate to the cell-method
+        // table — that's the canonical naming the dispatch code
+        // already uses for these.
+        0xC0..=0xFF => crate::cell::dispatch::cell_method_name(msg_id as u16),
+        _ => "unknown",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Pin the 157-method coverage. A regression that drops or
+    /// renumbers a row in the dispatch table will trip this guard.
+    #[test]
+    fn outbound_method_table_covers_full_range() {
+        // Indices 0..157 should all resolve to a non-"unknown" name.
+        for idx in 0..157u16 {
+            let name = outbound_method_name(idx);
+            assert_ne!(
+                name, "unknown",
+                "client method index {idx} missing from table"
+            );
+        }
+        // Index 157+ should fall through to "unknown".
+        assert_eq!(outbound_method_name(157), "unknown");
+        assert_eq!(outbound_method_name(999), "unknown");
+    }
+
+    #[test]
+    fn outbound_method_names_load_bearing_examples() {
+        assert_eq!(outbound_method_name(1), "onSequence");
+        assert_eq!(outbound_method_name(26), "BeingAppearance");
+        assert_eq!(outbound_method_name(105), "onDialogDisplay");
+        assert_eq!(outbound_method_name(154), "onThreatenedMobsUpdate");
+    }
+
+    #[test]
+    fn inbound_system_messages_named() {
+        assert_eq!(inbound_msg_name(0x01), "authenticate");
+        assert_eq!(inbound_msg_name(0x03), "avatarUpdateExplicit");
+        assert_eq!(inbound_msg_name(0x08), "enableEntities");
+        assert_eq!(inbound_msg_name(0x0C), "disconnect");
+    }
+}

--- a/crates/services/src/wire_log/decoders/generated.rs
+++ b/crates/services/src/wire_log/decoders/generated.rs
@@ -1,0 +1,1621 @@
+//! Auto-generated wire-format decoders for SGWPlayer client methods.
+//!
+//! **DO NOT EDIT BY HAND** — regenerate via:
+//!
+//! ```sh
+//! python tools/wire_decoder_codegen.py > \
+//!     crates/services/src/wire_log/decoders/generated.rs
+//! cargo fmt -p cimmeria-services
+//! ```
+//!
+//! Source schemas: `docs/protocol/client-method-dispatch-table.md`.
+//! Schemas using composite types (StatUpdateList, ClientEffectResultList,
+//! NameValuePair, FIXED_DICTs, MAILBOX, etc.) are skipped here — they
+//! fall through to the hand-written decoders in
+//! [`crate::wire_log::decoders::outbound`], which override the
+//! generated table when both define the same method.
+
+// Local variable names mirror the protocol's PascalCase / camelCase
+// field names so the codegen stays simple and the generated source
+// reads alongside the dispatch table. Clippy / rustc would otherwise
+// flag every binding.
+#![allow(non_snake_case, clippy::needless_question_mark)]
+
+use serde_json::{json, Value};
+
+use super::primitives::Cursor;
+
+/// Read an ARRAY<primitive> by reading a u32 count then `min(count,
+/// 32)` repeats. Truncates at 32 to bound per-event size; `count` and
+/// `truncated` fields preserve the original size for SigNoz queries.
+macro_rules! read_array {
+    ($cursor:expr, $read:expr) => {{
+        let count = $cursor.u32_le()?;
+        let cap = (count as usize).min(32);
+        let mut items: Vec<Value> = Vec::with_capacity(cap);
+        for _ in 0..cap {
+            items.push(json!($read));
+        }
+        json!({
+            "count": count,
+            "items": items,
+            "truncated": count > 32,
+        })
+    }};
+}
+
+/// Method 0: `onStaticMeshNameUpdate`. Auto-generated.
+pub(super) fn decode_0(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let staticMeshName = c.wstring()?;
+    let bodySetName = c.wstring()?;
+    Some(json!({
+        "StaticMeshName": staticMeshName,
+        "BodySetName": bodySetName,
+    }))
+}
+
+/// Method 2: `onEntityMove`. Auto-generated.
+pub(super) fn decode_2(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let locationX = c.f32_le()?;
+    let locationY = c.f32_le()?;
+    let locationZ = c.f32_le()?;
+    let velocityX = c.f32_le()?;
+    let velocityY = c.f32_le()?;
+    let velocityZ = c.f32_le()?;
+    let yaw = c.f32_le()?;
+    let pitch = c.f32_le()?;
+    let roll = c.f32_le()?;
+    Some(json!({
+        "locationX": locationX,
+        "locationY": locationY,
+        "locationZ": locationZ,
+        "velocityX": velocityX,
+        "velocityY": velocityY,
+        "velocityZ": velocityZ,
+        "yaw": yaw,
+        "pitch": pitch,
+        "roll": roll,
+    }))
+}
+
+/// Method 3: `InteractionType`. Auto-generated.
+pub(super) fn decode_3(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let typeId = c.u64_le()?;
+    Some(json!({
+        "TypeId": typeId,
+    }))
+}
+
+/// Method 4: `onEntityFlags`. Auto-generated.
+pub(super) fn decode_4(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let aFlags = c.u64_le()?;
+    Some(json!({
+        "aFlags": aFlags,
+    }))
+}
+
+/// Method 6: `toggleInteractionDebugging`. Auto-generated.
+pub(super) fn decode_6(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let playerId = c.i32_le()?;
+    Some(json!({
+        "playerId": playerId,
+    }))
+}
+
+/// Method 7: `onEntityProperty`. Auto-generated.
+pub(super) fn decode_7(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let type_ = c.i32_le()?;
+    let value = c.i32_le()?;
+    Some(json!({
+        "type": type_,
+        "value": value,
+    }))
+}
+
+/// Method 8: `onVisible`. Auto-generated.
+pub(super) fn decode_8(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let visible = c.i8()?;
+    Some(json!({
+        "visible": visible,
+    }))
+}
+
+/// Method 9: `onKismetEventSetUpdate`. Auto-generated.
+pub(super) fn decode_9(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let kismetEventSetId = c.i32_le()?;
+    Some(json!({
+        "kismetEventSetId": kismetEventSetId,
+    }))
+}
+
+/// Method 10: `onEntityTint`. Auto-generated.
+pub(super) fn decode_10(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let primaryColorId = c.u32_le()?;
+    let secondaryColorId = c.u32_le()?;
+    let skinColorId = c.u32_le()?;
+    Some(json!({
+        "primaryColorId": primaryColorId,
+        "secondaryColorId": secondaryColorId,
+        "skinColorId": skinColorId,
+    }))
+}
+
+/// Method 11: `onBeingNameIDUpdate`. Auto-generated.
+pub(super) fn decode_11(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let beingNameID = c.i32_le()?;
+    Some(json!({
+        "BeingNameID": beingNameID,
+    }))
+}
+
+/// Method 12: `onTimerUpdate`. Auto-generated.
+pub(super) fn decode_12(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let iD = c.i32_le()?;
+    let type_ = c.i8()?;
+    let sourceID = c.i32_le()?;
+    let totalTime = c.f32_le()?;
+    let bigWorldTimeComplete = c.f32_le()?;
+    Some(json!({
+        "ID": iD,
+        "Type": type_,
+        "SourceID": sourceID,
+        "TotalTime": totalTime,
+        "BigWorldTimeComplete": bigWorldTimeComplete,
+    }))
+}
+
+/// Method 13: `onEffectUserData`. Auto-generated.
+pub(super) fn decode_13(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let instanceId = c.i32_le()?;
+    let userDataNames = read_array!(c, c.wstring()?);
+    let userDataValues = read_array!(c, c.wstring()?);
+    Some(json!({
+        "InstanceId": instanceId,
+        "UserDataNames": userDataNames,
+        "UserDataValues": userDataValues,
+    }))
+}
+
+/// Method 15: `onLevelUpdate`. Auto-generated.
+pub(super) fn decode_15(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let level = c.i32_le()?;
+    Some(json!({
+        "Level": level,
+    }))
+}
+
+/// Method 16: `onTargetUpdate`. Auto-generated.
+pub(super) fn decode_16(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let targetId = c.i32_le()?;
+    Some(json!({
+        "TargetId": targetId,
+    }))
+}
+
+/// Method 17: `onBeingNameUpdate`. Auto-generated.
+pub(super) fn decode_17(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let beingName = c.wstring()?;
+    Some(json!({
+        "BeingName": beingName,
+    }))
+}
+
+/// Method 18: `onTopSpeedUpdate`. Auto-generated.
+pub(super) fn decode_18(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let topSpeed = c.f32_le()?;
+    Some(json!({
+        "TopSpeed": topSpeed,
+    }))
+}
+
+/// Method 19: `onStateFieldUpdate`. Auto-generated.
+pub(super) fn decode_19(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let bStateField = c.i32_le()?;
+    Some(json!({
+        "bStateField": bStateField,
+    }))
+}
+
+/// Method 22: `onMeleeRangeUpdate`. Auto-generated.
+pub(super) fn decode_22(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let range = c.i32_le()?;
+    Some(json!({
+        "range": range,
+    }))
+}
+
+/// Method 23: `onArchetypeUpdate`. Auto-generated.
+pub(super) fn decode_23(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let archetype = c.i32_le()?;
+    Some(json!({
+        "archetype": archetype,
+    }))
+}
+
+/// Method 24: `onAlignmentUpdate`. Auto-generated.
+pub(super) fn decode_24(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let alignment = c.i8()?;
+    Some(json!({
+        "alignment": alignment,
+    }))
+}
+
+/// Method 25: `onFactionUpdate`. Auto-generated.
+pub(super) fn decode_25(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let faction = c.i8()?;
+    Some(json!({
+        "faction": faction,
+    }))
+}
+
+/// Method 26: `BeingAppearance`. Auto-generated.
+pub(super) fn decode_26(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let bodySet = c.wstring()?;
+    let components = read_array!(c, c.wstring()?);
+    Some(json!({
+        "BodySet": bodySet,
+        "Components": components,
+    }))
+}
+
+/// Method 28: `onPlayerCommunication`. Auto-generated.
+pub(super) fn decode_28(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let speaker = c.wstring()?;
+    let speakerFlags = c.u8()?;
+    let channel = c.u8()?;
+    let text = c.wstring()?;
+    Some(json!({
+        "Speaker": speaker,
+        "SpeakerFlags": speakerFlags,
+        "Channel": channel,
+        "Text": text,
+    }))
+}
+
+/// Method 30: `onTellSent`. Auto-generated.
+pub(super) fn decode_30(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let aTarget = c.wstring()?;
+    let aText = c.wstring()?;
+    Some(json!({
+        "aTarget": aTarget,
+        "aText": aText,
+    }))
+}
+
+/// Method 31: `onChatJoined`. Auto-generated.
+pub(super) fn decode_31(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let channelName = c.wstring()?;
+    let channelID = c.u8()?;
+    Some(json!({
+        "ChannelName": channelName,
+        "ChannelID": channelID,
+    }))
+}
+
+/// Method 32: `onChatLeft`. Auto-generated.
+pub(super) fn decode_32(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let channelName = c.wstring()?;
+    Some(json!({
+        "ChannelName": channelName,
+    }))
+}
+
+/// Method 33: `onNickChanged`. Auto-generated.
+pub(super) fn decode_33(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let aPlayerName = c.wstring()?;
+    let aPlayerNickname = c.wstring()?;
+    let aAddRemoveFlag = c.u8()?;
+    Some(json!({
+        "aPlayerName": aPlayerName,
+        "aPlayerNickname": aPlayerNickname,
+        "aAddRemoveFlag": aAddRemoveFlag,
+    }))
+}
+
+/// Method 34: `onOrganizationInvite`. Auto-generated.
+pub(super) fn decode_34(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let aInviterName = c.wstring()?;
+    let aOrganizationType = c.u8()?;
+    let aRequestID = c.i32_le()?;
+    let aName = c.wstring()?;
+    let aIsStrikeTeam = c.u8()?;
+    Some(json!({
+        "aInviterName": aInviterName,
+        "aOrganizationType": aOrganizationType,
+        "aRequestID": aRequestID,
+        "aName": aName,
+        "aIsStrikeTeam": aIsStrikeTeam,
+    }))
+}
+
+/// Method 35: `onOrganizationJoined`. Auto-generated.
+pub(super) fn decode_35(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let aOrganizationId = c.i32_le()?;
+    let aOrganizationType = c.u8()?;
+    let aRank = c.u8()?;
+    let aNewMember = c.u8()?;
+    Some(json!({
+        "aOrganizationId": aOrganizationId,
+        "aOrganizationType": aOrganizationType,
+        "aRank": aRank,
+        "aNewMember": aNewMember,
+    }))
+}
+
+/// Method 36: `onOrganizationLeft`. Auto-generated.
+pub(super) fn decode_36(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let aReason = c.u8()?;
+    let aOrganizationId = c.i32_le()?;
+    Some(json!({
+        "aReason": aReason,
+        "aOrganizationId": aOrganizationId,
+    }))
+}
+
+/// Method 37: `onMemberJoinedOrganization`. Auto-generated.
+pub(super) fn decode_37(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let aMemberName = c.wstring()?;
+    let aMember = c.i32_le()?;
+    let aOrganizationId = c.i32_le()?;
+    let aRank = c.u8()?;
+    let aNewMember = c.u8()?;
+    Some(json!({
+        "aMemberName": aMemberName,
+        "aMember": aMember,
+        "aOrganizationId": aOrganizationId,
+        "aRank": aRank,
+        "aNewMember": aNewMember,
+    }))
+}
+
+/// Method 39: `onMemberLeftOrganization`. Auto-generated.
+pub(super) fn decode_39(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let aMember = c.i32_le()?;
+    let aReason = c.u8()?;
+    let aOrganizationId = c.i32_le()?;
+    let aMemberName = c.wstring()?;
+    Some(json!({
+        "aMember": aMember,
+        "aReason": aReason,
+        "aOrganizationId": aOrganizationId,
+        "aMemberName": aMemberName,
+    }))
+}
+
+/// Method 40: `onMemberRankChangedOrganization`. Auto-generated.
+pub(super) fn decode_40(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let aMember = c.i32_le()?;
+    let aRank = c.u8()?;
+    let aOrganizationId = c.i32_le()?;
+    let aMemberName = c.wstring()?;
+    Some(json!({
+        "aMember": aMember,
+        "aRank": aRank,
+        "aOrganizationId": aOrganizationId,
+        "aMemberName": aMemberName,
+    }))
+}
+
+/// Method 41: `onStrikeTeamUpdate`. Auto-generated.
+pub(super) fn decode_41(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let aOrganizationId = c.i32_le()?;
+    let aPvPValue = c.u8()?;
+    Some(json!({
+        "aOrganizationId": aOrganizationId,
+        "aPvPValue": aPvPValue,
+    }))
+}
+
+/// Method 42: `onPvPOrganizationLeaveRequest`. Auto-generated.
+pub(super) fn decode_42(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let aOrganizationId = c.i32_le()?;
+    let aPvPValue = c.u8()?;
+    Some(json!({
+        "aOrganizationId": aOrganizationId,
+        "aPvPValue": aPvPValue,
+    }))
+}
+
+/// Method 43: `onOrganizationNameUpdate`. Auto-generated.
+pub(super) fn decode_43(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let aOrganizationId = c.i32_le()?;
+    let aName = c.wstring()?;
+    Some(json!({
+        "aOrganizationId": aOrganizationId,
+        "aName": aName,
+    }))
+}
+
+/// Method 44: `onOrganizationExperienceUpdate`. Auto-generated.
+pub(super) fn decode_44(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let aOrganizationId = c.i32_le()?;
+    let aExperience = c.u64_le()?;
+    Some(json!({
+        "aOrganizationId": aOrganizationId,
+        "aExperience": aExperience,
+    }))
+}
+
+/// Method 45: `onOrganizationMOTDUpdate`. Auto-generated.
+pub(super) fn decode_45(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let aOrganizationId = c.i32_le()?;
+    let aMOTD = c.wstring()?;
+    Some(json!({
+        "aOrganizationId": aOrganizationId,
+        "aMOTD": aMOTD,
+    }))
+}
+
+/// Method 46: `onOrganizationNoteUpdate`. Auto-generated.
+pub(super) fn decode_46(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let aOrganizationId = c.i32_le()?;
+    let aName = c.wstring()?;
+    let aNote = c.wstring()?;
+    Some(json!({
+        "aOrganizationId": aOrganizationId,
+        "aName": aName,
+        "aNote": aNote,
+    }))
+}
+
+/// Method 47: `onOrganizationOfficerNoteUpdate`. Auto-generated.
+pub(super) fn decode_47(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let aOrganizationId = c.i32_le()?;
+    let aName = c.wstring()?;
+    let aNote = c.wstring()?;
+    Some(json!({
+        "aOrganizationId": aOrganizationId,
+        "aName": aName,
+        "aNote": aNote,
+    }))
+}
+
+/// Method 48: `onOrganizationCashUpdate`. Auto-generated.
+pub(super) fn decode_48(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let aOrganizationId = c.i32_le()?;
+    let aCash = c.u64_le()?;
+    Some(json!({
+        "aOrganizationId": aOrganizationId,
+        "aCash": aCash,
+    }))
+}
+
+/// Method 49: `onOrganizationRankUpdate`. Auto-generated.
+pub(super) fn decode_49(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let aOrganizationId = c.i32_le()?;
+    let aRankIds = read_array!(c, c.i32_le()?);
+    let aRankFlags = read_array!(c, c.i32_le()?);
+    Some(json!({
+        "aOrganizationId": aOrganizationId,
+        "aRankIds": aRankIds,
+        "aRankFlags": aRankFlags,
+    }))
+}
+
+/// Method 50: `onOrganizationRankNameUpdate`. Auto-generated.
+pub(super) fn decode_50(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let aOrganizationId = c.i32_le()?;
+    let aRankIds = read_array!(c, c.i32_le()?);
+    let aRankNames = read_array!(c, c.wstring()?);
+    Some(json!({
+        "aOrganizationId": aOrganizationId,
+        "aRankIds": aRankIds,
+        "aRankNames": aRankNames,
+    }))
+}
+
+/// Method 51: `onSquadLootType`. Auto-generated.
+pub(super) fn decode_51(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let aOrganizationId = c.i32_le()?;
+    let aLootType = c.i32_le()?;
+    Some(json!({
+        "aOrganizationId": aOrganizationId,
+        "aLootType": aLootType,
+    }))
+}
+
+/// Method 52: `onStartMinigame`. Auto-generated.
+pub(super) fn decode_52(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let uRL = c.wstring()?;
+    Some(json!({
+        "URL": uRL,
+    }))
+}
+
+/// Method 53: `onStartMinigameDialog`. Auto-generated.
+pub(super) fn decode_53(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let name = c.wstring()?;
+    let difficulty = c.wstring()?;
+    let tCLevel = c.i32_le()?;
+    let verb = c.wstring()?;
+    let archetypeBitfield = c.i32_le()?;
+    let canPlay = c.u8()?;
+    let canCall = c.u8()?;
+    let canSpectate = c.u8()?;
+    Some(json!({
+        "Name": name,
+        "Difficulty": difficulty,
+        "TCLevel": tCLevel,
+        "Verb": verb,
+        "ArchetypeBitfield": archetypeBitfield,
+        "CanPlay": canPlay,
+        "CanCall": canCall,
+        "CanSpectate": canSpectate,
+    }))
+}
+
+/// Method 56: `onSpectateList`. Auto-generated.
+pub(super) fn decode_56(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let playerIds = read_array!(c, c.i32_le()?);
+    let playerNames = read_array!(c, c.wstring()?);
+    Some(json!({
+        "playerIds": playerIds,
+        "playerNames": playerNames,
+    }))
+}
+
+/// Method 57: `onMinigameRegistrationPrompt`. Auto-generated.
+pub(super) fn decode_57(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let cost = c.i32_le()?;
+    Some(json!({
+        "Cost": cost,
+    }))
+}
+
+/// Method 58: `minigameRegistrationInfo`. Auto-generated.
+pub(super) fn decode_58(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let registered = c.u8()?;
+    let inRangeOnly = c.u8()?;
+    let wantsRequests = c.u8()?;
+    let note = c.wstring()?;
+    Some(json!({
+        "Registered": registered,
+        "InRangeOnly": inRangeOnly,
+        "WantsRequests": wantsRequests,
+        "Note": note,
+    }))
+}
+
+/// Method 59: `addOrUpdateMinigameHelper`. Auto-generated.
+pub(super) fn decode_59(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let playerId = c.i32_le()?;
+    let name = c.wstring()?;
+    let note = c.wstring()?;
+    let level = c.u8()?;
+    let archetype = c.u8()?;
+    let friend = c.u8()?;
+    Some(json!({
+        "PlayerId": playerId,
+        "Name": name,
+        "Note": note,
+        "Level": level,
+        "Archetype": archetype,
+        "Friend": friend,
+    }))
+}
+
+/// Method 60: `removeMinigameHelper`. Auto-generated.
+pub(super) fn decode_60(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let playerId = c.i32_le()?;
+    Some(json!({
+        "PlayerId": playerId,
+    }))
+}
+
+/// Method 61: `minigameCallDisplay`. Auto-generated.
+pub(super) fn decode_61(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let callingPlayerId = c.i32_le()?;
+    let name = c.wstring()?;
+    let archetype = c.i32_le()?;
+    let level = c.i32_le()?;
+    let tipAmount = c.i32_le()?;
+    let expiresAt = c.i32_le()?;
+    let gameName = c.wstring()?;
+    let gameDifficulty = c.wstring()?;
+    let gameVerb = c.wstring()?;
+    let gameTC = c.i32_le()?;
+    let nPCTitle = c.wstring()?;
+    Some(json!({
+        "CallingPlayerId": callingPlayerId,
+        "Name": name,
+        "Archetype": archetype,
+        "Level": level,
+        "TipAmount": tipAmount,
+        "ExpiresAt": expiresAt,
+        "GameName": gameName,
+        "GameDifficulty": gameDifficulty,
+        "GameVerb": gameVerb,
+        "GameTC": gameTC,
+        "NPCTitle": nPCTitle,
+    }))
+}
+
+/// Method 62: `minigameCallResult`. Auto-generated.
+pub(super) fn decode_62(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let resultCode = c.i32_le()?;
+    let startTime = c.f32_le()?;
+    Some(json!({
+        "ResultCode": resultCode,
+        "StartTime": startTime,
+    }))
+}
+
+/// Method 63: `minigameCallAbort`. Auto-generated.
+pub(super) fn decode_63(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let callingPlayerId = c.i32_le()?;
+    Some(json!({
+        "CallingPlayerId": callingPlayerId,
+    }))
+}
+
+/// Method 64: `showMinigameContact`. Auto-generated.
+pub(super) fn decode_64(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let id = c.i32_le()?;
+    let name = c.wstring()?;
+    let title = c.wstring()?;
+    let icon = c.wstring()?;
+    let time = c.i32_le()?;
+    let success = c.i32_le()?;
+    let cost = c.i32_le()?;
+    Some(json!({
+        "Id": id,
+        "Name": name,
+        "Title": title,
+        "Icon": icon,
+        "Time": time,
+        "Success": success,
+        "Cost": cost,
+    }))
+}
+
+/// Method 65: `setupStargateInfo`. Auto-generated.
+pub(super) fn decode_65(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let worldStargateList = read_array!(c, c.i32_le()?);
+    let knownStargateList = read_array!(c, c.i32_le()?);
+    let hiddenStargateList = read_array!(c, c.i32_le()?);
+    Some(json!({
+        "worldStargateList": worldStargateList,
+        "knownStargateList": knownStargateList,
+        "hiddenStargateList": hiddenStargateList,
+    }))
+}
+
+/// Method 66: `updateStargateAddress`. Auto-generated.
+pub(super) fn decode_66(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let addressId = c.i32_le()?;
+    let hasAddress = c.u8()?;
+    let hidden = c.u8()?;
+    Some(json!({
+        "addressId": addressId,
+        "hasAddress": hasAddress,
+        "hidden": hidden,
+    }))
+}
+
+/// Method 67: `stargateRotationOverride`. Auto-generated.
+pub(super) fn decode_67(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let yaw = c.f32_le()?;
+    Some(json!({
+        "yaw": yaw,
+    }))
+}
+
+/// Method 68: `onStargatePassage`. Auto-generated.
+pub(super) fn decode_68(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let addressId = c.i32_le()?;
+    Some(json!({
+        "addressId": addressId,
+    }))
+}
+
+/// Method 70: `onActiveSlotUpdate`. Auto-generated.
+pub(super) fn decode_70(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let bagId = c.i32_le()?;
+    let slotId = c.i32_le()?;
+    Some(json!({
+        "BagId": bagId,
+        "SlotId": slotId,
+    }))
+}
+
+/// Method 71: `onRemoveItem`. Auto-generated.
+pub(super) fn decode_71(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let itemIdList = read_array!(c, c.i32_le()?);
+    Some(json!({
+        "ItemIdList": itemIdList,
+    }))
+}
+
+/// Method 73: `onRefreshItem`. Auto-generated.
+pub(super) fn decode_73(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let itemId = c.i32_le()?;
+    Some(json!({
+        "ItemId": itemId,
+    }))
+}
+
+/// Method 74: `onClearOrgVaultInventory`. Auto-generated.
+pub(super) fn decode_74(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let organizationId = c.i32_le()?;
+    Some(json!({
+        "OrganizationId": organizationId,
+    }))
+}
+
+/// Method 75: `onCashChanged`. Auto-generated.
+pub(super) fn decode_75(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let cash = c.i32_le()?;
+    Some(json!({
+        "cash": cash,
+    }))
+}
+
+/// Method 77: `onMailHeaderRemove`. Auto-generated.
+pub(super) fn decode_77(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let mailId = c.i32_le()?;
+    Some(json!({
+        "MailId": mailId,
+    }))
+}
+
+/// Method 78: `onMailRead`. Auto-generated.
+pub(super) fn decode_78(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let mailId = c.i32_le()?;
+    let bodyText = c.wstring()?;
+    let bodyId = c.i32_le()?;
+    let toText = c.wstring()?;
+    Some(json!({
+        "MailId": mailId,
+        "BodyText": bodyText,
+        "BodyId": bodyId,
+        "ToText": toText,
+    }))
+}
+
+/// Method 79: `sendMailResult`. Auto-generated.
+pub(super) fn decode_79(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let resultCode = c.u8()?;
+    let failedRecipients = read_array!(c, c.wstring()?);
+    let failedRecipientFlags = c.i32_le()?;
+    Some(json!({
+        "ResultCode": resultCode,
+        "FailedRecipients": failedRecipients,
+        "FailedRecipientFlags": failedRecipientFlags,
+    }))
+}
+
+/// Method 80: `onMissionUpdate`. Auto-generated.
+pub(super) fn decode_80(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let missionID = c.i32_le()?;
+    let status = c.i8()?;
+    let missionGiverName = c.i32_le()?;
+    Some(json!({
+        "MissionID": missionID,
+        "Status": status,
+        "MissionGiverName": missionGiverName,
+    }))
+}
+
+/// Method 81: `onStepUpdate`. Auto-generated.
+pub(super) fn decode_81(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let stepID = c.i32_le()?;
+    let status = c.i8()?;
+    Some(json!({
+        "StepID": stepID,
+        "Status": status,
+    }))
+}
+
+/// Method 82: `onObjectiveUpdate`. Auto-generated.
+pub(super) fn decode_82(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let objectiveID = c.i32_le()?;
+    let status = c.i8()?;
+    let hidden = c.i8()?;
+    let optional = c.i8()?;
+    Some(json!({
+        "ObjectiveID": objectiveID,
+        "Status": status,
+        "Hidden": hidden,
+        "Optional": optional,
+    }))
+}
+
+/// Method 83: `onTaskUpdate`. Auto-generated.
+pub(super) fn decode_83(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let taskID = c.i32_le()?;
+    let status = c.i8()?;
+    let count = c.i32_le()?;
+    Some(json!({
+        "TaskID": taskID,
+        "Status": status,
+        "Count": count,
+    }))
+}
+
+/// Method 84: `offerSharedMission`. Auto-generated.
+pub(super) fn decode_84(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let missionId = c.i32_le()?;
+    Some(json!({
+        "MissionId": missionId,
+    }))
+}
+
+/// Method 85: `onContactListUpdate`. Auto-generated.
+pub(super) fn decode_85(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let aListId = c.i32_le()?;
+    let aName = c.wstring()?;
+    let aFlags = c.u32_le()?;
+    Some(json!({
+        "aListId": aListId,
+        "aName": aName,
+        "aFlags": aFlags,
+    }))
+}
+
+/// Method 86: `onContactListDelete`. Auto-generated.
+pub(super) fn decode_86(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let aListId = c.i32_le()?;
+    Some(json!({
+        "aListId": aListId,
+    }))
+}
+
+/// Method 87: `onContactListAddMembers`. Auto-generated.
+pub(super) fn decode_87(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let aListId = c.i32_le()?;
+    let aPlayerNames = read_array!(c, c.wstring()?);
+    Some(json!({
+        "aListId": aListId,
+        "aPlayerNames": aPlayerNames,
+    }))
+}
+
+/// Method 88: `onContactListRemoveMembers`. Auto-generated.
+pub(super) fn decode_88(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let aListId = c.i32_le()?;
+    let aPlayerNames = read_array!(c, c.wstring()?);
+    Some(json!({
+        "aListId": aListId,
+        "aPlayerNames": aPlayerNames,
+    }))
+}
+
+/// Method 89: `onContactListEvent`. Auto-generated.
+pub(super) fn decode_89(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let aPlayerName = c.wstring()?;
+    let aEventId = c.u32_le()?;
+    let aDataValue = c.i32_le()?;
+    Some(json!({
+        "aPlayerName": aPlayerName,
+        "aEventId": aEventId,
+        "aDataValue": aDataValue,
+    }))
+}
+
+/// Method 90: `onBMOpen`. Auto-generated.
+pub(super) fn decode_90(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let entityId = c.i32_le()?;
+    Some(json!({
+        "entityId": entityId,
+    }))
+}
+
+/// Method 91: `onBMError`. Auto-generated.
+pub(super) fn decode_91(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let errorId = c.i32_le()?;
+    Some(json!({
+        "errorId": errorId,
+    }))
+}
+
+/// Method 93: `onBMAuctionRemove`. Auto-generated.
+pub(super) fn decode_93(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let sequenceId = c.i32_le()?;
+    Some(json!({
+        "sequenceId": sequenceId,
+    }))
+}
+
+/// Method 95: `onBMWatchedItemsUpdate`. Auto-generated.
+pub(super) fn decode_95(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let itemList = read_array!(c, c.i32_le()?);
+    Some(json!({
+        "itemList": itemList,
+    }))
+}
+
+/// Method 96: `onVersionInfo`. Auto-generated.
+pub(super) fn decode_96(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let categoryId = c.i32_le()?;
+    let version = c.i32_le()?;
+    let requiredUpdates = c.i32_le()?;
+    let invalidateAll = c.i8()?;
+    let invalidKeys = read_array!(c, c.i32_le()?);
+    Some(json!({
+        "CategoryId": categoryId,
+        "Version": version,
+        "RequiredUpdates": requiredUpdates,
+        "InvalidateAll": invalidateAll,
+        "InvalidKeys": invalidKeys,
+    }))
+}
+
+/// Method 97: `onCookedDataError`. Auto-generated.
+pub(super) fn decode_97(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let categoryID = c.i32_le()?;
+    let elementKey = c.i32_le()?;
+    Some(json!({
+        "categoryID": categoryID,
+        "elementKey": elementKey,
+    }))
+}
+
+/// Method 100: `onDHDReply`. Auto-generated.
+pub(super) fn decode_100(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let aMessage = c.wstring()?;
+    Some(json!({
+        "aMessage": aMessage,
+    }))
+}
+
+/// Method 101: `onKnownAbilitiesUpdate`. Auto-generated.
+pub(super) fn decode_101(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let abilityData = read_array!(c, c.i32_le()?);
+    Some(json!({
+        "AbilityData": abilityData,
+    }))
+}
+
+/// Method 102: `onTimeofDay`. Auto-generated.
+pub(super) fn decode_102(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let time = c.f32_le()?;
+    let wind = c.f32_le()?;
+    let weather = c.i8()?;
+    Some(json!({
+        "Time": time,
+        "Wind": wind,
+        "Weather": weather,
+    }))
+}
+
+/// Method 103: `onOverridePerfStatsRate`. Auto-generated.
+pub(super) fn decode_103(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let newIntervalMS = c.i32_le()?;
+    Some(json!({
+        "NewIntervalMS": newIntervalMS,
+    }))
+}
+
+/// Method 105: `onDialogDisplay`. Auto-generated.
+pub(super) fn decode_105(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let entityId = c.i32_le()?;
+    let dialogID = c.i32_le()?;
+    let missionFlags = c.i32_le()?;
+    let isImmediate = c.u8()?;
+    let aMissionId = c.i32_le()?;
+    Some(json!({
+        "EntityId": entityId,
+        "DialogID": dialogID,
+        "MissionFlags": missionFlags,
+        "IsImmediate": isImmediate,
+        "aMissionId": aMissionId,
+    }))
+}
+
+/// Method 106: `onVaultOpen`. Auto-generated.
+pub(super) fn decode_106(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let entityId = c.i32_le()?;
+    let position_x = c.f32_le()?;
+    let position_y = c.f32_le()?;
+    let position_z = c.f32_le()?;
+    Some(json!({
+        "EntityId": entityId,
+        "Position_x": position_x,
+        "Position_y": position_y,
+        "Position_z": position_z,
+    }))
+}
+
+/// Method 107: `onTeamVaultOpen`. Auto-generated.
+pub(super) fn decode_107(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let entityId = c.i32_le()?;
+    let position_x = c.f32_le()?;
+    let position_y = c.f32_le()?;
+    let position_z = c.f32_le()?;
+    Some(json!({
+        "EntityId": entityId,
+        "Position_x": position_x,
+        "Position_y": position_y,
+        "Position_z": position_z,
+    }))
+}
+
+/// Method 108: `onCommandVaultOpen`. Auto-generated.
+pub(super) fn decode_108(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let entityId = c.i32_le()?;
+    let position_x = c.f32_le()?;
+    let position_y = c.f32_le()?;
+    let position_z = c.f32_le()?;
+    Some(json!({
+        "EntityId": entityId,
+        "Position_x": position_x,
+        "Position_y": position_y,
+        "Position_z": position_z,
+    }))
+}
+
+/// Method 112: `onCraftingRespecPrompt`. Auto-generated.
+pub(super) fn decode_112(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let costToRespec = c.i32_le()?;
+    Some(json!({
+        "CostToRespec": costToRespec,
+    }))
+}
+
+/// Method 116: `onPlayerTeleport`. Auto-generated.
+pub(super) fn decode_116(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let location_x = c.f32_le()?;
+    let location_y = c.f32_le()?;
+    let location_z = c.f32_le()?;
+    let direction_x = c.f32_le()?;
+    let direction_y = c.f32_le()?;
+    let direction_z = c.f32_le()?;
+    Some(json!({
+        "Location_x": location_x,
+        "Location_y": location_y,
+        "Location_z": location_z,
+        "Direction_x": direction_x,
+        "Direction_y": direction_y,
+        "Direction_z": direction_z,
+    }))
+}
+
+/// Method 117: `onClientMapLoad`. Auto-generated.
+pub(super) fn decode_117(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let areaName = c.wstring()?;
+    let mapPath = c.wstring()?;
+    let worldID = c.i32_le()?;
+    let location_x = c.f32_le()?;
+    let location_y = c.f32_le()?;
+    let location_z = c.f32_le()?;
+    let direction_x = c.f32_le()?;
+    let direction_y = c.f32_le()?;
+    let direction_z = c.f32_le()?;
+    Some(json!({
+        "areaName": areaName,
+        "mapPath": mapPath,
+        "WorldID": worldID,
+        "Location_x": location_x,
+        "Location_y": location_y,
+        "Location_z": location_z,
+        "Direction_x": direction_x,
+        "Direction_y": direction_y,
+        "Direction_z": direction_z,
+    }))
+}
+
+/// Method 118: `giveAbility`. Auto-generated.
+pub(super) fn decode_118(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let abilityId = c.i32_le()?;
+    let persist = c.i8()?;
+    Some(json!({
+        "abilityId": abilityId,
+        "persist": persist,
+    }))
+}
+
+/// Method 119: `giveXPForLevel`. Auto-generated.
+pub(super) fn decode_119(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let level = c.i32_le()?;
+    Some(json!({
+        "level": level,
+    }))
+}
+
+/// Method 120: `onDisplayDHD`. Auto-generated.
+pub(super) fn decode_120(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let pointOfOrigin = c.u8()?;
+    Some(json!({
+        "PointOfOrigin": pointOfOrigin,
+    }))
+}
+
+/// Method 121: `onErrorCode`. Auto-generated.
+pub(super) fn decode_121(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let systemID = c.u8()?;
+    let instanceID = c.i32_le()?;
+    let errorCodeID = c.u16_le()?;
+    Some(json!({
+        "SystemID": systemID,
+        "InstanceID": instanceID,
+        "ErrorCodeID": errorCodeID,
+    }))
+}
+
+/// Method 123: `onMapInfo`. Auto-generated.
+pub(super) fn decode_123(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let sysTypeID = c.u32_le()?;
+    let sysID = c.u32_le()?;
+    let keyID = c.u32_le()?;
+    let worldID = c.i32_le()?;
+    let location_x = c.f32_le()?;
+    let location_y = c.f32_le()?;
+    let location_z = c.f32_le()?;
+    let lifetime = c.u32_le()?;
+    let delete = c.u8()?;
+    Some(json!({
+        "SysTypeID": sysTypeID,
+        "SysID": sysID,
+        "KeyID": keyID,
+        "WorldID": worldID,
+        "Location_x": location_x,
+        "Location_y": location_y,
+        "Location_z": location_z,
+        "Lifetime": lifetime,
+        "Delete": delete,
+    }))
+}
+
+/// Method 130: `onExtraNameUpdate`. Auto-generated.
+pub(super) fn decode_130(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let extraName = c.wstring()?;
+    Some(json!({
+        "ExtraName": extraName,
+    }))
+}
+
+/// Method 131: `onExpUpdate`. Auto-generated.
+pub(super) fn decode_131(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let exp = c.i32_le()?;
+    Some(json!({
+        "Exp": exp,
+    }))
+}
+
+/// Method 132: `onMaxExpUpdate`. Auto-generated.
+pub(super) fn decode_132(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let maxExp = c.i32_le()?;
+    Some(json!({
+        "MaxExp": maxExp,
+    }))
+}
+
+/// Method 134: `onOrganizationCreationResult`. Auto-generated.
+pub(super) fn decode_134(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let result = c.u8()?;
+    let retCode = c.u8()?;
+    Some(json!({
+        "Result": result,
+        "RetCode": retCode,
+    }))
+}
+
+/// Method 135: `launchOrganizationCreation`. Auto-generated.
+pub(super) fn decode_135(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let aOrgType = c.u8()?;
+    Some(json!({
+        "aOrgType": aOrgType,
+    }))
+}
+
+/// Method 136: `onUpdateDiscipline`. Auto-generated.
+pub(super) fn decode_136(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let aDisciplineSeqId = c.i32_le()?;
+    let aExpertise = c.i32_le()?;
+    Some(json!({
+        "aDisciplineSeqId": aDisciplineSeqId,
+        "aExpertise": aExpertise,
+    }))
+}
+
+/// Method 138: `onUpdateRacialParadigmLevel`. Auto-generated.
+pub(super) fn decode_138(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let aRacialParadigmId = c.i32_le()?;
+    let aLevel = c.i8()?;
+    Some(json!({
+        "aRacialParadigmId": aRacialParadigmId,
+        "aLevel": aLevel,
+    }))
+}
+
+/// Method 139: `onUpdateKnownCrafts`. Auto-generated.
+pub(super) fn decode_139(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let aCraftList = read_array!(c, c.i32_le()?);
+    Some(json!({
+        "aCraftList": aCraftList,
+    }))
+}
+
+/// Method 142: `onClientChallenge`. Auto-generated.
+pub(super) fn decode_142(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let aClientChallenge = c.i32_le()?;
+    let aChallengeType = c.i32_le()?;
+    let aChallengeObject = c.wstring()?;
+    let aChallengeID1 = c.i32_le()?;
+    let aChallengeID2 = c.i32_le()?;
+    Some(json!({
+        "aClientChallenge": aClientChallenge,
+        "aChallengeType": aChallengeType,
+        "aChallengeObject": aChallengeObject,
+        "aChallengeID1": aChallengeID1,
+        "aChallengeID2": aChallengeID2,
+    }))
+}
+
+/// Method 143: `onDuelChallenge`. Auto-generated.
+pub(super) fn decode_143(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let aEntityId = c.i32_le()?;
+    let aSquadList = read_array!(c, c.i32_le()?);
+    Some(json!({
+        "aEntityId": aEntityId,
+        "aSquadList": aSquadList,
+    }))
+}
+
+/// Method 145: `onTradeResults`. Auto-generated.
+pub(super) fn decode_145(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let entityId = c.i32_le()?;
+    let result = c.i32_le()?;
+    Some(json!({
+        "EntityId": entityId,
+        "Result": result,
+    }))
+}
+
+/// Method 146: `onSpaceQueued`. Auto-generated.
+pub(super) fn decode_146(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let aSpaceName = c.wstring()?;
+    Some(json!({
+        "aSpaceName": aSpaceName,
+    }))
+}
+
+/// Method 147: `onSpaceQueueReady`. Auto-generated.
+pub(super) fn decode_147(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let aSpaceName = c.wstring()?;
+    Some(json!({
+        "aSpaceName": aSpaceName,
+    }))
+}
+
+/// Method 148: `onRemoteEntityCreate`. Auto-generated.
+pub(super) fn decode_148(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let aEntityId = c.i32_le()?;
+    let aEntityType = c.wstring()?;
+    let aPosition_x = c.f32_le()?;
+    let aPosition_y = c.f32_le()?;
+    let aPosition_z = c.f32_le()?;
+    let aWorldId = c.i32_le()?;
+    let aSpaceId = c.i32_le()?;
+    Some(json!({
+        "aEntityId": aEntityId,
+        "aEntityType": aEntityType,
+        "aPosition_x": aPosition_x,
+        "aPosition_y": aPosition_y,
+        "aPosition_z": aPosition_z,
+        "aWorldId": aWorldId,
+        "aSpaceId": aSpaceId,
+    }))
+}
+
+/// Method 149: `onRemoteEntityMove`. Auto-generated.
+pub(super) fn decode_149(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let aEntityId = c.i32_le()?;
+    let aPosition_x = c.f32_le()?;
+    let aPosition_y = c.f32_le()?;
+    let aPosition_z = c.f32_le()?;
+    let aWorldId = c.i32_le()?;
+    let aSpaceId = c.i32_le()?;
+    Some(json!({
+        "aEntityId": aEntityId,
+        "aPosition_x": aPosition_x,
+        "aPosition_y": aPosition_y,
+        "aPosition_z": aPosition_z,
+        "aWorldId": aWorldId,
+        "aSpaceId": aSpaceId,
+    }))
+}
+
+/// Method 150: `onRemoteEntityRemove`. Auto-generated.
+pub(super) fn decode_150(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let aEntityId = c.i32_le()?;
+    Some(json!({
+        "aEntityId": aEntityId,
+    }))
+}
+
+/// Method 151: `onDuelEntitiesSet`. Auto-generated.
+pub(super) fn decode_151(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let aEntityList = read_array!(c, c.i32_le()?);
+    Some(json!({
+        "aEntityList": aEntityList,
+    }))
+}
+
+/// Method 152: `onDuelEntitiesRemove`. Auto-generated.
+pub(super) fn decode_152(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let aEntityId = c.i32_le()?;
+    Some(json!({
+        "aEntityId": aEntityId,
+    }))
+}
+
+/// Method 154: `onThreatenedMobsUpdate`. Auto-generated.
+pub(super) fn decode_154(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let entityId = c.i32_le()?;
+    let hasThreat = c.u8()?;
+    Some(json!({
+        "EntityId": entityId,
+        "HasThreat": hasThreat,
+    }))
+}
+
+/// Method 155: `onPlayMovie`. Auto-generated.
+pub(super) fn decode_155(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let movieName = c.wstring()?;
+    let fullScreen = c.u8()?;
+    Some(json!({
+        "MovieName": movieName,
+        "FullScreen": fullScreen,
+    }))
+}
+
+/// Method 156: `onCancelMovie`. Auto-generated.
+pub(super) fn decode_156(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let movieName = c.wstring()?;
+    let entityId = c.i32_le()?;
+    Some(json!({
+        "MovieName": movieName,
+        "EntityId": entityId,
+    }))
+}
+
+/// Dispatch — returns `Some` when the codegen has a decoder for this
+/// method index. Methods missing here fall through to the hand-
+/// written decoders in [`crate::wire_log::decoders::outbound`], then
+/// to the args_hex fallback.
+pub(super) fn decode_generated(method_index: u16, args: &[u8]) -> Option<Value> {
+    match method_index {
+        0 => decode_0(args),
+        2 => decode_2(args),
+        3 => decode_3(args),
+        4 => decode_4(args),
+        6 => decode_6(args),
+        7 => decode_7(args),
+        8 => decode_8(args),
+        9 => decode_9(args),
+        10 => decode_10(args),
+        11 => decode_11(args),
+        12 => decode_12(args),
+        13 => decode_13(args),
+        15 => decode_15(args),
+        16 => decode_16(args),
+        17 => decode_17(args),
+        18 => decode_18(args),
+        19 => decode_19(args),
+        22 => decode_22(args),
+        23 => decode_23(args),
+        24 => decode_24(args),
+        25 => decode_25(args),
+        26 => decode_26(args),
+        28 => decode_28(args),
+        30 => decode_30(args),
+        31 => decode_31(args),
+        32 => decode_32(args),
+        33 => decode_33(args),
+        34 => decode_34(args),
+        35 => decode_35(args),
+        36 => decode_36(args),
+        37 => decode_37(args),
+        39 => decode_39(args),
+        40 => decode_40(args),
+        41 => decode_41(args),
+        42 => decode_42(args),
+        43 => decode_43(args),
+        44 => decode_44(args),
+        45 => decode_45(args),
+        46 => decode_46(args),
+        47 => decode_47(args),
+        48 => decode_48(args),
+        49 => decode_49(args),
+        50 => decode_50(args),
+        51 => decode_51(args),
+        52 => decode_52(args),
+        53 => decode_53(args),
+        56 => decode_56(args),
+        57 => decode_57(args),
+        58 => decode_58(args),
+        59 => decode_59(args),
+        60 => decode_60(args),
+        61 => decode_61(args),
+        62 => decode_62(args),
+        63 => decode_63(args),
+        64 => decode_64(args),
+        65 => decode_65(args),
+        66 => decode_66(args),
+        67 => decode_67(args),
+        68 => decode_68(args),
+        70 => decode_70(args),
+        71 => decode_71(args),
+        73 => decode_73(args),
+        74 => decode_74(args),
+        75 => decode_75(args),
+        77 => decode_77(args),
+        78 => decode_78(args),
+        79 => decode_79(args),
+        80 => decode_80(args),
+        81 => decode_81(args),
+        82 => decode_82(args),
+        83 => decode_83(args),
+        84 => decode_84(args),
+        85 => decode_85(args),
+        86 => decode_86(args),
+        87 => decode_87(args),
+        88 => decode_88(args),
+        89 => decode_89(args),
+        90 => decode_90(args),
+        91 => decode_91(args),
+        93 => decode_93(args),
+        95 => decode_95(args),
+        96 => decode_96(args),
+        97 => decode_97(args),
+        100 => decode_100(args),
+        101 => decode_101(args),
+        102 => decode_102(args),
+        103 => decode_103(args),
+        105 => decode_105(args),
+        106 => decode_106(args),
+        107 => decode_107(args),
+        108 => decode_108(args),
+        112 => decode_112(args),
+        116 => decode_116(args),
+        117 => decode_117(args),
+        118 => decode_118(args),
+        119 => decode_119(args),
+        120 => decode_120(args),
+        121 => decode_121(args),
+        123 => decode_123(args),
+        130 => decode_130(args),
+        131 => decode_131(args),
+        132 => decode_132(args),
+        134 => decode_134(args),
+        135 => decode_135(args),
+        136 => decode_136(args),
+        138 => decode_138(args),
+        139 => decode_139(args),
+        142 => decode_142(args),
+        143 => decode_143(args),
+        145 => decode_145(args),
+        146 => decode_146(args),
+        147 => decode_147(args),
+        148 => decode_148(args),
+        149 => decode_149(args),
+        150 => decode_150(args),
+        151 => decode_151(args),
+        152 => decode_152(args),
+        154 => decode_154(args),
+        155 => decode_155(args),
+        156 => decode_156(args),
+        _ => None,
+    }
+}

--- a/crates/services/src/wire_log/decoders/inbound.rs
+++ b/crates/services/src/wire_log/decoders/inbound.rs
@@ -1,0 +1,82 @@
+//! Inbound (client → server) message decoders — Phase 1 priority set.
+//!
+//! Only handles the system messages with fixed wire formats. Entity-
+//! method calls (msg_id 0xC0+) carry args sized by their WORD_LENGTH
+//! prefix; the bundle scanner reads those and passes the payload here
+//! by their effective method index. Most rich decoding for those will
+//! land in Phase 2.
+
+use serde_json::{json, Value};
+
+use super::primitives::Cursor;
+
+pub fn decode(msg_id: u8, payload: &[u8]) -> Option<Value> {
+    match msg_id {
+        0x03 => decode_avatar_update_explicit(payload),
+        // SGWPlayer client method 70 — `onActiveSlotUpdate` is OUTBOUND,
+        // but the wire-symmetric inbound `requestActiveSlotChange` is
+        // a cell-method call (msg_id encoded via extended dispatch at
+        // 0xBD/subbyte). It arrives via `dispatch_cell_method`, not
+        // through the system-message slot. Same shape applies to
+        // `useAbility`.
+        //
+        // System-message decoders only.
+        _ => None,
+    }
+}
+
+/// 0x03 `avatarUpdateExplicit` — client movement update. Wire:
+/// `INT32 spaceId, INT32 vehicleId, VECTOR3 pos, VECTOR3 vel, INT8x3
+/// dir, UINT8 flags, UINT8x3 cells, UINT8 updateId` = 40 bytes.
+fn decode_avatar_update_explicit(payload: &[u8]) -> Option<Value> {
+    if payload.len() < 40 {
+        return None;
+    }
+    let mut c = Cursor::new(payload);
+    let space_id = c.i32_le()?;
+    let vehicle_id = c.i32_le()?;
+    let pos = [c.f32_le()?, c.f32_le()?, c.f32_le()?];
+    let vel = [c.f32_le()?, c.f32_le()?, c.f32_le()?];
+    let dir = [c.i8()?, c.i8()?, c.i8()?];
+    let flags = c.u8()?;
+    let cells = [c.u8()?, c.u8()?, c.u8()?];
+    let update_id = c.u8()?;
+    Some(json!({
+        "space_id": space_id,
+        "vehicle_id": vehicle_id,
+        "pos": pos,
+        "vel": vel,
+        "dir": dir,
+        "flags": flags,
+        "cells": cells,
+        "update_id": update_id,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn avatar_update_explicit_decodes_position() {
+        // space=1, vehicle=0, pos=(1.0, 2.0, 3.0), zeros for the rest
+        let mut payload = Vec::new();
+        payload.extend_from_slice(&1i32.to_le_bytes());
+        payload.extend_from_slice(&0i32.to_le_bytes());
+        payload.extend_from_slice(&1.0f32.to_le_bytes());
+        payload.extend_from_slice(&2.0f32.to_le_bytes());
+        payload.extend_from_slice(&3.0f32.to_le_bytes());
+        payload.extend(std::iter::repeat_n(0u8, 40 - 20));
+
+        let decoded = decode_avatar_update_explicit(&payload).unwrap();
+        assert_eq!(decoded["space_id"], 1);
+        assert_eq!(decoded["pos"][0], 1.0);
+        assert_eq!(decoded["pos"][1], 2.0);
+        assert_eq!(decoded["pos"][2], 3.0);
+    }
+
+    #[test]
+    fn truncated_avatar_update_returns_none() {
+        assert!(decode_avatar_update_explicit(&[0u8; 20]).is_none());
+    }
+}

--- a/crates/services/src/wire_log/decoders/mod.rs
+++ b/crates/services/src/wire_log/decoders/mod.rs
@@ -10,14 +10,15 @@
 //!
 //! # Phase 1 coverage (this PR)
 //!
-//! Ten priority decoders covering the methods that immediately matter
-//! for active debugging:
+//! Outbound hand-decoders: `BeingAppearance`, `onSequence`,
+//! `onDialogDisplay`, `onEffectResults`, `onStateFieldUpdate`,
+//! `onStatUpdate`, `onTimerUpdate`. Plus ~120 auto-generated decoders
+//! covering pure-primitive methods (see [`generated`]).
 //!
-//! * Outbound: `BeingAppearance`, `onSequence`, `onDialogDisplay`,
-//!   `onEffectResults`, `onStateFieldUpdate`, `onStatUpdate`,
-//!   `onTimerUpdate`
-//! * Inbound: `avatarUpdateExplicit`, `requestActiveSlotChange`,
-//!   `useAbility`
+//! Inbound hand-decoders: `avatarUpdateExplicit` (0x03). Entity-method
+//! calls (msg_id 0xC0+) arrive at the wire-log capture site with the
+//! raw payload but no per-method decoder — they fall through to the
+//! `args_hex` fallback. Inbound codegen is Phase 2 follow-up.
 //!
 //! # Phase 2 plan (deferred)
 //!

--- a/crates/services/src/wire_log/decoders/mod.rs
+++ b/crates/services/src/wire_log/decoders/mod.rs
@@ -1,0 +1,45 @@
+//! Per-method schema decoders.
+//!
+//! # The contract
+//!
+//! Each decoder takes raw arg bytes and returns a [`serde_json::Value`]
+//! (typically `Value::Object`) with named fields per the method's wire
+//! schema. Decoders are **best-effort**: a parse failure returns
+//! `None` and the wire-log capture falls back to `args_hex` only —
+//! never panics, never loses the event.
+//!
+//! # Phase 1 coverage (this PR)
+//!
+//! Ten priority decoders covering the methods that immediately matter
+//! for active debugging:
+//!
+//! * Outbound: `BeingAppearance`, `onSequence`, `onDialogDisplay`,
+//!   `onEffectResults`, `onStateFieldUpdate`, `onStatUpdate`,
+//!   `onTimerUpdate`
+//! * Inbound: `avatarUpdateExplicit`, `requestActiveSlotChange`,
+//!   `useAbility`
+//!
+//! # Phase 2 plan (deferred)
+//!
+//! Remaining ~240 method decoders. The right approach is a small
+//! codegen tool that parses the canonical schema strings in
+//! `docs/protocol/client-method-dispatch-table.md` (and the
+//! `.def` files under `entities/defs/`) and emits decoders. Hand-
+//! writing all 240 would take ~40 hours; codegen is ~6-hour build
+//! plus per-method tuning. Tracked as a separate work stream.
+
+mod inbound;
+mod outbound;
+mod primitives;
+
+/// Decode an outbound entity-method payload. Returns `None` when no
+/// decoder is registered for the method index or the parse fails.
+pub fn decode_outbound(method_index: u16, args: &[u8]) -> Option<serde_json::Value> {
+    outbound::decode(method_index, args)
+}
+
+/// Decode an inbound bundle message payload. Returns `None` when no
+/// decoder is registered for the message id or the parse fails.
+pub fn decode_inbound(msg_id: u8, payload: &[u8]) -> Option<serde_json::Value> {
+    inbound::decode(msg_id, payload)
+}

--- a/crates/services/src/wire_log/decoders/mod.rs
+++ b/crates/services/src/wire_log/decoders/mod.rs
@@ -28,14 +28,23 @@
 //! writing all 240 would take ~40 hours; codegen is ~6-hour build
 //! plus per-method tuning. Tracked as a separate work stream.
 
+mod generated;
 mod inbound;
 mod outbound;
 mod primitives;
 
 /// Decode an outbound entity-method payload. Returns `None` when no
 /// decoder is registered for the method index or the parse fails.
+///
+/// Lookup order:
+///   1. Hand-written decoders in [`outbound`] — overrides codegen for
+///      methods where we want richer semantic fields (BSF bits on
+///      onStateFieldUpdate, etc.).
+///   2. Codegen decoders in [`generated`] — covers ~120 methods with
+///      pure-primitive schemas, parsed from the dispatch table doc.
+///   3. `None` — caller falls back to the always-on `args_hex` field.
 pub fn decode_outbound(method_index: u16, args: &[u8]) -> Option<serde_json::Value> {
-    outbound::decode(method_index, args)
+    outbound::decode(method_index, args).or_else(|| generated::decode_generated(method_index, args))
 }
 
 /// Decode an inbound bundle message payload. Returns `None` when no

--- a/crates/services/src/wire_log/decoders/outbound.rs
+++ b/crates/services/src/wire_log/decoders/outbound.rs
@@ -1,0 +1,244 @@
+//! Outbound (server → client) method decoders — Phase 1 priority set.
+//!
+//! Each `decode_*` function reads the wire schema for one method and
+//! returns a [`serde_json::Value`] (typically an Object) with named
+//! fields. Failures return `None` and the wire-log capture falls back
+//! to `args_hex` only.
+//!
+//! Schemas come from `docs/protocol/client-method-dispatch-table.md`
+//! and the canonical `.def` files under `entities/defs/`.
+
+use serde_json::{json, Value};
+
+use super::primitives::Cursor;
+
+pub fn decode(method_index: u16, args: &[u8]) -> Option<Value> {
+    match method_index {
+        // SGWSpawnableEntity
+        1 => decode_on_sequence(args),
+        // SGWBeing interface
+        12 => decode_on_timer_update(args),
+        14 => decode_on_effect_results(args),
+        19 => decode_on_state_field_update(args),
+        // SGWCombatant interface
+        20 => decode_on_stat_update(args),
+        // SGWBeing own
+        26 => decode_being_appearance(args),
+        // SGWPlayer own
+        105 => decode_on_dialog_display(args),
+        _ => None,
+    }
+}
+
+/// Method 1: `onSequence` — the wire packet that plays a kismet
+/// sequence client-side. This is the fire-animation broadcast (and
+/// every other weapon/spell visual).
+///
+/// Wire: `INT32 KismetEventSetSeqID, INT32 SourceID, INT32 TargetID,
+/// INT8 PrimaryTarget, FLOAT ImpactTime, ARRAY<NameValuePair>
+/// NameValuePairs, INT8 ViewType, INT32 InstanceId`
+///
+/// We decode the fixed prefix + the ARRAY count; per-pair NVPs are
+/// captured as `nvp_count` only (they're rarely diagnostic and have
+/// their own variable-length payloads).
+fn decode_on_sequence(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let seq_id = c.i32_le()?;
+    let source_id = c.i32_le()?;
+    let target_id = c.i32_le()?;
+    let primary_target = c.i8()?;
+    let impact_time = c.f32_le()?;
+    let nvp_count = c.u32_le()?;
+    Some(json!({
+        "kismet_event_set_seq_id": seq_id,
+        "source_id": source_id,
+        "target_id": target_id,
+        "primary_target": primary_target,
+        "impact_time": impact_time,
+        "nvp_count": nvp_count,
+    }))
+}
+
+/// Method 12: `onTimerUpdate` — cooldown / channel timer broadcasts.
+/// Wire: `INT32 ID, INT8 Type, INT32 SourceID, FLOAT TotalTime,
+/// FLOAT BigWorldTimeComplete`
+fn decode_on_timer_update(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    Some(json!({
+        "id": c.i32_le()?,
+        "timer_type": c.i8()?,
+        "source_id": c.i32_le()?,
+        "total_time": c.f32_le()?,
+        "completion_time": c.f32_le()?,
+    }))
+}
+
+/// Method 14: `onEffectResults` — the per-hit damage broadcast.
+/// Wire: `INT32 SourceID, INT32 AbilityID, INT32 EffectID, INT32
+/// TargetID, UINT8 ResultCode, ClientEffectResultList`
+///
+/// The ClientEffectResultList tail is variable-length; we capture
+/// the fixed prefix + the tail's first byte (typically the result
+/// count) for at-a-glance diagnostics.
+fn decode_on_effect_results(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let source_id = c.i32_le()?;
+    let ability_id = c.i32_le()?;
+    let effect_id = c.i32_le()?;
+    let target_id = c.i32_le()?;
+    let result_code = c.u8()?;
+    let result_list_byte = c.u8();
+    Some(json!({
+        "source_id": source_id,
+        "ability_id": ability_id,
+        "effect_id": effect_id,
+        "target_id": target_id,
+        "result_code": result_code,
+        "result_list_first_byte": result_list_byte,
+    }))
+}
+
+/// Method 19: `onStateFieldUpdate` — the BSF flags broadcast (in-combat,
+/// dead, auto-cycling, etc.). The bug-relevant bits are `BSF_DEAD`
+/// (bit 0), `BSF_IN_COMBAT` (bit 3), `BSF_AUTO_CYCLING` (bit 4).
+/// Wire: `INT32 bStateField`
+fn decode_on_state_field_update(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let state_field = c.i32_le()?;
+    Some(json!({
+        "state_field": state_field,
+        "state_field_hex": format!("0x{state_field:08x}"),
+        "dead": (state_field & 0x01) != 0,
+        "in_combat": (state_field & 0x08) != 0,
+        "auto_cycling": (state_field & 0x10) != 0,
+    }))
+}
+
+/// Method 20: `onStatUpdate` — stat dirty-flush broadcasts.
+/// Wire: `StatUpdateList Stats` — `UINT32 count` then `count` repeats
+/// of `INT32 statId, INT32 value`. We decode the count + first few
+/// entries for visibility.
+fn decode_on_stat_update(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let count = c.u32_le()?;
+    let mut sample = Vec::new();
+    for _ in 0..count.min(8) {
+        let stat_id = c.i32_le()?;
+        let value = c.i32_le()?;
+        sample.push(json!({ "stat_id": stat_id, "value": value }));
+    }
+    Some(json!({
+        "count": count,
+        "sample": sample,
+        "sample_truncated": count > 8,
+    }))
+}
+
+/// Method 26: `BeingAppearance` — the visual model + component list.
+/// **This is the broadcast that controls weapon visibility** — the
+/// drone-aggro-breaks-weapon-display bug lives here.
+///
+/// Wire: `WSTRING BodySet, ARRAY<WSTRING> Components`
+///
+/// `body_set` names the body mesh (e.g., `"BodySet_HumanMale"`).
+/// `components` is the ARRAY of visual attachments — weapon, armor,
+/// helmet. If the weapon is missing from this list, the client won't
+/// render it regardless of bandolier state.
+fn decode_being_appearance(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    let body_set = c.wstring()?;
+    let component_count = c.u32_le()?;
+    let mut components = Vec::with_capacity(component_count.min(32) as usize);
+    for _ in 0..component_count.min(32) {
+        components.push(c.wstring()?);
+    }
+    Some(json!({
+        "body_set": body_set,
+        "component_count": component_count,
+        "components": components,
+        "components_truncated": component_count > 32,
+    }))
+}
+
+/// Method 105: `onDialogDisplay` — the dialog open packet. PR #401
+/// fixed the bug where this was being sent with the player's entity
+/// id instead of the NPC's.
+///
+/// Wire: `INT32 entityId, INT32 dialogId, INT32 missionFlags, UINT8
+/// isImmediate, INT32 missionId`
+fn decode_on_dialog_display(args: &[u8]) -> Option<Value> {
+    let mut c = Cursor::new(args);
+    Some(json!({
+        "entity_id": c.i32_le()?,
+        "dialog_id": c.i32_le()?,
+        "mission_flags": c.i32_le()?,
+        "is_immediate": c.u8()?,
+        "mission_id": c.i32_le()?,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn on_state_field_update_decodes_in_combat() {
+        // INT32 = 0x00000008 = BSF_IN_COMBAT alone
+        let args = [0x08, 0x00, 0x00, 0x00];
+        let decoded = decode_on_state_field_update(&args).unwrap();
+        assert_eq!(decoded["state_field"], 8);
+        assert_eq!(decoded["in_combat"], true);
+        assert_eq!(decoded["dead"], false);
+    }
+
+    #[test]
+    fn on_dialog_display_decodes_npc_id() {
+        // entity=0x64 (100), dialog=0x2A (42), flags=0, immediate=1, mission=0
+        let args = [
+            0x64, 0x00, 0x00, 0x00, // entity
+            0x2A, 0x00, 0x00, 0x00, // dialog
+            0x00, 0x00, 0x00, 0x00, // flags
+            0x01, // immediate
+            0x00, 0x00, 0x00, 0x00, // mission
+        ];
+        let decoded = decode_on_dialog_display(&args).unwrap();
+        assert_eq!(decoded["entity_id"], 100);
+        assert_eq!(decoded["dialog_id"], 42);
+        assert_eq!(decoded["is_immediate"], 1);
+    }
+
+    #[test]
+    fn being_appearance_decodes_body_and_components() {
+        let mut args = Vec::new();
+        // BodySet WSTRING
+        let body = "Body";
+        args.extend_from_slice(&(body.len() as u32).to_le_bytes());
+        for ch in body.encode_utf16() {
+            args.extend_from_slice(&ch.to_le_bytes());
+        }
+        // 2 components
+        args.extend_from_slice(&2u32.to_le_bytes());
+        for comp in ["Wep", "Armor"] {
+            args.extend_from_slice(&(comp.len() as u32).to_le_bytes());
+            for ch in comp.encode_utf16() {
+                args.extend_from_slice(&ch.to_le_bytes());
+            }
+        }
+        let decoded = decode_being_appearance(&args).unwrap();
+        assert_eq!(decoded["body_set"], "Body");
+        assert_eq!(decoded["component_count"], 2);
+        assert_eq!(decoded["components"][0], "Wep");
+        assert_eq!(decoded["components"][1], "Armor");
+    }
+
+    #[test]
+    fn truncated_payload_returns_none() {
+        assert!(decode_on_dialog_display(&[0x00, 0x01]).is_none());
+        assert!(decode_being_appearance(&[]).is_none());
+    }
+
+    #[test]
+    fn dispatch_unknown_method_returns_none() {
+        assert!(decode(9999, &[0u8; 16]).is_none());
+    }
+}

--- a/crates/services/src/wire_log/decoders/primitives.rs
+++ b/crates/services/src/wire_log/decoders/primitives.rs
@@ -1,0 +1,151 @@
+//! Wire-format primitive readers.
+//!
+//! Cursor-style readers over `&[u8]` for the BigWorld wire types used
+//! across SGW methods. Each returns `Option` — bounds failures yield
+//! `None` so decoders compose with `?` and fall back to "no decoded
+//! field" rather than panicking on malformed payloads.
+
+/// Cursor for in-order primitive reads. Tracks position; advances on
+/// successful reads. Failures leave the cursor untouched (caller
+/// will typically abort the decode and return `None`).
+pub struct Cursor<'a> {
+    buf: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Cursor<'a> {
+    pub fn new(buf: &'a [u8]) -> Self {
+        Self { buf, pos: 0 }
+    }
+
+    /// Bytes left in the buffer. Used by callers that need to decide
+    /// whether to keep reading variable-length tails (NVP arrays,
+    /// component lists with truncated decoders). Allow unused — most
+    /// current decoders read fixed schemas and don't need it; Phase 2
+    /// decoders for ARRAY-tailed methods will use it heavily.
+    #[allow(dead_code)]
+    pub fn remaining(&self) -> usize {
+        self.buf.len().saturating_sub(self.pos)
+    }
+
+    pub fn u8(&mut self) -> Option<u8> {
+        let b = *self.buf.get(self.pos)?;
+        self.pos += 1;
+        Some(b)
+    }
+
+    pub fn i8(&mut self) -> Option<i8> {
+        self.u8().map(|b| b as i8)
+    }
+
+    #[allow(dead_code)]
+    pub fn u16_le(&mut self) -> Option<u16> {
+        let end = self.pos.checked_add(2)?;
+        let slice = self.buf.get(self.pos..end)?;
+        self.pos = end;
+        Some(u16::from_le_bytes([slice[0], slice[1]]))
+    }
+
+    #[allow(dead_code)]
+    pub fn i16_le(&mut self) -> Option<i16> {
+        self.u16_le().map(|v| v as i16)
+    }
+
+    pub fn u32_le(&mut self) -> Option<u32> {
+        let end = self.pos.checked_add(4)?;
+        let slice = self.buf.get(self.pos..end)?;
+        self.pos = end;
+        Some(u32::from_le_bytes([slice[0], slice[1], slice[2], slice[3]]))
+    }
+
+    pub fn i32_le(&mut self) -> Option<i32> {
+        self.u32_le().map(|v| v as i32)
+    }
+
+    // u64/i64 readers — kept for Phase 2 decoders (UINT64 TypeId on
+    // InteractionType, UINT64 aFlags on onEntityFlags, etc.). Allow
+    // unused at the function level rather than the module level so a
+    // genuine unused primitive elsewhere still warns.
+    #[allow(dead_code)]
+    pub fn u64_le(&mut self) -> Option<u64> {
+        let end = self.pos.checked_add(8)?;
+        let slice = self.buf.get(self.pos..end)?;
+        self.pos = end;
+        Some(u64::from_le_bytes([
+            slice[0], slice[1], slice[2], slice[3], slice[4], slice[5], slice[6], slice[7],
+        ]))
+    }
+
+    #[allow(dead_code)]
+    pub fn i64_le(&mut self) -> Option<i64> {
+        self.u64_le().map(|v| v as i64)
+    }
+
+    pub fn f32_le(&mut self) -> Option<f32> {
+        self.u32_le().map(f32::from_bits)
+    }
+
+    /// Read a BigWorld `WSTRING`: `u32` UTF-16 char count, then that
+    /// many `u16` LE code units. Returns the decoded UTF-8 string
+    /// (lossy on invalid surrogates — observability shouldn't fail
+    /// the parse for cosmetic encoding issues).
+    pub fn wstring(&mut self) -> Option<String> {
+        let char_count = self.u32_le()? as usize;
+        let bytes_needed = char_count.checked_mul(2)?;
+        let end = self.pos.checked_add(bytes_needed)?;
+        let slice = self.buf.get(self.pos..end)?;
+        self.pos = end;
+        let utf16: Vec<u16> = slice
+            .chunks_exact(2)
+            .map(|pair| u16::from_le_bytes([pair[0], pair[1]]))
+            .collect();
+        Some(String::from_utf16_lossy(&utf16))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cursor_reads_primitives_in_order() {
+        let buf = [
+            0x42, // u8 = 0x42
+            0xFF, 0x00, // u16_le = 0x00FF
+            0x04, 0x03, 0x02, 0x01, // u32_le = 0x01020304
+        ];
+        let mut c = Cursor::new(&buf);
+        assert_eq!(c.u8(), Some(0x42));
+        assert_eq!(c.u16_le(), Some(0x00FF));
+        assert_eq!(c.u32_le(), Some(0x01020304));
+        assert_eq!(c.remaining(), 0);
+        assert_eq!(c.u8(), None, "past end returns None");
+    }
+
+    #[test]
+    fn cursor_truncated_payload_returns_none() {
+        let buf = [0x01, 0x02]; // only 2 bytes
+        let mut c = Cursor::new(&buf);
+        assert_eq!(c.u32_le(), None, "u32_le needs 4 bytes");
+        assert_eq!(c.pos, 0, "failed read does not advance");
+    }
+
+    #[test]
+    fn wstring_round_trips_ascii() {
+        // char_count = 5, "Hello"
+        let mut buf = vec![0x05, 0x00, 0x00, 0x00];
+        for ch in "Hello".encode_utf16() {
+            buf.extend_from_slice(&ch.to_le_bytes());
+        }
+        let mut c = Cursor::new(&buf);
+        assert_eq!(c.wstring(), Some("Hello".to_string()));
+    }
+
+    #[test]
+    fn wstring_truncated_length_returns_none() {
+        // Claims 100 chars but only 4 bytes follow.
+        let buf = [0x64, 0x00, 0x00, 0x00, 0x41, 0x00, 0x42, 0x00];
+        let mut c = Cursor::new(&buf);
+        assert_eq!(c.wstring(), None);
+    }
+}

--- a/crates/services/src/wire_log/mod.rs
+++ b/crates/services/src/wire_log/mod.rs
@@ -1,0 +1,153 @@
+//! Wire-packet decode stream — every inbound and outbound Mercury
+//! method goes through this module on its way to SigNoz, with the
+//! method-name lookup and (when registered) the per-method schema
+//! decoder attached.
+//!
+//! # Why this exists
+//!
+//! `mercury.packet` events (in [`crate::mercury` instrumentation]) give
+//! per-UDP-datagram metadata: direction, peer, length. That's enough
+//! to answer "did the network move bytes?" but not "what was IN the
+//! bundle?" — which is the question every wire-format bug starts with.
+//!
+//! This module adds the layer above: per-message-in-bundle capture
+//! with `msg_id`, human-readable `msg_name`, raw args hex (truncated),
+//! and a structured `decoded` JSON field when a schema decoder is
+//! registered for the method.
+//!
+//! # Three tiers of fidelity
+//!
+//! 1. **Always-on**: every message logs `msg_id` + `msg_name` + `args_len`
+//!    + `args_hex` (first 256 bytes). Answers "what method was called?"
+//! 2. **Schema-decoded** (when a decoder is registered): adds a
+//!    structured `decoded` JSON field with named fields. Answers "what
+//!    was inside the method call?"
+//! 3. **Full coverage** (Phase 2 follow-up): every method index in the
+//!    protocol has a decoder. Right now we have ~10 priority decoders
+//!    hand-written; the rest fall through to `args_hex` only.
+//!
+//! # Capture points
+//!
+//! * **Inbound** — [`log_inbound`] is called from the bundle scanner
+//!   in `crates/services/src/base/connect_loop/encrypted/mod.rs` after
+//!   `read_client_message_payload` extracts each message's payload.
+//! * **Outbound** — [`log_outbound_entity_method`] is called from the
+//!   `CellToBaseMsg::EntityMethodCall` and `WitnessEntityMethod` recv
+//!   sites in `crates/services/src/base/world_entry/cell_dispatch/`.
+//!
+//! # SigNoz targets
+//!
+//! Inbound events use `target: "wire.in"`. Outbound use `target:
+//! "wire.out"`. Both ship at info level. The OTLP filter in
+//! `crates/server/src/main.rs` whitelists both targets explicitly
+//! because they don't match the `cimmeria_services` prefix rule.
+
+use std::net::SocketAddr;
+
+pub mod client_names;
+pub mod decoders;
+
+/// Maximum bytes of `args_hex` to record per event. Caps the per-event
+/// size at ~512 hex chars + structured fields → ~1 KB/event. Larger
+/// payloads (resource fragments, char list bursts) get truncated; the
+/// `args_len` field is the source of truth for actual size.
+const HEX_DUMP_CAP: usize = 256;
+
+/// Record an inbound message from a client bundle.
+///
+/// Called from the bundle scanner once per message in a decrypted
+/// packet body. Most messages are entity-method calls; system messages
+/// like `AUTHENTICATE` (0x01) and `ENABLE_ENTITIES` (0x08) pass
+/// through this helper too.
+pub fn log_inbound(peer: SocketAddr, msg_id: u8, payload: &[u8]) {
+    let msg_name = client_names::inbound_msg_name(msg_id);
+    let args_len = payload.len();
+    let args_hex = hex_truncate(payload);
+    let decoded = decoders::decode_inbound(msg_id, payload);
+    let decoded_str = decoded.as_ref().map(serde_json::Value::to_string);
+
+    tracing::info!(
+        target: "wire.in",
+        msg_id,
+        msg_name,
+        args_len,
+        truncated = args_len > HEX_DUMP_CAP,
+        args_hex = %args_hex,
+        decoded = decoded_str.as_deref().unwrap_or(""),
+        peer = %peer,
+        "wire_inbound"
+    );
+}
+
+/// Record an outbound entity-method call (the cell-to-base bridge).
+///
+/// `witness_id` is the player who will receive the message; for
+/// self-targeted methods this equals `target_entity_id`. For AoI
+/// fanout (`WitnessEntityMethod`), the witness is the observer and
+/// the entity_id is the entity whose method is being broadcast.
+pub fn log_outbound_entity_method(
+    witness_id: u32,
+    target_entity_id: u32,
+    method_index: u16,
+    args: &[u8],
+) {
+    let msg_name = client_names::outbound_method_name(method_index);
+    let args_len = args.len();
+    let args_hex = hex_truncate(args);
+    let decoded = decoders::decode_outbound(method_index, args);
+    let decoded_str = decoded.as_ref().map(serde_json::Value::to_string);
+
+    tracing::info!(
+        target: "wire.out",
+        method_index,
+        msg_name,
+        args_len,
+        truncated = args_len > HEX_DUMP_CAP,
+        args_hex = %args_hex,
+        decoded = decoded_str.as_deref().unwrap_or(""),
+        witness_id,
+        target_entity_id,
+        "wire_outbound"
+    );
+}
+
+/// Hex-encode the first [`HEX_DUMP_CAP`] bytes of `bytes`. Inline
+/// encoder — adding the `hex` crate dep just for this would be
+/// disproportionate to the use.
+fn hex_truncate(bytes: &[u8]) -> String {
+    const HEX_CHARS: &[u8; 16] = b"0123456789abcdef";
+    let len = bytes.len().min(HEX_DUMP_CAP);
+    let mut out = String::with_capacity(len * 2);
+    for &b in &bytes[..len] {
+        out.push(HEX_CHARS[(b >> 4) as usize] as char);
+        out.push(HEX_CHARS[(b & 0x0F) as usize] as char);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hex_truncate_caps_long_payloads() {
+        let bytes = vec![0xAB; 1024];
+        let hex = hex_truncate(&bytes);
+        assert_eq!(
+            hex.len(),
+            HEX_DUMP_CAP * 2,
+            "should cap at HEX_DUMP_CAP bytes"
+        );
+    }
+
+    #[test]
+    fn hex_truncate_short_payload_complete() {
+        let bytes = vec![0x12, 0x34, 0x56];
+        assert_eq!(hex_truncate(&bytes), "123456");
+    }
+
+    #[test]
+    fn hex_truncate_empty_is_empty() {
+        assert_eq!(hex_truncate(&[]), "");
+    }
+}

--- a/tools/wire_decoder_codegen.py
+++ b/tools/wire_decoder_codegen.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+"""Generate per-method Rust decoders for the SGWPlayer wire surface.
+
+Reads schemas from `docs/protocol/client-method-dispatch-table.md` and
+emits a Rust file the wire_log module compiles in. The generated file
+covers every method whose schema parses cleanly; methods using
+composite types not covered here (StatUpdateList, ClientEffectResultList,
+MAILBOX, NameValuePair, FIXED_DICTs) fall back to the hand-written
+priority decoders in `outbound.rs`.
+
+Run from the repo root:
+    python tools/wire_decoder_codegen.py \
+        > crates/services/src/wire_log/decoders/generated.rs
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+PRIMITIVES: dict[str, str] = {
+    "INT8": "c.i8()?",
+    "INT16": "c.i16_le()?",
+    "INT32": "c.i32_le()?",
+    "INT64": "c.i64_le()?",
+    "UINT8": "c.u8()?",
+    "UINT16": "c.u16_le()?",
+    "UINT32": "c.u32_le()?",
+    "UINT64": "c.u64_le()?",
+    "FLOAT": "c.f32_le()?",
+    "WSTRING": "c.wstring()?",
+    "BOOL": "(c.u8()? != 0)",
+}
+
+# Helper functions emitted at the top of the file for ARRAY decoding.
+ARRAY_HELPERS = """
+/// Read an ARRAY<primitive> by reading a u32 count then `min(count,
+/// 32)` repeats. Truncates at 32 to bound per-event size; `count` and
+/// `truncated` fields preserve the original size for SigNoz queries.
+macro_rules! read_array {
+    ($cursor:expr, $read:expr) => {{
+        let count = $cursor.u32_le()?;
+        let cap = (count as usize).min(32);
+        let mut items: Vec<Value> = Vec::with_capacity(cap);
+        for _ in 0..cap {
+            items.push(json!($read));
+        }
+        json!({
+            "count": count,
+            "items": items,
+            "truncated": count > 32,
+        })
+    }};
+}
+"""
+
+
+# Composite types we recognize but can't decode cleanly without
+# per-type schemas. These methods skip codegen entirely and fall
+# through to the hand-written priority decoders (or to the
+# `args_hex` fallback) so the generated file stays correct-by-default.
+UNDECODABLE = {
+    "StatUpdateList",
+    "ClientEffectResultList",
+    "MAILBOX",
+    "NameValuePair",
+    "RosterInfo",
+    "BMAuction",
+    "MissionRewardsList",
+    "MissionOffer",
+    "AbilityTreeInfo",
+    "StoreItem",
+    "TradeProposalItem",
+    "TradeResults",
+    "ContactListEntry",
+    "MinigameContact",
+    "MailHeader",
+    "MailAttachment",
+}
+
+
+@dataclass
+class Arg:
+    """One arg in a method schema. `kind` is the parsed shape."""
+    name: str
+    rust_decoder: str  # the Rust expr that reads + returns a serde_json::Value
+    # If this arg is variable-length (WSTRING, ARRAY), the decoder
+    # needs to do bounds checks at runtime; we just emit `?` chains.
+
+
+@dataclass
+class Method:
+    index: int
+    name: str
+    args: list[Arg]
+
+
+def parse_schema(schema: str) -> list[Arg] | None:
+    """Tokenize a schema string into args. Return None if unsupported."""
+    schema = schema.strip()
+    if schema == "*(none)*" or schema == "—":
+        return []
+
+    # Split by comma — but ARRAY<T> may contain a nested type with
+    # commas? In practice the doc never uses commas inside ARRAY<>;
+    # the type T is always a single token. Verified by hand-scan.
+    parts = [p.strip() for p in schema.split(",") if p.strip()]
+    out: list[Arg] = []
+
+    for part in parts:
+        # Special syntactic sugar in the docs: `FLOAT locationX/Y/Z`
+        # means three sequential floats with the X/Y/Z suffixes. Expand
+        # before the normal parse.
+        slash = re.match(r"^(\w+)\s+(\w+)([XYZ])(?:/[XYZ])+$", part)
+        if slash:
+            type_tok = slash.group(1)
+            base_name = slash.group(2)
+            if type_tok not in PRIMITIVES:
+                return None
+            for suffix in "XYZ":
+                out.append(make_primitive_arg(type_tok, f"{base_name}{suffix}"))
+            continue
+
+        # Special: `INT8x3 dir` → three i8's
+        repeat = re.match(r"^(\w+)x(\d+)\s+(\w+)$", part)
+        if repeat:
+            type_tok = repeat.group(1)
+            count = int(repeat.group(2))
+            base_name = repeat.group(3)
+            if type_tok not in PRIMITIVES:
+                return None
+            for i in range(count):
+                out.append(make_primitive_arg(type_tok, f"{base_name}_{i}"))
+            continue
+
+        # Generic: `<TYPE> <NAME>` or `ARRAY<T> <NAME>`
+        m = re.match(r"^(\S+)\s+(\w+)$", part)
+        if not m:
+            # Possibly a bare composite type with no field name (e.g.
+            # `ClientEffectResultList`) — skip the whole method.
+            if part in UNDECODABLE:
+                return None
+            return None
+        type_tok, name = m.group(1), m.group(2)
+
+        if type_tok in PRIMITIVES:
+            out.append(make_primitive_arg(type_tok, name))
+            continue
+
+        # VECTOR3 = three floats.
+        if type_tok == "VECTOR3":
+            for suffix in "xyz":
+                out.append(make_primitive_arg("FLOAT", f"{name}_{suffix}"))
+            continue
+
+        # ARRAY<T> — read count, then T repeats. Only supported when
+        # T is a primitive; nested composite arrays need hand-decode.
+        # Emits `read_array!(c, <inner_expr>)` which calls the macro
+        # defined at the top of the generated file.
+        arr = re.match(r"^ARRAY<(\w+)>$", type_tok)
+        if arr:
+            inner = arr.group(1)
+            if inner in UNDECODABLE:
+                return None
+            if inner not in PRIMITIVES:
+                return None
+            inner_expr = PRIMITIVES[inner]
+            out.append(Arg(name=name, rust_decoder=f"read_array!(c, {inner_expr})"))
+            continue
+
+        # Unrecognized composite — bail on the whole method, let the
+        # hand-written decoder or args_hex cover it.
+        return None
+
+    return out
+
+
+def make_primitive_arg(type_tok: str, name: str) -> Arg:
+    """Build an Arg for a primitive type token. The decoder expr is
+    suitable for use as both a let-binding RHS and a json! value."""
+    return Arg(name=name, rust_decoder=PRIMITIVES[type_tok])
+
+
+def parse_dispatch_table(path: Path) -> list[Method]:
+    """Extract all `| idx | name | args |` rows from the dispatch table."""
+    pattern = re.compile(r"^\|\s*(\d+)\s*\|\s*`([^`]+)`\s*\|\s*`([^`]*)`\s*\|?")
+    methods: list[Method] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        m = pattern.match(line)
+        if not m:
+            continue
+        idx = int(m.group(1))
+        name = m.group(2)
+        schema = m.group(3)
+        args = parse_schema(schema)
+        if args is None:
+            # Unsupported schema — skip; hand-decoder or fallback covers it.
+            continue
+        methods.append(Method(index=idx, name=name, args=args))
+    return methods
+
+
+def emit_decoder(method: Method) -> str:
+    """Return Rust source for the per-method decoder fn.
+
+    Emits a let-binding per arg, then a json! that references each
+    binding. This avoids putting block expressions inside the json!
+    macro (which json! doesn't accept) while still letting each let
+    use `?` for the bail-out path.
+    """
+    lines = [
+        f"/// Method {method.index}: `{method.name}`. Auto-generated.",
+        f"pub(super) fn decode_{method.index}(args: &[u8]) -> Option<Value> {{",
+        "    let mut c = Cursor::new(args);",
+    ]
+    if not method.args:
+        lines.append("    let _ = c;")
+        lines.append("    Some(json!({}))")
+        lines.append("}")
+        return "\n".join(lines)
+
+    # Compute each arg into a local. Use field-name as the var name,
+    # lowercased for Rust convention; if it collides with a Rust
+    # keyword the var gets `_arg` suffix.
+    KEYWORDS = {"type", "ref", "fn", "let", "mut", "move", "match", "self"}
+    var_names: list[str] = []
+    for arg in method.args:
+        var = arg.name
+        # Lowercase first letter for Rust local-var convention
+        var = var[0].lower() + var[1:] if var else var
+        # If still ambiguous (e.g., starts with digit after lower), prefix
+        if var and not (var[0].isalpha() or var[0] == "_"):
+            var = "_" + var
+        if var in KEYWORDS:
+            var = var + "_"
+        var_names.append(var)
+        lines.append(f"    let {var} = {arg.rust_decoder};")
+
+    lines.append("    Some(json!({")
+    for arg, var in zip(method.args, var_names):
+        lines.append(f"        \"{arg.name}\": {var},")
+    lines.append("    }))")
+    lines.append("}")
+    return "\n".join(lines)
+
+
+def emit_dispatch(methods: list[Method]) -> str:
+    """Return the dispatch fn that routes by method_index."""
+    arms = "\n".join(
+        f"        {m.index} => decode_{m.index}(args),"
+        for m in methods
+    )
+    return f"""
+/// Dispatch — returns `Some` when the codegen has a decoder for this
+/// method index. Methods missing here fall through to the hand-
+/// written decoders in [`crate::wire_log::decoders::outbound`], then
+/// to the args_hex fallback.
+pub(super) fn decode_generated(method_index: u16, args: &[u8]) -> Option<Value> {{
+    match method_index {{
+{arms}
+        _ => None,
+    }}
+}}
+"""
+
+
+HEADER = """//! Auto-generated wire-format decoders for SGWPlayer client methods.
+//!
+//! **DO NOT EDIT BY HAND** — regenerate via:
+//!
+//! ```sh
+//! python tools/wire_decoder_codegen.py > \\
+//!     crates/services/src/wire_log/decoders/generated.rs
+//! cargo fmt -p cimmeria-services
+//! ```
+//!
+//! Source schemas: `docs/protocol/client-method-dispatch-table.md`.
+//! Schemas using composite types (StatUpdateList, ClientEffectResultList,
+//! NameValuePair, FIXED_DICTs, MAILBOX, etc.) are skipped here — they
+//! fall through to the hand-written decoders in
+//! [`crate::wire_log::decoders::outbound`], which override the
+//! generated table when both define the same method.
+
+// Local variable names mirror the protocol's PascalCase / camelCase
+// field names so the codegen stays simple and the generated source
+// reads alongside the dispatch table. Clippy / rustc would otherwise
+// flag every binding.
+#![allow(non_snake_case, clippy::needless_question_mark)]
+
+use serde_json::{json, Value};
+
+use super::primitives::Cursor;
+""" + ARRAY_HELPERS
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parent.parent
+    dispatch_table = repo_root / "docs" / "protocol" / "client-method-dispatch-table.md"
+    if not dispatch_table.exists():
+        sys.stderr.write(f"missing: {dispatch_table}\n")
+        return 1
+
+    methods = parse_dispatch_table(dispatch_table)
+    sys.stderr.write(
+        f"parsed {len(methods)} decodable methods out of the full set\n"
+    )
+
+    parts = [HEADER, ""]
+    for m in methods:
+        parts.append(emit_decoder(m))
+        parts.append("")
+    parts.append(emit_dispatch(methods))
+
+    sys.stdout.write("\n".join(parts))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Every inbound + outbound Mercury method now ships to SigNoz with its msg_id, human-readable msg_name, args length, args hex (truncated to 256 bytes), and a structured JSON-decoded payload when a schema decoder is registered.

This closes the gap between PR #402's per-UDP-packet metadata (\"is the network alive?\") and Tier 3 schema-decoded application data (\"what was in the bundle?\").

## Three tiers of fidelity

| Tier | Coverage | What it answers |
|---|---|---|
| **Always-on** (this PR) | every message logs `msg_id` + `msg_name` + `args_len` + `args_hex` | \"What method was called?\" |
| **Schema-decoded** (this PR — 8 priority decoders) | structured `decoded` JSON field with named per-method fields | \"What was IN the method call?\" |
| **Full coverage** (Phase 2, separate PR) | every method index has a schema decoder | \"What was in EVERY method call?\" |

## Phase 1 priority decoders (this PR)

| Method | Why it's priority |
|---|---|
| `BeingAppearance` (#26) | Decodes `ComponentList` → catches the drone-aggro-breaks-weapon-display bug |
| `onSequence` (#1) | Fire animation broadcast → catches the first-equip-no-animation bug |
| `onDialogDisplay` (#105) | PR #401 verification surface |
| `onStateFieldUpdate` (#19) | BSF bits decoded (`in_combat`, `dead`, `auto_cycling`) |
| `onTimerUpdate` (#12), `onEffectResults` (#14), `onStatUpdate` (#20) | Core combat resolution surface |
| `avatarUpdateExplicit` (0x03) | Inbound movement updates with decoded pos/vel/dir |

## Cross-system observability lift

What this PR makes newly possible:

- **End-to-end bug verification in SigNoz alone** — for the drone-aggro + first-equip-fire-animation bugs, the `decoded.components` field on `BeingAppearance` and `decoded.kismet_event_set_seq_id` on `onSequence` are the missing pieces.
- **PR #401 final-mile check** — `name = \"wire.out\" AND msg_name = \"onDialogDisplay\"` returns every dialog send with its resolved NPC id in `decoded.entity_id`.
- **Trace parenting** — wire_log fires inside existing spans (`cell.dispatch`, `base.encrypted_datagram`, `interaction.interact`) so decoded methods nest under their parent operation in SigNoz Traces view.

## Known gaps (Phase 2 follow-ups)

- **Direct `transport.send_to` sends** — auth/login flow (`build_connect_reply`, `build_logged_off`, `build_time_sync`, `build_char_list`, `build_create_player`, `build_ongoing_tick_sync`) bypass `CellToBaseMsg` and use the lower transport directly. tickSync is the only high-volume one and is already captured at the `mercury.packet` metadata layer.
- **Remaining ~240 method decoders** — codegen tool that parses `docs/protocol/client-method-dispatch-table.md` schemas is the right path. Hand-writing all 240 = ~40 hours; codegen build = ~6 hours + per-method tuning. Methods without decoders still log `msg_name + args_hex` so partial coverage is useful from day one.

## Test plan

- [x] `cargo fmt --all -- --check` ✅
- [x] `cargo clippy -p cimmeria-services --all-targets -- -D warnings` ✅
- [x] 994/994 services tests pass (24 new wire_log tests + existing 970)
- [ ] Manual on colo: deploy + verify `scope_name = \"wire.in\"` and `scope_name = \"wire.out\"` return events with `msg_name` populated and `decoded` JSON present for the 8 priority methods

## Budget

- ~200-500 method events/sec during active play × ~300-500 bytes/event = ~30-50 GB/day uncompressed → ~5-10 GB/day compressed in ClickHouse. Bounded by retention (default 7-15 days).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced wire-packet logging for inbound and outbound client-server communication with human-readable message decoding
  * Improved telemetry integration for better observability and debugging of network events
  * Added support for capturing and decoding message payloads into structured JSON format for analysis

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SandboxServers/Cimmeria/pull/404?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->