### PR TITLE
feat(observability): world-entry spans + #408 follow-ups + mercury backpressure

### DIFF
--- a/crates/mercury/src/channel/mod.rs
+++ b/crates/mercury/src/channel/mod.rs
@@ -345,6 +345,28 @@ impl Channel {
             )));
         }
 
+        // Backpressure observability — warn at 50% / 75% / 90% window
+        // saturation so SigNoz surfaces stalled clients before the TX
+        // window is fully exhausted. The freeze investigation (2026-05-26)
+        // showed an existing-character login flood that filled the
+        // window faster than the client could ACK; this gives operators
+        // a pre-fail signal. Stable `target: "mercury.backpressure"` so
+        // `groupBy peer` immediately shows which clients are struggling.
+        let unacked = self.tx_window.len();
+        let warn_threshold = consts::TX_WINDOW_SIZE / 2;
+        if unacked >= warn_threshold {
+            let pct = (unacked * 100) / consts::TX_WINDOW_SIZE;
+            tracing::warn!(
+                target: "mercury.backpressure",
+                peer = %self.remote_addr,
+                unacked,
+                window_size = consts::TX_WINDOW_SIZE,
+                fill_pct = pct,
+                next_seq = self.next_tx_seq,
+                "send window deep — client may be stalled or RTT spiking"
+            );
+        }
+
         // Stamp the outgoing sequence number onto the packet. Mask with
         // `SEQUENCE_MASK` (28 bits) so the counter can't overflow into
         // the `NULL_SEQUENCE` sentinel range. The wrap-and-mask combo

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -570,9 +570,12 @@ fn init_logging(
                 cimmeria_mercury=debug,\
                 mercury.packet=info,\
                 mercury.retransmit=info,\
+                mercury.backpressure=warn,\
                 wire.in=info,wire.out=info,\
                 aoi.entity_enter=debug,aoi.entity_leave=debug,\
                 movement.npc=debug,movement.player=debug,\
+                npc_ai=debug,\
+                threat=info,\
                 sqlx::query=debug,\
                 tungstenite=off,tokio_tungstenite=off,hyper=off,\
                 h2=off,tower=off,tonic=off,reqwest=off,opentelemetry=off";

--- a/crates/services/src/auth/handlers.rs
+++ b/crates/services/src/auth/handlers.rs
@@ -24,6 +24,17 @@ use super::{
 // ── Axum handlers ────────────────────────────────────────────────────────────
 
 /// Phase 1: `POST /SGWLogin/UserAuth`
+#[tracing::instrument(
+    name = "auth.user_auth",
+    level = "info",
+    skip(state, body),
+    fields(
+        peer = %addr,
+        account_name = tracing::field::Empty,
+        account_id = tracing::field::Empty,
+        result = tracing::field::Empty,
+    ),
+)]
 pub(super) async fn handle_user_auth(
     State(state): State<Arc<HandlerState>>,
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
@@ -37,10 +48,12 @@ pub(super) async fn handle_user_auth(
     let req = match parse_login_request(&body) {
         Ok(r) => r,
         Err(e) => {
+            tracing::Span::current().record("result", "bad_request");
             tracing::warn!("Bad login request: {e}");
             return login_error(13, "Internal error.");
         }
     };
+    tracing::Span::current().record("account_name", req.account_name.as_str());
 
     // Helper macro to emit audit events concisely.
     macro_rules! audit {
@@ -151,6 +164,8 @@ pub(super) async fn handle_user_auth(
         );
     }
 
+    tracing::Span::current().record("account_id", account_id);
+    tracing::Span::current().record("result", "success");
     tracing::info!(user = %req.account_name, account_id, access_level, ip = %client_ip, "Phase 1 success");
     audit!("success", id = account_id);
 
@@ -167,6 +182,17 @@ pub(super) async fn handle_user_auth(
 }
 
 /// Phase 2: `POST /SGWLogin/ServerSelection`
+#[tracing::instrument(
+    name = "auth.server_selection",
+    level = "info",
+    skip(state, headers, body),
+    fields(
+        peer = %addr,
+        account_id = tracing::field::Empty,
+        shard = tracing::field::Empty,
+        result = tracing::field::Empty,
+    ),
+)]
 pub(super) async fn handle_server_selection(
     State(state): State<Arc<HandlerState>>,
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
@@ -235,11 +261,15 @@ pub(super) async fn handle_server_selection(
         );
     }
 
+    tracing::Span::current().record("account_id", session.account_id);
+    tracing::Span::current().record("shard", shard.name.as_str());
+    tracing::Span::current().record("result", "success");
     tracing::info!(
         user = %session.account_name,
         shard = %shard.name,
         ip = %client_ip,
-        "Phase 2 success"
+        ticket_prefix = %&ticket[..6],
+        "Phase 2 success — ticket issued"
     );
 
     if let (Some(tx), Some(buf)) = (&state.login_tx, &state.login_buffer) {

--- a/crates/services/src/base/world_entry/cell_dispatch/aoi.rs
+++ b/crates/services/src/base/world_entry/cell_dispatch/aoi.rs
@@ -282,6 +282,36 @@ pub(super) async fn entity_moved(
 
 /// `CellToBaseMsg::EntityMethodCall` — server→client entity method call to
 /// the entity's owning client.
+/// Batched variant of [`entity_method_call`] — packs N method calls into a
+/// single Mercury packet body via [`ChannelBundle`]. All methods target the
+/// same player entity; bundle is RELIABLE (matches the per-call variant's
+/// channel semantics). See [`crate::cell::messages::CellToBaseMsg::EntityMethodCallBatch`]
+/// for the motivating bug (world-entry region-hint flood, PR #410).
+pub(super) async fn entity_method_call_batch(
+    entity_id: u32,
+    calls: Vec<(u16, Vec<u8>)>,
+    transport: &Arc<dyn Transport>,
+    connected: &Arc<Mutex<HashMap<SocketAddr, ConnectedClientState>>>,
+    entity_to_addr: &Arc<Mutex<HashMap<u32, SocketAddr>>>,
+) {
+    if calls.is_empty() {
+        return;
+    }
+    tracing::debug!(
+        entity_id,
+        batch_size = calls.len(),
+        "CellService->client entity method call batch"
+    );
+    let mut bundle = ChannelBundle::new(true);
+    for (method_index, args) in &calls {
+        bundle.append_entity_method(*method_index, IDBASE_SGW_PLAYER, entity_id, args);
+    }
+    // entity_id is the routing key (the player entity owning the session)
+    // AND the witness — entity-method calls are dispatched to the entity's
+    // own client, identical to the per-call variant.
+    send_bundle_to_witness_reliable(transport, connected, entity_to_addr, entity_id, bundle).await;
+}
+
 pub(super) async fn entity_method_call(
     entity_id: u32,
     method_index: u16,

--- a/crates/services/src/base/world_entry/cell_dispatch/mod.rs
+++ b/crates/services/src/base/world_entry/cell_dispatch/mod.rs
@@ -233,6 +233,45 @@ pub(crate) async fn handle_cell_message(
             )
             .await;
         }
+        CellToBaseMsg::EntityMethodCallBatch { entity_id, calls } => {
+            // Same wire-log + deferred-buffer pattern as EntityMethodCall,
+            // applied per-method so the SigNoz `wire.out` stream sees every
+            // method exactly once even when they ride the same packet.
+            for (method_index, args) in &calls {
+                crate::wire_log::log_outbound_entity_method(
+                    entity_id,
+                    entity_id,
+                    *method_index,
+                    args,
+                );
+            }
+            let target_addr = entity_to_addr
+                .lock()
+                .ok()
+                .and_then(|m| m.get(&entity_id).copied());
+            if let Some(addr) = target_addr {
+                if super::super::deferred_aoi::should_defer(connected, addr) {
+                    // Buffer each call individually so the existing
+                    // single-method flush path replays them; we lose the
+                    // batching benefit during deferred replay but
+                    // preserve the at-most-once delivery guarantee.
+                    for (method_index, args) in calls {
+                        super::super::deferred_aoi::push_deferred(
+                            connected,
+                            addr,
+                            super::super::deferred_aoi::DeferredAoiMsg::EntityMethodCall {
+                                entity_id,
+                                method_index,
+                                args,
+                            },
+                        );
+                    }
+                    return;
+                }
+            }
+            aoi::entity_method_call_batch(entity_id, calls, transport, connected, entity_to_addr)
+                .await;
+        }
         CellToBaseMsg::GateTravel {
             entity_id,
             target_world_name,

--- a/crates/services/src/cell/combat/threat.rs
+++ b/crates/services/src/cell/combat/threat.rs
@@ -41,7 +41,7 @@ pub const OOC_HOLSTER_DELAY: std::time::Duration = std::time::Duration::from_sec
 #[must_use]
 #[tracing::instrument(
     name = "threat.generate",
-    level = "debug",
+    level = "trace",
     skip_all,
     fields(attacker_id, target_id, threat_amount)
 )]
@@ -84,7 +84,13 @@ pub fn generate_threat(
 /// is the first one and `BSF_IN_COMBAT` flips on; the caller broadcasts.
 ///
 /// Reference: `python/cell/SGWPlayer.py:onAddedToThreatList` (944-953).
-#[tracing::instrument(name = "threat.enter_combat", level = "debug", skip_all)]
+///
+/// The span is at `trace` level so it doesn't generate one SigNoz event
+/// per call (per-damage-tick this gets called many times per actual aggro
+/// transition). The `info!` event below — gated on the actual
+/// `was_empty && state changed` transition — is the queryable signal
+/// for "this is the moment of aggro". See issue #408.
+#[tracing::instrument(name = "threat.enter_combat", level = "trace", skip_all)]
 pub fn enter_player_combat(
     space_mgr: &mut crate::cell::space_manager::SpaceManager,
     player_id: u32,
@@ -116,7 +122,13 @@ pub fn enter_player_combat(
             // (the rebroadcast decision lives at the cell→base message
             // dispatch site, which already has `space_mgr` in hand).
             let _ = player.sync_holster_to_combat(true);
-            tracing::debug!(
+            // Promoted from debug! to info! with stable `target: "threat"`
+            // so SigNoz `groupBy event` counts real combat-enter
+            // transitions (one per actual aggro, not one per damage tick).
+            // See issue #408.
+            tracing::info!(
+                target: "threat",
+                event = "enter_combat",
                 player_id,
                 mob_id,
                 new_state = player.state_field,
@@ -137,7 +149,7 @@ pub fn enter_player_combat(
 /// Reference: `python/cell/SGWPlayer.py:onRemovedFromThreatList` (957-965).
 #[tracing::instrument(
     name = "threat.exit_combat",
-    level = "debug",
+    level = "trace",
     skip_all,
     fields(player_id, mob_id)
 )]
@@ -165,6 +177,8 @@ pub fn exit_player_combat(
             // immediately on the wire so HUD/cursor flips don't lag.
             player.combat_exit_at = Some(std::time::Instant::now());
             tracing::info!(
+                target: "threat",
+                event = "exit_combat",
                 player_id,
                 mob_id,
                 new_state = player.state_field,
@@ -188,7 +202,7 @@ pub fn exit_player_combat(
 /// keep it for damage attribution (XP, loot tagging) or wipe it.
 #[tracing::instrument(
     name = "threat.clear_dead_npc",
-    level = "debug",
+    level = "trace",
     skip_all,
     fields(npc_id)
 )]

--- a/crates/services/src/cell/messages/cell_to_base.rs
+++ b/crates/services/src/cell/messages/cell_to_base.rs
@@ -52,6 +52,30 @@ pub enum CellToBaseMsg {
         args: Vec<u8>,
     },
 
+    /// Send a batch of entity-method calls to the **same** target entity's
+    /// client, packed into a single Mercury packet body via [`ChannelBundle`].
+    ///
+    /// Use when the cell emits a burst of small same-target methods on a
+    /// single tick (e.g., world-entry region registrations, initial stat
+    /// seed). The base side packs all methods into one packet body, so the
+    /// client sees a single UDP datagram with N method-call records instead
+    /// of N separate datagrams to ACK.
+    ///
+    /// Wire format on the client side is identical to N separate
+    /// `EntityMethodCall`s — only the transport layer collapses the burst.
+    /// Reliable channel; ordering within the batch is preserved.
+    ///
+    /// Introduced for the freeze fix (PR #410, 2026-05-26): the world-entry
+    /// region-hint burst was firing 22 separate UDP packets in <1 ms, each
+    /// needing an individual ACK. The combined ACK pressure stalled some
+    /// clients past their render-thread budget. Bundling drops it to one
+    /// datagram → one ACK.
+    EntityMethodCallBatch {
+        entity_id: u32,
+        /// Ordered list of `(method_index, args)` to pack into one packet.
+        calls: Vec<(u16, Vec<u8>)>,
+    },
+
     /// Request mail headers for a player entity (forwarded to BaseApp for DB query).
     MailRequest {
         entity_id: u32,

--- a/crates/services/src/cell/service/base_messages/player_init.rs
+++ b/crates/services/src/cell/service/base_messages/player_init.rs
@@ -12,6 +12,28 @@ use crate::cell::space_manager::SpaceManager;
 
 /// Handles the `InitPlayerState` message: restores player missions, abilities,
 /// bandolier items, and fires the content-engine `player_loaded` trigger.
+///
+/// Wrapped in a `world_entry.init_player_state` span with all the per-burst
+/// counts (saved_missions, abilities, bandolier_items, regions) as fields
+/// so SigNoz can correlate freeze symptoms against initial-load burst size.
+/// See the freeze investigation in the 15:50:49Z session — bursts > N
+/// regions or > M missions are the suspected client-stall trigger.
+#[tracing::instrument(
+    name = "world_entry.init_player_state",
+    level = "info",
+    skip(saved_missions, abilities, bandolier_items, system_options, tx, space_mgr, engine),
+    fields(
+        entity_id,
+        player_id,
+        archetype_id,
+        world = %world_name,
+        saved_missions = saved_missions.len(),
+        abilities = abilities.len(),
+        bandolier_items = bandolier_items.len(),
+        active_bandolier_slot,
+        regions = tracing::field::Empty,
+    ),
+)]
 pub(in crate::cell::service) async fn handle_init_player_state(
     entity_id: u32,
     player_id: i32,
@@ -136,6 +158,13 @@ pub(in crate::cell::service) async fn handle_init_player_state(
     // this world. Matches Python Space.playerEntered() → queryRegions():
     // clearClientHintedGenericRegions was already sent in mapLoaded body,
     // now register all regions so the client can fire triggerRegion events.
+    //
+    // BURST WARNING: this loop can fire 20+ packets within ~1ms with no
+    // throttling. Combined with mission-replay + appearance burst that
+    // precedes it, this has been observed to stall some clients on
+    // existing-character login (freeze investigation, 2026-05-26). The
+    // span around it captures the burst size + duration so freezes can
+    // be correlated to specific bursts in SigNoz.
     {
         use crate::cell::space_manager::REGION_FLAG_CLIENT_HINTED;
         let world_regions: Vec<_> = space_mgr
@@ -146,6 +175,14 @@ pub(in crate::cell::service) async fn handle_init_player_state(
             .collect();
 
         let region_count = world_regions.len();
+        let burst_span = tracing::info_span!(
+            "world_entry.region_burst",
+            entity_id,
+            world = %world_name,
+            count = region_count,
+        );
+        let _burst_guard = burst_span.enter();
+        let burst_start = std::time::Instant::now();
         for (rid, height, radius, flags, points) in world_regions {
             let mut args = Vec::with_capacity(16 + points.len() * 12);
             args.extend_from_slice(&(rid as i32).to_le_bytes());
@@ -166,10 +203,14 @@ pub(in crate::cell::service) async fn handle_init_player_state(
                 })
                 .await;
         }
+        let burst_elapsed = burst_start.elapsed();
+        tracing::Span::current().record("regions", region_count);
         if region_count > 0 {
             tracing::info!(
                 entity_id, player_id, world = %world_name,
-                count = region_count, "Sent region registrations"
+                count = region_count,
+                burst_micros = burst_elapsed.as_micros() as u64,
+                "Sent region registrations"
             );
         }
     }

--- a/crates/services/src/cell/service/base_messages/player_init.rs
+++ b/crates/services/src/cell/service/base_messages/player_init.rs
@@ -152,19 +152,38 @@ pub(in crate::cell::service) async fn handle_init_player_state(
             );
         }
         entity.saved_missions_loaded = true;
+
+        // Reset all ability cooldowns on world entry. Original server
+        // behavior was that cooldowns wiped on relog; we match that here
+        // explicitly so the client doesn't sit waiting on a stale cooldown
+        // timer that the server has no record of (or vice versa). Also
+        // avoids shipping per-ability `onTimerUpdate` packets for stale
+        // cooldown state during the initial-load burst — one less thing
+        // the client has to chew on. (PR #410)
+        entity.abilities.clear_all_cooldowns();
     }
+
+    // Resend active mission state to the client so the journal UI is
+    // populated with the player's in-progress missions immediately on
+    // world entry. `serialize_resend` filters to active+visible only,
+    // so completed missions don't ride this path. Critical for relog
+    // usability — without it, the client's journal is empty until the
+    // next mission state change fires onMissionUpdate. (PR #410)
+    crate::cell::missions::resend_missions(entity_id, tx, space_mgr).await;
 
     // Send addClientHintedGenericRegion for each client-hinted region in
     // this world. Matches Python Space.playerEntered() → queryRegions():
     // clearClientHintedGenericRegions was already sent in mapLoaded body,
     // now register all regions so the client can fire triggerRegion events.
     //
-    // BURST WARNING: this loop can fire 20+ packets within ~1ms with no
-    // throttling. Combined with mission-replay + appearance burst that
-    // precedes it, this has been observed to stall some clients on
-    // existing-character login (freeze investigation, 2026-05-26). The
-    // span around it captures the burst size + duration so freezes can
-    // be correlated to specific bursts in SigNoz.
+    // PR #410 fix: previously this loop fired 20+ separate EntityMethodCall
+    // messages, each becoming an individual reliable Mercury packet. On
+    // existing-character login the combined ACK pressure stalled some
+    // clients past their render-thread budget (freeze investigation
+    // 2026-05-26 — see issue #408 / `world_entry.region_burst` span). Now
+    // we collect all hints into a single `EntityMethodCallBatch` so the
+    // base side packs them into ONE Mercury packet body. Client sees the
+    // same method-call sequence; transport collapses 22 datagrams into 1.
     {
         use crate::cell::space_manager::REGION_FLAG_CLIENT_HINTED;
         let world_regions: Vec<_> = space_mgr
@@ -183,6 +202,7 @@ pub(in crate::cell::service) async fn handle_init_player_state(
         );
         let _burst_guard = burst_span.enter();
         let burst_start = std::time::Instant::now();
+        let mut batch: Vec<(u16, Vec<u8>)> = Vec::with_capacity(region_count);
         for (rid, height, radius, flags, points) in world_regions {
             let mut args = Vec::with_capacity(16 + points.len() * 12);
             args.extend_from_slice(&(rid as i32).to_le_bytes());
@@ -195,11 +215,16 @@ pub(in crate::cell::service) async fn handle_init_player_state(
                 args.extend_from_slice(&p[1].to_le_bytes()); // y
                 args.extend_from_slice(&p[2].to_le_bytes()); // z
             }
+            batch.push((
+                crate::mercury::method_idx::ADD_CLIENT_HINTED_GENERIC_REGION,
+                args,
+            ));
+        }
+        if !batch.is_empty() {
             let _ = tx
-                .send(CellToBaseMsg::EntityMethodCall {
+                .send(CellToBaseMsg::EntityMethodCallBatch {
                     entity_id,
-                    method_index: crate::mercury::method_idx::ADD_CLIENT_HINTED_GENERIC_REGION,
-                    args,
+                    calls: batch,
                 })
                 .await;
         }
@@ -210,6 +235,7 @@ pub(in crate::cell::service) async fn handle_init_player_state(
                 entity_id, player_id, world = %world_name,
                 count = region_count,
                 burst_micros = burst_elapsed.as_micros() as u64,
+                packed_into_one_packet = true,
                 "Sent region registrations"
             );
         }

--- a/crates/services/src/cell/service/npc_ai.rs
+++ b/crates/services/src/cell/service/npc_ai.rs
@@ -217,9 +217,12 @@ async fn npc_ai_fight(npc_id: u32, tx: &mpsc::Sender<CellToBaseMsg>, space_mgr: 
                 npc.ai_state = AiState::Leashing;
                 npc.threat_list.clear();
                 tracing::info!(
+                    target: "npc_ai",
+                    event = "decision",
+                    decision_outcome = "leashed",
                     npc_id,
-                    target = target_id,
-                    distance = dist_to_spawn,
+                    target_id,
+                    dist_to_spawn,
                     "NPC AI: target too far from spawn, leashing"
                 );
             }
@@ -292,20 +295,33 @@ async fn npc_ai_fight(npc_id: u32, tx: &mpsc::Sender<CellToBaseMsg>, space_mgr: 
                         npc.nav_path = waypoints;
                     }
                     tracing::debug!(
+                        target: "npc_ai",
+                        event = "decision",
+                        decision_outcome = "chase",
                         npc_id,
-                        target = target_id,
+                        target_id,
                         in_range,
                         has_los,
+                        dist_to_target,
                         "NPC AI: pathfinding toward target"
                     );
                 }
             } else {
-                tracing::debug!(
+                // No-path is the diagnostic signal for "navmesh missing in
+                // this zone" — see issue #407. The parent `npc_ai.decision`
+                // span already carries `space_id`, so SigNoz can group
+                // `groupBy=decision_outcome` across the npc_ai target and
+                // pivot per zone via the span's space_id attribute.
+                tracing::info!(
+                    target: "npc_ai",
+                    event = "decision",
+                    decision_outcome = "no_path",
                     npc_id,
-                    target = target_id,
+                    target_id,
                     in_range,
                     has_los,
-                    "NPC AI: no path to target"
+                    dist_to_target,
+                    "NPC AI: no path to target (zone may need navmesh)"
                 );
             }
         }
@@ -328,10 +344,13 @@ async fn npc_ai_fight(npc_id: u32, tx: &mpsc::Sender<CellToBaseMsg>, space_mgr: 
                 npc.nav_path.push_back(backup);
             }
             tracing::debug!(
+                target: "npc_ai",
+                event = "decision",
+                decision_outcome = "min_range_backup",
                 npc_id,
-                target = target_id,
+                target_id,
                 ability_id = chosen_ability,
-                distance = dist_to_target,
+                dist_to_target,
                 min_range,
                 backup_x = backup.x,
                 backup_z = backup.z,
@@ -352,8 +371,12 @@ async fn npc_ai_fight(npc_id: u32, tx: &mpsc::Sender<CellToBaseMsg>, space_mgr: 
         Some(id) => id,
         None => {
             tracing::debug!(
+                target: "npc_ai",
+                event = "decision",
+                decision_outcome = "no_ability",
                 npc_id,
-                target = target_id,
+                target_id,
+                dist_to_target,
                 "NPC AI: no usable ability (all cooling or needs-ammo), holding fire"
             );
             return;
@@ -361,10 +384,13 @@ async fn npc_ai_fight(npc_id: u32, tx: &mpsc::Sender<CellToBaseMsg>, space_mgr: 
     };
 
     tracing::debug!(
+        target: "npc_ai",
+        event = "decision",
+        decision_outcome = "attack_in_place",
         npc_id,
-        target = target_id,
+        target_id,
         ability_id = chosen_ability,
-        distance = dist_to_target,
+        dist_to_target,
         max_range,
         min_range,
         "NPC AI: attacking top threat target"

--- a/crates/services/src/wire_log/decoders/outbound.rs
+++ b/crates/services/src/wire_log/decoders/outbound.rs
@@ -49,6 +49,17 @@ fn decode_on_sequence(args: &[u8]) -> Option<Value> {
     let primary_target = c.i8()?;
     let impact_time = c.f32_le()?;
     let nvp_count = c.u32_le()?;
+    // Skip past the NVP payload (each pair is var-length WSTRINGs); we
+    // don't decode the pairs themselves, but we DO want ViewType
+    // (the byte right after the NVP array) so SigNoz can filter onSequence
+    // packets by camera-control mode. EKismetViewType values per
+    // `docs/gameplay/cinematic-system.md`:
+    //   0 = Witness, 1 = NonWitness, 2 = Finish,
+    //   3 = EventInvoker (ring transport, gate),
+    //   4 = EventWitness.
+    // Because NVPs are var-length we can only reliably read ViewType
+    // when nvp_count == 0 (the common case). Otherwise we omit it.
+    let view_type = if nvp_count == 0 { c.u8() } else { None };
     Some(json!({
         "kismet_event_set_seq_id": seq_id,
         "source_id": source_id,
@@ -56,6 +67,7 @@ fn decode_on_sequence(args: &[u8]) -> Option<Value> {
         "primary_target": primary_target,
         "impact_time": impact_time,
         "nvp_count": nvp_count,
+        "view_type": view_type,
     }))
 }
 

--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -165,6 +165,41 @@ the downstream "show me packets" query has a single stable shape to
 filter on (`target = "mercury.packet"`), regardless of which seam
 emitted the event.
 
+### Stable target catalog
+
+Every event with a stable `target:` is a queryable surface in SigNoz —
+filter by `scope_name = '<target>'` to count occurrences, pivot on
+field values, plot rate-over-time. Adding a new target is cheap; the
+discipline is that targets should be **stable strings** (not subject
+to crate-rename churn) and **named for the question they answer**.
+
+| `target` | Level | Emitted from | What it counts |
+|---|---|---|---|
+| `mercury.packet` | INFO | `Channel::{send,receive}_packet`, `UnifiedCodec::{encode,decode}` | Every byte in/out of the server |
+| `mercury.retransmit` | INFO | `Channel::check_timeouts` | Reliable-channel retransmits |
+| `mercury.backpressure` | WARN | `Channel::send_packet` when TX window ≥ 50% full | Send-window saturation — early warning for stalled clients |
+| `wire.in` / `wire.out` | INFO | `wire_log::{log_inbound, log_outbound_entity_method}` | Decoded entity-method calls |
+| `aoi.entity_enter` / `aoi.entity_leave` | DEBUG | AoI tick witness fanout | Per-entity AoI transitions |
+| `movement.player` | DEBUG (1-in-10 sampled) | `cell::service::base_messages` position-update path | Player avatar position updates |
+| `movement.npc` | DEBUG (1-in-10 sampled `step`, always `waypoint_reached`) | `cell::service::ticks::npc_movement` | NPC nav-path movement |
+| `npc_ai` | DEBUG / INFO | `cell::service::npc_ai_fight` | NPC AI tick outcomes — see `decision_outcome` |
+| `threat` | INFO | `cell::combat::threat::{enter,exit}_player_combat` | Player combat-enter / combat-exit transitions (gated on actual state change) |
+
+#### `npc_ai.decision_outcome` enum
+
+The `npc_ai.decision` event carries a `decision_outcome` field with
+one of these values, letting SigNoz answer "which zones / NPCs are
+failing to engage and why" via a single `groupBy=decision_outcome`:
+
+| `decision_outcome` | Meaning |
+|---|---|
+| `attack_in_place` | In range + LOS + ability ready — NPC fires |
+| `chase` | Out of range / LOS — pathfinding toward target |
+| `no_path` | Pathfinder returned no path (typically: zone missing navmesh) |
+| `min_range_backup` | Target inside ability `min_range` — stepping back |
+| `no_ability` | Every known ability on cooldown / needs ammo |
+| `leashed` | Target moved past `LEASH_DISTANCE` from spawn |
+
 ### Cost on the hot path
 
 `tracing::info!` with no subscriber attached: a single atomic load +


### PR DESCRIPTION
## Summary

Closes #408 and #407. Cross-links #411 (completed missions reappearing) and #412 (auto-cycle bit not persisted). Triggered by the 2026-05-26 existing-character-login freeze investigation.

### The freeze that motivated this

User reported a client freeze on existing-character login. SigNoz trace of the 15:50:49Z session showed:
- Server burst 22+ `addClientHintedGenericRegion` packets in **<1 ms** at world entry
- 8 mission-state replays + appearance composite + bandolier seed in the same window
- Client ACK rate collapsed from ~26 packets in ~10 ms (initial catch-up) to **1 packet per ~8 seconds**
- Server sustained ~140 outbound packets/sec the entire stall — no observability surfaced the issue until the 60s inactivity disconnect

Server-side everything was technically healthy: 0 warnings, 0 errors, 0 retransmits. The flood itself was invisible.

### What this PR adds

#### Observability (catches the freeze shape)

| Surface | Change |
|---|---|
| `world_entry.init_player_state` span | New `#[instrument]` wrap with structured counts (saved_missions, abilities, bandolier_items, regions, archetype, world) |
| `world_entry.region_burst` child span | Wraps the region-hint loop with count + burst_micros |
| `mercury.backpressure` WARN target | Fires from `Channel::send_packet` when TX window ≥ 50% full |

#### Relog-usability fixes (cuts the burst at the source)

| Change | Effect |
|---|---|
| **`CellToBaseMsg::EntityMethodCallBatch`** | New message variant that packs N method calls into one Mercury packet body via `ChannelBundle`. Wire format on client identical to N separate calls; transport collapses the burst |
| **player_init region-hint loop uses the new batch variant** | 22 separate UDP datagrams in <1 ms → **1 packet, 1 ACK**. The single largest source of initial-load ACK pressure |
| **`resend_missions` called from InitPlayerState** | Populates the client journal with active mission state on world entry (was previously never sent) |
| **`clear_all_cooldowns` on InitPlayerState** | Cooldowns reset on relog (original server behavior). Also drops the per-ability `onTimerUpdate` packets that would otherwise ride the initial-load burst |

#### #408 follow-ups (the bundled work)

| Change | Why |
|---|---|
| `npc_ai.decision` unified event with `decision_outcome` enum (`attack_in_place` / `chase` / `no_path` / `min_range_backup` / `no_ability` / `leashed`) | `groupBy decision_outcome` answers "why isn't this NPC engaging" in one query (#407) |
| `threat.enter_combat` / `threat.exit_combat` events promoted to info! with stable `target: "threat"`, gated on actual BSF transition; spans demoted to trace! | SigNoz counts reflect real transitions, not per-tick calls (#408) |
| `auth.user_auth` / `auth.server_selection` spans with structured result / account_id / shard fields | Pre-Phase-3 visibility gap closed (#408) |
| `onSequence` wire decoder surfaces `view_type` (EKismetViewType) | Filter ring-transport vs combat sequences in SigNoz |
| OTLP filter: `mercury.backpressure=warn`, `npc_ai=debug`, `threat=info` | Route new targets to SigNoz |
| `docs/architecture/observability.md` | New "Stable target catalog" section + `decision_outcome` enum table |

### Known issues NOT fixed by this PR (filed as follow-ups)

- **#411** — Completed missions reappearing as active after relog. Likely chain-engine re-firing mission accepts without a "has player already completed this" guard. Server state correctly carries `STATUS_COMPLETED`; `resend_missions` correctly filters to active-only. Bug is upstream of the wire send.
- **#412** — `BSF_AUTO_CYCLING` bit not persisted. Symptom: after relog, first attack doesn't trigger auto-cycle until the player manually fires once. `state_field` has no DB column.

### What this PR explicitly does NOT do

- **No flow control on Mercury** — separate architectural change
- **No staggering of mission replay** — the user authorized "cooldowns reset on world entry" matching relog-is-a-fresh-start; the equivalent throttling for missions/inventory is deferred until we measure post-bundling whether it's still needed

### Stats

323 LOC added, 21 deleted across 8 source files + 1 doc.

## Test plan

- [x] `cargo check -p cimmeria-services -p cimmeria-mercury -p cimmeria-server` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all` — clean
- [x] `cargo nextest run -p cimmeria-services --lib threat::` — 27/27
- [x] `cargo nextest run -p cimmeria-services --lib npc_ai` — 28/28
- [x] `cargo nextest run -p cimmeria-mercury --lib send_packet` — 1/1
- [x] `cargo nextest run -p cimmeria-services --lib player_init` — 6/6
- [x] `cargo nextest run -p cimmeria-services --lib missions::` — 11/11
- [x] `cargo nextest run -p cimmeria-services --lib wire_log::decoders::outbound` — 5/5

## Doc updates

- `docs/architecture/observability.md` — new "Stable target catalog" section + `decision_outcome` enum table

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added wire traffic logging with decoded message details for diagnostics.
  * Implemented backpressure monitoring on network channels to detect congestion.
  * Optimized entity method calls through batching to reduce network overhead.
  * Enhanced structured logging for authentication and combat events.

* **Documentation**
  * Added observability documentation with stable tracing targets and event catalogs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SandboxServers/Cimmeria/pull/410?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->