### PR TITLE
chore(cell): remove shadow SPEND_APPLIED_SCIENCE_POINTS arm in social dispatch (#431)

### DIFF
--- a/crates/services/src/cell/cell_methods/player/dispatch.rs
+++ b/crates/services/src/cell/cell_methods/player/dispatch.rs
@@ -173,7 +173,9 @@ mod tests {
 
         // Non-empty args so the crafting handler takes the parse-and-log
         // path, not the truncated-args warn path. Either path returns
-        // `true`, but the parse path is the realistic success shape.
+        // `true`, but the parse path is the realistic success shape. The
+        // numeric payload itself is irrelevant — this test pins WHERE the
+        // dispatch lands, not what the handler computes from the value.
         let args = 42i32.to_le_bytes();
         let handled = dispatch(
             1,
@@ -206,8 +208,8 @@ mod tests {
     /// paste), both the crafting and social handlers fire for index 95
     /// — the count goes from 1 to 2 — and routing tests that assert only
     /// `handled == true` cannot distinguish "routed to the right place"
-    /// from "routed to two places". That's the shadow-arm trap from
-    /// issue \#431.
+    /// from "routed to two places". That's the shadow-arm trap this
+    /// guard exists to prevent.
     ///
     /// We pin BOTH the count (exactly one) and the suffix `(Phase 2)`
     /// because:
@@ -226,6 +228,7 @@ mod tests {
         let (tx, _rx) = mpsc::channel(8);
         let engine = ChainEngine::new();
 
+        // Payload value is irrelevant — only the routing target matters here.
         let args = 42i32.to_le_bytes();
         let handled = dispatch(
             1,
@@ -252,8 +255,8 @@ mod tests {
             1,
             "expected exactly one `spendAppliedSciencePoints` log for method 95; \
              got {}. More than one log indicates the social-submodule shadow \
-             arm at cell_methods/player/social.rs (deleted in PR \\#431) has \
-             been reintroduced. All captured events: {:#?}",
+             arm at cell_methods/player/social.rs has been reintroduced. \
+             All captured events: {:#?}",
             asp_logs.len(),
             capture.all(),
         );
@@ -290,6 +293,7 @@ mod tests {
         let mut mgr = make_space_manager_with_player(1);
         let (tx, _rx) = mpsc::channel(8);
 
+        // Payload value is irrelevant — only the routing target matters here.
         let args = 42i32.to_le_bytes();
         // `super` inside this `mod tests` is `dispatch`; the sibling
         // `social` module lives one level up under `player`.
@@ -307,9 +311,9 @@ mod tests {
             "social::dispatch must NOT handle method 95 (SPEND_APPLIED_SCIENCE_POINTS). \
              A `true` here means a SPEND_APPLIED_SCIENCE_POINTS arm has been \
              re-added to crates/services/src/cell/cell_methods/player/social.rs \
-             — that's the shadow-arm trap from issue \\#431. Index 95 belongs \
-             to the crafting submodule; the outer dispatcher already routes \
-             it there. Delete the social-side arm.",
+             — that's the shadow-arm trap this regression guard exists to \
+             catch. Index 95 belongs to the crafting submodule; the outer \
+             dispatcher already routes it there. Delete the social-side arm.",
         );
     }
 

--- a/crates/services/src/cell/cell_methods/player/dispatch.rs
+++ b/crates/services/src/cell/cell_methods/player/dispatch.rs
@@ -158,25 +158,65 @@ mod tests {
     /// sub-range from `CRAFT..=RESPEC_CRAFTING` (96..=100) to
     /// `SPEND_APPLIED_SCIENCE_POINTS..=RESPEC_CRAFTING` (95..=100).
     ///
-    /// Bug shape: the previous narrow range silently dropped index 95
-    /// into the social arm of the outer dispatcher. Social's own
-    /// `dispatch` *also* has a `SPEND_APPLIED_SCIENCE_POINTS` arm (a
-    /// stub left from an earlier wiring attempt), so the bug is
-    /// invisible to a bare `assert!(handled)`: both branches return
-    /// `true`. The two arms emit distinguishable log messages —
-    /// crafting tags its log with `"(Phase 2)"`, social does not —
-    /// so we install `LogCapture` and assert the crafting variant
-    /// fired.
-    ///
-    /// If the outer router is narrowed back to `CRAFT..=RESPEC_CRAFTING`,
-    /// index 95 reaches the social arm; the `"(Phase 2)"` log never
-    /// fires, and this test fails. This is the assertion the existing
-    /// `spend_applied_science_points_routes_to_crafting` test in
-    /// `crafting.rs` *intended* to make but cannot, because that test
-    /// calls `crafting::dispatch` directly and bypasses the outer
-    /// router entirely.
+    /// With the social-side `SPEND_APPLIED_SCIENCE_POINTS` shadow arm
+    /// removed, no arm in the social submodule handles index 95 — so
+    /// `assert!(handled)` against the outer dispatcher is now sufficient
+    /// proof of correct routing. (Before the shadow was removed, both
+    /// submodules' arms returned `true`, making this assertion ambiguous
+    /// — that's the trap [`route_index_95_must_go_to_crafting_not_social`]
+    /// guards against re-introducing.)
     #[tokio::test]
-    async fn outer_dispatch_routes_spend_asp_to_crafting_not_social() {
+    async fn outer_dispatch_routes_spend_asp_to_crafting() {
+        let mut mgr = make_space_manager_with_player(1);
+        let (tx, _rx) = mpsc::channel(8);
+        let engine = ChainEngine::new();
+
+        // Non-empty args so the crafting handler takes the parse-and-log
+        // path, not the truncated-args warn path. Either path returns
+        // `true`, but the parse path is the realistic success shape.
+        let args = 42i32.to_le_bytes();
+        let handled = dispatch(
+            1,
+            SPEND_APPLIED_SCIENCE_POINTS,
+            &args,
+            &tx,
+            &mut mgr,
+            &engine,
+        )
+        .await;
+        assert!(
+            handled,
+            "outer dispatch must route method 95 (SPEND_APPLIED_SCIENCE_POINTS) \
+             to the crafting submodule and return true. A `false` here means \
+             the crafting sub-range in `dispatch` regressed and 95 fell into \
+             the social arm — which (after the shadow-arm removal) has no \
+             case for 95 and returns false.",
+        );
+    }
+
+    /// Shadow-arm regression guard. Asserts that the
+    /// `SPEND_APPLIED_SCIENCE_POINTS` arm in
+    /// `crates/services/src/cell/cell_methods/player/social.rs` stays
+    /// deleted: dispatching index 95 must produce **exactly one** info-
+    /// level log carrying the `spendAppliedSciencePoints` substring, and
+    /// that log must be the crafting submodule's `"(Phase 2)"` variant.
+    ///
+    /// Bug shape this catches: if a future PR reintroduces the social
+    /// shadow arm (e.g., by reverting this PR or by an unrelated copy-
+    /// paste), both the crafting and social handlers fire for index 95
+    /// — the count goes from 1 to 2 — and routing tests that assert only
+    /// `handled == true` cannot distinguish "routed to the right place"
+    /// from "routed to two places". That's the shadow-arm trap from
+    /// issue \#431.
+    ///
+    /// We pin BOTH the count (exactly one) and the suffix `(Phase 2)`
+    /// because:
+    /// 1. Count alone would miss a future shadow that adopts a different
+    ///    log message but still returns `true`.
+    /// 2. Suffix alone would miss the same crafting log firing twice
+    ///    (unlikely, but cheap to guard).
+    #[tokio::test]
+    async fn route_index_95_must_go_to_crafting_not_social() {
         use crate::test_support::LogCapture;
         use tracing::Level;
 
@@ -186,9 +226,6 @@ mod tests {
         let (tx, _rx) = mpsc::channel(8);
         let engine = ChainEngine::new();
 
-        // Non-empty args so the parse-and-log path runs (rather than the
-        // truncated-args warn path, which both arms emit at different
-        // levels but with identical-shape strings).
         let args = 42i32.to_le_bytes();
         let handled = dispatch(
             1,
@@ -201,22 +238,78 @@ mod tests {
         .await;
         assert!(handled, "outer dispatch must handle method 95");
 
-        // Crafting's stub uniquely tags its log with "(Phase 2)" — the
-        // social-side stub at social.rs:66 emits the same UNIMPLEMENTED
-        // prefix but without that suffix. Pinning the suffix is what
-        // distinguishes "routed to crafting" from "routed to social".
-        let crafting_event = capture.find_message(Level::INFO, "(Phase 2)");
+        // Count INFO events that mention spendAppliedSciencePoints —
+        // the substring is shared by both submodules' historical log
+        // shapes, so a re-emerged social shadow shows up as count == 2.
+        let asp_logs: Vec<_> = capture
+            .all()
+            .into_iter()
+            .filter(|c| c.level == Level::INFO && c.message_contains("spendAppliedSciencePoints"))
+            .collect();
+
+        assert_eq!(
+            asp_logs.len(),
+            1,
+            "expected exactly one `spendAppliedSciencePoints` log for method 95; \
+             got {}. More than one log indicates the social-submodule shadow \
+             arm at cell_methods/player/social.rs (deleted in PR \\#431) has \
+             been reintroduced. All captured events: {:#?}",
+            asp_logs.len(),
+            capture.all(),
+        );
+
+        // The single log must be the crafting submodule's `(Phase 2)`
+        // variant — proves it's the right handler.
+        let only = &asp_logs[0];
         assert!(
-            crafting_event.is_some(),
-            "outer dispatch must route method 95 (SPEND_APPLIED_SCIENCE_POINTS) \
-             to the crafting submodule. The expected log \
-             'UNIMPLEMENTED: spendAppliedSciencePoints (Phase 2)' from \
-             cell_methods/player/crafting.rs did not fire. \
-             A passing `handled == true` is not sufficient because the \
-             social submodule also has a SPEND_APPLIED_SCIENCE_POINTS arm \
-             that returns true — the (Phase 2) suffix uniquely identifies \
-             the crafting branch.\n\nCaptured events: {:#?}",
-            capture.all()
+            only.message_contains("(Phase 2)"),
+            "the single spendAppliedSciencePoints log must be the crafting \
+             handler's `(Phase 2)` variant — its message was {:?}. A log \
+             without `(Phase 2)` is the social-submodule shape and means \
+             index 95 is being routed to social instead of crafting.",
+            only,
+        );
+    }
+
+    /// Companion guard to [`route_index_95_must_go_to_crafting_not_social`].
+    ///
+    /// The outer-dispatcher test catches a *combined* regression (shadow
+    /// arm restored AND outer router narrowed). It can't catch a lone
+    /// shadow restoration on its own: with the outer router still
+    /// correctly routing 95 to crafting, a re-added social arm never
+    /// fires through `dispatch`, the captured-log count stays at 1, and
+    /// the test happily passes.
+    ///
+    /// This test calls `social::dispatch` **directly** with method 95
+    /// and asserts the social submodule does NOT claim it. If a future
+    /// PR re-introduces the shadow arm at `social.rs:66`, this assertion
+    /// catches it at the source — before it can pair with an outer-
+    /// router regression to silently re-route real traffic.
+    #[tokio::test]
+    async fn social_submodule_must_not_handle_index_95() {
+        let mut mgr = make_space_manager_with_player(1);
+        let (tx, _rx) = mpsc::channel(8);
+
+        let args = 42i32.to_le_bytes();
+        // `super` inside this `mod tests` is `dispatch`; the sibling
+        // `social` module lives one level up under `player`.
+        let handled = crate::cell::cell_methods::player::social::dispatch(
+            1,
+            SPEND_APPLIED_SCIENCE_POINTS,
+            &args,
+            &tx,
+            &mut mgr,
+        )
+        .await;
+
+        assert!(
+            !handled,
+            "social::dispatch must NOT handle method 95 (SPEND_APPLIED_SCIENCE_POINTS). \
+             A `true` here means a SPEND_APPLIED_SCIENCE_POINTS arm has been \
+             re-added to crates/services/src/cell/cell_methods/player/social.rs \
+             — that's the shadow-arm trap from issue \\#431. Index 95 belongs \
+             to the crafting submodule; the outer dispatcher already routes \
+             it there. Delete the social-side arm.",
         );
     }
 

--- a/crates/services/src/cell/cell_methods/player/social.rs
+++ b/crates/services/src/cell/cell_methods/player/social.rs
@@ -63,18 +63,15 @@ pub async fn dispatch(
             true
         }
 
-        SPEND_APPLIED_SCIENCE_POINTS => {
-            if args.len() >= 4 {
-                let discipline_seq_id = i32::from_le_bytes([args[0], args[1], args[2], args[3]]);
-                tracing::info!(
-                    entity_id,
-                    discipline_seq_id,
-                    "UNIMPLEMENTED: spendAppliedSciencePoints"
-                );
-            }
-            true
-        }
-
+        // No arm for SPEND_APPLIED_SCIENCE_POINTS here — index 95 is owned
+        // by the crafting submodule. The outer dispatcher's
+        // `SPEND_APPLIED_SCIENCE_POINTS..=RESPEC_CRAFTING` range routes 95
+        // to `crafting::dispatch` before social ever sees it. A shadow arm
+        // previously lived at this location and would silently re-handle
+        // 95 if the outer router were narrowed back to `CRAFT..=RESPEC_CRAFTING`,
+        // making `assert!(handled)`-style routing tests theatre. The
+        // `route_index_95_must_go_to_crafting_not_social` test in
+        // `dispatch.rs` is the regression guard.
         CLIENT_CHALLENGE_RESPONSE => {
             if args.len() >= 4 {
                 let challenge = i32::from_le_bytes([args[0], args[1], args[2], args[3]]);

--- a/crates/services/src/cell/cell_methods/player/social.rs
+++ b/crates/services/src/cell/cell_methods/player/social.rs
@@ -66,10 +66,15 @@ pub async fn dispatch(
         // No arm for SPEND_APPLIED_SCIENCE_POINTS here — index 95 is owned
         // by the crafting submodule. The outer dispatcher's
         // `SPEND_APPLIED_SCIENCE_POINTS..=RESPEC_CRAFTING` range routes 95
-        // to `crafting::dispatch` before social ever sees it. A shadow arm
-        // previously lived at this location and would silently re-handle
-        // 95 if the outer router were narrowed back to `CRAFT..=RESPEC_CRAFTING`,
-        // making `assert!(handled)`-style routing tests theatre. The
+        // to `crafting::dispatch` before social ever sees it.
+        //
+        // A shadow stub used to live at this location: it was a legacy
+        // artifact from before crafting got its own submodule, when every
+        // post-ORG_CREATION method either landed in social or was a no-op.
+        // After crafting was extracted, the shadow stayed behind and would
+        // silently re-handle 95 if the outer router were ever narrowed back
+        // to `CRAFT..=RESPEC_CRAFTING` — making `assert!(handled)`-style
+        // routing tests theatre because both arms returned `true`. The
         // `route_index_95_must_go_to_crafting_not_social` test in
         // `dispatch.rs` is the regression guard.
         CLIENT_CHALLENGE_RESPONSE => {


### PR DESCRIPTION
## Summary

PR #427 wired the canonical `SPEND_APPLIED_SCIENCE_POINTS` (cell method
index 95) handler into the crafting submodule and widened the outer
dispatcher range to include 95. It left behind an orphaned arm in
`social.rs:66` that also returned `true` for index 95 — a stub from an
earlier wiring attempt that never reached real traffic post-#427 but
that creates a stealth regression trap.

## The trap

Both submodules' arms returned `true`. A future regression that
narrowed the outer router back to `CRAFT..=RESPEC_CRAFTING` would
silently re-route 95 into social — and an `assert!(handled)`-style
regression test would still pass, because social's arm also returns
`true`. The adversarial review on PR #427 caught this only by using
`LogCapture` to pin the unique `(Phase 2)` suffix on the crafting log;
without that discriminator, the trap is invisible.

## Changes

- **Delete** the social-side arm at `crates/services/src/cell/cell_methods/player/social.rs:66` plus its parsing/log body. Replaced with a sentinel comment explaining why the slot is intentionally empty and pointing at the regression guard.
- **Replace** the single `outer_dispatch_routes_spend_asp_to_crafting_not_social` test in `dispatch.rs` with three layered guards (see below).

## Tests — three-layer regression guard

Each guard targets a distinct regression shape. Without all three, the
trap re-opens.

1. **`outer_dispatch_routes_spend_asp_to_crafting`** — simplified
   `assert!(handled)` against the outer dispatcher. The issue body
   asked for this simplification; it's only valid once the shadow is
   gone. With the shadow removed, `handled == false` cleanly catches
   a lone outer-router regression.

2. **`route_index_95_must_go_to_crafting_not_social`** — `LogCapture`
   count guard. Asserts exactly one `INFO+spendAppliedSciencePoints`
   log fires AND that single log carries the crafting submodule's
   `(Phase 2)` suffix. Catches the *combined* regression where both
   the shadow is re-added AND the outer router is narrowed (the bug
   shape where a simple `assert!(handled)` would silently pass).

3. **`social_submodule_must_not_handle_index_95`** — direct call into
   `social::dispatch` with method 95, asserts `!handled`. Catches a
   *lone* shadow re-introduction at the source, even if the outer
   router is still correctly routing 95 to crafting.

## Regression-guard verification

Per the testing-validation-engineer `revert_to_verify_regression_guards`
rule, each guard was tested against its target regression shape:

| Regression shape                          | Guard #1 | Guard #2 | Guard #3 |
|-------------------------------------------|----------|----------|----------|
| Restore social shadow only                | PASS     | PASS     | **FAIL** |
| Narrow outer router only                  | **FAIL** | **FAIL** | PASS     |
| Restore both (the historical trap)        | PASS     | **FAIL** | **FAIL** |

Note row 3: guard #1 alone is insufficient against the combined trap
— exactly why guards #2 and #3 also exist. The matrix proves every
single-axis regression is caught by at least one guard.

## Shadow audit

Per the issue body's grep across the player submodule:

```bash
for c in CRAFT RESEARCH REVERSE_ENGINEER ALLOYING RESPEC_CRAFTING SPEND_APPLIED_SCIENCE_POINTS; do
  grep -rn "$c" crates/services/src/cell/cell_methods/player/ | grep -v test
done
```

- `CRAFT`, `RESEARCH`, `REVERSE_ENGINEER`, `ALLOYING`, `RESPEC_CRAFTING` — each appears in exactly one submodule (`crafting.rs`). **No shadows.**
- `SPEND_APPLIED_SCIENCE_POINTS` — appears in `crafting.rs:23` (canonical) and `social.rs:66` (shadow). **The only shadow; this PR removes it.**

## Test plan

- [x] `cargo check -p cimmeria-services` clean
- [x] `cargo nextest run -p cimmeria-services --lib cell::cell_methods::player` — 84/84 pass with fix
- [x] `cargo nextest run -p cimmeria-services --lib --profile=ci` — 1194/1194 pass
- [x] Verify guards by reverting each regression shape — all three matrix cells confirmed (see table above)
- [x] Restore real fix — all three guards pass
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p cimmeria-services --all-targets -- -D warnings` clean

## Notes for reviewers

- **PR #427 has merged** (`b5042962`) so this PR can land at any time without dependency ordering. The simplification of the existing LogCapture test is included here directly rather than deferred to a follow-up.
- **The `LogCapture` thread-local pattern is flaky under `cargo test` parallel in-process execution** but stable under `cargo nextest` (per-test process isolation), which is what CI uses. The `route_index_95_must_go_to_crafting_not_social` guard inherits this property from the existing `LogCapture` infrastructure in `test_support.rs` — not a new constraint.
- **Cross-module test call.** The third guard uses `crate::cell::cell_methods::player::social::dispatch(...)` (absolute path) rather than `super::social::dispatch` because the `tests` module is nested one level deeper than the outer code's `super::` would resolve to.

Closes #431

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed routing of the Apply Science Points action to process through the correct crafting system instead of the social subsystem.

* **Tests**
  * Added comprehensive test coverage for science points routing, including regression tests to verify correct system handling and prevent future routing errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->