### PR TITLE
feat(chat): wire speaker_flags from access_level + DND state (#65)

### DIFF
--- a/crates/services/src/base/dispatch.rs
+++ b/crates/services/src/base/dispatch.rs
@@ -12,6 +12,22 @@ use crate::mercury::read_wstring;
 
 use super::ConnectedClientState;
 
+/// `ESpeakerFlags` bitfield constants from `entities/defs/enumerations.xml`.
+///
+/// The wire field is a UINT8 sent in every `onPlayerCommunication` message.
+/// Only `SPEAKER_GM` and `SPEAKER_DND` are computed today — matches
+/// `python/base/Chat.py::getSpeakerFlags`. `SPEAKER_Petition` (0x02) is
+/// declared in the enum but never set by the Python reference, so it is
+/// intentionally omitted here (see issue #65 deep dive).
+pub(crate) mod speaker_flags {
+    /// Set when the speaker's `access_level >= 1` (Moderator or GameMaster).
+    /// Python parity: `if player.accessLevel > 0`.
+    pub const GM: u8 = 0x01;
+    /// Set when the speaker has a non-empty DND auto-reply message.
+    /// Python parity: `if player.dndMessage is not None`.
+    pub const DND: u8 = 0x04;
+}
+
 /// SGWPlayer base-method message IDs we currently handle explicitly.
 ///
 /// The client also sends protocol-level messages such as `versionInfoRequest`
@@ -66,12 +82,19 @@ pub(crate) async fn dispatch_sgw_player_base_method(
             let channel = payload[0];
             let mut offset = 1;
 
-            // Parse target (WSTRING)
-            let (target, new_offset) = match read_wstring(payload, offset) {
+            // Parse target (WSTRING). `read_wstring` returns the number of
+            // BYTES CONSUMED (not the new absolute offset), so accumulate
+            // with `+=`. The earlier code did `offset = new_offset` which
+            // dropped the +1 for the channel byte and mis-aligned the text
+            // WSTRING read — discovered while wiring #65 speaker_flags
+            // (the dispatch never reached the cell-forward branch on
+            // empty-target spatial channels because `read_wstring(buf, 4)`
+            // saw garbage where the text length should have been).
+            let (target, target_bytes) = match read_wstring(payload, offset) {
                 Ok(v) => v,
                 Err(_) => return Ok(()),
             };
-            offset = new_offset;
+            offset += target_bytes;
 
             // Parse text (WSTRING)
             let (text, _) = match read_wstring(payload, offset) {
@@ -90,10 +113,30 @@ pub(crate) async fn dispatch_sgw_player_base_method(
                 "sendPlayerCommunication"
             );
 
-            // Route to CellService for spatial channels (say/emote/yell)
-            let player_eid = {
+            // Route to CellService for spatial channels (say/emote/yell).
+            //
+            // Read player_eid + access_level + dnd_message under a single
+            // lock acquisition. Computing `speaker_flags` matches
+            // `python/base/Chat.py::getSpeakerFlags`:
+            //   - SPEAKER_GM  if accessLevel > 0  (Moderator or higher)
+            //   - SPEAKER_DND if dndMessage is not None
+            // SPEAKER_Petition (0x02) is in the enum but never set by the
+            // Python reference, so it is intentionally not computed.
+            let (player_eid, speaker_flags_value) = {
                 let clients = connected.lock().unwrap();
-                clients.get(&addr).and_then(|c| c.player_entity_id)
+                match clients.get(&addr) {
+                    Some(c) => {
+                        let mut flags: u8 = 0;
+                        if c.access_level >= 1 {
+                            flags |= speaker_flags::GM;
+                        }
+                        if c.dnd_message.is_some() {
+                            flags |= speaker_flags::DND;
+                        }
+                        (c.player_entity_id, flags)
+                    }
+                    None => (None, 0),
+                }
             };
 
             if let Some(player_eid) = player_eid {
@@ -102,7 +145,7 @@ pub(crate) async fn dispatch_sgw_player_base_method(
                         .send(BaseToCellMsg::ChatMessage {
                             entity_id: player_eid,
                             speaker_name: speaker.to_string(),
-                            speaker_flags: 0, // TODO: compute from AFK/DND/GM status
+                            speaker_flags: speaker_flags_value,
                             channel,
                             text,
                         })
@@ -130,8 +173,40 @@ pub(crate) async fn dispatch_sgw_player_base_method(
             tracing::debug!(%addr, channel_id, "chatLeave -- acknowledged");
         }
 
-        sgw_player_base::CHAT_SET_AFK | sgw_player_base::CHAT_SET_DND => {
-            tracing::debug!(%addr, msg_id = format_args!("{:#04x}", msg_id), "Chat status update -- acknowledged");
+        sgw_player_base::CHAT_SET_AFK => {
+            // AFK is intentionally log-only. AFK is NOT a speaker flag
+            // (see issue #65 deep dive: `enumerations.xml` has no
+            // `SPEAKER_AFK` token). In Python, `chatSetAFKMessage` only
+            // affects the auto-reply-tell path in `sendPlayerMessage`,
+            // which is a separate feature we have not ported yet.
+            tracing::debug!(
+                %addr,
+                "chatSetAFKMessage -- acknowledged (auto-reply not yet implemented)",
+            );
+        }
+
+        sgw_player_base::CHAT_SET_DND => {
+            // chatSetDNDMessage(WSTRING message)
+            //
+            // Mirrors `python/base/SGWPlayer.py::chatSetDNDMessage`: an
+            // empty or 1-char message clears DND; anything longer sets
+            // it. The stored message itself is currently only used as
+            // an "is DND active?" signal for the speaker_flags bit —
+            // the auto-reply-tell path is future work.
+            let message = read_wstring(payload, 0).map(|(s, _)| s).unwrap_or_default();
+            let mut clients = connected.lock().unwrap();
+            if let Some(c) = clients.get_mut(&addr) {
+                c.dnd_message = if message.chars().count() > 1 {
+                    Some(message)
+                } else {
+                    None
+                };
+                tracing::debug!(
+                    %addr,
+                    dnd_active = c.dnd_message.is_some(),
+                    "chatSetDNDMessage",
+                );
+            }
         }
 
         sgw_player_base::LOG_OFF => {
@@ -396,6 +471,219 @@ mod tests {
         assert!(
             event.has_field("base_method_index", "63"),
             "base_method_index must be 0xFF - 0xC0 = 63; got {event:#?}",
+        );
+    }
+
+    // ── Speaker flags (#65) regression guards ──────────────────────────
+    //
+    // The chat dispatch at `SEND_PLAYER_COMMUNICATION` must compute
+    // `speaker_flags` from per-connection state:
+    //   - SPEAKER_GM  (0x01) when access_level >= 1
+    //   - SPEAKER_DND (0x04) when dnd_message.is_some()
+    // matching `python/base/Chat.py::getSpeakerFlags`. The wire
+    // serializer is byte-exact already (pinned by
+    // `serialize_on_player_communication_basic` in `cell/chat.rs`); the
+    // guard surface here is the bit-assembly done before the cell
+    // forward. Reverting any of these branches to the old hardcoded
+    // `speaker_flags: 0` trips tests 1–4; reverting the DND handler to
+    // its stub trips test 5.
+
+    /// Build a `sendPlayerCommunication` payload:
+    /// `[u8 channel][WSTRING target][WSTRING text]`. `target` is the
+    /// recipient name for tell/private channels — empty for spatial
+    /// channels (say/emote/yell).
+    fn build_send_player_communication_payload(channel: u8, target: &str, text: &str) -> Vec<u8> {
+        let mut buf = Vec::new();
+        buf.push(channel);
+        crate::mercury::write_wstring(&mut buf, target);
+        crate::mercury::write_wstring(&mut buf, text);
+        buf
+    }
+
+    /// Drive the SEND_PLAYER_COMMUNICATION dispatch arm against a
+    /// freshly built `ConnectedClientState` (with the requested
+    /// `access_level` and `dnd_message`) and return the resulting
+    /// `speaker_flags` value sent to the cell. `player_entity_id` is
+    /// pre-set so the cell-forward branch is reached.
+    async fn drive_send_player_communication_and_get_flags(
+        access_level: u32,
+        dnd_message: Option<String>,
+    ) -> u8 {
+        let addr: SocketAddr = "127.0.0.1:54400".parse().unwrap();
+        let key = [0u8; 32];
+        let transport: Arc<dyn Transport> = Arc::new(TestTransport::default());
+
+        let mut state = test_default_connected_client_state();
+        state.player_entity_id = Some(1234);
+        state.access_level = access_level;
+        state.dnd_message = dnd_message;
+        let connected = Arc::new(Mutex::new(HashMap::from([(addr, state)])));
+        let entity_to_addr = Arc::new(Mutex::new(HashMap::<u32, SocketAddr>::new()));
+        let entity_manager = Arc::new(Mutex::new(EntityManager::new()));
+
+        let (tx, mut rx) = mpsc::channel::<BaseToCellMsg>(4);
+        let cell_tx: Option<mpsc::Sender<BaseToCellMsg>> = Some(tx);
+
+        // channel=0 (say), no target, "hi" as text.
+        let payload = build_send_player_communication_payload(0, "", "hi");
+
+        dispatch_sgw_player_base_method(
+            sgw_player_base::SEND_PLAYER_COMMUNICATION,
+            &payload,
+            &Some("Tester".to_string()),
+            addr,
+            &transport,
+            key,
+            &connected,
+            &entity_manager,
+            &cell_tx,
+            &entity_to_addr,
+        )
+        .await
+        .expect("sendPlayerCommunication dispatch should not propagate Err");
+
+        // Drop cell_tx so rx.recv() returns None instead of hanging if
+        // dispatch didn't actually emit a message — gives a clear panic
+        // path rather than a 60-second test timeout.
+        drop(cell_tx);
+
+        match rx.recv().await {
+            Some(BaseToCellMsg::ChatMessage { speaker_flags, .. }) => speaker_flags,
+            Some(_) => panic!("expected BaseToCellMsg::ChatMessage; got a different variant"),
+            None => panic!("dispatch did not forward a ChatMessage to the cell"),
+        }
+    }
+
+    /// Test 1: a default connection (access_level=0, no DND) sends
+    /// `speaker_flags == 0`. Regression for the hardcoded-zero literal.
+    #[tokio::test]
+    async fn send_player_communication_default_state_has_zero_speaker_flags() {
+        let flags = drive_send_player_communication_and_get_flags(0, None).await;
+        assert_eq!(
+            flags, 0,
+            "default state must produce speaker_flags == 0 (no GM, no DND)"
+        );
+    }
+
+    /// Test 2: access_level=1 (Moderator) sets SPEAKER_GM (0x01).
+    /// Python parity: `accessLevel > 0`, so Moderators get the bit too.
+    #[tokio::test]
+    async fn send_player_communication_access_level_one_sets_gm_flag() {
+        let flags = drive_send_player_communication_and_get_flags(1, None).await;
+        assert_eq!(
+            flags & speaker_flags::GM,
+            speaker_flags::GM,
+            "access_level >= 1 must set SPEAKER_GM (0x01); got {flags:#04x}",
+        );
+        assert_eq!(
+            flags & speaker_flags::DND,
+            0,
+            "SPEAKER_DND must NOT be set when dnd_message is None; got {flags:#04x}",
+        );
+    }
+
+    /// Test 3: dnd_message present sets SPEAKER_DND (0x04) even when
+    /// access_level == 0 (non-GM user).
+    #[tokio::test]
+    async fn send_player_communication_dnd_message_sets_dnd_flag() {
+        let flags =
+            drive_send_player_communication_and_get_flags(0, Some("busy raiding".to_string()))
+                .await;
+        assert_eq!(
+            flags & speaker_flags::DND,
+            speaker_flags::DND,
+            "dnd_message.is_some() must set SPEAKER_DND (0x04); got {flags:#04x}",
+        );
+        assert_eq!(
+            flags & speaker_flags::GM,
+            0,
+            "SPEAKER_GM must NOT be set when access_level == 0; got {flags:#04x}",
+        );
+    }
+
+    /// Test 4: GM with DND active sets both bits — verifies bitwise OR
+    /// composition and that neither branch clobbers the other.
+    #[tokio::test]
+    async fn send_player_communication_gm_with_dnd_sets_both_flags() {
+        let flags =
+            drive_send_player_communication_and_get_flags(2, Some("on duty, dnd".to_string()))
+                .await;
+        assert_eq!(
+            flags,
+            speaker_flags::GM | speaker_flags::DND,
+            "access_level=2 + dnd_message=Some must produce 0x05; got {flags:#04x}",
+        );
+    }
+
+    /// Test 5: `CHAT_SET_DND` handler round-trip: a >1-char payload
+    /// sets the field; a follow-up 0-char payload clears it. Pins the
+    /// handler's set/clear semantics (matches the Python `<= 1 char`
+    /// rule). Reverting `CHAT_SET_DND` to the stub trips this.
+    #[tokio::test]
+    async fn chat_set_dnd_handler_sets_then_clears_dnd_message() {
+        let addr: SocketAddr = "127.0.0.1:54401".parse().unwrap();
+        let key = [0u8; 32];
+        let transport: Arc<dyn Transport> = Arc::new(TestTransport::default());
+
+        let state = test_default_connected_client_state();
+        let connected = Arc::new(Mutex::new(HashMap::from([(addr, state)])));
+        let entity_to_addr = Arc::new(Mutex::new(HashMap::<u32, SocketAddr>::new()));
+        let entity_manager = Arc::new(Mutex::new(EntityManager::new()));
+        let cell_tx: Option<mpsc::Sender<BaseToCellMsg>> = None;
+
+        // ── Set: a >1-char message populates dnd_message ───────────
+        let mut set_payload = Vec::new();
+        crate::mercury::write_wstring(&mut set_payload, "afk for dinner");
+        dispatch_sgw_player_base_method(
+            sgw_player_base::CHAT_SET_DND,
+            &set_payload,
+            &Some("Tester".to_string()),
+            addr,
+            &transport,
+            key,
+            &connected,
+            &entity_manager,
+            &cell_tx,
+            &entity_to_addr,
+        )
+        .await
+        .expect("chatSetDNDMessage (set) must not propagate Err");
+        // Bind the cloned Option so the MutexGuard's lifetime ends
+        // before any assert macro evaluates its arguments.
+        let after_set = {
+            let g = connected.lock().unwrap();
+            g.get(&addr).and_then(|c| c.dnd_message.clone())
+        };
+        assert_eq!(
+            after_set,
+            Some("afk for dinner".to_string()),
+            "chatSetDNDMessage with a >1-char message must populate dnd_message",
+        );
+
+        // ── Clear: an empty message clears dnd_message ─────────────
+        let mut clear_payload = Vec::new();
+        crate::mercury::write_wstring(&mut clear_payload, "");
+        dispatch_sgw_player_base_method(
+            sgw_player_base::CHAT_SET_DND,
+            &clear_payload,
+            &Some("Tester".to_string()),
+            addr,
+            &transport,
+            key,
+            &connected,
+            &entity_manager,
+            &cell_tx,
+            &entity_to_addr,
+        )
+        .await
+        .expect("chatSetDNDMessage (clear) must not propagate Err");
+        let after_clear = {
+            let g = connected.lock().unwrap();
+            g.get(&addr).and_then(|c| c.dnd_message.clone())
+        };
+        assert_eq!(
+            after_clear, None,
+            "chatSetDNDMessage with an empty payload must clear dnd_message",
         );
     }
 }

--- a/crates/services/src/base/dispatch.rs
+++ b/crates/services/src/base/dispatch.rs
@@ -714,4 +714,261 @@ mod tests {
             "chatSetDNDMessage with an empty payload must clear dnd_message",
         );
     }
+
+    /// Test 6: a 1-character DND payload clears `dnd_message`, matching
+    /// Python's `chatSetDNDMessage` which treats `len(message) <= 1`
+    /// as a clear. Pins the `> 1` threshold so a regression from
+    /// `> 1` to `> 0` (which would treat "x" as setting DND to "x")
+    /// trips this test.
+    ///
+    /// Boundary case: existing tests prove `>1` sets and empty clears.
+    /// This guards the exact discriminator between the two branches.
+    #[tokio::test]
+    async fn chat_set_dnd_handler_one_char_payload_clears_dnd_message() {
+        let addr: SocketAddr = "127.0.0.1:54402".parse().unwrap();
+        let key = [0u8; 32];
+        let transport: Arc<dyn Transport> = Arc::new(TestTransport::default());
+
+        // Seed the connection with DND already active so the 1-char
+        // payload has something to clear (otherwise None->None looks
+        // identical to a no-op handler).
+        let mut state = test_default_connected_client_state();
+        state.dnd_message = Some("previously busy".to_string());
+        let connected = Arc::new(Mutex::new(HashMap::from([(addr, state)])));
+        let entity_to_addr = Arc::new(Mutex::new(HashMap::<u32, SocketAddr>::new()));
+        let entity_manager = Arc::new(Mutex::new(EntityManager::new()));
+        let cell_tx: Option<mpsc::Sender<BaseToCellMsg>> = None;
+
+        // 1-char payload.
+        let mut payload = Vec::new();
+        crate::mercury::write_wstring(&mut payload, "x");
+
+        dispatch_sgw_player_base_method(
+            sgw_player_base::CHAT_SET_DND,
+            &payload,
+            &Some("Tester".to_string()),
+            addr,
+            &transport,
+            key,
+            &connected,
+            &entity_manager,
+            &cell_tx,
+            &entity_to_addr,
+        )
+        .await
+        .expect("chatSetDNDMessage (1-char) must not propagate Err");
+
+        let after = {
+            let g = connected.lock().unwrap();
+            g.get(&addr).and_then(|c| c.dnd_message.clone())
+        };
+        assert_eq!(
+            after, None,
+            "1-char DND payload must clear dnd_message (matches Python `len <= 1` clear rule)",
+        );
+    }
+
+    /// Test 7: a malformed `CHAT_SET_DND` payload (too short for the
+    /// WSTRING char_count header) must leave existing `dnd_message`
+    /// untouched. Reverting the handler to `unwrap_or_default()`
+    /// (which coerces the decode failure to `""` and then runs the
+    /// "≤1 char clears" rule) would wipe DND on a garbage packet —
+    /// this guard trips that revert.
+    ///
+    /// Also asserts a WARN with `reason = "read_wstring_failed"` so
+    /// the failure is visible in SigNoz rather than a silent drop.
+    #[tokio::test]
+    async fn chat_set_dnd_handler_malformed_payload_preserves_dnd_message() {
+        let capture = LogCapture::install();
+
+        let addr: SocketAddr = "127.0.0.1:54403".parse().unwrap();
+        let key = [0u8; 32];
+        let transport: Arc<dyn Transport> = Arc::new(TestTransport::default());
+
+        let mut state = test_default_connected_client_state();
+        state.dnd_message = Some("do not disturb".to_string());
+        let connected = Arc::new(Mutex::new(HashMap::from([(addr, state)])));
+        let entity_to_addr = Arc::new(Mutex::new(HashMap::<u32, SocketAddr>::new()));
+        let entity_manager = Arc::new(Mutex::new(EntityManager::new()));
+        let cell_tx: Option<mpsc::Sender<BaseToCellMsg>> = None;
+
+        // 2 bytes: shorter than the 4-byte WSTRING char_count header
+        // `read_wstring` requires. `read_wstring(payload, 0)` returns
+        // Err — the handler must NOT then clear dnd_message.
+        let payload = [0u8, 0u8];
+
+        dispatch_sgw_player_base_method(
+            sgw_player_base::CHAT_SET_DND,
+            &payload,
+            &Some("Tester".to_string()),
+            addr,
+            &transport,
+            key,
+            &connected,
+            &entity_manager,
+            &cell_tx,
+            &entity_to_addr,
+        )
+        .await
+        .expect("chatSetDNDMessage (malformed) must not propagate Err -- just warn + skip");
+
+        let after = {
+            let g = connected.lock().unwrap();
+            g.get(&addr).and_then(|c| c.dnd_message.clone())
+        };
+        assert_eq!(
+            after,
+            Some("do not disturb".to_string()),
+            "malformed CHAT_SET_DND must NOT clear existing dnd_message",
+        );
+
+        // Pin the `reason` field so a generic refactor that drops the
+        // structured tag (but still warns) is also flagged.
+        let event = capture
+            .find_message(Level::WARN, "chatSetDNDMessage: WSTRING decode failed")
+            .unwrap_or_else(|| {
+                panic!(
+                    "expected WARN for malformed CHAT_SET_DND payload; \
+                     a silent unwrap_or_default revert fails this. Captured: {:#?}",
+                    capture.all()
+                )
+            });
+        assert!(
+            event.has_field("reason", "read_wstring_failed"),
+            "reason field must be `read_wstring_failed` for SigNoz pivots; got {event:#?}",
+        );
+    }
+
+    /// Test 8: the post-character-select reset path clears
+    /// `dnd_message`. Without this, char A's `/dnd` would leak into
+    /// char B on the same connection — every subsequent
+    /// `sendPlayerCommunication` from char B would incorrectly carry
+    /// `SPEAKER_DND` until char B's user toggled DND explicitly.
+    ///
+    /// Drives the disconnect=0 (return-to-character-select) branch of
+    /// `LOG_OFF`, which is the only path that resets per-character
+    /// state without dropping the connection. Reverting the
+    /// `c.dnd_message = None;` line in that block trips this test.
+    #[tokio::test]
+    async fn logoff_disconnect_zero_clears_dnd_message_for_next_character() {
+        let addr: SocketAddr = "127.0.0.1:54404".parse().unwrap();
+        let entity_id: u32 = 4243;
+        let key = [0u8; 32];
+        let transport: Arc<dyn Transport> = Arc::new(TestTransport::default());
+
+        let mut state = test_default_connected_client_state();
+        state.player_entity_id = Some(entity_id);
+        state.dnd_message = Some("char A is busy".to_string());
+        let connected = Arc::new(Mutex::new(HashMap::from([(addr, state)])));
+        let entity_to_addr = Arc::new(Mutex::new(HashMap::from([(entity_id, addr)])));
+        let entity_manager = Arc::new(Mutex::new(EntityManager::new()));
+
+        // Open cell_tx receiver so the DisconnectEntity / DestroyEntity
+        // sends don't warn (we're testing the reset path, not the
+        // send-failure path).
+        let (tx, mut rx) = mpsc::channel::<BaseToCellMsg>(8);
+        let cell_tx: Option<mpsc::Sender<BaseToCellMsg>> = Some(tx);
+
+        // disconnect == 0 => return-to-character-select reset path.
+        let payload = [0u8];
+
+        dispatch_sgw_player_base_method(
+            sgw_player_base::LOG_OFF,
+            &payload,
+            &Some("CharA".to_string()),
+            addr,
+            &transport,
+            key,
+            &connected,
+            &entity_manager,
+            &cell_tx,
+            &entity_to_addr,
+        )
+        .await
+        .expect("logOff (disconnect=0) must not propagate Err");
+
+        // Drain the cell-tx so nothing leaks (and so the assertion
+        // panic message stays clean).
+        while rx.try_recv().is_ok() {}
+
+        let after = {
+            let g = connected.lock().unwrap();
+            g.get(&addr).and_then(|c| c.dnd_message.clone())
+        };
+        assert_eq!(
+            after, None,
+            "disconnect=0 (return-to-character-select) must clear dnd_message \
+             so char A's DND state does not leak into char B on the same connection",
+        );
+    }
+
+    /// Test 9: the `CHAT_SET_AFK` handler is log-only and must not
+    /// crash or mutate connection state for any payload shape. AFK is
+    /// intentionally NOT wired into `speaker_flags` (no `SPEAKER_AFK`
+    /// token exists in `entities/defs/enumerations.xml`). This guard
+    /// pins both invariants so a future "AFK should set a flag" change
+    /// trips the test and forces a deliberate review of the enum.
+    #[tokio::test]
+    async fn chat_set_afk_handler_is_log_only_and_preserves_state() {
+        let addr: SocketAddr = "127.0.0.1:54405".parse().unwrap();
+        let key = [0u8; 32];
+        let transport: Arc<dyn Transport> = Arc::new(TestTransport::default());
+
+        // Seed non-default state to verify AFK doesn't stomp on it.
+        let mut state = test_default_connected_client_state();
+        state.player_entity_id = Some(9999);
+        state.dnd_message = Some("on a raid".to_string());
+        state.access_level = 1;
+        let connected = Arc::new(Mutex::new(HashMap::from([(addr, state)])));
+        let entity_to_addr = Arc::new(Mutex::new(HashMap::<u32, SocketAddr>::new()));
+        let entity_manager = Arc::new(Mutex::new(EntityManager::new()));
+        let cell_tx: Option<mpsc::Sender<BaseToCellMsg>> = None;
+
+        // Drive several payload shapes to exercise both the empty-buf
+        // and decoded-WSTRING paths the handler's body never reads.
+        let mut valid_wstring_payload = Vec::new();
+        crate::mercury::write_wstring(&mut valid_wstring_payload, "afk for lunch");
+        let payloads: &[&[u8]] = &[
+            &[],                          // empty payload
+            &[0u8, 0u8, 0u8, 0u8],        // valid 0-length WSTRING header
+            &valid_wstring_payload,       // valid non-empty WSTRING
+            &[0xFFu8, 0xFFu8],            // malformed (too short for char_count)
+        ];
+
+        for (i, payload) in payloads.iter().enumerate() {
+            dispatch_sgw_player_base_method(
+                sgw_player_base::CHAT_SET_AFK,
+                payload,
+                &Some("Tester".to_string()),
+                addr,
+                &transport,
+                key,
+                &connected,
+                &entity_manager,
+                &cell_tx,
+                &entity_to_addr,
+            )
+            .await
+            .unwrap_or_else(|e| {
+                panic!("chatSetAFKMessage (payload {i}) must not propagate Err: {e}")
+            });
+        }
+
+        // Every per-connection field the speaker_flags wiring touches
+        // must survive AFK dispatch unchanged.
+        let snapshot = {
+            let g = connected.lock().unwrap();
+            let c = g.get(&addr).expect("client state must still be present");
+            (
+                c.player_entity_id,
+                c.dnd_message.clone(),
+                c.access_level,
+            )
+        };
+        assert_eq!(
+            snapshot,
+            (Some(9999), Some("on a raid".to_string()), 1),
+            "chatSetAFKMessage is log-only and must not mutate connection state",
+        );
+    }
 }

--- a/crates/services/src/base/dispatch.rs
+++ b/crates/services/src/base/dispatch.rs
@@ -18,9 +18,9 @@ use super::ConnectedClientState;
 /// Only `SPEAKER_GM` and `SPEAKER_DND` are computed today — matches
 /// `python/base/Chat.py::getSpeakerFlags`. `SPEAKER_Petition` (0x02) is
 /// declared in the enum but never set by the Python reference, so it is
-/// intentionally omitted here (see issue #65 deep dive).
+/// intentionally omitted here.
 pub(crate) mod speaker_flags {
-    /// Set when the speaker's `access_level >= 1` (Moderator or GameMaster).
+    /// Set when the speaker's `access_level > 0` (Moderator or higher).
     /// Python parity: `if player.accessLevel > 0`.
     pub const GM: u8 = 0x01;
     /// Set when the speaker has a non-empty DND auto-reply message.
@@ -82,14 +82,15 @@ pub(crate) async fn dispatch_sgw_player_base_method(
             let channel = payload[0];
             let mut offset = 1;
 
-            // Parse target (WSTRING). `read_wstring` returns the number of
-            // BYTES CONSUMED (not the new absolute offset), so accumulate
-            // with `+=`. The earlier code did `offset = new_offset` which
-            // dropped the +1 for the channel byte and mis-aligned the text
-            // WSTRING read — discovered while wiring #65 speaker_flags
-            // (the dispatch never reached the cell-forward branch on
-            // empty-target spatial channels because `read_wstring(buf, 4)`
-            // saw garbage where the text length should have been).
+            // Parse target (WSTRING). `read_wstring` returns the number
+            // of BYTES CONSUMED (not the new absolute offset), so
+            // accumulate with `+=` — `offset = ret` would drop the +1
+            // for the channel byte and mis-align the subsequent text
+            // WSTRING read. Empty-target spatial channels (say / emote /
+            // yell) are the case this matters most: with a 0-length
+            // target the text length lives at the byte right after the
+            // channel byte, and the old `=` assignment made the text
+            // read see garbage.
             let (target, target_bytes) = match read_wstring(payload, offset) {
                 Ok(v) => v,
                 Err(_) => return Ok(()),
@@ -127,7 +128,7 @@ pub(crate) async fn dispatch_sgw_player_base_method(
                 match clients.get(&addr) {
                     Some(c) => {
                         let mut flags: u8 = 0;
-                        if c.access_level >= 1 {
+                        if c.access_level > 0 {
                             flags |= speaker_flags::GM;
                         }
                         if c.dnd_message.is_some() {
@@ -174,11 +175,13 @@ pub(crate) async fn dispatch_sgw_player_base_method(
         }
 
         sgw_player_base::CHAT_SET_AFK => {
-            // AFK is intentionally log-only. AFK is NOT a speaker flag
-            // (see issue #65 deep dive: `enumerations.xml` has no
-            // `SPEAKER_AFK` token). In Python, `chatSetAFKMessage` only
-            // affects the auto-reply-tell path in `sendPlayerMessage`,
-            // which is a separate feature we have not ported yet.
+            // AFK is intentionally log-only. AFK is NOT a speaker flag:
+            // `entities/defs/enumerations.xml` has no `SPEAKER_AFK`
+            // token, and `python/base/Chat.py::getSpeakerFlags` only
+            // checks `accessLevel > 0` / `dndMessage is not None`. In
+            // Python, `chatSetAFKMessage` only affects the
+            // auto-reply-tell path in `sendPlayerMessage`, which is a
+            // separate feature we have not ported yet.
             tracing::debug!(
                 %addr,
                 "chatSetAFKMessage -- acknowledged (auto-reply not yet implemented)",
@@ -502,11 +505,11 @@ mod tests {
         );
     }
 
-    // ── Speaker flags (#65) regression guards ──────────────────────────
+    // ── Speaker flags regression guards ────────────────────────────────
     //
     // The chat dispatch at `SEND_PLAYER_COMMUNICATION` must compute
     // `speaker_flags` from per-connection state:
-    //   - SPEAKER_GM  (0x01) when access_level >= 1
+    //   - SPEAKER_GM  (0x01) when access_level > 0
     //   - SPEAKER_DND (0x04) when dnd_message.is_some()
     // matching `python/base/Chat.py::getSpeakerFlags`. The wire
     // serializer is byte-exact already (pinned by
@@ -601,7 +604,7 @@ mod tests {
         assert_eq!(
             flags & speaker_flags::GM,
             speaker_flags::GM,
-            "access_level >= 1 must set SPEAKER_GM (0x01); got {flags:#04x}",
+            "access_level > 0 must set SPEAKER_GM (0x01); got {flags:#04x}",
         );
         assert_eq!(
             flags & speaker_flags::DND,
@@ -929,10 +932,10 @@ mod tests {
         let mut valid_wstring_payload = Vec::new();
         crate::mercury::write_wstring(&mut valid_wstring_payload, "afk for lunch");
         let payloads: &[&[u8]] = &[
-            &[],                          // empty payload
-            &[0u8, 0u8, 0u8, 0u8],        // valid 0-length WSTRING header
-            &valid_wstring_payload,       // valid non-empty WSTRING
-            &[0xFFu8, 0xFFu8],            // malformed (too short for char_count)
+            &[],                    // empty payload
+            &[0u8, 0u8, 0u8, 0u8],  // valid 0-length WSTRING header
+            &valid_wstring_payload, // valid non-empty WSTRING
+            &[0xFFu8, 0xFFu8],      // malformed (too short for char_count)
         ];
 
         for (i, payload) in payloads.iter().enumerate() {
@@ -959,11 +962,7 @@ mod tests {
         let snapshot = {
             let g = connected.lock().unwrap();
             let c = g.get(&addr).expect("client state must still be present");
-            (
-                c.player_entity_id,
-                c.dnd_message.clone(),
-                c.access_level,
-            )
+            (c.player_entity_id, c.dnd_message.clone(), c.access_level)
         };
         assert_eq!(
             snapshot,

--- a/crates/services/src/base/dispatch.rs
+++ b/crates/services/src/base/dispatch.rs
@@ -193,7 +193,27 @@ pub(crate) async fn dispatch_sgw_player_base_method(
             // it. The stored message itself is currently only used as
             // an "is DND active?" signal for the speaker_flags bit —
             // the auto-reply-tell path is future work.
-            let message = read_wstring(payload, 0).map(|(s, _)| s).unwrap_or_default();
+            //
+            // A decode failure (truncated / malformed payload) must NOT
+            // be coerced to `""` and then treated as a clear — that
+            // silently destroys existing DND state on a garbage packet.
+            // Bind the Result explicitly, warn-log on Err per
+            // `docs/architecture/negative-logging-convention.md`, and
+            // leave `dnd_message` untouched so a flaky packet doesn't
+            // surprise the user.
+            let message = match read_wstring(payload, 0) {
+                Ok((s, _)) => s,
+                Err(e) => {
+                    tracing::warn!(
+                        %addr,
+                        payload_len = payload.len(),
+                        reason = "read_wstring_failed",
+                        error = %e,
+                        "chatSetDNDMessage: WSTRING decode failed -- existing DND state preserved",
+                    );
+                    return Ok(());
+                }
+            };
             let mut clients = connected.lock().unwrap();
             if let Some(c) = clients.get_mut(&addr) {
                 c.dnd_message = if message.chars().count() > 1 {
@@ -281,6 +301,14 @@ pub(crate) async fn dispatch_sgw_player_base_method(
                         c.cached_tint_args = None;
                         c.world_entry_sent = false;
                         c.char_list_sent = false;
+                        // DND is per-character state. Without this reset,
+                        // char A's /dnd would leak into char B on the
+                        // same connection — every subsequent
+                        // `sendPlayerCommunication` would carry
+                        // `SPEAKER_DND` until char B's user toggled DND
+                        // explicitly. Mirrors the other per-character
+                        // fields cleared on return-to-character-select.
+                        c.dnd_message = None;
                     }
                 }
 

--- a/crates/services/src/base/login/mod.rs
+++ b/crates/services/src/base/login/mod.rs
@@ -154,6 +154,7 @@ pub(crate) async fn handle_login(
                 key,
                 account_id: login.account_id,
                 access_level: login.access_level,
+                dnd_message: None,
                 char_list_sent: false,
                 world_entry_sent: false,
                 pending_player_entity_id: None,

--- a/crates/services/src/base/mod.rs
+++ b/crates/services/src/base/mod.rs
@@ -108,8 +108,23 @@ pub(crate) struct ConnectedClientState {
     pub enc: MercuryEncryption,
     pub key: [u8; 32],
     pub account_id: u32,
-    #[allow(dead_code)]
+    /// Account access level, populated from the login row. Used by
+    /// chat dispatch to set the `SPEAKER_GM` bit on `speaker_flags`
+    /// when `access_level >= 1` (matches `python/base/Chat.py::getSpeakerFlags`
+    /// which uses `accessLevel > 0`). 0=Player, 1=Moderator, 2=GameMaster
+    /// per `crates/commands/src/permissions.rs::AccessLevel`.
     pub access_level: u32,
+    /// DND auto-reply message. `Some(_)` means DND is active and the
+    /// chat dispatch sets `SPEAKER_DND` (0x04) on outgoing
+    /// `onPlayerCommunication`; `None` means not in DND. Set/cleared
+    /// by the `chatSetDNDMessage` (CHAT_SET_DND, 0xC4) handler. A
+    /// payload whose decoded message is empty or 1-char clears the
+    /// field, matching `python/base/SGWPlayer.py::chatSetDNDMessage`.
+    ///
+    /// AFK (`chatSetAFKMessage`) is a separate auto-reply-tells feature
+    /// and does NOT contribute to `ESpeakerFlags` — see issue #65 deep
+    /// dive and `entities/defs/enumerations.xml` (no `SPEAKER_AFK` token).
+    pub dnd_message: Option<String>,
     pub char_list_sent: bool,
     pub world_entry_sent: bool,
     pub pending_player_entity_id: Option<u32>,

--- a/crates/services/src/base/mod.rs
+++ b/crates/services/src/base/mod.rs
@@ -110,9 +110,9 @@ pub(crate) struct ConnectedClientState {
     pub account_id: u32,
     /// Account access level, populated from the login row. Used by
     /// chat dispatch to set the `SPEAKER_GM` bit on `speaker_flags`
-    /// when `access_level >= 1` (matches `python/base/Chat.py::getSpeakerFlags`
-    /// which uses `accessLevel > 0`). 0=Player, 1=Moderator, 2=GameMaster
-    /// per `crates/commands/src/permissions.rs::AccessLevel`.
+    /// when `access_level > 0` (matches
+    /// `python/base/Chat.py::getSpeakerFlags`). 0=Player, 1=Moderator,
+    /// 2=GameMaster per `crates/commands/src/permissions.rs::AccessLevel`.
     pub access_level: u32,
     /// DND auto-reply message. `Some(_)` means DND is active and the
     /// chat dispatch sets `SPEAKER_DND` (0x04) on outgoing
@@ -122,8 +122,10 @@ pub(crate) struct ConnectedClientState {
     /// field, matching `python/base/SGWPlayer.py::chatSetDNDMessage`.
     ///
     /// AFK (`chatSetAFKMessage`) is a separate auto-reply-tells feature
-    /// and does NOT contribute to `ESpeakerFlags` — see issue #65 deep
-    /// dive and `entities/defs/enumerations.xml` (no `SPEAKER_AFK` token).
+    /// and does NOT contribute to `ESpeakerFlags` — the enum
+    /// (`entities/defs/enumerations.xml`) has no `SPEAKER_AFK` token,
+    /// and the Python reference (`python/base/Chat.py::getSpeakerFlags`)
+    /// only checks `accessLevel > 0` and `dndMessage is not None`.
     pub dnd_message: Option<String>,
     pub char_list_sent: bool,
     pub world_entry_sent: bool,

--- a/crates/services/src/base/world_entry/gate_travel/tests.rs
+++ b/crates/services/src/base/world_entry/gate_travel/tests.rs
@@ -44,6 +44,7 @@ fn make_state() -> ConnectedClientState {
         key: [0xCDu8; 32],
         account_id: 0xAABB,
         access_level: 0,
+        dnd_message: None,
         char_list_sent: true,
         world_entry_sent: true, // post-playCharacter
         pending_player_entity_id: Some(42),

--- a/crates/services/src/base/world_entry/methods/inventory/appearance.rs
+++ b/crates/services/src/base/world_entry/methods/inventory/appearance.rs
@@ -127,6 +127,7 @@ mod tests {
             key: [0u8; 32],
             account_id,
             access_level: 0,
+            dnd_message: None,
             char_list_sent: false,
             world_entry_sent: false,
             pending_player_entity_id: None,

--- a/crates/services/src/base/world_entry/play_character.rs
+++ b/crates/services/src/base/world_entry/play_character.rs
@@ -185,6 +185,7 @@ mod tests {
             key: [0xCDu8; 32],
             account_id,
             access_level: 0,
+            dnd_message: None,
             char_list_sent: false,
             world_entry_sent: false,
             pending_player_entity_id: None,

--- a/crates/services/src/test_support.rs
+++ b/crates/services/src/test_support.rs
@@ -146,6 +146,7 @@ pub(crate) fn test_default_connected_client_state() -> ConnectedClientState {
         key,
         account_id: 0,
         access_level: 0,
+        dnd_message: None,
         char_list_sent: false,
         world_entry_sent: false,
         pending_player_entity_id: None,


### PR DESCRIPTION
## Summary

- Computes `speaker_flags` on every chat dispatch from per-connection state instead of the hardcoded `0` TODO at `crates/services/src/base/dispatch.rs:105`. Matches `python/base/Chat.py::getSpeakerFlags`: `SPEAKER_GM` (0x01) when `access_level >= 1`, `SPEAKER_DND` (0x04) when `dnd_message.is_some()`.
- Adds `ConnectedClientState::dnd_message` and wires the previously-stub `CHAT_SET_DND` (0xC4) handler to set/clear it (Python parity: a ≤1-char payload clears, anything longer sets).
- Removes the `#[allow(dead_code)]` on `ConnectedClientState::access_level` — now read by chat dispatch.
- Drive-by fix in the same dispatch arm: `read_wstring` returns BYTES CONSUMED, not a new absolute offset, but the existing code did `offset = new_offset`, dropping the +1 from the channel byte. Switched to `offset += target_bytes` (with a comment citing the discovery context). Caught by the new tests because the default-target spatial-channel case never reached the cell-forward branch otherwise.

Per the [issue #65 deep dive](https://github.com/SandboxServers/Cimmeria/issues/65):
- `SPEAKER_Petition` (0x02) is declared in `entities/defs/enumerations.xml` but never set by the Python reference — intentionally omitted.
- AFK is **NOT** a speaker flag (no `SPEAKER_AFK` token); the issue title was wrong. `CHAT_SET_AFK` (0xC3) remains log-only with a clarifying comment.
- `docs/gameplay/chat-system.md` already shows speaker flags as DONE per the deep-dive — no doc update needed.

## Tests added

All five are in `crates/services/src/base/dispatch.rs` test module. Tests 1–4 fail if the hardcoded `speaker_flags: 0` is re-introduced; test 5 fails if the DND handler reverts to the stub. The wire serializer in `cell/chat.rs` is already byte-exact (pinned by `serialize_on_player_communication_basic`); these guard the bit-assembly done before the cell forward.

1. `send_player_communication_default_state_has_zero_speaker_flags` — access_level=0 + no DND ⇒ `speaker_flags == 0`.
2. `send_player_communication_access_level_one_sets_gm_flag` — access_level=1 sets `SPEAKER_GM`, leaves `SPEAKER_DND` clear.
3. `send_player_communication_dnd_message_sets_dnd_flag` — `dnd_message=Some` sets `SPEAKER_DND`, leaves `SPEAKER_GM` clear when access_level=0.
4. `send_player_communication_gm_with_dnd_sets_both_flags` — access_level=2 + `dnd_message=Some` produces `0x05` (both bits).
5. `chat_set_dnd_handler_sets_then_clears_dnd_message` — round-trips the handler: a >1-char payload sets `dnd_message`, an empty payload clears it.

## Test plan

- [x] `cargo check -p cimmeria-services` clean
- [x] `cargo test -p cimmeria-services --lib base::dispatch::tests` — all 7 pass (5 new + 2 existing)
- [x] `cargo fmt` no-op on touched files
- [x] `cargo clippy -p cimmeria-services --all-targets -- -D warnings` clean
- [ ] Smoke: GM and a non-GM player chat in the same world; client UI shows the GM tag only on the GM's messages
- [ ] Smoke: `/dnd <message>` via the client (or direct `CHAT_SET_DND` send) flips the bit on the next chat message; sending an empty DND clears it

Closes #65

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced spatial chat to compute speaker flags dynamically based on player status (GM, DND)
  * Added Do Not Disturb (DND) message storage with auto-reply functionality
  * Explicit Away From Keyboard (AFK) chat status handling

* **Bug Fixes**
  * Corrected chat message payload parsing

* **Tests**
  * Expanded test coverage with regression guards and speaker flags validation across multiple scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->