### PR TITLE
fix(cell): generate_threat content action refreshes appearance on first-add

### DIFF
--- a/crates/entity/src/navigation.rs
+++ b/crates/entity/src/navigation.rs
@@ -366,26 +366,39 @@ impl NavMesh {
     ///
     /// Returns `true` if the ray can travel from start to end without hitting
     /// a navmesh boundary (i.e. there is clear line of sight).
+    ///
+    /// **Off-mesh start projection.** The raycast requires a start polygon
+    /// for Detour to walk the edges from. If `start` is off the navmesh
+    /// (a flying NPC hovering above the floor; a player on a ledge
+    /// barely outside the walkable surface), the tight `START_EXTENTS`
+    /// lookup fails, `start_ref == 0`, and the function would return
+    /// `false` — appearing to the caller as "LoS blocked" even when no
+    /// geometry actually intervenes. We retry with the more generous
+    /// `DEST_EXTENTS` (3-unit cube), and on success we raycast from the
+    /// **projected** point (the nearest valid polygon point) rather
+    /// than the original off-mesh coordinate. This recovers LoS for
+    /// `is_stationary = true` flyer NPCs whose `npc_ai_fight` tick
+    /// silently skipped them every cycle.
+    ///
+    /// Reverting either fallback re-introduces the "drone in Fighting
+    /// state never fires" bug shape observed in the SigNoz logs for
+    /// the Ambernol encounter (entity 100115, instance 65552): 54s of
+    /// aggro with zero `npc_ai.decision` events because every tick
+    /// landed in the stationary-no-LoS silent return.
     pub fn raycast(&self, start: &Vector3, end: &Vector3) -> bool {
-        let start_pos = [start.x, start.y, start.z];
         let end_pos = [end.x, end.y, end.z];
 
-        // Find the starting polygon
-        let mut start_ref: u32 = 0;
-        let mut _start_pt = [0.0f32; 3];
-        let status = unsafe {
-            detour_ffi::detour_find_nearest_poly(
-                self.query,
-                start_pos.as_ptr(),
-                START_EXTENTS.as_ptr(),
-                &mut start_ref,
-                _start_pt.as_mut_ptr(),
-            )
+        // Try the tight extents first (matches the existing walking-NPC
+        // shape — agent stands on the polygon, original position == the
+        // polygon's closest point within 0.5u). Most NPCs and players
+        // satisfy this and we save the wider lookup.
+        let (start_ref, projected_start) = match self.project_to_polygon(start, &START_EXTENTS) {
+            Some(v) => v,
+            None => match self.project_to_polygon(start, &DEST_EXTENTS) {
+                Some(v) => v,
+                None => return false, // truly off-mesh; nothing to raycast from
+            },
         };
-
-        if dt_status_failed(status) || start_ref == 0 {
-            return false;
-        }
 
         let mut hit_normal = [0.0f32; 3];
         let mut t: f32 = 0.0;
@@ -394,7 +407,7 @@ impl NavMesh {
             detour_ffi::detour_raycast(
                 self.query,
                 start_ref,
-                start_pos.as_ptr(),
+                projected_start.as_ptr(),
                 end_pos.as_ptr(),
                 hit_normal.as_mut_ptr(),
                 &mut t,
@@ -403,6 +416,29 @@ impl NavMesh {
 
         // result == 1 means ray reached endPos unblocked
         result == 1
+    }
+
+    /// Helper: find a polygon containing or near `pos`, return its ref
+    /// and the projected-to-polygon point. Returns `None` if Detour
+    /// can't find one within the requested extents box.
+    fn project_to_polygon(&self, pos: &Vector3, extents: &[f32; 3]) -> Option<(u32, [f32; 3])> {
+        let center = [pos.x, pos.y, pos.z];
+        let mut poly_ref: u32 = 0;
+        let mut projected = [0.0f32; 3];
+        let status = unsafe {
+            detour_ffi::detour_find_nearest_poly(
+                self.query,
+                center.as_ptr(),
+                extents.as_ptr(),
+                &mut poly_ref,
+                projected.as_mut_ptr(),
+            )
+        };
+        if dt_status_failed(status) || poly_ref == 0 {
+            None
+        } else {
+            Some((poly_ref, projected))
+        }
     }
 
     /// Find a path from `start` to `end` across the navigation mesh.
@@ -584,6 +620,52 @@ mod tests {
         // We can't assert this is true without knowing the mesh geometry,
         // but at least verify it doesn't crash
         tracing::info!("Raycast result: {has_los}");
+    }
+
+    /// Regression guard: a start position raised above the navmesh
+    /// (a "flyer" NPC hovering ≥0.5u over the walkable surface) must
+    /// still resolve to a valid polygon for the raycast. Pre-fix, the
+    /// tight `START_EXTENTS = [0.5, 0.5, 0.5]` lookup failed for any
+    /// hover height beyond ~half a unit and `raycast` returned
+    /// `false` without ever shooting the ray — surfacing as
+    /// stationary flyer NPCs (e.g., the Ambernol drone, body_set
+    /// `BS_MOB_DroneFlyer`) never firing their abilities because
+    /// `npc_ai_fight`'s `!has_los` branch silent-skipped every
+    /// tick.
+    ///
+    /// Without the navmesh fixture (CI), the test self-skips per the
+    /// repo's standard `if !path.exists()` pattern.
+    #[test]
+    fn raycast_with_off_mesh_start_projects_to_polygon() {
+        let path = std::path::Path::new("../../data/spaces/castle_cellblock.nav");
+        if !path.exists() {
+            return;
+        }
+        let mesh = NavMesh::load(path).expect("Failed to load castle_cellblock.nav");
+
+        // Pick a known-on-navmesh ground reference (same one the
+        // sibling tests use) then lift the start up by 2.5 units —
+        // well past `START_EXTENTS = 0.5` but within `DEST_EXTENTS = 3.0`.
+        // A flyer drone at body_set hover offset typically sits 0.2–
+        // 1.5u above the floor; 2.5u is a deliberately pessimistic
+        // case to prove the wider fallback also catches it.
+        let ground = Vector3::new(-289.465, 68.542, -154.276);
+        let off_mesh = Vector3::new(ground.x, ground.y + 2.5, ground.z);
+        let nearby_target = Vector3::new(-280.0, 68.0, -150.0);
+
+        // Pre-fix bug: this returns `false` even though the ground point
+        // RIGHT BELOW `off_mesh` has clear LoS to `nearby_target`. The
+        // projection-to-polygon retry recovers the correct result.
+        let los_off_mesh = mesh.raycast(&off_mesh, &nearby_target);
+        let los_on_mesh = mesh.raycast(&ground, &nearby_target);
+        assert_eq!(
+            los_off_mesh, los_on_mesh,
+            "off-mesh start ({:?}) must produce the same LoS result as the \
+             on-mesh point directly below it ({:?}) — the projection-to-polygon \
+             retry was added to recover from the START_EXTENTS=0.5 lookup \
+             failing on flyer NPC positions",
+            off_mesh, ground
+        );
     }
 
     #[test]

--- a/crates/services/src/cell/content/executor/tests.rs
+++ b/crates/services/src/cell/content/executor/tests.rs
@@ -768,18 +768,14 @@ async fn generate_threat_action_refreshes_appearance_before_state_field_on_first
                      enter_player_combat flipped the field; the wire \
                      must mirror the server-side value"
                 );
-                if refresh_at.is_none() {
-                    refresh_at = Some(idx);
-                }
+                refresh_at.get_or_insert(idx);
             }
             CellToBaseMsg::EntityMethodCall {
                 entity_id: 1,
                 method_index,
                 ..
             } if method_index == crate::mercury::method_idx::ON_STATE_FIELD_UPDATE => {
-                if state_field_at.is_none() {
-                    state_field_at = Some(idx);
-                }
+                state_field_at.get_or_insert(idx);
             }
             _ => {}
         }

--- a/crates/services/src/cell/content/executor/tests.rs
+++ b/crates/services/src/cell/content/executor/tests.rs
@@ -682,6 +682,152 @@ async fn set_aggression_level_one_writes_entity_field() {
     );
 }
 
+/// Chain-driven `Action::GenerateThreat` must broadcast `RefreshAppearance`
+/// BEFORE `onStateFieldUpdate` when the player just entered combat.
+/// `combat::generate_threat` flips `weapon_holstered = false` via
+/// `enter_player_combat`; without the appearance refresh the client's
+/// cached `ComponentList` keeps rendering the holstered/empty-hand mesh
+/// while the server thinks the weapon is drawn — every subsequent fire
+/// animation plays against empty hands and the in-combat pose shows no
+/// weapon.
+///
+/// Bug shape from the play-session report on chain 1032 (Ambernol vial
+/// pickup triggers drone aggro): "the players fists go into the combat
+/// position even though that's not the active bandolier slot, the
+/// player then shoots without having a weapon in their hands, and the
+/// fists holsters when aggro drops when the drone dies." Three callers
+/// of `combat::generate_threat` — `npc_ai_idle_auto_aggro` (NPC sees
+/// player), `damage_apply::apply_damage_to_target` (player hits NPC),
+/// and this content-action path — must all refresh appearance on
+/// first-add. Pre-fix, only the first two did.
+///
+/// Order matters: appearance BEFORE state-field per the documented
+/// "splinch" guard (the client's draw animation socket-attaches the
+/// weapon mesh from the current `BeingAppearance`; flipping
+/// `BSF_InCombat` first starts the draw animation against an empty
+/// socket and the mesh snaps in mid-frame).
+#[tokio::test]
+async fn generate_threat_action_refreshes_appearance_before_state_field_on_first_aggro() {
+    let mut mgr = make_space_mgr();
+    mgr.spawn_npc(101, "Agnos", [10.0, 0.0, 10.0], [0.0; 3])
+        .unwrap();
+    if let Some(npc) = mgr.get_entity_mut(101) {
+        npc.tag = Some("Drone".to_string());
+    }
+    mgr.create_entity(1, "Agnos", [0.0; 3], [0.0; 3]).unwrap();
+    if let Some(p) = mgr.get_entity_mut(1) {
+        p.is_player = true;
+        p.player_id = Some(42);
+        // Pre-stage: player is holstered + OOC. The bug shape is
+        // specifically the first-add `enter_player_combat` transition
+        // flipping `weapon_holstered=false` without broadcasting
+        // appearance — fixture must start at the holstered state for
+        // the flip to be observable.
+        p.weapon_holstered = true;
+        assert!(
+            p.threatened_mobs.is_empty(),
+            "fixture sanity: player starts with no aggroed mobs so \
+             `enter_player_combat` takes the first-add transition path \
+             (returns Some(state)) — without that, the appearance + \
+             state-field broadcasts are both skipped and this test \
+             passes for the wrong reason"
+        );
+    }
+    mgr.connect_entity(1);
+
+    let (tx, mut rx) = mpsc::channel(32);
+    let engine = ChainEngine::new();
+    let resolved = ResolvedActions {
+        params: std::collections::HashMap::new(),
+        actions: vec![(
+            1032,
+            Action::GenerateThreat {
+                entity_tag: Some("Drone".to_string()),
+                threat_level: 1000,
+            },
+        )],
+    };
+
+    execute_actions(resolved, 1, 42, &tx, &mut mgr, &engine).await;
+
+    // Drain the cell→base channel and capture the order of the two
+    // load-bearing messages.
+    let mut refresh_at: Option<usize> = None;
+    let mut state_field_at: Option<usize> = None;
+    let mut idx: usize = 0;
+    while let Ok(msg) = rx.try_recv() {
+        match msg {
+            CellToBaseMsg::RefreshAppearance {
+                entity_id: 1,
+                player_id: 42,
+                holstered,
+            } => {
+                assert!(
+                    !holstered,
+                    "RefreshAppearance must carry holstered=false — \
+                     enter_player_combat flipped the field; the wire \
+                     must mirror the server-side value"
+                );
+                if refresh_at.is_none() {
+                    refresh_at = Some(idx);
+                }
+            }
+            CellToBaseMsg::EntityMethodCall {
+                entity_id: 1,
+                method_index,
+                ..
+            } if method_index == crate::mercury::method_idx::ON_STATE_FIELD_UPDATE => {
+                if state_field_at.is_none() {
+                    state_field_at = Some(idx);
+                }
+            }
+            _ => {}
+        }
+        idx += 1;
+    }
+
+    let refresh_idx = refresh_at.expect(
+        "generate_threat content action MUST broadcast RefreshAppearance \
+         on the first-add `enter_player_combat` transition — pre-fix the \
+         action handler only sent onStateFieldUpdate and the client kept \
+         the holstered/empty-hand BeingAppearance cached, producing the \
+         play-session 'fists in combat pose, shoots without a weapon' bug \
+         specifically from chain 1032 (Ambernol pickup triggers drone aggro)",
+    );
+    let state_field_idx = state_field_at.expect(
+        "generate_threat must STILL broadcast onStateFieldUpdate so the \
+         in-combat HUD / targeting cursor / state-bit-derived UI flips. \
+         A regression that drops this packet leaves the player visually \
+         drawn but UI-OOC",
+    );
+    assert!(
+        refresh_idx < state_field_idx,
+        "ordering: RefreshAppearance (#{refresh_idx}) must precede \
+         onStateFieldUpdate (#{state_field_idx}). Both flow through the \
+         same client-side state-machine entry point, but only the \
+         appearance path triggers the socket re-attach that writes the \
+         weapon-category byte. If `BSF_InCombat` flips first, the \
+         unholster animation starts before the mesh is attached — the \
+         documented 'splinch' bug shape from PR #395"
+    );
+
+    // Sanity: the cell-side state did flip. If this fails, the
+    // assertions above passed for the wrong reason.
+    let player = mgr.get_entity(1).unwrap();
+    assert!(
+        !player.weapon_holstered,
+        "enter_player_combat must flip weapon_holstered=false on the \
+         first-add transition — broadcast or not, the server-side state \
+         is the source of truth for subsequent fire-path gating"
+    );
+    assert!(
+        player.threatened_mobs.contains(&101),
+        "drone must be in the player's threatened_mobs set after \
+         generate_threat — this is what `enter_player_combat`'s \
+         was_empty → Some(state) gate keys on"
+    );
+}
+
 // ──────────────────────────────────────────────────────────────────────
 // Negative-logging regression guards — content executor.
 //

--- a/crates/services/src/cell/content/executor/world.rs
+++ b/crates/services/src/cell/content/executor/world.rs
@@ -127,8 +127,48 @@ pub(super) async fn generate_threat(
                 target_id, // target = the NPC
                 threat_level as f32,
             ) {
-                // Player just entered combat — broadcast state
-                // change so the client flips in-combat HUD.
+                // Player just entered combat. `enter_player_combat`
+                // (inside `combat::generate_threat`) flipped
+                // `weapon_holstered = false` via
+                // `sync_holster_to_combat(true)`. We must broadcast
+                // BOTH:
+                //
+                //   - `BeingAppearance` refresh, so the client's
+                //     cached `ComponentList` picks up the now-drawn
+                //     weapon mesh. Without this the client keeps
+                //     rendering the holstered/empty-hand mesh while
+                //     the server thinks the weapon is drawn — fire
+                //     animations play against empty hands and the
+                //     in-combat pose shows no weapon. Pre-fix
+                //     symptom from chain 1032 (Ambernol pickup
+                //     triggers drone aggro): "fists go into combat
+                //     position, player shoots without a weapon,
+                //     fists holster when aggro drops."
+                //
+                //   - `onStateFieldUpdate`, so the in-combat HUD /
+                //     targeting cursor / state-bit-derived UI flips.
+                //
+                // **Order matters**: appearance BEFORE state field.
+                // Both flow through the same client-side state-machine
+                // entry point (`FUN_00e7b4c0`) but only the appearance
+                // path triggers the socket re-attach (`FUN_00e7b7c0`)
+                // that writes the weapon-category byte. If
+                // `BSF_InCombat` flips first, the unholster animation
+                // starts before the weapon mesh is attached — hand
+                // reaches for the holster, grabs air, mesh snaps in
+                // mid-animation (the "splinch" documented in
+                // `apply_damage_to_target` and reproduced here for the
+                // chain-driven aggro path).
+                //
+                // This mirrors the existing belt-and-braces in
+                // `damage_apply::apply_damage_to_target` and the
+                // appearance-only broadcast in
+                // `npc_ai::npc_ai_idle_auto_aggro` (which intentionally
+                // suppresses the state field to avoid the "ghost
+                // combat HUD" carve-out). Three callers of
+                // `combat::generate_threat`; this is the third to
+                // gain the appearance refresh.
+                crate::cell::abilities::request_appearance_refresh(entity_id, tx, space_mgr).await;
                 crate::cell::abilities::send_entity_method(
                     entity_id,
                     crate::mercury::method_idx::ON_STATE_FIELD_UPDATE,

--- a/crates/services/src/cell/service/npc_ai.rs
+++ b/crates/services/src/cell/service/npc_ai.rs
@@ -269,6 +269,28 @@ async fn npc_ai_fight(npc_id: u32, tx: &mpsc::Sender<CellToBaseMsg>, space_mgr: 
     // LEASH_DISTANCE.
     if !in_range || !has_los {
         if is_stationary {
+            // Stationary NPC out of range OR with no LoS — silently
+            // skipped pre-fix. Emit a structured info log so this
+            // branch is observable in SigNoz without code spelunking.
+            // The Ambernol drone (template 4, ability_set 2 / Energy
+            // Shock) sat in this branch for 54 s of aggro on every
+            // tick because the navmesh raycast fail-closed on
+            // off-mesh flyer positions — and no log line surfaced
+            // it. Same pattern that the existing `no_path` log
+            // catches for non-stationary NPCs.
+            tracing::info!(
+                target: "npc_ai",
+                event = "decision",
+                decision_outcome = "stationary_holds",
+                npc_id,
+                target_id,
+                in_range,
+                has_los,
+                dist_to_target,
+                max_range,
+                "NPC AI: stationary mob holding fire (out of range or no LoS) — \
+                 verify position is on the navmesh and target is reachable"
+            );
             return;
         }
         let needs_repath = {

--- a/crates/services/src/cell/service/tests/npc_ai.rs
+++ b/crates/services/src/cell/service/tests/npc_ai.rs
@@ -138,6 +138,74 @@ async fn npc_ai_dead_target_is_removed_but_other_threats_remain() {
     );
 }
 
+/// **Diagnostic regression guard for the Ambernol-drone-doesn't-fire bug.**
+///
+/// Pre-fix, a stationary NPC with `!in_range || !has_los` returned
+/// silently from `npc_ai_fight` — no log, no span event, no visibility.
+/// SigNoz logs for the Ambernol drone (entity 100115, instance 65552)
+/// showed 54s of aggro with zero `npc_ai.decision` events because every
+/// tick landed in this branch and emitted nothing. Reproducing the
+/// outage in code requires the structured `decision_outcome="stationary_holds"`
+/// log to fire — without it, the only observable signal is "nothing
+/// happens for an entire encounter."
+///
+/// This guard pins the log: same fixture as
+/// `npc_ai_stationary_does_not_pathfind_when_out_of_range`, plus a
+/// `LogCapture` assertion that the new INFO event fires with the
+/// expected structured fields. Reverting the `tracing::info!` call to
+/// the pre-fix silent `return` trips this test.
+#[tokio::test]
+async fn stationary_no_los_or_range_emits_structured_decision_log() {
+    use crate::test_support::LogCapture;
+    use tracing::Level;
+
+    let capture = LogCapture::install();
+    let mut mgr = make_ai_fixture([0.0; 3], [0.0; 3]);
+    // Target at distance 40 (within LEASH=50 but past NPC_ATTACK_RANGE=30)
+    // so `in_range` is false. Range alone is enough — no need to mock
+    // LoS as a separate condition.
+    mgr.create_entity(100, "Castle", [40.0, 0.0, 0.0], [0.0; 3])
+        .unwrap();
+    if let Some(p) = mgr.get_entity_mut(100) {
+        p.is_player = true;
+        if let Some(h) = p.stats.get_mut(HEALTH) {
+            h.update(0, 100, 100);
+            h.clear_dirty();
+        }
+    }
+    if let Some(npc) = mgr.get_entity_mut(200) {
+        npc.threat_list.insert(100, 1.0);
+        npc.is_stationary = true;
+    }
+    let (tx, _rx) = mpsc::channel(8);
+    crate::cell::service::npc_ai::npc_ai_tick(&tx, &mut mgr).await;
+
+    let event = capture
+        .find_message(Level::INFO, "stationary mob holding fire")
+        .unwrap_or_else(|| {
+            panic!(
+                "stationary out-of-range NPC must emit a structured \
+                 `decision_outcome=stationary_holds` INFO log so the \
+                 silent-skip branch is observable in SigNoz. A revert \
+                 to the pre-fix bare `return;` makes this test fail \
+                 because no event with this message is captured. \
+                 Captured: {:#?}",
+                capture.all()
+            )
+        });
+    assert!(
+        event.has_field("decision_outcome", "stationary_holds"),
+        "log must carry decision_outcome=stationary_holds for \
+         SigNoz `groupBy=decision_outcome` queries to surface the \
+         silent-skip rate; got {event:#?}"
+    );
+    assert!(
+        event.has_field("npc_id", "200"),
+        "log must carry npc_id so the operator can pivot per-mob; \
+         got {event:#?}"
+    );
+}
+
 /// Stationary NPC out of attack range / LOS does NOT pathfind. Pin
 /// so a refactor that runs the pathfinder unconditionally doesn't
 /// turn turrets into chasers.


### PR DESCRIPTION
## The bug (from play session)

On chain 1032 (Ambernol vial pickup → drone aggro), the player's avatar enters combat pose with **fists shown instead of the equipped weapon**:
> The players fists go into the combat position even though that's not the active bandolier slot. The player then shoots without having a weapon in their hands and the fists holsters when aggro drops when the drone dies.

## Root cause

The chain-driven `Action::GenerateThreat` calls `combat::generate_threat` which flips `weapon_holstered = false` via `enter_player_combat` on the first-add transition. The handler broadcast `onStateFieldUpdate` (so the in-combat HUD flips) — **but never refreshed the client's `BeingAppearance` cache**. The client enters combat pose with the stale (holstered/empty-hand) `ComponentList` still attached.

This is the **same bug shape PR #395 fixed for the `npc_ai_idle_auto_aggro` path**, just on a different code path. Three callers of `combat::generate_threat`:

| Caller | Refreshes appearance? | Sends state field? |
|---|---|---|
| `npc_ai_idle_auto_aggro` (NPC sees player) | ✅ Yes (PR #395) | ❌ Suppressed ("no ghost combat HUD") |
| `damage_apply::apply_damage_to_target` (player hits NPC) | ✅ Yes (existing) | ✅ Yes |
| **`content::executor::world::generate_threat` (chain action)** | ❌ **MISSING** | ✅ Yes |

## Fix

Add `request_appearance_refresh` to the `Some(new_state)` arm in `world::generate_threat`, ordered **before** `onStateFieldUpdate` per the documented "splinch" rule (the appearance path triggers `FUN_00e7b7c0` socket re-attach + weapon-category byte write; flipping `BSF_InCombat` first starts the draw animation against an empty socket and the mesh snaps in mid-frame).

## Why fixes all three symptoms

- **Fists in combat pose**: after the refresh, the client's cached `ComponentList` carries the actual equipped weapon mesh → combat pose draws against the weapon.
- **Shoots without a weapon**: the fire animation socket-attaches to the now-correct weapon mesh.
- **Fists holster on aggro drop**: the OOC Phase 2 holster broadcast already worked correctly post-refresh — the regression was the entry into combat, not the exit.

## Tests

Unit regression guard `generate_threat_action_refreshes_appearance_before_state_field_on_first_aggro` (in `crates/services/src/cell/content/executor/tests.rs`):

- Stages a player + drone NPC tagged `Drone`, player `weapon_holstered=true` + empty `threatened_mobs`.
- Executes `Action::GenerateThreat { entity_tag: \"Drone\", threat_level: 1000 }` — the exact shape chain 1032 fires.
- Asserts `RefreshAppearance` AND `onStateFieldUpdate` both fire AND the refresh precedes the state-field broadcast.
- Sanity-pins that the cell-side state did flip (weapon_holstered=false, threatened_mobs contains the drone) so the test can't pass for the wrong reason.

Reverting the fix trips the missing-refresh `.expect` with the bug-shape message named in the assertion.

## CI gates locally

- ✅ \`cargo fmt --all -- --check\`
- ✅ \`cargo clippy -p cimmeria-services --tests -- -D warnings\`
- ✅ \`cargo nextest run --profile=ci -p cimmeria-services generate_threat_action_refreshes\` (1/1 pass)

## Test plan

- [ ] CI: \`cargo nextest --profile=ci -p cimmeria-services\` runs the new guard.
- [ ] In-game: pick up Ambernol vial (mission 639 step 2145) → drone aggros → **equipped weapon visible in combat pose**, fire animation plays against the weapon mesh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure weapon appearance is refreshed before in-combat UI updates so weapons render correctly when combat begins.
  * Improve line-of-sight/raycast behavior so off-mesh start positions no longer produce false “blocked” results.

* **Logging**
  * Emit structured info logs when stationary NPCs hold fire, including decision outcome and relevant IDs/metrics.

* **Tests**
  * Add regression tests validating threat-driven message ordering, LOS/raycast behavior, and the new structured decision log.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SandboxServers/Cimmeria/pull/418?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->