### PR TITLE
docs(testing): codebase-wide test audit 2026-05-31

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -60,6 +60,7 @@ Want to start contributing? Read **[../CONTRIBUTING.md](../CONTRIBUTING.md)** â€
 | [SigNoz Remote Access](operations/signoz-remote-access.md) | Cloudflare Tunnel + Cloudflare Access for secure UI access and Cimmeria-MCP service-token auth â€” no inbound firewall ports. |
 | [Testing Guide](../TESTING.md) | Test types, picker for which to use when, gotchas mined from PR reviews |
 | [Test Inventory](testing/inventory/README.md) | Catalogue of every test in the workspace, one file per crate, with kind / system / first-commit date / what-it-tests |
+| [Test Audit 2026-05-31](testing/audit-2026-05-31.md) | Point-in-time codebase-wide audit: real bugs surfaced by the test suite, tests to delete, tests to tighten, coverage gaps, strategic recommendations |
 | [Game Systems](game-systems.md) | Survey of every game feature: combat, abilities, stargates, missions, crafting |
 | [Game Data](game-data.md) | What game content exists (items, abilities, missions) and what is missing |
 | [Commands Reference](commands.md) | Player commands, chat, GM tools, and debug commands |

--- a/docs/testing/audit-2026-05-31.md
+++ b/docs/testing/audit-2026-05-31.md
@@ -1,0 +1,364 @@
+# Codebase-wide Test Audit — 2026-05-31
+
+> **Type**: reference (point-in-time snapshot)
+> **Audience**: engineers
+> **Scope reviewed**: ~1,500 test functions across the codebase covered by Codecov — combat, inventory, AI/spawn, content engine, mercury/wire, AoI/cell-methods, foundational crates, and the test infrastructure itself.
+> **Snapshot commit**: `d9513a0a` on `feat/npc-ai-phases-2-7-48` (now merged to `main`).
+> **Companion docs**: [TESTING.md](../../TESTING.md) (how to write tests), [inventory/README.md](inventory/README.md) (catalogue of existing tests), [inventory/maintenance.md](inventory/maintenance.md) (sweep policy).
+> **Tracking issue**: see the rollup issue linked from this doc's PR for the planned remediation order.
+
+This is a single-pass audit produced by seven parallel `testing-validation-engineer` agents on 2026-05-31. It is point-in-time — file:line references will rot as the code moves. The synthesis is meant to be triaged into work items (see [Section 8](#section-8--recommended-order-of-operations)) and then archived; subsequent audits should produce a fresh `audit-YYYY-MM-DD.md`, not amend this one.
+
+## TL;DR
+
+Two real bugs surfaced. One is in source (bandolier-ammo TOCTOU keyed on the wrong column — confessed by a doc-comment instead of fixed). One is in the test scaffolding (sentinel-id collision between two live-DB tests, masked today by ci-live-db's `threads-required = "num-test-threads"` serialization).
+
+Beyond that the audit has the usual shape: ~12 deletes, ~30 tightens, ~25 gaps. The dominant pattern across the codebase is "test exercises a real code path but asserts a weaker property than the code actually guarantees" — `len() > 0` where the answer is exactly 1, `is_err()` where the answer is `Empty` not `Disconnected`, substring matches against JSON where deserialize-and-pattern-match would pin the variant. Those are not theatre, but each one is a test that would still pass under a regression class it was implicitly meant to catch.
+
+Eight unimplemented `cell_methods/*.rs` files (mail, minigame, organization, contact_list, missionary, black_market, ability_manager, gate_travel) are correctly testless today, but they ship no scaffolding either — the first PR that lands real behavior in any of them will have to invent the fixture pattern.
+
+The single biggest strategic recommendation: **promote shared fixtures to `test_support.rs`**. Castle non-instanced is duplicated across 27 files, Agnos non-instanced across 18, Castle_CellBlock-instanced across 18, `SpawnRecord` literal across 2. Every one of those is a 5-to-20-line block reproduced ~by hand~, and every field addition to `SpawnRecord` requires N coordinated edits.
+
+---
+
+## Section 1 — Real bugs
+
+These are not test smells; they're product code or test infrastructure that's wrong today.
+
+### Bug 1: Bandolier-ammo TOCTOU keyed on the wrong column
+
+**Location**: `crates/services/src/base/world_entry/methods/inventory/ammo.rs` — `update_bandolier_ammo` filters `AND type_id = $5` and binds `BandolierItem.item_id` (which is in fact the **design id** per `cell_entity/mod.rs:744`).
+
+**Bug shape**: a same-slot same-design swap (different physical inventory instance, same design — e.g. picking up a fresh stack of 9mm rounds while the previous identical stack is still slotted) silently passes the predicate, and the ammo write scribbles the wrong row.
+
+**Self-confessing test**: `inventory/ammo.rs:209 update_no_op_when_slot_holds_different_type` admits the gap in lines 203-208's doc-comment: *"a same-type swap (a different physical row of the same design replacing the original at the same slot) still passes the predicate and would silently scribble"*. Reviewer-acknowledged in prose instead of caught by a guard.
+
+**Fix paths** (pick one — both end the lie):
+
+1. Add the inventory instance id to `BandolierItem` and the SQL predicate `AND item_id = $5`.
+2. Decide the contract is "design-level only" and rename the field to `expected_type_id` and the test to `update_no_op_when_slot_holds_different_design`. Then add a `#[ignore]`'d failing guard for the unfixed-by-design case.
+
+Either way the test name `update_no_op_when_slot_holds_different_type` needs to die — it says "different type" but the SQL is "different design," and those are not the same thing in SGW's inventory model.
+
+### Bug 2: Sentinel-id collision in live-DB tests
+
+**Location**: both `crates/services/src/base/world_entry/methods/mail/tests.rs:17` and `crates/services/src/base/world_entry/methods/inventory/core/resync_tests.rs:26` reserve `TEST_BASE: i32 = 0x7000_0500`. Both INSERT into `account` and `sgw_player`.
+
+**Masked by**: ci-live-db's `threads-required = "num-test-threads"` filter that forces all live-DB tests to run on a single thread. The collision can't currently surface because the second test that owns `0x7000_0500` doesn't start until the first finishes and cleans up.
+
+**Why it's still a bug**: TESTING.md §"Sentinel id discipline" forbids exactly this. The mail test's neighbour-comment is stale (lines 14-16 list prior sentinels through `0x7000_0400` only and omits `inventory/core/resync`). The next contributor who consults the comment to pick a fresh sentinel will read the wrong canon.
+
+**Fix**: move `inventory/core/resync_tests.rs` to a fresh sentinel (next-free is `0x7000_0E00` per the audit-test-infra inventory) and refresh the mail-side neighbour comment.
+
+### Bug 3 (latent): `destroy_entity` (non-disconnect path) does not scrub witness sets
+
+**Location**: `crates/services/src/cell/space_manager/entities.rs:48-74`.
+
+**Recovery mechanism**: the next AoI tick observes the destroyed entity missing from `space.entities.get(&cid)` and emits `LeftAoI`. So the leak does NOT survive a single AoI tick today.
+
+**Why it's still listed**: there is no test that pins the recovery. A regression that adds a fast-path caching layer to `LeftAoI` emission (e.g., caching the witness set at tick start) would silently drop the leave broadcast for entities destroyed mid-tick. The npc_respawn tick exercises alive→dead→respawn, not alive→destroyed.
+
+**Recommended fix**: add one test that calls `destroy_entity` mid-test, then drives one AoI tick, then asserts the destroyed entity's old observers received `LeftAoI`.
+
+### Bug 4 (process): TESTING.md is internally inconsistent on the number of test types
+
+CLAUDE.md and the file headline say "eleven test types". The "Test types we use" section lists **twelve** (§§1-12 including type 12 "Negative-log regression guards"). Pick a number and update the other place.
+
+### Bug 5 (process): inventory snapshot is ~33% stale
+
+`docs/testing/inventory/README.md` says 1,351 tests; current workspace count is 2,012 (the worktree CLAUDE.md was already updated to reflect 2,012 — main is ahead of the inventory snapshot by 661 tests). Past the 5% / 100-test threshold by 6×. Schedule a regen sweep.
+
+---
+
+## Section 2 — Tests to delete
+
+13 tests in total. None is load-bearing.
+
+### Pure tautologies / framework-tests-the-framework
+
+| File:line | Test | Why delete |
+|---|---|---|
+| `crates/services/src/cell/messages/tests.rs:3,20,43,62` | `saved_mission_debug_prints`, `saved_mission_clone`, `saved_mission_completed_status`, `npc_aoi_data_default` | Test `#[derive(Debug/Clone/Default)]`. Pure derive tests. |
+| `crates/services/src/cell/interactions/loot.rs:232` | `loot_display_args_format` | Constructs 9 bytes by hand then asserts those same bytes. Never invokes a serializer. |
+| `crates/common/src/math.rs:138,146,214,222,231,237` | 6× constructor/getter tautologies | `Vector3::new(1.0).x == 1.0` doesn't catch any plausible bug. |
+| `crates/common/src/types.rs:127,132,156,162` | 4× `Display`/equality tautologies | `format!("Entity({})", 42) == "Entity(42)"`. |
+| `crates/common/src/error.rs:80-124` | 7× `*_error_display` | Asserts `format!("{}", err)` produces the exact string `#[error("…")]` declares. `thiserror` is being tested by its own crate. |
+| `crates/common/src/config.rs:147` | `load_config_returns_default_for_now` | Pins "the stub is still a stub." Will mask the real-impl test seam when the XML parser lands. |
+| `crates/defs/src/registry.rs:102` | `registry_constructs_without_panic` | Doc-comment admits "we don't assert on the count itself" — the definition of theatre. Replace with `lookup_by_name("SGWPlayer").is_some()`. |
+| `crates/discord/src/lib.rs:579` | `global_accessor_does_not_panic` | Doc-comment admits "Either outcome is a valid no-panic exercise of the read path". |
+
+### "Did the function get called" non-guards
+
+| File:line | Test | Why delete |
+|---|---|---|
+| `crates/services/src/cell/service/tests/npc_ai_phase7.rs:32` | `despawning_removes_entity_from_space` | "Despawning state → tick → `destroy_entity` called." Catches only `someone deleted destroy_entity`. Recommend: rewrite as "Despawning NPC + player witness → witness gets `LeftAoI` in the same tick" (real fan-out byte test). |
+| `crates/services/src/cell/service/tests/npc_ai_phase7.rs:84` | `error_state_is_inert_per_tick` | Handler is `tracing::debug!()`. Test would pass if the handler were deleted. Rust's exhaustiveness checker already enforces the match arm exists. |
+| `crates/services/src/cell/service/tests/npc_ai.rs:744` (note: this is the LogCapture flake-suspect — see Section 5) | `npc_ai_fight_warns_when_handle_use_ability_returns_false` | **Don't delete** — but the suspected flake is not a LogCapture bug. See Section 5 ("LogCapture flake root cause"). |
+| `crates/services/src/cell/dispatch/tests.rs:168` | `dispatch_trigger_region_exit` | Only assertion is `// No panic = success`. Either tighten or merge with the enter test. |
+| `crates/services/src/cell/content/event_dispatch/mod.rs:113` | `fire_player_loaded_with_empty_engine_emits_nothing` | Survives — but tighten `is_err()` to `matches!(rx.try_recv(), Err(TryRecvError::Empty))` so a Disconnected-not-Empty regression doesn't pass. Same pattern at `event_dispatch/mission.rs:243` and `executor/tests.rs:110`. |
+
+### Dead-code coverage (game crate)
+
+`cimmeria-game`'s ~69 tests pin `MissionTracker`, `MailMessage`, `Groups`, `Guilds`, `Chat` — production paths are `todo!()` panics and **nothing in `cimmeria-services` references them** (verified: services pulls only `MAX_LEVEL` and `TRAINING_POINTS_PER_LEVEL` from game). All ~60-65 dead-code tests are valid against the in-memory `HashMap` portion but guard code that doesn't ship.
+
+**Recommendation**: gate the crate on a single decision — wire it up or delete it. Don't selectively delete tests.
+
+### Sized-shape tests rendered redundant by byte-level neighbors
+
+| File:line | Test | Why delete |
+|---|---|---|
+| `crates/services/src/mercury/protocol/tests.rs:218-221` | `version_info_produces_output` (`!out.is_empty()`) | Covered by byte-level test at line 228. |
+| `crates/services/src/mercury/protocol/tests.rs:577-580` | `logged_off_produces_output` (`!out.is_empty()`) | Covered by `logged_off_with_acks_includes_ack_flag` at line 583. |
+| `crates/services/src/mercury/protocol/tests.rs:193-220` | 4× `*_produces_output` for char_list / char_create_failed / resource_fragment | Bare presence checks, all vulnerable to layout drift the byte-level neighbors would catch. Either delete or upgrade — see Section 3. |
+
+---
+
+## Section 3 — Tests to tighten
+
+The majority of audit findings. Grouped by failure mode.
+
+### A. Loose collection assertions (`len() == N` without `contains` / pair checks)
+
+| File:line | Test | Tighten how |
+|---|---|---|
+| `crates/services/src/cell/space_manager/tests/aoi.rs:7,27` | `aoi_detects_nearby_players`, `aoi_detects_entity_leaving` | Asserts `entered.len() == 2` / `left.len() == 2`. Add `contains(&(100, 200))` + `contains(&(200, 100))` pair checks — matches the better-formed assertion at `aoi.rs:224-228`. |
+| `crates/entity/src/cell_entity/tests.rs:30,42` | `add_and_remove_witness`, `duplicate_witness_is_idempotent` | `len() == 1` doesn't catch swap-on-remove regressions. Add `contains(&EntityId(3))`. |
+| `crates/services/src/cell/service/tests/holster.rs:355` | `holster_timer_tick_phase2_removes_mesh_when_animation_done` | `saw_refresh = true;` in a recv loop. Count refreshes; assert `== 1`. |
+| `crates/services/src/cell/service/ticks/auto_cycle.rs:289` | `auto_cycle_tick_clears_loop_when_target_dead` | Iterates rx checking `entity_id: 1, method_index: ON_STATE_FIELD_UPDATE`. A spurious second broadcast to *any other entity* would pass. Tighten with a count + `== 1`. |
+| `crates/services/src/cell/service/tests/npc_ai_patrol.rs:337` | `patrol_with_single_waypoint_holds_position_and_re_stamps_dwell` | Three ticks but never asserts `last_movement_type` stays `Some(Patrol)` throughout. Drain the rx channel between ticks 2 and 3; assert zero `setMovementType` packets. |
+| `crates/services/src/cell/abilities/loot_drop.rs:272` | `each_dropped_item_gets_a_unique_increasing_index` | Single-corpse uniqueness only. Cross-corpse is unproven (see Section 4). |
+
+### B. Substring-on-JSON in lieu of deserialize-and-match
+
+| File:line | Test | Tighten how |
+|---|---|---|
+| `crates/content-engine/src/actions.rs:386,394,409` | `action_serialization_roundtrip`, `property_op_serialization_roundtrip`, `complex_action_serialization` | All three do `let _ = format!(...)` or `json.contains("Subtract")` after serialize. Deserialize and `assert_eq!(*op, deserialized)`. Derive `PartialEq` on `PropertyOp` first. |
+| `crates/content-engine/src/conditions.rs:314,325` | `condition_serialization_roundtrip`, `has_item_condition_serialization` | Same substring-on-JSON shape (`json.contains("42")`). Parse back and pattern-match. |
+| `crates/content-engine/src/loader/tests.rs:719` | `set_npc_ai_state_parses_lowercase_strings` | Uses `matches!(state, _ if std::mem::discriminant(&state) == std::mem::discriminant(&expected))`. Brittle. Derive `PartialEq, Eq` on `NpcAiStateAction` (it's already `Copy`); use `assert_eq!`. |
+
+### C. propId / constant assertions that should pin the literal AND the bug-shape negative
+
+`crates/services/src/cell/cell_methods/player/world/tests.rs:691 handle_reload_emits_ammo_type_under_correct_propid` is the canonical strong shape (asserts literal `3` AND `no (7, _)` pair). Promote it as the model for these:
+
+| File:line | Test | Tighten how |
+|---|---|---|
+| `crates/services/src/cell/cell_methods/inventory/tests/ammo_change.rs:16` | `request_ammo_change_updates_slot_and_sends_property` | Asserts `prop_id == GENERICPROPERTY_AMMO_TYPE_ID` — a constant flip to `7` silently flips the test. Assert the literal `3` plus a sentinel `assert_eq!(GENERICPROPERTY_AMMO_TYPE_ID, 3)`. |
+| `crates/services/src/cell/cell_methods/inventory/tests/slot_swap.rs` | `slot_swap_preserves_per_slot_ammo` | Same shape. |
+| `crates/services/src/cell/service/tests/reload.rs:144` | `reload_completion_tick_emits_ability_end_sequence_when_event_set_present` | Hard-codes `const ABILITY_RELOAD_WEAPON: i32 = 596`. Re-fetch from `mgr.item_defs`. |
+| `crates/services/src/cell/service/tests/reload.rs:218` | ON_SEQUENCE byte parsing loop | `continue`s on `seq_id != END_SEQ_ID` — a wrong-sequence-at-right-id regression is invisible. Count Ability_End hits AND assert total ON_SEQUENCE count == 1. |
+
+### D. AI dwell/state machine — the d9513a0a-fix guards
+
+The user's explicit ask: which Phase-2-7 dwell tests reproduce the d9513a0a "knockback clears dwell" bug shape vs would pass against either implementation?
+
+**Answer: only 2 of 9.** The remaining 7 test orthogonal state-machine branches; they're fine tests but they don't pin the d9513a0a fix.
+
+| Test | Reproduces bug? | Notes |
+|---|---|---|
+| `npc_ai_patrol.rs:128 patrol_arrival_stamps_dwell_deadline` | **No** | Pre-arranges `patrol_dwell_until = None`; the pre-fix code also stamped at queue time. |
+| `npc_ai_patrol.rs:85` | **No** | Index-advance branch — independent. |
+| `npc_ai_patrol.rs:225` | **No** | Future-dwell early-return — independent. |
+| `npc_ai_patrol.rs:267 patrol_knockback_during_dwell_re_stamps_on_re_arrival` | **YES** | Exact bug shape. Reverting `npc.patrol_dwell_until = None;` at npc_ai.rs:910 trips it. |
+| `npc_ai_patrol.rs:337` | **No** | 1-wp stationary case never enters not-close branch. |
+| `npc_ai_investigate.rs:36,63,90` | **No (3×)** | Same shapes as above for the investigate handler. |
+| `npc_ai_investigate.rs:160 investigate_knockback_during_dwell_re_stamps_on_re_arrival` | **YES** | Exact bug shape. Reverting `npc.investigate_until = None;` at npc_ai.rs:1226 trips it. |
+
+**Wander has zero knockback guard.** The Wander state machine semantics differ enough (`wander_next_at` gates the whole arrival branch, not just the post-arrival dwell) that the 1:1 fix may not apply — but the absence of a test means we don't know.
+
+### E. Coverage-by-name-not-by-shape
+
+| File:line | Test | Fix |
+|---|---|---|
+| `crates/services/src/cell/service/tests/npc_respawn.rs:736` | `kill_via_damage_apply_then_respawn_then_kill_again` | Body only does cycle 1. Rename to `_then_respawn`, let the sibling loop test cover the loop. |
+| `crates/services/src/cell/service/tests/npc_respawn.rs:443` | `ready_dead_npc_respawns_to_idle_at_spawn_position` | Asserts `position.x == 10.0`, `.z == 0.0` but **not `.y`**. Tighten to `assert_eq!(npc.position, Vector3::new(10.0, 0.0, 0.0))`. |
+| `crates/services/src/cell/dispatch/tests.rs:124` | `dispatch_trigger_region_enter_fires_event` | Asserts `rx.try_recv().is_err()` after dispatching with empty engine. The success criterion is no emit — rename to `_with_empty_engine_is_a_no_op`. |
+| `crates/services/src/cell/content/chain_replay_tests/mission_1562.rs:50` | `chain_3026_fires_dialog_5365_when_mission_1562_is_not_active` | `chain_3026_actions > 0`. Tighten to `== N` where N is the seed's action count. Loose for a chain-replay regression. |
+
+### F. Pcap/deterministic-input lower-bound asserts
+
+`crates/mercury/src/test_harness/tests/chaos/replay_lomiada.rs:46,99` — the fixture is deterministic bytes; the expected event count and per-payload parse outcome are determinate. Asserts `events.len() > 500` and `success_rate >= 0.95`. Replace with the exact integer counts captured on first green run.
+
+### G. Math edges (NaN / Infinity / very-large / very-small)
+
+`crates/common/src/math.rs:177,189,197` — `Vector3::distance_to(NaN_vec, ...)`, `normalized([f32::MAX; 3])` silently returns NaN or overflows. No coverage on overflow/NaN. The `normalized_zero` guard at `:206` is the model; extend it to the rest of the math surface.
+
+### H. The `is_err()` vs `Empty` pattern (already mentioned in Section 2)
+
+3 sites, all in event-dispatch tests. Replace `assert!(rx.try_recv().is_err())` with `assert!(matches!(rx.try_recv(), Err(TryRecvError::Empty)))`. The repo already does this elsewhere (e.g., `executor/world/tests.rs:372`).
+
+---
+
+## Section 4 — Coverage gaps
+
+What's missing entirely. Bug-shape first; fix-type second.
+
+### Critical (a code path with no test that pins the contract the code already claims to enforce)
+
+**G1. UseInventoryItem → ItemUsed → RemoveItem double-consume.** Each piece has a test; the contract that *the item is consumed exactly once* has no guard. A chain that includes both `ChangeStat` (heal) and `RemoveItem` (consume) is untested. A future change that adds a `DELETE FROM sgw_inventory` in `handle_use_inventory_item` next to the outbox insert would silently double-consume on stacks of N. **Fix**: end-to-end live-DB test through `use_instance.rs` + outbox → cell `OnItemUse` chain → assert exactly one `DELETE FROM sgw_inventory` row.
+
+**G2. Action variant coverage at the loader layer.** `Action` has ~46 variants; `convert_action` handles ~30; **only ~17 have a direct loader unit test**. Missing: `add_dialog_set`, `remove_dialog_set`, `add_item`, `remove_item`, `play_sequence`, `set_interaction_type` (all three branches), `start_minigame`, `destroy_entity`, `trigger_transporter`, `system_message`, `qr_combat_damage`, `change_stat` overflow path, `apply_effect`, `remove_effect`, `abandon_mission`, `fail_objective`, `complete_objective`, `set_visible`, `move_entity`, `add_dialog`, `generate_threat`. Bug shape: param-key typo at the loader site silently drops the action; chain-replay tests at the resolve_event layer still pass for chains with OTHER actions; the missing one only surfaces in playtest. **Fix**: ~25 loader-row tests, each ~10 lines.
+
+**G3. Executor dispatch table** at `crates/services/src/cell/content/executor/mod.rs:71-410` has 40+ match arms. The three newest (`SetNpcPoi`, `SetFollowTarget`, `SetNpcAiState`) ARE dispatch-tested. The 30+ older arms are only tested via the per-handler functions called directly. A refactor that swaps two adjacent arms with overlapping field shapes (`SetAggression { entity_tag, level }` vs `IncrementCounter { counter_name, amount }` — both `(String, i32)`) routes the wrong handler. **Fix**: one arm-routing smoke test per action family (mission / inventory / dialog / world / counter / transport / stats), each asserts an observable side-effect unique to the correct handler.
+
+**G4. Trigger variant coverage at the loader layer.** ~10 untested trigger arms: `player_loaded`, `dialog_open`, `dialog_choice`, `enter_region`, `exit_region`, `interact_template`, `entity_dead_tag`, `item_use`, `teleport_in`, `effect_*` (4), `mission_completed`, `dialog_set_open`. Same bug shape as G2.
+
+**G5. Inbound witness scrub on disconnect.** `tests/aoi.rs:247 disconnect_emits_left_aoi_to_observers_then_destroys_entity` is missing the canonical leak assertion. After the disconnect, `mgr.spaces[&space_id].entities[&200].witnesses` should NOT contain `EntityId(100)`. The code does the scrub at `entities.rs:135-137` — the test doesn't pin it. **Fix**: one assertion, three lines.
+
+**G6. SetNpcPoi does not clear `investigate_until`.** Mid-Investigate at POI-A with `investigate_until = Some(future)`. Content fires fresh `SetNpcPoi` at POI-B. Handler sets `poi = Some(B)`, but **`investigate_until` from POI-A survives**. On arrival at POI-B, NPC observes `Some(past_for_POI-A)` and immediately Idles. **Untested**. Fix: unit test on `set_npc_poi` asserting `investigate_until = None` on the fresh-POI path.
+
+**G7. SetNpcAiState(Idle) on Wander/Investigating/Follow doesn't clear scratch.** Content fires `SetNpcAiState { state: Idle }`; handler clears `nav_path` but NOT `wander_next_at` / `poi` / `investigate_until` / `follow_target_id`. Snapshot filter re-admits Wander on the next tick because `has_wander` is still true. The content author's "drop to Idle" intent is silently ignored beyond one tick. Existing test only covers the Patrol path (which CORRECTLY preserves `patrol_next_index` by design). **Fix**: 3 unit tests asserting preservation OR clearing — current code preserves; design intent unclear. Pin one direction.
+
+**G8. Threat preemption preserves per-state scratch — only Patrol is at risk.** Patrol NPC dwelling at waypoint with `patrol_dwell_until = Some(future)`. Preempted → Fighting → Leashing → Idle → Patrol again. `patrol_dwell_until = Some(original_arrival_relative)` falls into the elapsed→advance branch, skipping the dwell at the waypoint NPC was supposed to resume. **Same shape exists for `wander_next_at` on Wander preemption and `investigate_until` on Investigate preemption.** None of the three preemption tests checks the scratch deadline.
+
+**G9. Multi-NPC isolation in a single `npc_ai_tick` call.** Zero tests spawn ≥2 NPCs and run one `npc_ai_tick`. Today the handlers don't cross-call so it's not a bug, but there's no pin. Fix: 10-line test — Patrol NPC + Wander NPC, one tick, assert independent scratch fields.
+
+**G10. Despawn while player has `current_target_id == npc_id` or `looting_entity == npc_id`.** Respawn tick handles this case explicitly (`npc_respawn.rs:227-269`). Despawn handler doesn't. `current_target_id` would point at destroyed entity; next take-item call would 404. **Fix**: 2 tests.
+
+**G11. Wander knockback during dwell.** Patrol and Investigate have explicit knockback guards. Wander doesn't. The semantics differ enough that the 1:1 fix may not apply — but the absence of a test means we don't know.
+
+**G12. No conformance test between `mercury::method_idx` constants and `entities/defs/*.def`.** `mercury/mod.rs:160-238` hand-lists 33 ClientMethod indices. The `crates/defs` build-time generator parses `.def` files but **does not extract method indices**. A `.def` edit that changes an inheritance ordering shifts the flat method indices silently; the hand-written constants stay put. Same exposure for the 109-method cell-side table at `cell/dispatch/constants.rs`. **Fix**: extend the build script to extract method indices and add a `crates/defs/src/method_idx_conformance.rs` test that asserts hand-written constants match the extracted indices.
+
+### Important
+
+**G13. Vendor sell with full main bag.** Sell routes to `INV_BUYBACK` (container 16), not main. No test pins "sell succeeds with main full." A regression that re-routes via main's slot allocator would silently fail.
+
+**G14. Vendor partial-rollback fan-out byte test.** Vendor live-DB tests cover state-before vs state-after, not the dispatch surface. A regression that emitted `RefreshInventory` BEFORE tx commit would corrupt the client view on rollback.
+
+**G15. Vendor recharge with insufficient credits + multi-item bundle.** `handle_paid_recharge_inventory_items` accepts `vec![item]` so bundle is reachable. Single-item-only tests miss per-line vs per-bundle rollback distinction.
+
+**G16. Loot fan-out beyond single-witness.** Two players witnessing one corpse, contested loot, looter dies mid-loot, `looting_entity` referring to despawned corpse — no guards.
+
+**G17. Auto-equip with full bandolier → active-slot replacement.** `resolve_auto_equip_target` falls back to "replace what I'm holding" when all 4 bandolier slots full. Existing test covers empty-bandolier; full-bandolier case (the more interesting branch — it consumes the active slot's inventory) untested.
+
+**G18. Negative-quantity sell / buyback.** `negative_quantity_is_whole_stack_sentinel` proves move handler accepts `quantity = -1`. Sell / buyback do not. A forged `-1` could either drain stack and pay nothing, or i32-multiply underflow.
+
+**G19. Holster recomposite chain end-to-end through AoI.** `set_weapon_holstered` rebroadcast tested at cell-side return-value AND at handler-broadcast level, but never seeded with a witness to verify the witness sees the new appearance via witness-routed `RefreshAppearance`.
+
+**G20. Position-snap across grid-cell boundary AoI refresh.** Proptest covers up-to-80-unit-per-axis steps; 5000-unit teleport exercised but only counts `LeftAoI` events, doesn't verify `world_grid::update_position` grid cleanup. Add `assert!(!space.space.grid.cells.contains_key(&(0,0)))` after teleport.
+
+**G21. AoI tick + regen tick interaction.** No test exercises `run_aoi_tick` + `regen_tick` in the same tick body. A regen broadcast targeting a player who just AoI-left a witness could panic or misroute.
+
+**G22. Build pipeline coverage for `crates/defs`.** `crates/defs/build/{codegen,def_parser,entities_xml,main,types}.rs` — 5 modules, **zero tests**. The crate doc-comment promises "If entity files are missing or malformed, the build script gracefully generates empty stubs" — that guarantee is unguarded. A `.def` shape change can silently break codegen and produce a registry with one stub; runtime tests won't catch it.
+
+**G23. Admin-API route handlers untested.** ~3000 LOC of axum route handlers (config, content, editor, entities, players, spaces, audit, all 4 WS streams) — zero tests. Only `dev_session.rs` (576 LOC) and `telemetry.rs` (~660 LOC) covered.
+
+**G24. Supervisor untested.** Binary crate, 0 tests. ~565 LOC of process management + WS log streaming + tracing layer. The spawn/kill/rebuild state machine has no guards.
+
+**G25. Combined chaos primitives.** All 6 chaos scenarios use exactly ONE primitive (loss OR latency OR reorder, never combined). Real failures rarely are. A `transatlantic_with_jitter` scenario (`drop_probability=2pct` + `latency=60ms` + `reorder_buffer_size=2`) would pin the "RTO under realistic conditions" envelope.
+
+---
+
+## Section 5 — LogCapture flake root cause
+
+Parent agent's hypothesis was "LogCapture seems to be global and other tests' logs interleave." **The audit refutes this from code.**
+
+- `LogCapture::install` uses `tracing::subscriber::set_default` — *thread-local*. Other tests on other threads install their own thread-local subscribers. No cross-talk.
+- `Registry::default().with(layer)` allocates a fresh `events: Arc<Mutex<Vec<Captured>>>` per `install()`. Two captures cannot share storage.
+- No `set_global_default` calls anywhere in `crates/` (verified by grep).
+
+**Most likely actual cause** of the flake the user reported on `npc_ai_fight_warns_when_handle_use_ability_returns_false`: an `Instant::now()`-based cooldown / retry gate elsewhere in `npc_ai_tick` emits an *extra* WARN with a different `reason` when the test thread is preempted long enough for some `last_*` timestamp to expire, and the test's `find_event` first hit matches that path instead. The fix is not "harden LogCapture" — it's grep the `npc_ai_tick` call tree for sibling `tracing::warn!` sites and disambiguate the assertion by `reason` value, not by mere presence.
+
+**LogCapture risks worth flagging anyway** (not flake-causing, but latent):
+
+- Multi-thread runtime panic in `install()` only fires if a runtime is *already running*. A test that `install()`s then `std::thread::spawn`s a worker that emits events would silently drop those events. No current tests do this; the runtime check is a guard, not a fence.
+- `LogCaptureGuard` drop-order is correct but unpinned (field-declaration order). A refactor that reorders the fields would break assertion-after-drop patterns. The 11 self-tests at `:423-619` don't pin this.
+
+---
+
+## Section 6 — Cross-cutting patterns + strategic recommendations
+
+These are themes that recur across 4+ of the 7 audits. Fixing them is higher-leverage than any single test change.
+
+### P1. Fixture duplication (highest leverage)
+
+| Fixture | Files reproducing it | Recommendation |
+|---|---|---|
+| Castle non-instanced (~15 lines XML + `create_startup_spaces`) | 27 | Promote `make_castle_non_instanced()` to `crates/services/src/test_support.rs`. Used in all 7 `npc_ai*.rs` + 20 others. |
+| Agnos non-instanced | 18 | `test_support::make_space_manager` (line 104) already exists — most callers hand-roll. Document the canonical helper in TESTING.md. |
+| Castle_CellBlock instanced | 18 | `cell/service/tests/mod.rs::make_test_space_mgr` covers 4 sub-modules; 14 others hand-roll. |
+| `SpawnRecord` full literal | 2 (`spawner/tests.rs:22`, `space_manager/tests/npc_spawn.rs:69`) | `impl Default for SpawnRecord` — drop ~40 lines per call site. |
+
+**Bonus**: a `make_npc_at(mgr, npc_id, [x,y,z])` helper would consolidate the 8-line "spawn SGWMob NPC with HP=100/100, clear dirty, threat_list ready" block repeated in `npc_ai.rs:29-40`, `npc_ai_phase7.rs:19-29`, and ~5 others.
+
+**Hazard to address**: `make_test_space_mgr` is instanced; if a contributor needing same-space NPCs/players imports it from the sibling `mod.rs`, the witness set is silently empty and AoI assertions silently pass without exercising the witness path. Either rename to `make_castle_cellblock_instanced_for_solo_player_tests` or add a debug-assert in `SpaceManager::add_witness` that catches the misuse.
+
+### P2. Count-first fan-out pattern (canonical model)
+
+`executor/world/tests.rs:65 set_interaction_type_add_op_or_masks_flags_and_broadcasts_to_each_witness` is the model:
+
+1. Count fan-out cardinality (`== 2`, not `>= 2`).
+2. Per-recipient witness/entity routing pin.
+3. Method_index pin.
+4. Byte-exact 8-byte LE u64 payload.
+
+Promote this to TESTING.md as the type-8 (fan-out byte) reference shape. ~15 existing tests in the audit could be rewritten to this shape.
+
+### P3. Negative-pin discipline (the "AND it's not the wrong thing" assertion)
+
+`handle_reload_emits_ammo_type_under_correct_propid` asserts both:
+
+- The literal `3` IS used for ammo_type.
+- The literal `7` (AccessLevel) is NEVER used.
+
+This is the model for propId-sensitive, byte-offset-sensitive, and method-index-sensitive tests. Other instances in the audit:
+
+- `set_aggression_missing_tag_leaves_unrelated_entities_untouched` (no mutation of unrelated entities).
+- `set_interaction_type_broadcasts_to_target_witnesses_not_source_witnesses` (drives the exact source-vs-target witness bug shape).
+
+Promote as the type-2 (wire-format) shape extension. ~20 tightening opportunities apply.
+
+### P4. The eight unimplemented `cell_methods/*.rs` files
+
+`mail.rs`, `minigame.rs`, `organization.rs`, `contact_list.rs`, `missionary.rs`, `black_market.rs`, `ability_manager.rs`, `gate_travel.rs` — all 8 are pure `tracing::info!("UNIMPLEMENTED…")` dispatchers. Zero tests; **also zero scaffolding**.
+
+When the first real handler lands in any of them, the PR needs to invent BOTH the test fixture pattern AND the regression guard, which is a 2× burden that will get skipped or done badly. Recommendation: drop a 10-line scaffolding test in each that imports the make-mgr helper, calls one method-dispatch, asserts a basic byte. Even a `// no panic = success` placeholder establishes the file as "tested" and creates the import surface for the real test to expand.
+
+### P5. Build-script and binary-crate test absences
+
+`crates/defs/build/` (5 modules), `crates/supervisor/`, ~3000 LOC in `crates/admin-api/src/routes/` — all entirely untested. Together this is ~10% of the binary surface. Test cost is moderate (build-script tests in particular need a fixture-data harness), but the bug-detection value is high — the defs build is load-bearing for the entire wire-format dispatch and the supervisor is the production process manager.
+
+### P6. Theatre-shaped tests in `cell/messages/tests.rs` (only file with multiple derive-tautologies)
+
+Removed by Section 2; calling out separately so a future contributor doesn't add new derive-tautology tests in the same file template-style. Worth a comment in `cell/messages/mod.rs`: "this module is data; tests live in the consumer modules."
+
+### P7. Inventory-snapshot drift
+
+The 33% gap (1,351 → 2,012) is from PRs that added tests without touching `docs/testing/inventory/`. The 5%/100-test-per-PR threshold is the right guardrail (TESTING.md correctly identifies this) but only catches single-PR drift. A periodic sweep is documented as the recovery mechanism; schedule one. A test-count assertion in CI (`workspace_test_count_matches_snapshot_within_5pct`) would prevent the drift from accumulating.
+
+---
+
+## Section 7 — Where the audit found existing strength
+
+Don't change these. Use them as calibration anchors.
+
+- **`crates/mercury/src/packet/tests.rs`** — byte-exact wire layouts for the full flag matrix + NULL_SEQUENCE/28-bit-wrap regression guard.
+- **`crates/mercury/src/test_harness/`** — real UDP loopback, injected `TestClock`, encryption KAT uses independently-generated reference vectors (not self-referential).
+- **`crates/services/src/mercury/aoi/tests.rs`** — per-byte-offset every record in CREATE_ENTITY → cascade → UPDATE_AVATAR → ENTITY_INVISIBLE → LEAVE_AOI lifecycle.
+- **`crates/services/src/cell/space_manager/aoi_differential_test.rs`** — proptest pinning witness-set-equals-diff-accumulated invariant across ±80-unit step vectors.
+- **`crates/services/src/cell/space_manager/aoi_churn_smoke.rs`** — 50-NPC walk with bounded witness set, hardcoded bound justified by comment.
+- **`crates/services/src/cell/combat/state.rs`** — `drained_counter_drops_map_entry`, `unset_on_unowned_flag_does_not_grow_counter_map`, `clear_all_resets_counters_too` — refcount-discipline guards done right.
+- **`crates/services/src/cell/content/executor/world/tests.rs:65`** (`set_interaction_type_add_op_or_masks_flags_and_broadcasts_to_each_witness`) — the canonical count + addr + bytes fan-out byte test.
+- **`crates/services/src/cell/content/chain_replay_tests/mission_641.rs`** — positive + 2 negative guards, including the exact-bug-shape negative.
+- **`crates/services/src/cell/content/executor/tests.rs:709`** (`generate_threat_action_refreshes_appearance_before_state_field_on_first_aggro`) — message-ordering pin with fixture-sanity assert.
+- **`crates/services/src/cell/content/mission_context.rs:202`** (`active_step_overrides_stale_completed_entry`) — write-order precedence pin.
+- **`crates/discord/`** — `event_kind_all_matches_variant_count`, `every_event_kind_routes`, whisper-content privacy, redaction guard. Strongest test suite in the foundational layer.
+- **`crates/wireclient/tests/auth_smoke.rs`** — drives a real `AuthService`; handshake pins bytes against a real pcap.
+- **`crates/services/src/cell/cell_methods/player/world/tests.rs:691`** (`handle_reload_emits_ammo_type_under_correct_propid`) — propId discipline: positive (3) and negative (not 7) both pinned.
+- **`crates/services/src/base/world_entry/methods/vendor/buyback/tests.rs:198`** (`partial_buyback_preserves_price_on_remainder`) — multi-assertion done right: one invariant, three angles.
+
+---
+
+## Section 8 — Recommended order of operations
+
+If turning this audit into work tickets:
+
+1. **Section 1 bugs**, in order: bandolier-ammo column → sentinel collision → destroy_entity witness-scrub pin → TESTING.md count fix → inventory snapshot regen sweep. The first two are merge-blockers for any inventory or live-DB PR.
+2. **P1 fixture extraction** — single PR introducing `make_castle_non_instanced`, `make_npc_at`, `make_player_at`, `Default for SpawnRecord`. Migrate all 27 + 18 + 2 call sites. Single review; large diff but mechanical.
+3. **Section 4 critical gaps G1-G12** — these are bug-shape guards for contracts the code claims today. Each is a 10-50 line test against existing code. G12 (`method_idx` conformance) is the largest; the rest are small.
+4. **Section 3 tightening** — by group. Group A (loose collection asserts) and Group C (propId) are mechanical and high-volume; do those first. Group D (dwell knockback) is small and adds the missing Wander knockback guard.
+5. **P2/P3 pattern promotion** — update TESTING.md with the count-first and negative-pin reference shapes, then a follow-up PR migrating identified candidates. Defer to after #1-4.
+6. **P4 scaffolding** for the 8 unimplemented `cell_methods/*.rs` files — single PR, 10 lines each. Low-value alone but unblocks the next PR that lands real behavior.
+7. **Section 4 important gaps G13-G25** as opportunistic add-ons when the relevant subsystem is otherwise being touched.
+8. **G22-G24 (build-script + admin-api + supervisor)** as their own dedicated multi-PR effort. Largest cost, slowest-burn risk.
+
+Test count if every gap is closed and every delete is taken: ~1500 base → ~1500 - 13 + ~80 = ~1567. Roughly net +5%, well within the "snapshot regen pending" envelope.


### PR DESCRIPTION
## Summary

- Lands the single-pass synthesis of seven parallel `testing-validation-engineer` audits run on top of the freshly-merged NPC AI phases 2-7 (#48) at commit `d9513a0a`.
- Treated as a **point-in-time snapshot** — subsequent audits produce a fresh `audit-YYYY-MM-DD.md`, not an amendment.
- Linked from [`docs/readme.md`](../blob/main/docs/readme.md) as a reference-class testing doc, alongside `inventory/` and TESTING.md.

## What's in it

- **3 real bugs** — bandolier-ammo TOCTOU keyed on the wrong column (self-confessed in a doc-comment), sentinel-id collision `0x7000_0500` masked by ci-live-db serialization, `destroy_entity` non-disconnect path lacks a witness-scrub recovery pin.
- **LogCapture flake refuted from code** — root cause is sibling `tracing::warn!` sites in `npc_ai_tick`'s call tree firing under thread preemption, not subscriber contamination.
- **~13 tests to delete** (derive-tautologies + duplicate sized-shape tests).
- **~30 tightening opportunities** grouped by failure mode (loose collection asserts, substring-on-JSON, propId constants, AI dwell guards — only 2 of 9 reproduce the d9513a0a knockback fix).
- **~25 coverage gaps** organized critical / important, with bug-shape and fix-type called out.
- **Strategic recommendations** — fixture extraction (Castle non-instanced × 27 files, Agnos × 18, `SpawnRecord` literal × 2), promote `executor/world/tests.rs:65` as canonical fan-out-byte shape, promote `handle_reload_emits_ammo_type_under_correct_propid` as the propId positive+negative pin shape.
- **Section 8** is a recommended order of operations for triaging into work items.

## Tracking issue

A separate rollup tracking issue links every section here to a checklist of work items. Filed as #458.

## Test plan

- [x] `markdownlint-cli2` clean (the doc follows existing conventions in `docs/testing/`).
- [x] No code changes — pure doc add.

🤖 Generated with [Claude Code](https://claude.com/claude-code)