### PR TITLE
feat(observability): full auth + base + world-entry pipeline instrumentation

### DIFF
--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -576,6 +576,9 @@ fn init_logging(
                 movement.npc=debug,movement.player=debug,\
                 npc_ai=debug,\
                 threat=info,\
+                auth=info,\
+                world_entry=info,\
+                vendor=info,mail=info,progression=info,inventory=info,mission=info,\
                 sqlx::query=debug,\
                 tungstenite=off,tokio_tungstenite=off,hyper=off,\
                 h2=off,tower=off,tonic=off,reqwest=off,opentelemetry=off";

--- a/crates/services/src/base/world_entry/map_loaded.rs
+++ b/crates/services/src/base/world_entry/map_loaded.rs
@@ -32,6 +32,12 @@ use super::methods::default_player_load_data;
 /// In C++, this is triggered by the CellApp's `onCellPlayerCreateAck` callback
 /// (which itself fires after `connected()` sends `onClientMapLoad`) and the
 /// Python `onClientReady()` -> `mapLoaded()` callback chain.
+#[tracing::instrument(
+    name = "world_entry.map_loaded",
+    level = "info",
+    skip_all,
+    fields(peer = %addr),
+)]
 pub(crate) async fn handle_map_loaded(
     transport: &Arc<dyn Transport>,
     addr: SocketAddr,

--- a/crates/services/src/base/world_entry/methods/inventory/core/remove_by_type.rs
+++ b/crates/services/src/base/world_entry/methods/inventory/core/remove_by_type.rs
@@ -26,6 +26,12 @@ use crate::cell::messages::BaseToCellMsg;
 /// deleted) → full inventory refresh → `BaseToCellMsg::InventoryItemRemoved`
 /// (when the row is deleted). Bandolier sync runs when the source row was
 /// in container 3.
+#[tracing::instrument(
+    name = "inventory.remove_by_type",
+    level = "info",
+    skip_all,
+    fields(entity_id, player_id, type_id, count)
+)]
 pub async fn handle_remove_inventory_item_by_type(
     entity_id: u32,
     player_id: i32,

--- a/crates/services/src/base/world_entry/methods/mail/mod.rs
+++ b/crates/services/src/base/world_entry/methods/mail/mod.rs
@@ -15,6 +15,12 @@ use crate::mercury::{build_player_entity_method_packet, method_idx};
 mod tests;
 
 /// Handle a mail request from CellService by querying the DB and sending results to the client.
+#[tracing::instrument(
+    name = "mail.request",
+    level = "info",
+    skip_all,
+    fields(entity_id, player_id, op = ?op),
+)]
 pub async fn handle_mail_request(
     entity_id: u32,
     player_id: i32,

--- a/crates/services/src/base/world_entry/methods/missions.rs
+++ b/crates/services/src/base/world_entry/methods/missions.rs
@@ -75,6 +75,12 @@ pub async fn query_saved_missions(
     }
 }
 
+#[tracing::instrument(
+    name = "mission.persist",
+    level = "info",
+    skip_all,
+    fields(player_id, mission_id, status, ?current_step_id, repeats),
+)]
 pub async fn handle_mission_update(
     player_id: i32,
     mission_id: i32,

--- a/crates/services/src/base/world_entry/methods/progression/mod.rs
+++ b/crates/services/src/base/world_entry/methods/progression/mod.rs
@@ -32,6 +32,12 @@ const GENERICPROPERTY_TRAINING_POINTS: i32 = 1;
 /// Matches the Python `giveExperience()` flow: add XP, send updates, fire
 /// level-up events. Persists exp/level/training_points to `sgw_player` before
 /// emitting wire packets so a relog after a grant doesn't roll the player back.
+#[tracing::instrument(
+    name = "progression.grant_xp",
+    level = "info",
+    skip_all,
+    fields(entity_id, xp_amount)
+)]
 pub async fn handle_grant_xp(
     entity_id: u32,
     xp_amount: u64,
@@ -280,6 +286,12 @@ fn build_grant_xp_bundle(
 }
 
 /// Handle cash grant from CellService -- update DB and send client notification.
+#[tracing::instrument(
+    name = "progression.grant_cash",
+    level = "info",
+    skip_all,
+    fields(entity_id, player_id, amount)
+)]
 pub async fn handle_grant_cash(
     entity_id: u32,
     player_id: i32,

--- a/crates/services/src/base/world_entry/methods/vendor/buyback/mod.rs
+++ b/crates/services/src/base/world_entry/methods/vendor/buyback/mod.rs
@@ -25,6 +25,12 @@ struct BuybackInventoryRow {
 }
 
 /// Transactionally buy back recently sold items and refresh inventory/cash/store.
+#[tracing::instrument(
+    name = "vendor.buyback",
+    level = "info",
+    skip_all,
+    fields(entity_id, player_id, vendor_entity_id, vendor_template_id, item_count = items.len()),
+)]
 pub async fn handle_buyback_vendor_items(
     entity_id: u32,
     player_id: i32,

--- a/crates/services/src/base/world_entry/methods/vendor/paid_recharge/mod.rs
+++ b/crates/services/src/base/world_entry/methods/vendor/paid_recharge/mod.rs
@@ -25,6 +25,12 @@ struct StoreItemCostRow {
 }
 
 /// Transactionally recharge items for payment and refresh inventory/cash.
+#[tracing::instrument(
+    name = "vendor.paid_recharge",
+    level = "info",
+    skip_all,
+    fields(entity_id, player_id, vendor_template_id, item_count = item_ids.len()),
+)]
 pub async fn handle_paid_recharge_inventory_items(
     entity_id: u32,
     player_id: i32,

--- a/crates/services/src/base/world_entry/methods/vendor/paid_repair/mod.rs
+++ b/crates/services/src/base/world_entry/methods/vendor/paid_repair/mod.rs
@@ -25,6 +25,12 @@ struct StoreItemCostRow {
 }
 
 /// Transactionally repair items for payment and refresh inventory/cash.
+#[tracing::instrument(
+    name = "vendor.paid_repair",
+    level = "info",
+    skip_all,
+    fields(entity_id, player_id, vendor_template_id, item_count = item_ids.len()),
+)]
 pub async fn handle_paid_repair_inventory_items(
     entity_id: u32,
     player_id: i32,

--- a/crates/services/src/base/world_entry/methods/vendor/recharge.rs
+++ b/crates/services/src/base/world_entry/methods/vendor/recharge.rs
@@ -13,6 +13,12 @@ use super::super::inventory::grant::normalize_item_ids;
 /// equipment slots, and quick bars. Bank, mail attachments, and loot are excluded.
 use super::VENDOR_FILTER_BAGS;
 
+#[tracing::instrument(
+    name = "vendor.recharge",
+    level = "info",
+    skip_all,
+    fields(entity_id, player_id, ?vendor_template_id, item_count = item_ids.len()),
+)]
 pub async fn handle_recharge_inventory_items(
     entity_id: u32,
     player_id: i32,

--- a/crates/services/src/base/world_entry/methods/vendor/repair.rs
+++ b/crates/services/src/base/world_entry/methods/vendor/repair.rs
@@ -13,6 +13,12 @@ use super::super::inventory::grant::normalize_item_ids;
 /// equipment slots, and quick bars. Bank, mail attachments, and loot are excluded.
 use super::VENDOR_FILTER_BAGS;
 
+#[tracing::instrument(
+    name = "vendor.repair_item",
+    level = "info",
+    skip_all,
+    fields(entity_id, player_id, item_id, repair_ratio)
+)]
 pub async fn handle_repair_inventory_item(
     entity_id: u32,
     player_id: i32,
@@ -97,6 +103,12 @@ pub async fn handle_repair_inventory_item(
     }
 }
 
+#[tracing::instrument(
+    name = "vendor.repair_items",
+    level = "info",
+    skip_all,
+    fields(entity_id, player_id, ?vendor_template_id, item_count = item_ids.len()),
+)]
 pub async fn handle_repair_inventory_items(
     entity_id: u32,
     player_id: i32,

--- a/crates/services/src/base/world_entry/methods/vendor/store.rs
+++ b/crates/services/src/base/world_entry/methods/vendor/store.rs
@@ -25,6 +25,12 @@ pub struct VendorTemplateLists {
 }
 
 /// Open a vendor store for a player, loading all item lists and pricing.
+#[tracing::instrument(
+    name = "vendor.open_store",
+    level = "info",
+    skip_all,
+    fields(entity_id, player_id, vendor_entity_id, ?vendor_template_id),
+)]
 pub async fn handle_open_vendor_store(
     entity_id: u32,
     player_id: i32,

--- a/crates/services/src/base/world_entry/teleport.rs
+++ b/crates/services/src/base/world_entry/teleport.rs
@@ -32,6 +32,12 @@ use super::super::ConnectedClientState;
 /// 3. Persist new pos to `sgw_player` so a relog mid-ceremony doesn't
 ///    teleport the player back to the source pad. We fail closed on missing
 ///    `active_player_id` for the same reason as `gate_travel.rs`.
+#[tracing::instrument(
+    name = "world_entry.teleport_player",
+    level = "info",
+    skip_all,
+    fields(entity_id, space_id)
+)]
 pub(super) async fn handle_teleport_player(
     entity_id: u32,
     space_id: u32,

--- a/crates/services/src/base/world_entry_appearance.rs
+++ b/crates/services/src/base/world_entry_appearance.rs
@@ -118,6 +118,12 @@ fn build_on_client_ready_burst_bundle(
 /// mapLoaded bundle but may have been dropped because the entity was still in a
 /// "transaction" during bundle processing. The C++ server sends BeingAppearance
 /// 3-5 times via createCacheStamp replays; this second send mimics that.
+#[tracing::instrument(
+    name = "world_entry.on_client_ready",
+    level = "info",
+    skip_all,
+    fields(peer = %addr),
+)]
 pub(crate) async fn handle_on_client_ready(
     addr: SocketAddr,
     key: [u8; 32],


### PR DESCRIPTION
## Summary

Follow-up to #410. Closes the remaining instrumentation gaps in the auth → BaseApp → CellApp pipeline that surfaced while diagnosing the 2026-05-26 existing-character relog freeze.

After #410 landed, the cell-side world entry was well-instrumented (`world_entry.init_player_state`, `world_entry.region_burst`) but the **post-Phase-3, pre-cell BaseApp phase** was still mostly opaque. The 17:09:28Z disconnect (player_entity_id=None + inactivity_timeout) had no span chain to walk — we could see the player authenticated but had no visibility into what BaseApp was doing for the 60s inactivity window before timeout.

This PR adds spans to the 15 entry points that were missing them.

## What's instrumented

### World-entry pipeline (3 spans — highest priority for freeze diagnosis)
- `world_entry.map_loaded` — `handle_map_loaded` in `map_loaded.rs`
- `world_entry.on_client_ready` — `handle_on_client_ready` in `world_entry_appearance.rs`
- `world_entry.teleport_player` — `handle_teleport_player` in `teleport.rs`

### Vendor handlers (7 spans)
- `vendor.buyback`, `vendor.paid_recharge`, `vendor.paid_repair`
- `vendor.recharge`, `vendor.repair_item`, `vendor.repair_items`
- `vendor.open_store`

### Mission / mail / progression / inventory (5 spans)
- `mission.persist` — `handle_mission_update`
- `mail.request` — `handle_mail_request`
- `progression.grant_xp`, `progression.grant_cash`
- `inventory.remove_by_type`

### OTLP filter
Added new target prefixes: `auth=info`, `world_entry=info`, `vendor=info`, `mail=info`, `progression=info`, `inventory=info`, `mission=info`. All ride the existing exporter with no config changes.

## What the trace tree looks like after this PR

```
auth.user_auth (PR #410)
  → auth.server_selection (PR #410)
      → [BaseApp encrypted handshake — existing spans]
          → base login Phase 3 (existing log)
              → world_entry.play_character (existing)
                  → world_entry.enable_entities (existing)
                      → world_entry.map_loaded ← NEW
                          → world_entry.on_client_ready ← NEW
                              → world_entry.init_player_state (cell, PR #410)
                                  → world_entry.region_burst (PR #410)
```

Plus side-channels:
- `world_entry.teleport_player` (NEW) for forced-position
- `vendor.*` (7 NEW) for store interactions
- `mission.persist`, `mail.request`, `progression.*`, `inventory.*` (5 NEW)

When the cold-login freeze repros next, you can walk the span tree from `auth.user_auth` down to where it stops progressing. Any span sitting open for 30+ seconds is the wedge point.

## Test plan

- [x] `cargo check -p cimmeria-services -p cimmeria-server` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all` — clean
- [x] `cargo nextest run -p cimmeria-services --lib world_entry::methods` — 126/126 pass

No behavior changes — instrumentation only. Existing tests are the regression guard.

## Stats

14 files, ~93 LOC added. Zero behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved system monitoring and performance diagnostics with enhanced tracing across core operations: inventory management, mail handling, mission updates, experience and currency grants, vendor interactions, and world transitions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SandboxServers/Cimmeria/pull/414?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->