### PR TITLE
feat(items): stack-on-grant + Health Slappack PAK override + 3 new accounts

### DIFF
--- a/crates/services/src/base/item_overrides.rs
+++ b/crates/services/src/base/item_overrides.rs
@@ -1,0 +1,311 @@
+//! Cimmeria-side overrides for `CookedDataItems.pak` entries.
+//!
+//! The client's per-item display data — `IconLocation`, `Name`,
+//! `MaxStackSize`, etc. — lives in the `_<itemId>` entries inside
+//! `CookedDataItems.pak` on disk, not in any wire message the server
+//! sends. The `InvItem` wire payload only carries instance state
+//! (`stack_size`, `slot_id`, ammo, charges); the client looks up
+//! display + stacking caps from its own cooked catalogue keyed by
+//! `dbid`. So changing a row in `resources.items` server-side has
+//! zero in-game effect for the icon or the client's stack cap — the
+//! client never asks.
+//!
+//! Same trick as [`super::mission_overrides`]: patch the XML in
+//! memory at server startup and lean on the cooked-data wire path
+//! (`versionInfoRequest` → `onVersionInfo(InvalidKeys=[...])` →
+//! `resourceFragment(_key, patched XML)`) to push the patched entry
+//! to the client. Self-healing — runtime cache invalidation, no
+//! manual client steps.
+//!
+//! This module produces patched XML bytes for items whose canonical
+//! cooked entry shipped with the wrong icon or a stack cap that
+//! doesn't match Cimmeria's chosen value. The XML shape follows the
+//! Server-Build conventions documented in
+//! [`docs/engine/cooked-data-pak-format.md`]: alphabetized attributes
+//! on `<COOKED_ITEM>`, `MaxStackSize` attribute on the nested
+//! `<InventorySet>` element.
+
+/// One item's override: which item to patch and which display
+/// attributes to rewrite. Either / both of `new_icon_location` and
+/// `new_max_stack_size` may be `Some` — the patcher applies only
+/// the populated fields and leaves the rest of the XML intact.
+///
+/// `item_id` is the cooked catalogue key (`_<item_id>` in the PAK),
+/// which is the same as `resources.items.item_id` and the wire
+/// `dbid` carried by `InvItem`.
+pub struct ItemOverride {
+    pub item_id: u32,
+    /// Replacement value for the `IconLocation="..."` attribute on
+    /// the `<COOKED_ITEM>` root. Use a `set:<atlas> image:<sprite>`
+    /// string the cooked client GFX atlas actually contains; the
+    /// server can't add new sprites, only re-point at ones the
+    /// client already has baked.
+    pub new_icon_location: Option<&'static str>,
+    /// Replacement value for the `MaxStackSize="..."` attribute on
+    /// the nested `<InventorySet>` element. Must match the
+    /// server-side cap in `resources.items.max_stack_size` and the
+    /// stacking logic in `handle_grant_item` — drift here surfaces
+    /// as either lost pickups (server stacks past the client's cap)
+    /// or wasted slots (client never stacks above the server cap).
+    pub new_max_stack_size: Option<u32>,
+}
+
+/// All Cimmeria-introduced item overrides for the `CookedDataItems`
+/// category. Adding an entry here:
+///
+///   1. Update the matching row in
+///      `db/resources/Items/Seed/items.sql` so the server-side
+///      catalogue agrees (max_stack_size is read by the
+///      grant-stacking path; icon_location is documentary only).
+///   2. Add an `ItemOverride` here so the client's UI picks up the
+///      new display values via the per-key invalidation handshake.
+///   3. If the override's `new_icon_location` points at a sprite
+///      the client doesn't have baked, the inventory window
+///      renders the placeholder "missing icon" square — verify
+///      another item already uses the same string before adding a
+///      new one.
+///
+/// Server seed and client override must agree on `max_stack_size`
+/// — the in-game stacking experience requires both the server
+/// (which decides whether to merge into an existing slot on
+/// pickup) and the client (which enforces a per-display cap) to
+/// see the same value.
+pub const ITEM_OVERRIDES: &[ItemOverride] = &[
+    // Health Slappack TC1 (item 2893). The canonical PAK shipped
+    // with `IconLocation="set:CoreWidgets image:IconMissing"` (the
+    // placeholder broken-square icon) and `MaxStackSize="1"` —
+    // every looted slappack ate its own bag slot and rendered as
+    // the missing-icon sprite. Player-reported regression after
+    // PR #399's seed-only change had no visible effect.
+    //
+    // Medkit sprite is already used by Plasma Burn Treatment Kit
+    // and Evac-U-Pac, so we know it's in the client's
+    // ItemIcon001.upk atlas — no client-side patch needed for the
+    // sprite itself, only this redirect.
+    ItemOverride {
+        item_id: 2893,
+        new_icon_location: Some("set:ItemIcon001 image:Medkit"),
+        new_max_stack_size: Some(10),
+    },
+    // TC-18 craftable duplicate (same display name). The inventory
+    // UI keys icons + stack caps by item_id, not by name, so the
+    // craftable variant has to be patched independently or it
+    // would still render with the broken icon and refuse to stack.
+    ItemOverride {
+        item_id: 4735,
+        new_icon_location: Some("set:ItemIcon001 image:Medkit"),
+        new_max_stack_size: Some(10),
+    },
+];
+
+/// Apply a single item override to a chunk of XML bytes from the
+/// PAK.
+///
+/// Replaces:
+/// - `IconLocation="<old>"` on `<COOKED_ITEM>` with the new value,
+///   if `ov.new_icon_location` is `Some`.
+/// - `MaxStackSize="<old>"` on the nested `<InventorySet>` with
+///   the new value, if `ov.new_max_stack_size` is `Some`.
+///
+/// Returns `Some(patched)` on success, `None` if any requested
+/// patch couldn't find its anchor — caller logs and keeps the
+/// original bytes unmodified rather than risk shipping a partially
+/// patched entry that disagrees with the server-side seed.
+///
+/// Anchor strategy: substring scan for `IconLocation="` and
+/// `MaxStackSize="`. The Server-Build attribute order is
+/// alphabetical (verified in `docs/engine/cooked-data-pak-format.md`)
+/// and the cooked items each have a single `IconLocation` /
+/// single `<InventorySet MaxStackSize=...>` per item, so unbounded
+/// `str::find` is safe: the next match after the start of the
+/// element IS the attribute on the right element.
+pub fn apply_override(original: &[u8], ov: &ItemOverride) -> Option<Vec<u8>> {
+    let xml = std::str::from_utf8(original).ok()?;
+    let mut current = xml.to_string();
+
+    if let Some(new_icon) = ov.new_icon_location {
+        current = patch_attr(&current, "IconLocation", new_icon)?;
+    }
+    if let Some(new_stack) = ov.new_max_stack_size {
+        let new_value = new_stack.to_string();
+        current = patch_attr(&current, "MaxStackSize", &new_value)?;
+    }
+    Some(current.into_bytes())
+}
+
+/// Replace the value of `<attr_name>="<old>"` with
+/// `<attr_name>="<new_value>"` in `xml`. Returns `None` if the
+/// attribute isn't found — caller decides whether that's a hard
+/// failure or a benign skip.
+///
+/// Matches only the FIRST occurrence. The cooked item XMLs have a
+/// single `IconLocation` and a single `MaxStackSize` per entry, so
+/// "first" == "only" in practice. If a future override needs to
+/// patch multiple attributes of the same name, this helper grows
+/// to take an anchor.
+fn patch_attr(xml: &str, attr_name: &str, new_value: &str) -> Option<String> {
+    let attr_open = format!("{attr_name}=\"");
+    let attr_start = xml.find(&attr_open)?;
+    let value_start = attr_start + attr_open.len();
+    let value_end = value_start + xml[value_start..].find('"')?;
+
+    let mut out = String::with_capacity(xml.len() - (value_end - value_start) + new_value.len());
+    out.push_str(&xml[..value_start]);
+    out.push_str(new_value);
+    out.push_str(&xml[value_end..]);
+    Some(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Realistic 2893 (slappack) Server-Build shape, lifted from the
+    /// canonical XML conventions in
+    /// `docs/engine/cooked-data-pak-format.md`. Anchors the pre-patch
+    /// state so a regression that changes the attribute order or
+    /// drops an `<InventorySet>` element trips a clear failure here
+    /// instead of a subtle in-game miss.
+    const SAMPLE_2893: &[u8] = b"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\
+        <COOKED_ITEM AppliedScienceID=\"1\" Description=\"Health Slappack TC1 - +500 Health\" \
+        ID=\"2893\" IconLocation=\"set:CoreWidgets image:IconMissing\" \
+        IsElementaryComponent=\"false\" IsKicker=\"false\" IsResearchable=\"false\" \
+        IsReverseEngineerable=\"false\" Name=\"Health Slappack TC1\" QualityID=\"2000\" \
+        TechComp=\"1\" Tier=\"1\" ItemFlags=\"36224\">\
+        <InventorySet IsDeletable=\"true\" IsSellable=\"true\" MaxStackSize=\"1\" />\
+        <RequirementsSet IsUnique=\"false\" />\
+        <ItemEventSet AbilityID=\"5001\" EventID=\"5\" />\
+        <ContainerSet>1</ContainerSet>\
+        </COOKED_ITEM>";
+
+    /// Patcher must rewrite both attributes in one pass and leave
+    /// the rest of the XML byte-identical. Negative pin: `Name=`,
+    /// `Description=`, the nested `<ItemEventSet>` and
+    /// `<ContainerSet>` survive verbatim. Bug shape: a regression
+    /// that uses a too-greedy regex (e.g. `MaxStackSize="[^"]*"`
+    /// applied across the whole document) could chew through other
+    /// attributes if a future cooked entry gains a second
+    /// `MaxStackSize` reference (vendor offer XML, etc.).
+    #[test]
+    fn apply_override_rewrites_icon_and_stack_size_in_place() {
+        let ov = ItemOverride {
+            item_id: 2893,
+            new_icon_location: Some("set:ItemIcon001 image:Medkit"),
+            new_max_stack_size: Some(10),
+        };
+        let patched = apply_override(SAMPLE_2893, &ov).expect("override must apply");
+        let patched_str = std::str::from_utf8(&patched).expect("patched is utf-8");
+
+        assert!(
+            patched_str.contains("IconLocation=\"set:ItemIcon001 image:Medkit\""),
+            "IconLocation must be rewritten to the Medkit sprite"
+        );
+        assert!(
+            patched_str.contains("MaxStackSize=\"10\""),
+            "MaxStackSize must be rewritten to 10"
+        );
+        // Negative pins — surrounding XML unchanged.
+        assert!(
+            !patched_str.contains("IconMissing"),
+            "old placeholder icon must be removed entirely"
+        );
+        assert!(
+            patched_str.contains("Name=\"Health Slappack TC1\""),
+            "Name attribute must survive verbatim"
+        );
+        assert!(
+            patched_str.contains("<ItemEventSet AbilityID=\"5001\" EventID=\"5\" />"),
+            "nested ItemEventSet must survive verbatim"
+        );
+        assert!(
+            patched_str.contains("ID=\"2893\""),
+            "item ID attribute must survive verbatim — patcher must not chew through it"
+        );
+    }
+
+    /// Icon-only override leaves MaxStackSize alone. Pins that the
+    /// `Option` discipline actually gates the patch — a regression
+    /// that always rewrites MaxStackSize (regardless of `Some/None`)
+    /// would trip this.
+    #[test]
+    fn apply_override_with_only_icon_leaves_stack_size_untouched() {
+        let ov = ItemOverride {
+            item_id: 2893,
+            new_icon_location: Some("set:ItemIcon001 image:Spray_Injector"),
+            new_max_stack_size: None,
+        };
+        let patched = apply_override(SAMPLE_2893, &ov).expect("override must apply");
+        let patched_str = std::str::from_utf8(&patched).expect("patched is utf-8");
+
+        assert!(patched_str.contains("IconLocation=\"set:ItemIcon001 image:Spray_Injector\""));
+        assert!(
+            patched_str.contains("MaxStackSize=\"1\""),
+            "MaxStackSize must be unchanged when new_max_stack_size is None"
+        );
+    }
+
+    /// Stack-only override leaves IconLocation alone. Companion
+    /// to the icon-only case.
+    #[test]
+    fn apply_override_with_only_stack_leaves_icon_untouched() {
+        let ov = ItemOverride {
+            item_id: 2893,
+            new_icon_location: None,
+            new_max_stack_size: Some(5),
+        };
+        let patched = apply_override(SAMPLE_2893, &ov).expect("override must apply");
+        let patched_str = std::str::from_utf8(&patched).expect("patched is utf-8");
+
+        assert!(patched_str.contains("MaxStackSize=\"5\""));
+        assert!(
+            patched_str.contains("IconLocation=\"set:CoreWidgets image:IconMissing\""),
+            "IconLocation must be unchanged when new_icon_location is None"
+        );
+    }
+
+    /// Missing anchor → None. Defensive — if the cooked XML shape
+    /// drifts (attribute renamed, element removed), we refuse to
+    /// ship a half-patched entry. Caller logs the skip and keeps
+    /// the original bytes intact.
+    #[test]
+    fn apply_override_returns_none_when_anchor_missing() {
+        let no_icon = b"<COOKED_ITEM ID=\"2893\" Name=\"Foo\"><InventorySet MaxStackSize=\"1\"/></COOKED_ITEM>";
+        let ov = ItemOverride {
+            item_id: 2893,
+            new_icon_location: Some("set:ItemIcon001 image:Medkit"),
+            new_max_stack_size: Some(10),
+        };
+        assert!(
+            apply_override(no_icon, &ov).is_none(),
+            "missing IconLocation anchor must refuse the patch entirely"
+        );
+    }
+
+    /// Every override entry in `ITEM_OVERRIDES` applies cleanly
+    /// against a fixture shaped like the canonical PAK entry.
+    /// A new override added to the registry trips here if its
+    /// `new_*` fields are populated but the patcher can't find
+    /// the anchor on a typical COOKED_ITEM shape.
+    #[test]
+    fn all_registered_overrides_apply_to_sample() {
+        for ov in ITEM_OVERRIDES {
+            let patched = apply_override(SAMPLE_2893, ov)
+                .unwrap_or_else(|| panic!("override for item {} must apply", ov.item_id));
+            let patched_str = std::str::from_utf8(&patched).expect("patched is utf-8");
+            if let Some(want_icon) = ov.new_icon_location {
+                assert!(
+                    patched_str.contains(&format!("IconLocation=\"{want_icon}\"")),
+                    "override for item {} must land its icon",
+                    ov.item_id,
+                );
+            }
+            if let Some(want_stack) = ov.new_max_stack_size {
+                assert!(
+                    patched_str.contains(&format!("MaxStackSize=\"{want_stack}\"")),
+                    "override for item {} must land its stack size",
+                    ov.item_id,
+                );
+            }
+        }
+    }
+}

--- a/crates/services/src/base/mod.rs
+++ b/crates/services/src/base/mod.rs
@@ -25,6 +25,7 @@ pub(crate) mod cooked_data;
 pub(crate) mod deferred_aoi;
 pub(crate) mod dispatch;
 pub(crate) mod helpers;
+pub(crate) mod item_overrides;
 pub(crate) mod login;
 pub(crate) mod mission_overrides;
 pub(crate) mod outbox;

--- a/crates/services/src/base/resources/mod.rs
+++ b/crates/services/src/base/resources/mod.rs
@@ -107,6 +107,11 @@ pub(crate) const CATEGORY_PAKS: &[(u32, &str)] = &[
 /// Category id for `CookedDataMissions.pak` (see [`CATEGORY_PAKS`]).
 const CATEGORY_MISSIONS: u32 = 3;
 
+/// Category id for `CookedDataItems.pak` (see [`CATEGORY_PAKS`]).
+/// Source: the original C++ server's `resource.cpp` category map.
+/// Per-item icon, name, max-stack lookups land here on the client.
+const CATEGORY_ITEMS: u32 = 4;
+
 /// Compute the deterministic metadata bump for a set of overrides.
 ///
 /// The bump is hashed from every field that affects what the client sees:
@@ -133,6 +138,20 @@ fn compute_metadata_bump(
         ov.mission_id.hash(&mut hasher);
         ov.step_id.hash(&mut hasher);
         ov.new_step_display_log_text.hash(&mut hasher);
+    }
+    ((hasher.finish() as u32) & 0xFFFF) | 0x1
+}
+
+/// Companion of [`compute_metadata_bump`] for the items category.
+/// Same deterministic-hash + low-bit-set discipline so two server
+/// starts on identical override content produce identical bumps.
+fn compute_item_metadata_bump(overrides: &[super::item_overrides::ItemOverride]) -> u32 {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    for ov in overrides {
+        ov.item_id.hash(&mut hasher);
+        ov.new_icon_location.hash(&mut hasher);
+        ov.new_max_stack_size.hash(&mut hasher);
     }
     ((hasher.finish() as u32) & 0xFFFF) | 0x1
 }
@@ -172,12 +191,90 @@ impl ResourceCache {
             "Resource cache loaded"
         );
 
-        let overridden_elements = Self::apply_mission_overrides(&mut categories);
+        let mut overridden_elements = Self::apply_mission_overrides(&mut categories);
+        // Apply item overrides into the same overridden-elements map.
+        // `extend` over disjoint category keys means each call owns its
+        // own category id (missions=3, items=4) and there's no risk of
+        // one wiping the other's invalid-keys list. Cross-pollination
+        // between categories would surface as the client invalidating
+        // the wrong PAK category on handshake; the categories live in
+        // separate XML files on disk so it can't physically conflict,
+        // but keep both writes disjoint anyway in case a future
+        // override module starts producing entries for an existing
+        // category.
+        let item_overridden = Self::apply_item_overrides(&mut categories);
+        overridden_elements.extend(item_overridden);
 
         Ok(Self {
             categories: Arc::new(categories),
             overridden_elements: Arc::new(overridden_elements),
         })
+    }
+
+    /// Patch the freshly-loaded `CookedDataItems` category with
+    /// Cimmeria's icon + stack-size overrides, bumping the category
+    /// metadata so the client's next `versionInfoRequest` sees a
+    /// fresh value and triggers the per-key invalidation handshake.
+    ///
+    /// Same shape as [`Self::apply_mission_overrides`] — the cooked
+    /// data wire path is category-agnostic; only the per-category
+    /// override registry differs.
+    fn apply_item_overrides(categories: &mut HashMap<u32, CategoryData>) -> HashMap<u32, Vec<u32>> {
+        use super::item_overrides::{apply_override, ITEM_OVERRIDES};
+
+        let mut overridden: HashMap<u32, Vec<u32>> = HashMap::new();
+        let Some(items) = categories.get_mut(&CATEGORY_ITEMS) else {
+            tracing::warn!(
+                category = CATEGORY_ITEMS,
+                "CookedDataItems not loaded; skipping item overrides"
+            );
+            return overridden;
+        };
+
+        let mut applied: Vec<u32> = Vec::with_capacity(ITEM_OVERRIDES.len());
+        for ov in ITEM_OVERRIDES {
+            let Some(original) = items.elements.get(&ov.item_id) else {
+                tracing::warn!(
+                    item_id = ov.item_id,
+                    "item override skipped: entry not present in PAK",
+                );
+                continue;
+            };
+            match apply_override(original, ov) {
+                Some(patched) => {
+                    items.elements.insert(ov.item_id, patched);
+                    applied.push(ov.item_id);
+                    tracing::info!(
+                        item_id = ov.item_id,
+                        new_icon = ?ov.new_icon_location,
+                        new_max_stack_size = ?ov.new_max_stack_size,
+                        "Applied Cimmeria item override",
+                    );
+                }
+                None => {
+                    tracing::warn!(
+                        item_id = ov.item_id,
+                        "item override skipped: XML shape did not match — keeping unpatched entry",
+                    );
+                }
+            }
+        }
+
+        if !applied.is_empty() {
+            let bump = compute_item_metadata_bump(ITEM_OVERRIDES);
+            items.metadata = items.metadata.wrapping_add(bump);
+            applied.sort_unstable();
+            tracing::info!(
+                category = CATEGORY_ITEMS,
+                count = applied.len(),
+                bump,
+                bumped_metadata = items.metadata,
+                "Cimmeria item overrides applied; metadata bumped",
+            );
+            overridden.insert(CATEGORY_ITEMS, applied);
+        }
+
+        overridden
     }
 
     /// Mutate the freshly-loaded `CookedDataMissions` category to include

--- a/crates/services/src/base/resources/tests.rs
+++ b/crates/services/src/base/resources/tests.rs
@@ -360,3 +360,159 @@ fn overridden_elements_returns_empty_slice_for_unknown_category() {
         "unknown category must yield empty slice",
     );
 }
+
+// ── apply_item_overrides on hand-built CategoryData ──────────────
+// Mirrors the apply_mission_overrides tests above. The PAK-load path
+// is integration-tested by running the real server; this exercises
+// the in-memory mutation logic without ZIP IO.
+
+/// Minimal Server-Build COOKED_ITEM that satisfies the
+/// `apply_override` patcher's anchors (`IconLocation="..."` and
+/// `<InventorySet ... MaxStackSize="..." .../>`). Each item gets a
+/// distinct id so the test can pin per-id overrides.
+fn fake_item_xml(item_id: u32, icon: &str, max_stack: u32) -> Vec<u8> {
+    format!(
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\
+         <COOKED_ITEM ID=\"{item_id}\" \
+         IconLocation=\"{icon}\" \
+         Name=\"Item {item_id}\" Tier=\"1\">\
+         <InventorySet IsDeletable=\"true\" MaxStackSize=\"{max_stack}\" />\
+         </COOKED_ITEM>"
+    )
+    .into_bytes()
+}
+
+fn items_category_with(entries: &[(u32, &str, u32)], metadata: u32) -> CategoryData {
+    let mut elements = HashMap::new();
+    for (item_id, icon, max_stack) in entries {
+        elements.insert(*item_id, fake_item_xml(*item_id, icon, *max_stack));
+    }
+    CategoryData { metadata, elements }
+}
+
+/// Post-condition pin: every registered item override mutates its
+/// entry, the category metadata is bumped, and the overridden-ids
+/// map names the patched items.
+#[test]
+fn apply_item_overrides_patches_entries_and_bumps_metadata() {
+    let starting_metadata = 7542;
+    let mut categories: HashMap<u32, CategoryData> = HashMap::new();
+    // Slappack pre-fix shape (IconMissing + MaxStackSize=1) so the
+    // patcher has something to rewrite. Other entries are present
+    // to verify the patcher doesn't touch them.
+    categories.insert(
+        CATEGORY_ITEMS,
+        items_category_with(
+            &[
+                (2893, "set:CoreWidgets image:IconMissing", 1),
+                (4735, "set:CoreWidgets image:IconMissing", 1),
+                (9999, "set:ItemIcon001 image:SomeOther", 5),
+            ],
+            starting_metadata,
+        ),
+    );
+
+    let overridden = ResourceCache::apply_item_overrides(&mut categories);
+
+    let items = categories
+        .get(&CATEGORY_ITEMS)
+        .expect("items category must remain after apply");
+
+    assert_ne!(
+        items.metadata, starting_metadata,
+        "apply must bump the items metadata so the client invalidates and refetches",
+    );
+    let bump = items.metadata.wrapping_sub(starting_metadata);
+    assert_eq!(bump & 0x1, 0x1, "low bit of bump must be set");
+
+    // Slappack entries patched.
+    for &id in &[2893u32, 4735u32] {
+        let patched = std::str::from_utf8(
+            items
+                .elements
+                .get(&id)
+                .unwrap_or_else(|| panic!("item {id} missing")),
+        )
+        .unwrap();
+        assert!(
+            patched.contains("IconLocation=\"set:ItemIcon001 image:Medkit\""),
+            "item {id} must carry the Medkit icon after override; got: {patched}",
+        );
+        assert!(
+            patched.contains("MaxStackSize=\"10\""),
+            "item {id} must carry MaxStackSize=10 after override; got: {patched}",
+        );
+    }
+
+    // Untouched entry retains its original values byte-for-byte.
+    let other = std::str::from_utf8(items.elements.get(&9999).unwrap()).unwrap();
+    assert!(
+        other.contains("IconLocation=\"set:ItemIcon001 image:SomeOther\""),
+        "unrelated item 9999 must not be touched by item overrides"
+    );
+    assert!(
+        other.contains("MaxStackSize=\"5\""),
+        "unrelated item 9999 must keep its MaxStackSize=5"
+    );
+
+    let ids = overridden
+        .get(&CATEGORY_ITEMS)
+        .expect("items must appear in returned map");
+    assert_eq!(
+        ids.as_slice(),
+        &[2893u32, 4735u32],
+        "overridden_elements must name both slappack ids in ascending order",
+    );
+}
+
+/// Defensive path: items category absent (PAK missing) → no-op
+/// return, server startup keeps going. Mirrors the analogous
+/// missions test.
+#[test]
+fn apply_item_overrides_no_op_when_category_missing() {
+    let mut categories: HashMap<u32, CategoryData> = HashMap::new();
+    let overridden = ResourceCache::apply_item_overrides(&mut categories);
+    assert!(
+        overridden.is_empty(),
+        "missing items category must not produce override entries"
+    );
+}
+
+/// `compute_item_metadata_bump` is deterministic across calls and
+/// always sets the low bit. Companion of the mission-side pin
+/// `compute_metadata_bump_low_bit_is_always_set`.
+#[test]
+fn compute_item_metadata_bump_is_deterministic_and_low_bit_set() {
+    use super::super::item_overrides::ItemOverride;
+    let overrides = [ItemOverride {
+        item_id: 2893,
+        new_icon_location: Some("set:ItemIcon001 image:Medkit"),
+        new_max_stack_size: Some(10),
+    }];
+    let a = compute_item_metadata_bump(&overrides);
+    let b = compute_item_metadata_bump(&overrides);
+    assert_eq!(a, b, "same overrides must hash to the same bump");
+    assert_eq!(a & 0x1, 0x1, "low bit must be set");
+
+    // A change to either field changes the bump (so the client refetches).
+    let different_icon = [ItemOverride {
+        item_id: 2893,
+        new_icon_location: Some("set:ItemIcon001 image:Spray_Injector"),
+        new_max_stack_size: Some(10),
+    }];
+    assert_ne!(
+        compute_item_metadata_bump(&overrides),
+        compute_item_metadata_bump(&different_icon),
+        "icon edit must change the bump",
+    );
+    let different_stack = [ItemOverride {
+        item_id: 2893,
+        new_icon_location: Some("set:ItemIcon001 image:Medkit"),
+        new_max_stack_size: Some(99),
+    }];
+    assert_ne!(
+        compute_item_metadata_bump(&overrides),
+        compute_item_metadata_bump(&different_stack),
+        "stack-size edit must change the bump",
+    );
+}

--- a/crates/services/src/base/world_entry/methods/inventory/grant/mod.rs
+++ b/crates/services/src/base/world_entry/methods/inventory/grant/mod.rs
@@ -104,6 +104,184 @@ pub async fn handle_grant_item(
         }
     };
 
+    // Acquire the per-(player, container) advisory lock up front so the
+    // merge probe and the eventual reserve/INSERT see the same snapshot.
+    // `reserve_free_inventory_slots` re-acquires the same lock internally;
+    // `pg_advisory_xact_lock` is idempotent within a single transaction,
+    // so doing it here too is a no-op safety belt rather than a double
+    // wait. Without this, two concurrent grants for the same stackable
+    // item could each decide "no existing stack, allocate a new slot"
+    // and produce two single-stack rows instead of merging into one.
+    if let Err(e) = sqlx::query("SELECT pg_advisory_xact_lock($1, $2)")
+        .bind(player_id)
+        .bind(container_id)
+        .execute(&mut *db_tx)
+        .await
+    {
+        let _ = db_tx.rollback().await;
+        tracing::error!(
+            player_id,
+            item_id,
+            container_id,
+            "GrantItem: advisory lock failed: {e}"
+        );
+        return;
+    }
+
+    // ── Stack-merge fast path ────────────────────────────────────────
+    //
+    // Before reserving a fresh slot, look for an existing
+    // same-type row in the same container with room for the full
+    // count. When the row exists, UPDATE its `stack_size` and
+    // short-circuit — no slot reservation, no INSERT, no
+    // bandolier_slot reconcile (the merge target is already the
+    // active slot if it ever was). This is what makes consumables
+    // like the Health Slappack stack to their `max_stack_size`
+    // instead of eating one inventory slot per pickup.
+    //
+    // Gating predicates the WHERE clause enforces:
+    //   - `bound = false` — bound items are 1:1 with their owner
+    //     (no merging across two bound rows of the same type).
+    //   - `ri.max_stack_size > 1` — non-stackable item defs stay
+    //     on the one-row-per-pickup path even if a stale identical
+    //     row exists.
+    //   - `inv.stack_size + $count <= ri.max_stack_size` — refuse
+    //     partial merges. A pickup of 3 against a stack at 8/10
+    //     skips merge and allocates a new slot rather than
+    //     splitting (8 stays, 2 go to one new slot, 1 leftover);
+    //     the simpler "all-or-nothing into a single stack" rule
+    //     keeps the wire-level `onUpdateItem` set predictable and
+    //     dodges a tricky "two rows from one grant" outbox
+    //     enqueue. A future enhancement can split if needed.
+    //   - Charges and ammo_type are intentionally NOT in the
+    //     match criteria. Consumable charges are typically 0
+    //     (server tracks the count via stack_size, not via per-
+    //     instance charges); ammo_type only matters for weapons,
+    //     which are non-stackable.
+    //
+    // `FOR UPDATE` locks the target row for the rest of the
+    // transaction so the subsequent UPDATE can't race with a
+    // concurrent vendor sell of the same stack. The advisory
+    // lock above already serialises grants per container, but a
+    // vendor sell takes a different lock (per-item), so the row
+    // lock is the belt-and-braces.
+    #[derive(sqlx::FromRow)]
+    struct MergeCandidate {
+        item_id: i32,
+        slot_id: i32,
+    }
+    let merge_candidate: Option<MergeCandidate> = match sqlx::query_as(
+        "SELECT inv.item_id, inv.slot_id \
+           FROM sgw_inventory inv \
+           JOIN resources.items ri ON inv.type_id = ri.item_id \
+          WHERE inv.character_id = $1 \
+            AND inv.container_id = $2 \
+            AND inv.type_id = $3 \
+            AND inv.bound = false \
+            AND ri.max_stack_size > 1 \
+            AND inv.stack_size + $4 <= ri.max_stack_size \
+          ORDER BY inv.slot_id \
+          LIMIT 1 \
+          FOR UPDATE",
+    )
+    .bind(player_id)
+    .bind(container_id)
+    .bind(item_id)
+    .bind(count)
+    .fetch_optional(&mut *db_tx)
+    .await
+    {
+        Ok(c) => c,
+        Err(e) => {
+            let _ = db_tx.rollback().await;
+            tracing::error!(
+                player_id,
+                item_id,
+                container_id,
+                "GrantItem: merge candidate lookup failed: {e}"
+            );
+            return;
+        }
+    };
+
+    if let Some(target) = merge_candidate {
+        // Merge into the existing stack. The UPDATE is keyed by
+        // item_id (the primary key of sgw_inventory) so it can
+        // only touch the exact row we locked above.
+        if let Err(e) =
+            sqlx::query("UPDATE sgw_inventory SET stack_size = stack_size + $1 WHERE item_id = $2")
+                .bind(count)
+                .bind(target.item_id)
+                .execute(&mut *db_tx)
+                .await
+        {
+            let _ = db_tx.rollback().await;
+            tracing::error!(
+                player_id,
+                item_id,
+                target_item_id = target.item_id,
+                "GrantItem: stack merge UPDATE failed: {e}"
+            );
+            return;
+        }
+        tracing::info!(
+            player_id,
+            item_id,
+            container_id,
+            slot = target.slot_id,
+            count,
+            "GrantItem: merged into existing stack"
+        );
+
+        // Stackable items are non-bandolier consumables in
+        // practice (weapons have `max_stack_size = 1`), so the
+        // bandolier-active-slot reconcile is irrelevant on the
+        // merge path. Skip straight to outbox enqueue + commit +
+        // inventory resync.
+        let outbox_payload = CellOutboxPayload::InventoryItemGranted {
+            item_id,
+            container_id,
+            slot_id: target.slot_id,
+            quantity: count,
+        };
+        let outbox_id = match outbox::enqueue_in_tx(&mut db_tx, entity_id, &outbox_payload).await {
+            Ok(id) => id,
+            Err(e) => {
+                let _ = db_tx.rollback().await;
+                tracing::error!(
+                    player_id,
+                    item_id,
+                    "GrantItem (merge): outbox enqueue failed, aborting: {e}"
+                );
+                return;
+            }
+        };
+        if let Err(e) = db_tx.commit().await {
+            tracing::error!(player_id, item_id, "GrantItem (merge): commit failed: {e}");
+            return;
+        }
+        let total_items = send_full_inventory_update(
+            entity_id,
+            player_id,
+            pool,
+            transport,
+            connected,
+            entity_to_addr,
+        )
+        .await;
+        tracing::debug!(
+            entity_id,
+            player_id,
+            item_id,
+            total_items,
+            "GrantItem (merge): sent full onUpdateItem to client"
+        );
+        if let Some(tx) = cell_tx {
+            outbox::try_dispatch_now(pool.as_ref(), tx, outbox_id, entity_id, outbox_payload).await;
+        }
+        return;
+    }
+
     // Reserve a free slot via the same hole-filling helper used by vendor purchase.
     // (reserve_free_inventory_slots takes a per-(player, container) advisory lock.)
     let next_slot: i32 =

--- a/crates/services/src/base/world_entry/methods/inventory/grant/tests.rs
+++ b/crates/services/src/base/world_entry/methods/inventory/grant/tests.rs
@@ -252,4 +252,241 @@ mod handle_grant_item_tests {
 
         cleanup(&pool, account_id, player_id, entity_id).await;
     }
+
+    /// Health Slappack TC1 (item 2893). The canonical seed gives it
+    /// `max_stack_size = 10` and `container_sets = '{1,17}'`, which
+    /// makes it the obvious stackable consumable to pin the merge
+    /// path against. Hardcoding the id (instead of a SELECT) ties
+    /// the test to the actual on-disk seed shape — a regression
+    /// that drops the slappack's `max_stack_size` back to 1 would
+    /// trip these tests with a clear "merge expected, allocation
+    /// observed" message.
+    const SLAPPACK_TYPE_ID: i32 = 2893;
+    /// Mirrors the seed value. Used by the "full stack rejects
+    /// merge" guard.
+    const SLAPPACK_MAX_STACK: i32 = 10;
+
+    /// Two consecutive grants of the same stackable item must
+    /// produce ONE row with the combined `stack_size`, not two
+    /// rows occupying two slots. The merge fast path is what makes
+    /// looted slappacks stop eating one bag slot per pickup —
+    /// pre-fix every grant unconditionally reserved a fresh slot.
+    #[tokio::test]
+    async fn stackable_item_grants_merge_into_one_row() {
+        let pool = require_db_or_skip!();
+        let account_id = TEST_BASE + 200;
+        let player_id = TEST_BASE + 201;
+        let entity_id: u32 = 0x7000_0303;
+        cleanup(&pool, account_id, player_id, entity_id).await;
+        insert_account_and_player(&pool, account_id, player_id).await;
+
+        let (transport, e2a, conn) = make_state(entity_id);
+        let db_pool = Some(Arc::new(pool.clone()));
+
+        // First grant: 2 slappacks into main bag (container 1).
+        // Second grant: 3 more.  Expect one row at stack_size = 5.
+        handle_grant_item(
+            entity_id,
+            player_id,
+            SLAPPACK_TYPE_ID,
+            1,
+            2,
+            &db_pool,
+            &None,
+            &transport,
+            &conn,
+            &e2a,
+        )
+        .await;
+        handle_grant_item(
+            entity_id,
+            player_id,
+            SLAPPACK_TYPE_ID,
+            1,
+            3,
+            &db_pool,
+            &None,
+            &transport,
+            &conn,
+            &e2a,
+        )
+        .await;
+
+        let rows: Vec<(i32, i32)> = sqlx::query_as(
+            "SELECT slot_id, stack_size FROM sgw_inventory \
+             WHERE character_id = $1 AND container_id = 1 \
+               AND type_id = $2 \
+             ORDER BY slot_id",
+        )
+        .bind(player_id)
+        .bind(SLAPPACK_TYPE_ID)
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            rows.len(),
+            1,
+            "two grants of slappack (max_stack_size=10) must merge into ONE row — \
+             pre-fix the grant path reserved a fresh slot per pickup and produced \
+             two rows for what should be one stack of 5"
+        );
+        assert_eq!(
+            rows[0],
+            (0, 5),
+            "merged stack must occupy the first reserved slot with \
+             combined stack_size = 2 + 3 = 5"
+        );
+
+        cleanup(&pool, account_id, player_id, entity_id).await;
+    }
+
+    /// When the existing stack has no room for the full new count,
+    /// the merge path must REFUSE and allocate a fresh slot
+    /// instead. Partial-merge "fill the current stack, spill the
+    /// remainder" would produce a multi-row outbox payload from
+    /// one grant, which the cell side isn't shaped to consume.
+    /// Pinning the all-or-nothing rule here means the simpler
+    /// invariant — one grant = one row write — survives.
+    #[tokio::test]
+    async fn full_stack_falls_back_to_new_slot() {
+        let pool = require_db_or_skip!();
+        let account_id = TEST_BASE + 210;
+        let player_id = TEST_BASE + 211;
+        let entity_id: u32 = 0x7000_0304;
+        cleanup(&pool, account_id, player_id, entity_id).await;
+        insert_account_and_player(&pool, account_id, player_id).await;
+
+        let (transport, e2a, conn) = make_state(entity_id);
+        let db_pool = Some(Arc::new(pool.clone()));
+
+        // Fill a full stack (10 slappacks) into slot 0.
+        handle_grant_item(
+            entity_id,
+            player_id,
+            SLAPPACK_TYPE_ID,
+            1,
+            SLAPPACK_MAX_STACK,
+            &db_pool,
+            &None,
+            &transport,
+            &conn,
+            &e2a,
+        )
+        .await;
+        // One more — the existing stack is at max, so this must
+        // allocate slot 1 rather than try to push the existing
+        // row past its `max_stack_size`.
+        handle_grant_item(
+            entity_id,
+            player_id,
+            SLAPPACK_TYPE_ID,
+            1,
+            1,
+            &db_pool,
+            &None,
+            &transport,
+            &conn,
+            &e2a,
+        )
+        .await;
+
+        let rows: Vec<(i32, i32)> = sqlx::query_as(
+            "SELECT slot_id, stack_size FROM sgw_inventory \
+             WHERE character_id = $1 AND container_id = 1 \
+               AND type_id = $2 \
+             ORDER BY slot_id",
+        )
+        .bind(player_id)
+        .bind(SLAPPACK_TYPE_ID)
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            rows.len(),
+            2,
+            "full stack must NOT accept a merge — the second grant has \
+             to land in a fresh slot. Pre-fix bug shape: the merge \
+             gate `stack_size + count <= max_stack_size` regresses to \
+             `stack_size < max_stack_size` and a single +1 squeezes \
+             into a 10/10 stack, exceeding the cap."
+        );
+        assert_eq!(rows[0], (0, SLAPPACK_MAX_STACK));
+        assert_eq!(rows[1], (1, 1));
+
+        cleanup(&pool, account_id, player_id, entity_id).await;
+    }
+
+    /// Two grants for two DIFFERENT type_ids must not merge —
+    /// stacking is keyed on the type_id, not the container. Pin
+    /// this so a future refactor that drops the `inv.type_id = $3`
+    /// clause from the merge query doesn't silently start
+    /// merging a slappack pickup into the wrong stack.
+    #[tokio::test]
+    async fn different_type_ids_do_not_merge() {
+        let pool = require_db_or_skip!();
+        let account_id = TEST_BASE + 220;
+        let player_id = TEST_BASE + 221;
+        let entity_id: u32 = 0x7000_0305;
+        cleanup(&pool, account_id, player_id, entity_id).await;
+        insert_account_and_player(&pool, account_id, player_id).await;
+
+        let (transport, e2a, conn) = make_state(entity_id);
+        let db_pool = Some(Arc::new(pool.clone()));
+
+        // Slappack (2893) and an arbitrary non-stackable item in
+        // the same bag. `pick_main_bag_type_id` returns the
+        // lowest item_id with container_sets containing 1 —
+        // distinct from 2893 by construction.
+        let other_type_id = pick_main_bag_type_id(&pool).await;
+        assert_ne!(
+            other_type_id, SLAPPACK_TYPE_ID,
+            "fixture sanity: pick_main_bag_type_id must return a \
+             type_id different from the slappack so this test \
+             actually exercises the different-type path"
+        );
+
+        handle_grant_item(
+            entity_id,
+            player_id,
+            SLAPPACK_TYPE_ID,
+            1,
+            1,
+            &db_pool,
+            &None,
+            &transport,
+            &conn,
+            &e2a,
+        )
+        .await;
+        handle_grant_item(
+            entity_id,
+            player_id,
+            other_type_id,
+            1,
+            1,
+            &db_pool,
+            &None,
+            &transport,
+            &conn,
+            &e2a,
+        )
+        .await;
+
+        let count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM sgw_inventory \
+             WHERE character_id = $1 AND container_id = 1",
+        )
+        .bind(player_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            count, 2,
+            "different type_ids must each take their own slot — \
+             merging across type_ids would corrupt inventory by \
+             increasing a slappack stack with an unrelated item"
+        );
+
+        cleanup(&pool, account_id, player_id, entity_id).await;
+    }
 }

--- a/db/sgw/Accounts/Seed/account.sql
+++ b/db/sgw/Accounts/Seed/account.sql
@@ -4,10 +4,13 @@
 -- Data for Name: account; Type: TABLE DATA; Schema: public; Owner: -
 --
 
-INSERT INTO account (account_id, account_name, password, accesslevel, enabled) VALUES (2, 'test',  'a94a8fe5ccb19ba61c4c0873d391e987982fbbd3', 1, true);
-INSERT INTO account (account_id, account_name, password, accesslevel, enabled) VALUES (3, 'cady',  'a94a8fe5ccb19ba61c4c0873d391e987982fbbd3', 1, true);
-INSERT INTO account (account_id, account_name, password, accesslevel, enabled) VALUES (4, 'jorsh', 'a94a8fe5ccb19ba61c4c0873d391e987982fbbd3', 1, true);
-INSERT INTO account (account_id, account_name, password, accesslevel, enabled) VALUES (5, 'cake',  'a94a8fe5ccb19ba61c4c0873d391e987982fbbd3', 1, true);
+INSERT INTO account (account_id, account_name, password, accesslevel, enabled) VALUES (2, 'test',     'a94a8fe5ccb19ba61c4c0873d391e987982fbbd3', 1, true);
+INSERT INTO account (account_id, account_name, password, accesslevel, enabled) VALUES (3, 'cady',     'a94a8fe5ccb19ba61c4c0873d391e987982fbbd3', 1, true);
+INSERT INTO account (account_id, account_name, password, accesslevel, enabled) VALUES (4, 'jorsh',    'a94a8fe5ccb19ba61c4c0873d391e987982fbbd3', 1, true);
+INSERT INTO account (account_id, account_name, password, accesslevel, enabled) VALUES (5, 'cake',     'a94a8fe5ccb19ba61c4c0873d391e987982fbbd3', 1, true);
+INSERT INTO account (account_id, account_name, password, accesslevel, enabled) VALUES (6, 'lomiada1', 'a94a8fe5ccb19ba61c4c0873d391e987982fbbd3', 1, true);
+INSERT INTO account (account_id, account_name, password, accesslevel, enabled) VALUES (7, 'nonwo1984','a94a8fe5ccb19ba61c4c0873d391e987982fbbd3', 1, true);
+INSERT INTO account (account_id, account_name, password, accesslevel, enabled) VALUES (8, 'ishido972','a94a8fe5ccb19ba61c4c0873d391e987982fbbd3', 1, true);
 
 --
 -- TOC entry 2709 (class 0 OID 0)
@@ -15,5 +18,5 @@ INSERT INTO account (account_id, account_name, password, accesslevel, enabled) V
 -- Name: accounts_account_id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
 --
 
-SELECT pg_catalog.setval('accounts_account_id_seq', 5, true);
+SELECT pg_catalog.setval('accounts_account_id_seq', 8, true);
 


### PR DESCRIPTION
## Why

PR #399 (data-only seed change for items 2893/4735) had **zero in-game effect**: `max_stack_size` and `icon_location` are read from the client's local cooked PAK, not from any wire message. Slappacks still showed the IconMissing square and still ate one bag slot per pickup.

This PR delivers both halves: server-side stacking on the grant path AND a PAK override that pushes patched COOKED_ITEM XML to the client via the existing version-info handshake.

## Server-side stacking

`handle_grant_item` now attempts a merge into an existing same-`type_id` row before reserving a fresh slot. Locks: existing per-(player, container) advisory lock + `FOR UPDATE` on the merge candidate. Gate predicates:

| Predicate | Why |
|---|---|
| `inv.bound = false` | bound items are 1:1 with their owner |
| `ri.max_stack_size > 1` | non-stackable defs stay on the one-row-per-pickup path |
| `inv.stack_size + $count <= ri.max_stack_size` | all-or-nothing; no split across stacks today |

## PAK override (icon + stack cap)

New `crates/services/src/base/item_overrides.rs` mirrors `mission_overrides.rs`. Patches the COOKED_ITEM XML in memory at server startup, bumps category 4 (CookedDataItems) metadata, lets the existing `versionInfoRequest` → `onVersionInfo(InvalidKeys=[2893, 4735])` → `resourceFragment` handshake push patched XML to every client on next login. Self-healing; no PAK redistribution needed because the Medkit sprite is already in the cooked ItemIcon001 atlas (Plasma Burn Treatment Kit + Evac-U-Pac already use it).

## Test accounts

Added accounts 6/7/8 — **lomiada1**, **nonwo1984**, **ishido972** — to `db/sgw/Accounts/Seed/account.sql` with the same SHA1('test') password as the other test users. Sequence bumped to 8.

## Tests

**Unit (8 new, all passing):**
- `item_overrides::apply_override_*` (5 patcher cases including both attrs / icon-only / stack-only / missing-anchor / all-registered)
- `resources::apply_item_overrides_*` (patch + metadata bump + no-op-on-missing)
- `resources::compute_item_metadata_bump_*` (deterministic + low-bit-set + per-field sensitivity)

**Live-DB Type 3 regression guards (3 new):**
- `stackable_item_grants_merge_into_one_row` — two grants of a slappack → one row at combined stack_size.
- `full_stack_falls_back_to_new_slot` — overfill is rejected; fresh slot allocated instead.
- `different_type_ids_do_not_merge` — type_id gate pin.

## Test plan

- [ ] CI: `cargo nextest --profile=ci-live-db -p cimmeria-services` runs the 3 stacking guards against the seeded DB.
- [ ] In-game: pick up two slappacks from Cellblock guards → one bag row with "x2" + Medkit icon.
- [ ] In-game: pick up >10 slappacks → second row begins at slot N+1.
- [ ] Login as lomiada1 / nonwo1984 / ishido972 with the shared test password → auth succeeds, character creation works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added item property override system enabling customization of item icon locations and maximum stack sizes.
  * Implemented optimized inventory stacking with automatic merge support for stackable items into existing inventory slots.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SandboxServers/Cimmeria/pull/405?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->