### PR TITLE
docs(salvage): rescue agent-memory + audit docs from dead worktrees

### DIFF
--- a/.claude/agent-memory/rust-gameserver-dev/MEMORY.md
+++ b/.claude/agent-memory/rust-gameserver-dev/MEMORY.md
@@ -27,7 +27,12 @@
 ## Wire-format gotchas
 
 - [read-wstring-offset-semantic.md](read-wstring-offset-semantic.md) — `read_wstring` returns BYTES CONSUMED, not the new absolute offset; chain with `offset += n`, never `offset = n`.
+- [ue3-staticmesh-extraction.md](ue3-staticmesh-extraction.md) — UE3 StaticMeshActor→Component→Mesh resolution in SGW cooked .umap: tagged-prop offset varies by class kind (Actor=32, StaticMesh=4, Component=8); ~20% of actors use prefab archetypes; kDOP tri indices reference LOD0 vertices; master .umap files exist alongside chunks.
 
 ## Tooling quirks
 
 - [rustfmt-trailing-line-comment-quirk.md](rustfmt-trailing-line-comment-quirk.md) — rustfmt sucks standalone comments into the trailing-comment column of the previous statement; insert a blank line to break the run.
+
+## Testing patterns
+
+- [db-test-revert-verification.md](db-test-revert-verification.md) — split async DB-touching function into pure sync helper + DB shell; unit-test the helper so local revert-verification works when live-DB is the canonical guard.

--- a/.claude/agent-memory/rust-gameserver-dev/db-test-revert-verification.md
+++ b/.claude/agent-memory/rust-gameserver-dev/db-test-revert-verification.md
@@ -1,0 +1,43 @@
+# Revert-verifying DB-bound code without a live DB
+
+When fixing a bug in an async DB-touching function (slot reservation, balance
+checks, etc.) and the user can't run live Postgres locally, the
+revert-verification problem is: the live-DB test is the canonical guard but
+auto-skips locally, so you can't observe a revert failing.
+
+The pattern that works:
+
+1. **Split the production async function into a pure sync helper + thin async
+   shell.** The sync helper takes the raw DB data as a slice and returns the
+   algorithmic answer. The async shell does the DB query, calls the helper,
+   maps the result to the production error type.
+2. **Unit-test the pure helper.** Since the production async function delegates
+   to it, a revert in the helper trips both the unit test (locally) and the
+   live-DB test (in CI's `ci-live-db` profile).
+3. **Keep the live-DB test as well.** It's the integration coverage; the unit
+   test is the local revert-verifier. Document both layers in the test commit.
+
+Example shape (from trade slot reservation):
+
+```rust
+// Async shell — production entry point
+async fn reserve_main_slots_excluding(tx, recipient_id, needed, vacating) -> Result<Vec<i32>> {
+    let raw = sqlx::query_as::<...>("SELECT slot_id FROM ... FOR UPDATE")
+        .fetch_all(&mut **tx).await?;
+    match pick_free_main_slots_excluding(&raw, vacating, needed) {
+        Some(slots) => Ok(slots),
+        None => Err(TradeAbort::NotEnoughSlots { ... }),
+    }
+}
+
+// Pure sync helper — unit-testable
+fn pick_free_main_slots_excluding(raw_occupied: &[i32], vacating: &[i32], needed: usize) -> Option<Vec<i32>> {
+    let excluding: HashSet<i32> = vacating.iter().copied().collect();
+    let after: Vec<i32> = raw_occupied.iter().copied().filter(|s| !excluding.contains(s)).collect();
+    free_inventory_slots(min, max, &after, needed)
+}
+```
+
+Tip: write the test to demonstrate BOTH the pre-fix and post-fix shape side-by-side. Call the helper with `vacating: &[]` (pre-fix mimic) AND with `vacating: &[39]` (post-fix). Assert `None` for the former and `Some(_)` for the latter. The single test then "shows its work" — any reviewer can see the discriminator.
+
+Revert-verification protocol: temporarily revert the fix (drop the `.filter()`, or comment out the exclusion line), `cargo test -p cimmeria-services --lib trade::execute::slot_exclusion_accounting`, confirm the discriminating tests fail with the expected error. Restore the fix.

--- a/.claude/agent-memory/server-authority-enforcer/MEMORY.md
+++ b/.claude/agent-memory/server-authority-enforcer/MEMORY.md
@@ -1,6 +1,51 @@
+# Memory Index
+
+## Exploit references (concrete shapes found in code)
+
 - [Bandolier ammo TOCTOU](exploit_bandolier_ammo_toctou.md) — base UPDATE keys on `type_id` instead of `item_id`; same-type swap dupes ammo across instances.
 - [AVATAR_UPDATE_EXPLICIT trust](exploit_avatar_update_explicit.md) — base wire 0x03 accepts client position unconditionally; no anti-teleport, no speed check.
 - [Admin API unauthenticated](exploit_admin_api_unauth.md) — `/api/config/stop` and `/api/editor/content` bind on 0.0.0.0 with no auth middleware; trivially DoS-able.
 - [useAbility no faction check](exploit_use_ability_no_faction.md) — single-target ability resolves damage on any non-dead target in range; party/vendor friendly fire possible.
 - [Lootable no ownership](exploit_loot_no_ownership.md) — lootItem trusts player's own `looting_entity` state; no kill-credit check, no post-interact range re-check.
 - [Reference: authoritative state locations](reference_authority_sources.md) — where the server-of-truth state lives for inventory, position, currency, GM flag.
+
+## 2026-05-31 server-authority audit — per-system findings
+
+- [project_mail_handlers_unimplemented.md](project_mail_handlers_unimplemented.md) — Mail send/take/COD/return paths are stubs; future implementers inherit unvalidated wire surface
+- [project_trade_handlers_unimplemented.md](project_trade_handlers_unimplemented.md) — All four player-trade RPCs are stubs in social.rs; ordered invariant checklist for the next implementer
+- [project_black_market_unimplemented.md](project_black_market_unimplemented.md) — BM/Auction surface stubbed; entire economy vertical lands as exploit chain on implementation
+- [project_mission_dialog_audit_2026-05-31.md](project_mission_dialog_audit_2026-05-31.md) — CAT-J audit findings; mission/dialog/interaction trust posture as of 2026-05-31
+- [project_gm_commands_audit_2026-05-31.md](project_gm_commands_audit_2026-05-31.md) — CAT-N audit findings; GM/debug/cheat commands trust posture as of 2026-05-31
+- [project_org_squad_duel_unimplemented.md](project_org_squad_duel_unimplemented.md) — CAT-M audit findings; all 18 org/squad/duel wire surfaces are stubbed, full checklist for implementer
+- [project_crafting_unimplemented.md](project_crafting_unimplemented.md) — CAT-F audit findings; TrainAbility wired (with trainer-NPC gap), all other craft RPCs stubbed; future-implementer must-validate checklist
+- [project_chat_contact_audit_2026-05-31.md](project_chat_contact_audit_2026-05-31.md) — CAT-L audit findings; chat/contact/communication trust posture as of 2026-05-31
+- [project_world_space_gate_audit_2026-05-31.md](project_world_space_gate_audit_2026-05-31.md) — CAT-O audit findings; gate/ring/region/world-instance trust posture as of 2026-05-31
+
+## Wire-spec references (Ghidra + .def anchors per system)
+
+- [reference_mail_wire_spec.md](reference_mail_wire_spec.md) — SGWMailManager.def authoritative wire shapes for mail messages
+- [reference_mail_validation_locations.md](reference_mail_validation_locations.md) — Where mail validation lives (or needs to live) — file/line anchors
+- [reference_trade_wire_spec.md](reference_trade_wire_spec.md) — SGWPlayer.def + alias.xml authoritative wire shapes for trade RPCs + Ghidra anchors
+- [reference_black_market_wire_spec.md](reference_black_market_wire_spec.md) — Ghidra-extracted wire shapes for BMCreateAuction/BMPlaceBid/BMCancelAuction/BMSearch + inbound reply structs
+- [reference_org_squad_duel_wire_spec.md](reference_org_squad_duel_wire_spec.md) — OrganizationMember.def + SGWPlayer.def + SGWDuelMarker.def wire shapes + Ghidra RTTI anchors + permission/rank enums
+- [reference_chat_wire_spec.md](reference_chat_wire_spec.md) — Chat/contact/comm wire shapes; SGWPlayer base 0xC0..0xC4 + cell methods 10/55-60/73 + Ghidra anchors for unhandled NetOut events
+- [reference_gm_command_wire_spec.md](reference_gm_command_wire_spec.md) — Authoritative wire shapes for ~125 SGW GM commands; SGWGmPlayer.def + Ghidra Event_NetOut_* anchors
+- [reference_world_space_gate_wire_spec.md](reference_world_space_gate_wire_spec.md) — CAT-O wire shapes + Ghidra anchors + server-side authority sources for gate/ring/region/movie/system-options
+- [reference_cell_method_entity_id_authority.md](reference_cell_method_entity_id_authority.md) — Cell-method entity_id is overwritten with session player_eid in cell_arms.rs
+
+## Recurring exploit classes (rule-of-thumb anchors)
+
+- [reference_auth_handshake_layers.md](reference_auth_handshake_layers.md) — Where Cimmeria's auth/session/character-lifecycle handlers live; which layer is authoritative for what
+- [reference_auth_exploit_classes.md](reference_auth_exploit_classes.md) — Recurring SGW auth/handshake exploit classes — TLS, IV reuse, replay, race windows, dev-mode bypass
+- [reference_combat_exploit_classes.md](reference_combat_exploit_classes.md) — Recurring combat/abilities exploit classes — caller-state gating, target id existence/AoI, faction/LOS, stub-implementation debt
+- [reference_dialog_choice_exploit_shape.md](reference_dialog_choice_exploit_shape.md) — DIALOG_BUTTON_CHOICE has no open-dialog tracking; OnDialogChoice chains are replay-forgeable
+- [reference_gm_auth_plumbing_gap.md](reference_gm_auth_plumbing_gap.md) — Systemic gap: cell-method dispatch has no access_level; every future gm* handler is unauthenticated by default
+
+## Per-PR review findings
+
+- [trade-container-whitelist.md](trade-container-whitelist.md) — Trade swap must whitelist source containers (INV_MAIN only) — blacklist-only is a dupe-strip exploit
+- [advisory-lock-namespaces.md](advisory-lock-namespaces.md) — `pg_advisory_xact_lock(player_id, ns)` namespace assignments across vendor/trade — divergence is deadlock surface, not correctness
+- [pattern-checked-alloc-size.md](pattern-checked-alloc-size.md) — Canonical helper for count*stride bounds + overflow checks on attacker-influenced binary input
+- [pr-426-navmesh-extractor.md](pr-426-navmesh-extractor.md) — Build-time navmesh parser hardened with checked_alloc_size; pattern worth reusing for header-driven Vec allocation
+- [pr-427-crafting-phase1.md](pr-427-crafting-phase1.md) — Phase 1 dispatch+persist; no mutation surface yet; Phase 2 is where the real adversarial review lands
+- [open-followup-runtime-navmesh-load.md](open-followup-runtime-navmesh-load.md) — NavMesh::load in cimmeria-entity has the same unguarded count*stride pattern; worth a follow-up issue

--- a/.claude/agent-memory/server-authority-enforcer/advisory-lock-namespaces.md
+++ b/.claude/agent-memory/server-authority-enforcer/advisory-lock-namespaces.md
@@ -1,0 +1,27 @@
+---
+name: advisory-lock-namespaces
+description: PostgreSQL pg_advisory_xact_lock namespace assignments across the inventory / cash mutation paths — keep them consistent
+metadata:
+  type: reference
+---
+
+Multiple paths in `crates/services/src/base/world_entry/methods/` take `pg_advisory_xact_lock(player_id, ns)` to serialize themselves against concurrent mutations on the same player. The choice of `ns` matters because PG treats `(key1, key2)` advisory locks as independent — two paths with different `ns` values do NOT block each other at the advisory layer (only the row-level FOR UPDATE locks save you, and only on rows they both touch).
+
+As of PR #438:
+
+| Path | Advisory key | Namespace |
+|---|---|---|
+| Vendor stack (sell, purchase, recharge, repair, slot reserve) | player_id | container_id (typically `INV_MAIN=1`) |
+| Trade `atomic_swap` (PR #438) | player_id | `0` |
+
+This is a divergence — they don't block each other. Correctness is preserved by the row-level FOR UPDATE on `sgw_inventory` rows (both paths take it), but the deadlock surface widens: trade and vendor can lock in different orders (trade does naquadah-first, vendor does items-first) and the resulting ABBA gets resolved by PG's deadlock detector with a noisy `Cancelled` to the trade clients.
+
+**How to apply:** when reviewing any new inventory mutation that uses `pg_advisory_xact_lock(player_id, X)`, check what `X` is and confirm it matches the convention for the path. If trade gets fixed to use `(player_id, 1)` (INV_MAIN container_id), expect a third namespace to emerge soon for some other reason — document it here.
+
+Recommendation in the trade review: standardize trade on `(player_id, 1)` so it serializes against vendor on the same container, OR adopt `(player_id, FIXED_TRADE_NS)` and document the assignment table.
+
+Lock acquisition order matters for deadlock avoidance:
+- Vendor: items FOR UPDATE → naquadah FOR UPDATE.
+- Trade: advisory → naquadah FOR UPDATE → items FOR UPDATE.
+
+These should converge to a single order.

--- a/.claude/agent-memory/server-authority-enforcer/open-followup-runtime-navmesh-load.md
+++ b/.claude/agent-memory/server-authority-enforcer/open-followup-runtime-navmesh-load.md
@@ -1,0 +1,22 @@
+---
+name: open-followup-runtime-navmesh-load
+description: NavMesh::load in cimmeria-entity has the same unguarded count*stride pattern that PR #426 fixed in the build-time tool — worth a follow-up issue
+metadata:
+  type: project
+---
+
+**Open follow-up** (not blocking any current PR): `crates/entity/src/navigation.rs::NavMesh::load` is the runtime navmesh loader and is the production read path for `.nav` files at server startup / space load. It has the EXACT same unguarded patterns that PR #426 hardened in the build-time tool:
+
+```rust
+let mut verts = vec![0u16; (nverts * 3) as usize];
+let mut polys = vec![0u16; (npolys * nvp * 2) as usize];
+let mut detail_meshes = vec![0u32; (detail_nmeshes * 4) as usize];
+let mut detail_verts = vec![0.0f32; (detail_nverts * 3) as usize];
+let mut detail_tris = vec![0u8; (detail_ntris * 4) as usize];
+```
+
+**Why:** PR #426 only hardened the build-time tool's parser; the runtime loader was pre-existing and out of scope.
+
+**How to apply:** When opening a follow-up issue, point at [pattern-checked-alloc-size.md](pattern-checked-alloc-size.md) as the canonical helper shape to port over. The threat model for the runtime loader is "operator with file write access to `data/spaces/`", which is a higher trust boundary than the build-time tool but still not free — a server that crashes / OOMs on a malformed .nav at startup is a denial-of-service vector if an attacker can compromise the asset deploy pipeline.
+
+**Note on duplication:** Porting the helpers means either (a) duplicating them in cimmeria-entity, (b) extracting them into cimmeria-common, or (c) having cimmeria-entity depend on cimmeria-navmesh-extractor's helper crate (cyclic — extractor depends on entity? probably not). Option (b) is the cleanest — the helpers are domain-agnostic.

--- a/.claude/agent-memory/server-authority-enforcer/pattern-checked-alloc-size.md
+++ b/.claude/agent-memory/server-authority-enforcer/pattern-checked-alloc-size.md
@@ -1,0 +1,39 @@
+---
+name: pattern-checked-alloc-size
+description: Canonical idiom for safely sizing a Vec from attacker-influenced header counts and strides; lives in crates/navmesh-extractor/src/nav_roundtrip.rs
+metadata:
+  type: reference
+---
+
+The canonical pattern for safely sizing a `Vec` from attacker-influenced binary input (file format header counts, wire payload lengths, etc.) lives in `crates/navmesh-extractor/src/nav_roundtrip.rs`:
+
+```rust
+fn check_count(value: u32, max: u32, field: &'static str) -> Result<u32, ExtractError> {
+    if value > max {
+        return Err(ExtractError::NavHeaderOutOfRange {
+            field, value: value as u64, reason: "exceeds extractor sanity cap",
+        });
+    }
+    Ok(value)
+}
+
+fn checked_alloc_size(count: u32, stride: u32, field: &'static str) -> Result<usize, ExtractError> {
+    let product = (count as u64).checked_mul(stride as u64)
+        .ok_or(ExtractError::NavHeaderOutOfRange { field, value: count as u64, reason: "count * stride overflows u64" })?;
+    usize::try_from(product).map_err(|_| ExtractError::NavHeaderOutOfRange { field, value: product, reason: "count * stride does not fit in usize on this target" })
+}
+```
+
+**Why this is the right shape:**
+
+1. Two-stage validation: per-field sanity cap (`check_count`) PLUS overflow-safe multiplication (`checked_alloc_size`). The cap alone isn't enough — even with `MAX_NVERTS = 1M`, you still need to defend `1M * 64` from the next field's stride.
+2. `u32 * u32` arithmetic done as `u64` so no intermediate truncation hides the overflow.
+3. `usize::try_from` catches 32-bit-host edge cases where `u64 → usize` would truncate.
+4. Typed error variant with `field: &'static str` carries the violating header name to the log/diagnostic.
+
+**Where to apply this pattern next:**
+
+- `crates/entity/src/navigation.rs::NavMesh::load` — same XRC nav format, runtime path, currently UNGUARDED. The fix would be a direct port of the helpers above.
+- Anywhere else in the codebase where a Vec is sized from a (count, stride) pair read off the wire or off disk.
+
+**Regression-guard template** (also from PR #426, `read_rejects_oversized_*`): synthesise a header with `value = 0xFFFFFFFF`, pad zeros for the rest of the header so the cap fires before any subsequent read, then `assert_eq!(field, "<field_name>")` on the typed error variant. Failure mode if the bounds check is reverted: the multiplication wraps to a small `Vec` and the read loop consumes only a few elements while the claimed huge region goes unread — leaving every downstream offset wrong. Test must fail when the cap is removed.

--- a/.claude/agent-memory/server-authority-enforcer/pr-426-navmesh-extractor.md
+++ b/.claude/agent-memory/server-authority-enforcer/pr-426-navmesh-extractor.md
@@ -1,0 +1,22 @@
+---
+name: pr-426-navmesh-extractor
+description: Build-time UE3 navmesh extractor; XrcNav::read hardened with check_count + checked_alloc_size before any allocation
+metadata:
+  type: project
+---
+
+PR #426 (cimmeria-navmesh-extractor Phase 0) verdict: SHIP.
+
+**Threat model:** Build-time tool that consumes `data/spaces/*.nav` files. Only attackers with filesystem-write access to the repo can craft hostile inputs; if they have that, they own much more than the build tool. Still, defense-in-depth applied is the right call.
+
+**Where the hardening lives** (origin tip of `feat/navmesh-extractor-46-phase0`, commit `21b2b681`):
+
+- `crates/navmesh-extractor/src/nav_roundtrip.rs::check_count` validates header counts (`MAX_NVERTS=1M`, `MAX_NPOLYS=1M`, `MAX_NVP=64`, `MAX_DETAIL_NMESHES=1M`, `MAX_DETAIL_NVERTS=10M`, `MAX_DETAIL_NTRIS=10M`) before any allocation.
+- `crates/navmesh-extractor/src/nav_roundtrip.rs::checked_alloc_size` computes `count * stride` as `u64`, returns `ExtractError::NavHeaderOutOfRange` on overflow or `usize::try_from` failure.
+- Regression tests `read_rejects_oversized_nverts` + `read_rejects_oversized_npolys` synthesise hostile headers and assert the typed error before allocation.
+
+**Minor inconsistency** (advisory only): `regs`, `flags`, `areas` allocations still use `vec![0u16; npolys as usize]` directly. Safe because `npolys ≤ MAX_NPOLYS = 1M`, but stylistically inconsistent with the `checked_alloc_size` discipline. Not a fix-required item; flag if a future maintainer copies this and forgets the cap.
+
+**Open follow-up** (out of #426 scope): `crates/entity/src/navigation.rs::NavMesh::load` is the runtime navmesh loader and has the EXACT same unguarded `(nverts * 3) as usize`, `(npolys * nvp * 2) as usize` etc. patterns. This is loaded at runtime by the server from `data/spaces/*.nav`. An operator who manages to drop a malicious `.nav` into the data dir could trigger the same overflow there. Worth a follow-up issue to port `check_count` + `checked_alloc_size` to the runtime loader.
+
+**Pattern worth promoting:** see [pattern-checked-alloc-size.md](pattern-checked-alloc-size.md) — the helper shape from this PR is the right canonical idiom for any attacker-influenced count-and-stride Vec allocation in the codebase.

--- a/.claude/agent-memory/server-authority-enforcer/pr-427-crafting-phase1.md
+++ b/.claude/agent-memory/server-authority-enforcer/pr-427-crafting-phase1.md
@@ -1,0 +1,25 @@
+---
+name: pr-427-crafting-phase1
+description: Adversarial review verdict on PR #427 — crafting Phase 1 lands persistence + dispatch only; no exploitable surface yet, but Phase 2 will need a deeper pass
+metadata:
+  type: project
+---
+
+PR #427 (crafting Phase 1) verdict: SHIP (clean adversarial review).
+
+**Why the gate is clean:** Phase 1 is intentionally scoped to (a) DB schema + persistence helpers, (b) wire-format serializer for `onUpdateDiscipline` (method 136), and (c) the dispatch range widening that adds `SPEND_APPLIED_SCIENCE_POINTS` (95). The cell handlers for indices 95/96/97/98/99/100 are all UNIMPLEMENTED stubs that `tracing::info!` and return true. No state mutation, no item/currency mutation, no GM-bit dispatch, no item_id-vs-type_id surface. A malicious client gains nothing by calling these handlers except a log line.
+
+**How to apply:** When Phase 2 lands (the ASP-spend validation, paradigm gate, prerequisite expertise floor, DB UPDATE), re-run the adversarial review with the full handler ↔ DB mutation path in scope. Specific things to check at Phase 2:
+
+- `applied_science_points` decrement must be server-authoritative (`UPDATE sgw_player SET applied_science_points = applied_science_points - 1 WHERE player_id = $1 AND applied_science_points >= 1`) with `rows_affected() == 1` check. Naive `state.applied_science_points -= 1; save_crafting_state(...)` is racy with two concurrent ASP-spend packets.
+- `discipline_id` validation against the static discipline table — reject indices outside the canonical set, not just "negative".
+- Prerequisite checks (`expertise[prereq_id] >= required_expertise`) must be evaluated server-side using the freshly-loaded state, not the cached client-derived snapshot.
+- `racial_paradigm_levels[discipline.racial_paradigm_id] >= discipline.racial_paradigm_level` gate must also be evaluated against the just-loaded state.
+
+**Existing defensive primitives ready to use at Phase 2:**
+
+- `save_crafting_state` already returns `sqlx::Error::RowNotFound` for `rows_affected() == 0` on the player UPDATE — covers the missing-player case but NOT the "ASP balance was 0 so the conditional WHERE didn't match" case. Phase 2 needs a distinct `InsufficientFunds`-shaped error.
+- `set_expertise` clamps to `[0, 100]` per the Python `gainExpertise` hard cap.
+- `load_crafting_state` defensively clamps `i32 → i8` for paradigm levels via `i8::try_from(...).unwrap_or_else(... clamp ...)` — useful pattern.
+
+**No double-consume risk in Phase 1** — no `remove_item` or `UseInventoryItem` adjacency. Phase 4/5 (craft/research/alloy actually consuming items) is where the double-consume trap can re-emerge.

--- a/.claude/agent-memory/server-authority-enforcer/project_black_market_unimplemented.md
+++ b/.claude/agent-memory/server-authority-enforcer/project_black_market_unimplemented.md
@@ -1,0 +1,47 @@
+---
+name: project-black-market-unimplemented
+description: Black Market / Auction House surface is fully stubbed server-side — entire economy vertical lands as exploit chain on implementation
+metadata:
+  type: project
+---
+
+The SGW Black Market / Auction House surface (`SGWBlackMarketManager`,
+CellMethod indices 61–66) is fully unimplemented in
+`crates/services/src/cell/cell_methods/black_market.rs`. Every arm
+returns `true` (handled) after a `tracing::info!("UNIMPLEMENTED: …")`,
+no DB tables back the surface, no `ON_BM_*` ClientMethod is ever
+emitted from the server, no expiry sweep exists.
+
+**Why:** This is the same shape as [[project-mail-handlers-unimplemented]]
+and [[project-trade-handlers-unimplemented]] — the wire surface is
+fully exposed (Ghidra confirms the client emits
+`Event_NetOut_BMCreateAuction`, `BMPlaceBid`, `BMCancelAuction`,
+`BMSearch` with their full payloads), but the server stubs the
+mutation. Whoever fills in the handler bodies inherits a wire
+surface that accepts every client-asserted field with no
+validation plumbed in and no DB schema to enforce ownership /
+atomicity. The audit (CAT-I, 2026-05-31) pre-flagged six findings
+spanning create / bid / cancel / search / expiry-sweep so the
+invariants are nailed down before the implementation PR lands.
+
+**How to apply:** When auditing or designing the BM implementation,
+require:
+- BMCreateAuction: ownership join on `(character_id, item_id)`,
+  atomic item lock + listing-fee deduction + listing insert,
+  `startingPrice > 0`, `buyoutPrice >= startingPrice` (or 0),
+  `auctionLength` cap, per-player active-listing cap.
+- BMPlaceBid: `sequenceId` is a *paginated cursor*, not a row
+  id — must translate through caller-scoped (`clientKey`-keyed)
+  search-result cache; lock listing row, server-side bid >
+  current_bid comparison, currency hold at bid time, refund
+  prior bidder atomically, reject self-bid.
+- BMCancelAuction: ownership check, return escrowed item +
+  refund any active bidder atomically.
+- BMSearch: server-side result-size cap (e.g. 50 rows),
+  faction / region filter enforced server-side,
+  `(character_id, clientKey)` cache keying.
+- Expiry sweep: needs Tokio periodic tick + outbox-pattern
+  delivery (mail vertical is the natural surface but mail is
+  also unimplemented — see [[project-mail-handlers-unimplemented]]).
+
+Findings file: `.scratch/audit/findings/CAT-I-black-market.md`.

--- a/.claude/agent-memory/server-authority-enforcer/project_chat_contact_audit_2026-05-31.md
+++ b/.claude/agent-memory/server-authority-enforcer/project_chat_contact_audit_2026-05-31.md
@@ -1,0 +1,87 @@
+---
+name: project-chat-contact-audit-2026-05-31
+description: CAT-L audit findings; chat/contact/communication trust posture as of 2026-05-31
+metadata:
+  type: project
+---
+
+## CAT-L audit snapshot — 2026-05-31
+
+**Why:** captured the chat / contact-list / communication surface trust posture at
+the time of the 2026-05-31 server-authority audit so future re-reviews can pick up
+incrementally.
+
+**How to apply:** when re-auditing CAT-L or implementing a chat / contact / org-ping
+handler, start from this snapshot rather than re-discovering the wire surface.
+
+### Implemented (live exploit surface)
+
+- `sendPlayerCommunication` (base method `0xC2`, `dispatch.rs:77-156`) — the
+  ONLY chat path that broadcasts. Server-authoritative speaker_name +
+  speaker_flags (from session `access_level` / `dnd_message`). Cell-side
+  broadcast at `cell/chat.rs` filters channel to SAY/EMOTE/YELL only.
+  **Gaps:** no rate limit, no text length cap, no ignore-list filter, no
+  profanity filter. → CAT-L-01.
+- `chatSetDNDMessage` (base method `0xC4`, `dispatch.rs:191-233`) — stores
+  WSTRING on `ConnectedClientState.dnd_message` with no size cap. → CAT-L-02.
+
+### Stubbed / log-only (latent traps)
+
+- `chatJoin` / `chatLeave` / `chatSetAFKMessage` (base methods `0xC0`/`0xC1`/`0xC3`)
+  — debug-log only, discard the `password` field on chatJoin. → CAT-L-09.
+- All six contact-list cell methods (indices 55-60 in `cell_methods/contact_list.rs`)
+  — log-only stubs that decode the leading 4-8 bytes and return. No self-add
+  guard, no list-size cap, no ownership check. → CAT-L-04.
+- `BroadcastMinimapPing` (cell method index 10 in OrganizationMember interface,
+  `cell_methods/organization.rs:48-64`) — decodes `(org_id, x, y, z)` and logs.
+  No org-membership check, no NaN guard, no rate limit. → CAT-L-05.
+- `WHO` (cell method index 73, `cell_methods/player/interaction.rs:17-20`) —
+  single-line info-log stub. → CAT-L-07.
+
+### Unhandled (warn-arm only — no exploit until handler is added)
+
+- `Event_NetOut_SendGMShout` — registered NetOut event, no Rust handler;
+  needs `access_level >= GameMaster` gate when implemented. → CAT-L-06.
+- `Event_NetOut_Petition` — sender-identity must be session-authoritative.
+  → CAT-L-07.
+- `Event_NetOut_ChatFriend`, `Event_NetOut_ChatIgnore` — need same
+  ownership / cap / self-add discipline as contact-list. → CAT-L-07.
+- `Event_NetOut_ChatOp/Mute/Kick/Ban/Password` — need per-channel
+  server-tracked op-bit before applying admin action; channel name MUST be
+  normalized (case-fold, trim) before the op-bit lookup. → CAT-L-08.
+
+### Authority sources used correctly
+
+- `player_name` reads from `ConnectedClientState.player_name`, set from DB at
+  `play_character.rs:133`. **Authoritative.**
+- `access_level` reads from `ConnectedClientState.access_level`, set from DB at
+  `auth/handlers.rs:486-488` and `login/mod.rs:156`. **Authoritative** — used
+  to compute `SPEAKER_GM` bit, regression-pinned by tests 1-4 in
+  `dispatch.rs:588-660`.
+- Witness list reads from server-computed AoI
+  (`space_mgr.get_entity(sender_id).witnesses`). **Authoritative.**
+
+### Key dispatch entry points (for incremental re-audit)
+
+- Base layer: `crates/services/src/base/dispatch.rs:dispatch_sgw_player_base_method`
+  — handles msg_id 0xC0..=0xD8 range. Catch-all warn arm at `dispatch.rs:333-346`.
+- Cell layer: `crates/services/src/cell/dispatch/router.rs:dispatch_cell_method`
+  — routes by `method_index` through inheritance order. Catch-all warn arm at
+  `router.rs:101-106`.
+- Slash-command layer (separate path): `crates/commands/src/registry.rs` +
+  `crates/commands/src/permissions.rs` enforces `access_level` for typed `/give`,
+  `/spawn`, etc. — NOT used by the wire `Event_NetOut_*` path. Two GM dispatch
+  paths exist. → see [[reference-gm-auth-plumbing-gap]].
+
+### Tests covering chat correctness
+
+- `dispatch.rs:599-660` — speaker_flags = 0 default, =SPEAKER_GM when
+  access_level>0, =SPEAKER_DND when dnd_message set, combined when both. Tests
+  pin the byte-exact wire encoding.
+- `world_entry_chat.rs:62-237` — `DEFAULT_CHAT_CHANNELS` byte-exact channel set
+  + `onChatJoined` / welcome-message wire layout.
+- `chat.rs:200-339` — onPlayerCommunication serialization byte-exact;
+  witness fan-out; CHAN_TELL ignored by CellService.
+
+No rate-limit test, no length-cap test, no ignore-list test — because those
+features don't exist yet.

--- a/.claude/agent-memory/server-authority-enforcer/project_crafting_unimplemented.md
+++ b/.claude/agent-memory/server-authority-enforcer/project_crafting_unimplemented.md
@@ -1,0 +1,86 @@
+---
+name: project-crafting-unimplemented
+description: CAT-F crafting/research/alloy/RE/spendASP are Phase-1 stubs; only TrainAbility is wired; future implementer's must-validate checklist
+metadata:
+  type: project
+---
+
+CAT-F (Crafting / R&D / Training) audit complete on 2026-05-31. Trust posture:
+
+**TrainAbility (method 77)** — fully implemented, well-validated.
+- Cell side: archetype-tree membership + level + prereqs + already-known guard,
+  at `crates/services/src/cell/cell_methods/player/vendor.rs:491`.
+- Base side: atomic `UPDATE … WHERE training_points > 0 AND NOT (abilities @>
+  ARRAY[$1])` at `crates/services/src/base/world_entry/methods/progression/mod.rs:456`.
+- **BUT** missing trainer-NPC interaction state + distance check — Python
+  required `self.trainerEntity != None` AND `distanceTo(trainerEntity) <=
+  MAX_INTERACT_DISTANCE`; Rust dropped both. Filed as CAT-F-01 Medium. Fix:
+  add `trainer_entity: Option<u32>` on entity, parallel to `vendor_entity`,
+  set by `try_open_trainer` at `crates/services/src/cell/interactions/trainer.rs:55`.
+
+**The other five RPCs** — all stubs:
+- `spendAppliedSciencePoints` (95), `craft` (96), `research` (97),
+  `reverseEngineer` (98), `alloying` (99), `respecCrafting` (100) — all in
+  `crates/services/src/cell/cell_methods/player/crafting.rs:23-86`. All
+  return `true` (handled) with `tracing::info!(... "UNIMPLEMENTED")`.
+- Persistence layer EXISTS:
+  - `crates/services/src/base/crafting/persistence.rs` — load/save round-trip
+    with `RowNotFound` guard on save; `applied_science_points`,
+    `discipline_ids`, `blueprint_ids`, `racial_paradigm_levels`,
+    `expertise[]` all persisted.
+  - `crates/entity/src/crafting.rs` — `CraftingState` struct + serializer for
+    `onUpdateDiscipline` (method 136).
+- World-entry already sends `onUpdateKnownCrafts` from server-authoritative
+  `blueprint_ids` at `crates/services/src/mercury/world_data/map_loaded.rs:375`.
+
+**Wire shapes (from `entities/defs/SGWPlayer.def` lines 911-948, Ghidra-confirmed):**
+- `spendAppliedSciencePoints(INT32 aDisciplineSeqId)` — method 95
+- `craft(INT32 aCraftId, ARRAY<ItemID> aItems, INT32 aQuantity)` — method 96
+- `research(ItemID aItemId, ARRAY<ItemID> aKickers)` — method 97
+- `reverseEngineer(ItemID aItemId)` — method 98
+- `alloying(INT32 aCraftId, ItemID aCurrentTierItemId, ARRAY<ItemID> aLowerTierItems)` — method 99
+- `respecCrafting()` — method 100 (empty)
+
+**The future implementer's MUST-validate checklist** (per finding):
+1. **Blueprint known**: `aCraftId ∈ sgw_player.blueprint_ids` for caller.
+2. **Item ownership**: every `ItemID` in payload → `sgw_inventory.player_id =
+   caller`. NEVER trust the item_id alone.
+3. **Bag location**: `bag_id IN (INV_Main, INV_Crafting)` — Python
+   `Crafter.py:212-215`. Equipped/bandolier/mail items are NOT eligible.
+4. **Item type matches recipe**: lookup `resources.blueprints_components`
+   keyed by `(blueprint_id, component_set_id)`; verify supplied item types
+   cover requirement.
+5. **Quantity sufficient**: `sum(item.quantity ...) >= component.quantity *
+   aQuantity`. Bound `aQuantity ≥ 1` and protect against overflow.
+6. **Researchable / kicker / reverseEngineerable type flags** — resources lookup;
+   reject quest/soulbound items.
+7. **Outcome rolls server-side** — `research` chance + `reverseEngineer`
+   component quantities use server RNG, never client-supplied seed/result.
+8. **Atomic consume + produce**: single `BEGIN…COMMIT` with `FOR UPDATE` on
+   input rows, parallel to TrainAbility's `WHERE training_points > 0` pattern.
+9. **Alloy specifics**: `blueprint.alloy = true` check (Python `Crafter.py:464`
+   — `if not blueprint.alloy: reject`); elementary count matches
+   `ALLOYING_ELEMENTARY_COUNTS[quality]`; every elementary at `tier == current.tier - 1`.
+10. **Busy gate**: no `busy` flag exists in Rust today — add per-entity
+    `crafting_busy: Option<CraftTimer>` parallel to Python `@mustBeIdle`; reject
+    overlapping craft requests.
+11. **Validation BEFORE any mutation** — no `busy = true`, no
+    `onCraftingStarted`, no in-memory state change before the validation
+    chain completes.
+12. **Python bug NOT to port**: `Crafter.py:469` precedence error
+    `requirement['item'].id != component.typeId is None` evaluates as
+    `(x != y) and (y is None)` = always False; never actually validates
+    current-tier type. Rust must compare type ids directly.
+13. **Python bug NOT to port**: `randint(0, len(list))` is inclusive-upper;
+    Rust must use `rng.gen_range(0..n)`.
+
+**ASP balance** for `spendAppliedSciencePoints` — read from
+`sgw_player.applied_science_points`; decrement guarded by `WHERE
+applied_science_points >= 1 AND NOT (discipline_ids @> ARRAY[$1])`.
+
+**Cross-disciplinary**: items-systems-advisor owns the consume/produce path
+itself (UPDATE/INSERT against `sgw_inventory`); this enforcer owns the
+"client-supplied item_id must be validated" gate.
+
+Confidence: high — five separate exploit shapes filed (CAT-F-02 through
+CAT-F-05 + CAT-F-07 busy-gate). Ghidra confirmed all wire shapes.

--- a/.claude/agent-memory/server-authority-enforcer/project_gm_commands_audit_2026-05-31.md
+++ b/.claude/agent-memory/server-authority-enforcer/project_gm_commands_audit_2026-05-31.md
@@ -1,0 +1,93 @@
+---
+name: project-gm-commands-audit-2026-05-31
+description: CAT-N audit — GM/debug/cheat commands trust posture as of 2026-05-31
+metadata:
+  type: project
+---
+
+## CAT-N GM-commands trust posture — 2026-05-31
+
+**Why**: User commissioned a per-category server-authority audit;
+CAT-N is the largest single risk surface (~125 distinct wire
+events). Findings written to
+`.scratch/audit/findings/CAT-N-gm-commands.md`.
+
+**How to apply**: When future work touches any `gm*` handler, the
+SGWGmPlayer entity class enablement, or anything that plumbs
+caller identity into the cell layer — reference this audit. The
+core systemic finding (no access_level in cell dispatch) is the
+prerequisite for safely implementing any of the GM cell methods.
+
+### Key state
+
+- ZERO `gm*` cell methods are implemented in Rust. Every one
+  falls through to the warn! arm at
+  `crates/services/src/cell/dispatch/router.rs:101`.
+- `class_id` is hardcoded to SGWPlayer (0x02) regardless of
+  access_level (see TODO at
+  `crates/services/src/base/world_entry/play_character.rs:89-94`).
+  Legitimate GMs CANNOT use GM commands today.
+- Three GM-shaped methods ARE in the regular SGWPlayer flat-index
+  table (so reachable today even without the SGWGmPlayer class):
+  `onWorldInstanceReset` (CM 92), `resetMyAbilities` (CM 72),
+  and the combat/heal debug toggles (CM 2/3/6 on
+  SGWAbilityManager/SGWCombatant). All are stub handlers today.
+- Two parallel GM dispatch paths exist: (a) the chat slash-command
+  registry in `crates/commands` which DOES gate on access_level,
+  and (b) the wire cell-method dispatch which does NOT. The
+  in-process `crates/game/src/commands/gm_cmds.rs` handlers use
+  path (a); future implementers MUST NOT confuse the two.
+
+### What I filed
+
+40 numbered findings:
+
+- CAT-N-01: WORLD_INSTANCE_RESET reachable on regular player wire
+- CAT-N-02: resetMyAbilities reachable on regular player wire (free respec)
+- CAT-N-03: systemic — no access_level in cell dispatch (CRITICAL)
+- CAT-N-04: class hardcode + future flip without auth plumbing
+- CAT-N-05: SetHideGM exposed — if bHideGM ever becomes a privilege gate
+- CAT-N-06..16, 18..40: per-handler trust violations across
+  Set/Give/Show/Kill/Spawn/Goto/Load/Debug families. All share the
+  CAT-N-03 root cause but each is documented with its specific
+  wire shape, severity, and remediation.
+- CAT-N-30: TOGGLE_COMBAT_DEBUG family — exposed at SGWAbilityManager
+  CMs 2/3/6, stub today, info-disclosure when implemented.
+- CAT-N-39: SET_AUTO_CYCLE inherits CAT-C's missing perception
+  check on the target.
+
+### What I didn't file (with rationale in the file's Not Filed section)
+
+- Per-mission GM variants (gmMissionAssign/Advance/Reset/Complete/...)
+  — same shape as CAT-N-21 (flag mutation), not double-filed.
+- Per-debug shapes (DebugAbilityOnMob, BehaviorsOnMob, PathsOnMob,
+  MobData) — sibling shapes of CAT-N-31 (DebugEvents).
+- LogOff, Disconnect, Unstuck — owned by CAT-A / CAT-B.
+- Petition, Who, BroadcastMinimapPing — CAT-L (not GM despite name).
+- SetCallback's PYTHON arg — not directly filed because (a) the
+  Rust cell decoder doesn't handle PYTHON, (b) it's a CAT-A-style
+  RCE concern about the wire type itself.
+
+### Severity calibration used
+
+- Critical: anyone-becomes-GM (CAT-N-03 systemic; CAT-N-05 if
+  bHideGM becomes a privilege bit).
+- High: anyone mutates authoritative inventory/state of self or
+  others — SetGodMode, SetHealth, GiveItem, Kill, Spawn,
+  WorldInstanceReset, GotoXYZ, SetSpeed, SetLevel.
+- Medium: info disclosure or self-only power inflation (SetFlag,
+  SetMobAttribute, SetMobAbilitySet, ShowIP, ShowInventory,
+  Invisible, XRayEyes, GiveStargateAddress, SetNoXP, SetNoAggro,
+  AddBehaviorEventSet, GiveRespawner/Gearset/Inventory/Blueprint,
+  SetFaction, RemoveItem, Respec).
+- Low: log noise / DoS shape / corner-case (PerfStats trust,
+  SetMovementType enum exposure, gmUsers, ShowMobCount,
+  TestLOS/ToggleCombatLOS, PrintStats, RequestReload caller check).
+
+### Linked memory
+
+- [[reference-gm-command-wire-spec]] — authoritative wire shapes
+- [[reference-gm-auth-plumbing-gap]] — what needs to change to fix
+- [[reference-cell-method-entity-id-authority]] — related: the
+  entity_id substitution in cell_arms; CAT-N-29 relies on this
+  being correct.

--- a/.claude/agent-memory/server-authority-enforcer/project_mail_handlers_unimplemented.md
+++ b/.claude/agent-memory/server-authority-enforcer/project_mail_handlers_unimplemented.md
@@ -1,0 +1,28 @@
+---
+name: project-mail-handlers-unimplemented
+description: Mail send/take-cash/take-item/pay-COD/return are stubbed; cell dispatcher returns true so future implementations inherit unvalidated wire surface
+metadata:
+  type: project
+---
+
+`crates/services/src/cell/cell_methods/mail.rs` has five stubbed arms:
+`SEND_MAIL_MESSAGE` (44), `RETURN_MAIL_MESSAGE` (47), `TAKE_CASH_FROM_MAIL` (49),
+`TAKE_ITEM_FROM_MAIL` (50), `PAY_COD_FOR_MAIL` (51). Each logs
+`tracing::info!("UNIMPLEMENTED: …")` and returns `true` (claims to have handled
+the message). The dispatcher silently consumes the bundle; the client receives
+no `sendMailResult`/error path.
+
+**Why:** Audit (CAT-G, 2026-05-31) confirmed only `requestMailHeaders`,
+`requestMailBody`, `archiveMailMessage`, `deleteMailMessage` are wired to the DB.
+The implemented quartet correctly scopes by `character_id = $player_id` via
+`resolve_mail_player_id()` in [[reference-mail-validation-locations]].
+
+**How to apply:** When reviewing any future PR that touches mail handlers,
+re-derive the validation contract from scratch — there is no existing pattern
+in the file to copy from for the mutating paths. Required validations for
+each future arm are enumerated in `.scratch/audit/findings/CAT-G-mail.md` 
+CAT-G-01 through CAT-G-06. Send-mail dupe scenario uses TOCTOU on
+`sgw_gate_mail.cash` between take-cash and take-item — see CAT-G-04.
+
+Wire shape per arm comes from `entities/defs/interfaces/SGWMailManager.def`
+— see [[reference-mail-wire-spec]].

--- a/.claude/agent-memory/server-authority-enforcer/project_mission_dialog_audit_2026-05-31.md
+++ b/.claude/agent-memory/server-authority-enforcer/project_mission_dialog_audit_2026-05-31.md
@@ -1,0 +1,37 @@
+---
+name: project-mission-dialog-audit-2026-05-31
+description: CAT-J audit findings as of 2026-05-31 — mission/dialog/interaction handlers
+metadata:
+  type: project
+---
+
+CAT-J audit of mission/dialog/interaction handlers (cell methods 52-54
+Missionary + 74-76, 87 SGWPlayer + chain-engine event_dispatch path) found
+9 reportable findings; one Critical (DIALOG_BUTTON_CHOICE has no
+open-dialog tracking — allows forging any OnDialogChoice chain
+side-effect), one High (mission accept has no prereq validation), one
+High-latent (ChosenRewards unimplemented — reward-pick design constraint
+to lock in before implementation), one Medium-latent (the Mission*/Debug
+names that fall through unhandled today).
+
+**Why:** Pre-implementation findings are filed as advisory to lock the
+design constraints into reviewer-greppable evidence BEFORE the
+implementation PRs land — same pattern as the mail/trade handler
+findings, where filing the latent gap early let the implementer use the
+finding as a checklist rather than re-deriving it.
+
+**How to apply:** When `chosenRewards`, `MissionAdvance`,
+`MissionComplete`, `MissionAssign`, `MissionReset`, `MissionClear*`,
+`MissionSetAvailable`, `DebugInteract`, `ShareMission`,
+`ShareMissionResponse`, or `AbandonMission` (slash-cmd) handlers come
+off the UNIMPLEMENTED log path, ensure the implementing PR cites
+**CAT-J-04** (prereq validation for accepts), **CAT-J-05** (server-side
+offered-rewards-set pin for ChosenRewards), **CAT-J-06** (group +
+recipient-consent for ShareMission), or **CAT-J-08** (GM gating for the
+Debug + admin Mission* variants). Implementer should also clear
+**CAT-J-01** (open-dialog tracking) before any new chain-firing handler
+trusts a client-supplied dialog/state-key id.
+
+Links: [[reference-dialog-choice-exploit-shape]]
+[[project-trade-handlers-unimplemented]]
+[[project-mail-handlers-unimplemented]]

--- a/.claude/agent-memory/server-authority-enforcer/project_org_squad_duel_unimplemented.md
+++ b/.claude/agent-memory/server-authority-enforcer/project_org_squad_duel_unimplemented.md
@@ -1,0 +1,64 @@
+---
+name: project-org-squad-duel-unimplemented
+description: Organization / Squad / Duel wire surface is fully stubbed; CAT-M audit findings as of 2026-05-31
+metadata:
+  type: project
+---
+
+# CAT-M (Organization / Squad / Duel) — trust posture 2026-05-31
+
+**Status:** All 18 in-scope client wire surfaces are unimplemented.
+
+**Why:** Implementation has not started on guild/squad/duel systems. The
+cell-method handlers in `cell/cell_methods/organization.rs` (indices
+8–19) and `cell/cell_methods/player/social.rs` (`ORG_CREATION`=94,
+`SEND_DUEL_RESPONSE`=102, `DUEL_FORFEIT`=103) are all log-and-return-
+true stubs. The four BaseMethods (`organizationInvite`,
+`organizationInviteByType`, `organizationKick`, `organizationRankChange`,
+`sendDuelChallenge`) have no base-dispatch arm at all — they hit the
+catch-all `warn!` in `base/dispatch.rs:333-347` and silently return Ok.
+
+**How to apply:** When auditing or implementing org/squad/duel, treat
+the entire vertical as a single landing point — the same way [[project-
+black-market-unimplemented]] and [[project-trade-handlers-unimplemented]]
+landed. The 18 findings in `.scratch/audit/findings/CAT-M-org-squad-duel.md`
+form the checklist:
+
+- Org creation (CAT-M-03): founder fee, name uniqueness, length cap, faction binding
+- Org invite/leave (CAT-M-01, -02, -04, -18): caller permission, target state, request-id correlation
+- Destructive ops on roster (CAT-M-05, -06, -07, -08): rank-compare, rank-cap, perm-mask, perm-subset invariants
+- Guild bank (CAT-M-09): signed-i32 dupe, atomicity, per-rank withdraw cap — **critical severity**
+- Text fields (CAT-M-10): MOTD/Note/OfficerNote permission + length cap
+- Squad loot (CAT-M-11): squad-leader check, enum-range check
+- Duel state machine (CAT-M-12, -13, -14, -15): online/space/range/cooldown gates,
+  pending-challenge correlation, participant check on forfeit, disconnect auto-forfeit
+- PvP / strike-team responses (CAT-M-16, -17): pending-request correlation
+
+**Pattern callouts:**
+
+1. **Pending-request-correlation** is the recurring shape for invite-response,
+   pvp-leave-response, strike-team-response, duel-response. The
+   `OrganizationMember.def:26-57` properties (`strikeTeamTimers`,
+   `pendingPvPTimers`, `pendingGroups`, `pendingJoins`, `pendingInvitesByType`)
+   are exactly the per-session state needed. They already exist in the entity
+   model — implementer just has to wire them into the response handlers.
+2. **Permission bits in `enumerations.xml:1907-1937`** (`EOrganizationPermission`,
+   UINT32 union, ~22 defined bits) are the canonical mask for every
+   roster-mutation gate. Caller-perm bit + target-rank < caller-rank +
+   perm-subset constraint are the three invariants on destructive ops.
+3. **Wire shapes live in `entities/defs/interfaces/OrganizationMember.def`**
+   (BaseMethods at lines 421-447, CellMethods at lines 179-413).
+   `entities/defs/SGWPlayer.def` adds `sendDuelChallenge` (line 509),
+   `onOrganizationCreation` (line 877), `sendDuelResponse` (line 975),
+   `duelForfeit` (line 1015).
+
+**Critical implementation gotcha:** `organizationTransferCash`'s `aCash`
+field is signed `INT32`. The implementer **must** reject `aCash <= 0`
+or a negative deposit becomes a withdraw under naïve subtraction. The
+Python reference enforced this; the Rust reimplementation must too.
+
+Links: [[reference-org-squad-duel-wire-spec]] for wire-shape anchors,
+[[reference-cell-method-entity-id-authority]] for the framing-layer
+entity-id guarantee, [[reference-dialog-choice-exploit-shape]] for the
+analogous "no pending-prompt tracking" exploit shape that CAT-M-13/-16/
+-17/-18 all share.

--- a/.claude/agent-memory/server-authority-enforcer/project_trade_handlers_unimplemented.md
+++ b/.claude/agent-memory/server-authority-enforcer/project_trade_handlers_unimplemented.md
@@ -1,0 +1,50 @@
+---
+name: project-trade-handlers-unimplemented
+description: All four player-to-player trade RPCs are unimplemented stubs; future implementers inherit the full dupe-prone wire surface unvalidated
+metadata:
+  type: project
+---
+
+All four `<Exposed/>` trade RPCs on `SGWPlayer.def` — `tradeRequest`,
+`tradeRequestCancel`, `tradeUpdateProposal`, `tradeLockState` — dispatch to a
+single `match` block in `crates/services/src/cell/cell_methods/player/social.rs`
+(approximately lines 103–149) that decodes only the leading INT32 header bytes,
+logs `UNIMPLEMENTED: …`, and returns `true` (Handled). No `TradeTransaction`
+struct, no item-lock table, no escrow object, and no `onTradeState` /
+`onTradeResults` emitter exist anywhere in `crates/`.
+
+**Why:** The wire is exposed and the client UI fires the RPCs, but the server
+discards the proposal payload. The danger is the *next* PR that fills the match
+arms in piecewise without the dedicated state machine — this is exactly the shape
+that produced the named [[stack-duplication-via-disconnect-timing]] pattern in
+classic MMO history.
+
+**How to apply:** Any review touching `social.rs` trade handlers, or any new file
+under a `crates/services/src/.../trade/` directory, must verify the implementer
+has added (in this order):
+
+1. Same-space + range + alive + is-player + not-already-trading + not-self
+   validation on `tradeRequest`.
+2. Per-`instance_id` item-lock table at `tradeUpdateProposal` time (not at
+   confirm), keyed by item_id not type_id (per the
+   [[bandolier-ammo-key-by-item-id]] invariant).
+3. Strict version-counter enforcement on `tradeLockState` — reject on mismatch,
+   do not silently downgrade lockState to None as the deprecated Python
+   reference does at `cell/Trade.py:203-204`.
+4. Single-transaction confirm with rollback (all four item moves + both cash
+   deltas in one `BEGIN/COMMIT`).
+5. Disconnect cleanup hook from `cell/base` player-disconnect path that
+   force-cancels the trade and emits a single `onTradeResults(Cancelled)` to the
+   surviving partner; outbox must never re-fire trade messages on reconnect.
+6. `can_trade()` predicate that respects `ITEM_FLAG_BindOnAcquire` and
+   `ITEM_FLAG_BindOnEquip` (from `Atrea/enums.py:794-795`) — NOT `canSell()`,
+   which the deprecated Python conflates.
+
+The deprecated reference at `deprecated/python/cell/Trade.py` and
+`deprecated/python/cell/SGWPlayer.py:1669-1814` shows the *attempted* shape but
+itself contains gaps (no item lock, no atomicity, no disconnect handling, the
+`canSell` ≠ `canTrade` conflation) — it is **not safe to port verbatim**.
+
+Wire shape: `entities/defs/SGWPlayer.def:1033-1072` plus `LocalTradeProposal` /
+`RemoteTradeProposal` FIXED_DICTs in `entities/defs/alias.xml:355-379`. Lock-state
+enum at `entities/defs/enumerations.xml:1784-1791`.

--- a/.claude/agent-memory/server-authority-enforcer/project_world_space_gate_audit_2026-05-31.md
+++ b/.claude/agent-memory/server-authority-enforcer/project_world_space_gate_audit_2026-05-31.md
@@ -1,0 +1,78 @@
+---
+name: project-world-space-gate-audit-2026-05-31
+description: CAT-O audit findings; gate/ring/region/world trust posture as of 2026-05-31
+metadata:
+  type: project
+---
+
+CAT-O (World/Space/Gate/Ring) audit completed 2026-05-31. Six findings filed.
+
+**Fact**: The gate-travel handler (`crates/services/src/cell/gate_travel.rs`)
+validates the destination against the *global* `space_mgr.stargates` catalog
+only — it ignores the player's `knownStargateAddresses` (CELL_PRIVATE on
+GateTravel.def, persisted to `sgw_player.known_stargates`, hydrated into
+`PlayerLoadData::known_stargates` at world entry but never plumbed onto the
+CellEntity). This is **distinct** from [[CAT-B-02]]'s source-position gap;
+both must be fixed independently. CAT-O-01.
+
+**Fact**: `onWorldInstanceReset` is declared on the **player** entity
+(`SGWPlayer.def:868-870`, `<Exposed/>`) — NOT on `SGWGmPlayer.def`. The
+naming implies GM but the wire surface is open to every client. Currently
+UNIMPLEMENTED in Rust as a no-op stub; the trap fires when a future
+contributor implements it without an access-level check. CAT-O-04, links to
+[[reference_gm_auth_plumbing_gap]] for the systemic dispatch-layer fix.
+
+**Fact**: `triggerClientHintedGenericRegion` has *no rate-limit and no
+per-region debounce* in addition to the CAT-B-04 position-discard issue.
+A client can chain-fire enter/exit packets across multiple region IDs at
+packet rate, walking the content-chain engine through arbitrary mission
+sequences in seconds. CAT-O-03.
+
+**Fact**: `cancelMovie` (`Event_NetOut_CancelMovie`, wire shape
+`WSTRING MovieName`) is parsed by Cimmeria but the `MovieName` argument is
+**discarded** — the handler flips the global `cinematic_spam_cancel` flag
+regardless of which movie the client claims to cancel. Today only the
+first-login intro uses `send_cinematic`, so the bug is latent; the in-code
+comment at `world_entry_appearance.rs:533-536` explicitly anticipates
+"future cinematics (mission cutscenes, gate transitions, dialog overlays)"
+through the same path. CAT-O-05.
+
+**Fact**: `updateSystemOptions` is **structurally safe today** — apply
+allowlist is closed at `crates/entity/src/cell_entity/system_options.rs:59-71`
+to just `autoReload` and `reloadOnActivate`, both advisory booleans, and
+the wire parse is count-capped at 256. The trap is forward-looking:
+SystemOptions.xml has ~140 options and the wire `(WSTRING name, WSTRING
+value)` makes adding a server-authoritative option (PvP-flag, accept-duel-
+auto, etc.) to the apply match a one-line PR with privilege-escalation
+consequences. CAT-O-06.
+
+**Fact**: `onSpaceQueuedResponse`/`onSpaceQueueReadyResponse`/
+`onSpaceQueueStatus`/`onStrikeTeamResponse` are all **completely unwired**
+on the server — no cell-method arm, no dispatch entry. Server→client emits
+exist (`ON_SPACE_QUEUED` 146, `ON_SPACE_QUEUE_READY` 147) but the inbound
+responses go through the "unhandled cell method" warn path. No exploit
+until implementation; flagged in CAT-O "Not Filed".
+
+**Fact**: `Event_NetOut_DHD` and `Event_NetOut_onDialGate` map to the
+*same* server-side wire — cell method 35, `handle_dial_gate`. The C++
+client's `Event_SlashCmd_DHD` and the in-game dialer UI both emit to that
+single cell method. There is no separate `dhd` cell method in the SGWPlayer
+or GateTravel def.
+
+**Why this matters**: CAT-O's residual exploit shape is "destination
+authorization" — every position-anchored fix from CAT-B leaves the
+destination-authorization gap untouched. Any future review of gate/ring
+travel must verify both *source* and *destination* authority separately;
+the source-position fix alone does not stop CAT-O-01.
+
+**How to apply**: When reviewing future gate/ring/region handlers, run
+this three-check pass:
+1. Source authority (CAT-B-02/03/04 angle): is the player actually at the
+   place they're claiming to depart from?
+2. Destination authority (CAT-O-01 angle): does the player have the
+   destination unlocked?
+3. Transaction window (CAT-O-02 angle): is there a cancel/cost gate
+   between accept-press and irreversible-mutation?
+
+Links: [[reference_world_space_gate_wire_spec]],
+[[reference_gm_auth_plumbing_gap]], [[reference_cell_method_entity_id_authority]].

--- a/.claude/agent-memory/server-authority-enforcer/reference_auth_exploit_classes.md
+++ b/.claude/agent-memory/server-authority-enforcer/reference_auth_exploit_classes.md
@@ -1,0 +1,81 @@
+---
+name: reference-auth-exploit-classes
+description: Recurring SGW auth/handshake exploit classes — keep in mind for future audits of any login or session refactor
+metadata:
+  type: reference
+---
+
+# Cimmeria auth exploit classes
+
+Drawn from the CAT-A audit (2026-05-31). Each item is a shape that auth-adjacent
+code should be reviewed against, not a single finding.
+
+## Plaintext-handshake leakage
+The Phase 1/2 SOAP path runs HTTP (no TLS). Anything in the SOAP request body
+or response XML is sniffable: account_name, the 40-char hex SHA-1 password
+(which the wire protocol accepts as the credential — possession of the hash
+== possession of the account), the 64-hex AES session_key, and the 10-hex
+ticket. Until the SOAP path goes TLS, any auth-adjacent feature is on the
+"sniffable" side of the trust boundary. See `crates/services/src/auth/service.rs`
+`TcpListener::bind` (no rustls/TLS in scope).
+
+## No source-IP binding on the ticket
+`PendingLogin` stores `(account_id, access_level, ticket, session_key, created)`
+— no `source_ip`. `handle_login` accepts the inbound UDP from any peer. Anyone
+who captures the ticket can race-or-replay it from any network. Any "session
+hijacking" finding in CAT-A traces back here.
+
+## Phase 3 has no TICKET_TTL check at consumption time
+The 30s TTL is only enforced by a 10s background reaper. `handle_login`
+just does `pending_logins.remove(ticket)` with no `created.elapsed()` check.
+So a ticket can be consumed up to ~40s old.
+
+## AES-CBC with fixed all-zero IV reused per packet
+`MercuryEncryption::from_session_key` uses `iv: [0u8; 16]` for every packet
+on a session. Stable plaintext prefixes (msg_id + word_len, entity_id headers,
+recurring AVATAR_UPDATE_EXPLICIT layout) produce stable ciphertext prefixes.
+Encryption-as-obfuscation; not real confidentiality.
+
+## Inbound replay protection exists but is not wired
+`Channel::receive_packet` in `crates/mercury/src/channel/mod.rs:412` has the
+RX window + dedup logic from spec §1.7. It's never called for inbound game
+packets — `handle_encrypted_datagram` skips straight from
+decrypt→parse→dispatch. Captured ciphertext can be re-injected, re-dispatched.
+Per-session `Channel` is constructed at Phase 3 but only sees outbound ACKs.
+
+## CONNECTED.lock() drops between scan-evict-insert in handle_login
+Three separate `connected.lock()` acquisitions for the duplicate-eviction
+flow. Two concurrent Phase 3 packets for the same account can both pass the
+"no existing session" scan and both insert.
+
+## developer_mode + no DB pool = open admin server
+`handle_user_auth` returns `(account_id=1, access_level=99)` for any
+account_name+password if `developer_mode=true && db=None`. The default is
+`developer_mode=false` but the dual condition is an easy ops mistake.
+
+## Password equality is variable-time
+`row.password.to_uppercase() != client_password_hash.to_uppercase()` is
+`String::ne`, short-circuiting on the first byte mismatch. Timing oracle on
+the stored hash. Use `subtle::ConstantTimeEq` or `constant_time_eq`.
+
+## No rate limiting on Phase 1
+No per-IP / per-account failure throttle. Credential stuffing at full server
+speed. Combined with the plaintext-handshake leakage, leaked-credential
+databases trivially yield working accounts.
+
+## CreateCharacter has no profanity / reserved-word filter
+`validate_character_name` enforces only length + character class +
+whitespace. `Admin`, `Moderator`, `GM Sam` etc. are creatable. Impersonation
+vector.
+
+## onClientVersion is a no-op
+0xC7 is just `tracing::debug!`. No minimum-client-version enforcement.
+Defense-in-depth missing — modded clients pass through.
+
+## authenticate (0x01) is parsed-and-discarded
+The post-Phase-3 first message is consumed without inspection. The server
+never proves the client knows the session_key beyond the implicit HMAC
+verification. The C++ reference also ignored it, but it's still a defense-
+in-depth gap relative to a hardened design.
+
+Related: [[reference-auth-handshake-layers]] for where each handler lives.

--- a/.claude/agent-memory/server-authority-enforcer/reference_auth_handshake_layers.md
+++ b/.claude/agent-memory/server-authority-enforcer/reference_auth_handshake_layers.md
@@ -1,0 +1,61 @@
+---
+name: reference-auth-handshake-layers
+description: Where Cimmeria's auth/session/character-lifecycle handlers live and what each layer is authoritative about
+metadata:
+  type: reference
+---
+
+# SGW auth handshake — layer map
+
+The handshake has three layers; each owns a distinct server-authority property.
+
+## Phase 1 + 2 — SOAP/HTTP (TCP)
+- `crates/services/src/auth/handlers.rs`
+  - `handle_user_auth` (POST `/SGWLogin/UserAuth`) — credential check, SID issue.
+  - `handle_server_selection` (POST `/SGWLogin/ServerSelection`) — shard pick,
+    ticket+session_key issue.
+- `crates/services/src/auth/mod.rs` — `PendingLogin`, TTL constants, ShardInfo.
+- `crates/services/src/auth/service.rs` — listener bind, reaper loop.
+- Authoritative for: account_id, access_level (from `account.accesslevel`),
+  AES session key (random 32B), ticket (random 10B → 20 hex chars).
+
+## Phase 3 — UDP baseAppLogin (msg 0x00, flags 0x41)
+- `crates/services/src/base/login/mod.rs`
+  - `parse_baseapp_login` — wire decode; `_account_id` from body[9..13] is
+    DISCARDED — trusted account_id comes from the ticket map, not the wire.
+  - `handle_login` — consume ticket, evict duplicate-account session, register
+    encrypted channel + spawn tick loop.
+- Encrypted channel registration creates `ConnectedClientState` with the
+  account_id + access_level carried from the ticket.
+
+## Phase 4 — encrypted game packets
+- `crates/services/src/base/connect_loop/encrypted/mod.rs::handle_encrypted_datagram`
+  - decrypt → parse → dispatch bundle.
+- `crates/services/src/base/connect_loop/account_arms.rs::dispatch_base_method`
+  - 0xC2 logOff, 0xC3 createCharacter, 0xC4 playCharacter, 0xC5 deleteCharacter,
+    0xC6 requestCharacterVisuals, 0xC7 onClientVersion.
+- Once `player_entity_id` is Some on ConnectedClientState, the 0xC2..0xC7 range
+  flips to SGWPlayer base-method dispatch instead (handled by
+  `dispatch_sgw_player_base_method`).
+
+## Where authorization-affecting state actually lives
+- `account_id`, `access_level` — `ConnectedClientState` (sourced from the
+  Phase 1/2 SOAP credential check + ticket). This is the source of truth for
+  any "is this a GM?" decision in dispatch.
+- `player_entity_id` — set by `play_character.rs:131-133` after a successful
+  `query_world_entry`. Handlers gate on `Some(_)` to detect "in-world".
+- DB row `sgw_player.access_level` — only read by `query_player_load_data` and
+  fed back to the client as a property; NOT used for authorization. Two sources
+  of truth (account vs sgw_player), authorization uses account.
+
+## Static / server-only derivations from CharDefId on createCharacter
+- `crates/services/src/base/chardef.rs::chardef_lookup` — (alignment, archetype,
+  gender, bodyset, starting_world, pos_x/y/z). Client cannot spoof these.
+- `resources.char_creation_visgroups` + `_choices` — visual options, validated
+  per group (VIS_Optional vs VIS_Forced).
+- `resources.char_creation_abilities` — starting ability list per CharDefId.
+- `resources.items.container_sets` + `BAG_FILL_ORDER` — starting inventory bag
+  placement.
+
+Related: [[reference-cell-method-entity-id-authority]] for the analogous
+"client says X, server overwrites with session truth" pattern at cell layer.

--- a/.claude/agent-memory/server-authority-enforcer/reference_black_market_wire_spec.md
+++ b/.claude/agent-memory/server-authority-enforcer/reference_black_market_wire_spec.md
@@ -1,0 +1,102 @@
+---
+name: reference-black-market-wire-spec
+description: Ghidra-extracted wire field layouts for the four client-emitted Event_NetOut_BM* messages
+metadata:
+  type: reference
+---
+
+Wire shapes for the Black Market / Auction House outbound messages,
+extracted from SGW.exe via Ghidra. All four are emitted by the
+client to the server via Mercury (CellMethod indices 61–64). The
+encoding is Mercury **property tree** (name-tagged fields,
+type-driven widths from a registry — *not* a flat little-endian
+byte array). Field types listed below are the C++ parameter types
+to the emit constructors; the prop-tree encoder widens these
+according to the property registry.
+
+## Event_NetOut_BMCreateAuction (cell method 62)
+Ghidra anchor: `00e59970` `FUN_00e59970`; string `019dd370`.
+Fields in emit order:
+- `itemInstanceId` — u32 (the item to list, NOT a type id)
+- `startingPrice` — u32 (signed-context per Rust stub; range
+  check needed regardless)
+- `buyoutPrice` — i32
+- `auctionLength` — u8 widened (param_4 is `char`)
+
+## Event_NetOut_BMPlaceBid (cell method 63)
+Ghidra anchor: `00e59da0` `FUN_00e59da0`; string `019dd3e8`.
+Fields in emit order:
+- `sequenceId` — i8 widened (param_1 is `char`). **This is a
+  paginated-cursor index, not a stable auction row id.**
+  The pair `(clientKey from last BMSearch reply, sequenceId)`
+  is what selects an auction.
+- `bidAmount` — u32 (param_2 is `uint`)
+
+Client-side pre-emit gate (informational only, trivially
+bypassed): `bidAmount <= caller's_naqahdah_balance`. Comparison
+at `if ((int)param_2 <= *(int *)(*(int *)(*(int *)(iVar1 + 0x8c)
++ 0x24) + 0x60))`.
+
+## Event_NetOut_BMCancelAuction (cell method 64)
+Ghidra anchor: `00e59c70` `FUN_00e59c70`; string `019dd3ac`.
+Single field:
+- `sequenceId` — i8 widened (param_1 is `char`). Same paginated
+  cursor as PlaceBid.
+
+## Event_NetOut_BMSearch (cell method 61)
+Ghidra anchor: `00e59f70` `FUN_00e59f70`; string `019dd41c`.
+Fields in emit order (eleven total):
+- `sortId` — u32
+- `clientKey` — u32 (per-search correlation id; server hands
+  this back in the auctions reply so paged subsequent calls
+  match the cache)
+- `sequenceId` — u32 (page cursor)
+- `bForward` — bool (forward/backward pagination)
+- `sellerName` — wchar_t* (LIKE-pattern source)
+- `bidderName` — wchar_t*
+- `itemName` — wchar_t*
+- `minTC` — u32 (min tech-credit / level filter)
+- `maxTC` — u32
+- `quality` — u32
+- `filterFlags` — u32 (bitmask of category filters)
+
+## Inbound (server → client) — for reference
+- `Event_NetIn_BMOpen` — opens the BM UI on the client
+- `Event_NetIn_BMAuctions` — auction listing batch. Per-row
+  fields (see `FUN_00e58e40` at `00e58e40`): `sequenceId`,
+  `itemDefId`, `stackSize`, `durability`, `charges`,
+  `currentBid`, `buyoutPrice`, `nextMinBidPrice`, `endTimeValue`.
+  Outer envelope (`FUN_00e5aa10` at `00e5aa10`): `totalResults`,
+  `clientKey`, `auctionItems` (array of the above).
+- `Event_NetIn_BMAuctionUpdate` — single-row delta (bid placed,
+  current bid changed).
+- `Event_NetIn_BMAuctionRemove` — listing closed (expiry, win,
+  cancel).
+- `Event_NetIn_BMError` — generic BM operation error.
+
+## Server-side response constants
+`crates/services/src/cell/client_methods/black_market.rs`:
+```
+ON_BM_OPEN: u16 = 90;
+ON_BM_ERROR: u16 = 91;
+ON_BM_AUCTIONS: u16 = 92;
+ON_BM_AUCTION_REMOVE: u16 = 93;
+ON_BM_AUCTION_UPDATE: u16 = 94;
+ON_BM_WATCHED_ITEMS_UPDATE: u16 = 95;
+```
+None are emitted from the server today.
+
+## Stub mis-decodes to fix at implementation time
+The current `cell_methods/black_market.rs` stub decodes args as
+flat LE i32 sequences. This will collide with the real Mercury
+property-tree frame:
+- `BMCreateAuction` stub treats four fields as four i32s; the
+  real wire is `u32 + u32 + i32 + u8` plus prop-tree name tags.
+- `BMPlaceBid` stub names the field `auction_id` and reads
+  i32; the real field is `sequenceId` (paginated cursor, i8-
+  widened).
+- `BMCancelAuction` same — `auction_id` vs `sequenceId`.
+
+When implementing, decode through the same Mercury property-
+tree parser that other handlers use, not via `from_le_bytes`
+offsets.

--- a/.claude/agent-memory/server-authority-enforcer/reference_cell_method_entity_id_authority.md
+++ b/.claude/agent-memory/server-authority-enforcer/reference_cell_method_entity_id_authority.md
@@ -1,0 +1,28 @@
+---
+name: reference-cell-method-entity-id-authority
+description: Cell-method handlers receive player_eid from session, not the entity_id the client supplies in the 4-byte prefix
+metadata:
+  type: reference
+---
+
+In `crates/services/src/base/connect_loop/cell_arms.rs:64-89,119-138`,
+when a `0x80..0xBF` cell-method packet arrives:
+
+1. The 4-byte `entityId` prefix is parsed into `entity_id_from_client`
+   (line 87-88) and logged for diagnostics, but
+2. The value forwarded to `BaseToCellMsg::CellMethodCall` is `player_eid`,
+   the server-tracked entity id pulled from the `ConnectedClientState`
+   at the inbound `SocketAddr` (line 64-67, 122, 134).
+
+This means a client cannot route a cell-method call against another
+player's entity_id by lying in the prefix bytes. Useful when auditing
+any cell-method-shaped client message (mail, trade, vendor, ability,
+inventory, etc.) — the entity-id-spoof exploit class is blocked at
+the framing layer, so per-handler audits don't need to re-derive it.
+
+What is NOT blocked here:
+- The `args` payload (the rest of the bytes after the entity-id prefix)
+  remains fully client-supplied and must be validated per-handler.
+- Any handler that reads a target entity-id out of `args` (e.g.
+  `SetTarget`, `UseAbility target_id`, `payCODForMailMessage MailId`)
+  must validate ownership/perception/range itself.

--- a/.claude/agent-memory/server-authority-enforcer/reference_chat_wire_spec.md
+++ b/.claude/agent-memory/server-authority-enforcer/reference_chat_wire_spec.md
@@ -1,0 +1,91 @@
+---
+name: reference-chat-wire-spec
+description: Ghidra-anchored wire shapes for chat / contact-list / communication NetOut events + base/cell dispatch indices
+metadata:
+  type: reference
+---
+
+## Chat / Contact-list / Communication wire surface
+
+### Base-layer SGWPlayer methods (msg_id 0xC0..=0xD8)
+
+| msg_id | name | wire shape | Rust handler | status |
+|---|---|---|---|---|
+| `0xC0` | `chatJoin` | `WSTRING channelName, WSTRING password` | `dispatch.rs:158-169` | stub (auto-ack) |
+| `0xC1` | `chatLeave` | `UINT8 channelId` | `dispatch.rs:171-175` | stub (debug log) |
+| `0xC2` | `sendPlayerCommunication` | `UINT8 channel, WSTRING target, WSTRING text` | `dispatch.rs:77-156` | impl. |
+| `0xC3` | `chatSetAFKMessage` | `WSTRING message` | `dispatch.rs:177-189` | stub (log only) |
+| `0xC4` | `chatSetDNDMessage` | `WSTRING message` | `dispatch.rs:191-233` | impl. (sets `dnd_message`) |
+
+### Cell-method indices used by CAT-L surface
+
+| index | name | wire shape (after 4B entityId prefix stripped) | Rust handler |
+|---|---|---|---|
+| 10 | `BroadcastMinimapPing` | `i32 org_id, f32 x, f32 y, f32 z` | `cell_methods/organization.rs:48-64` stub |
+| 55 | `contactListCreate` | `WSTRING listName, u32 flags` | `cell_methods/contact_list.rs:22-26` stub |
+| 56 | `contactListDelete` | `i32 list_id` | `cell_methods/contact_list.rs:27-33` stub |
+| 57 | `contactListRename` | `i32 list_id, WSTRING newName` | `cell_methods/contact_list.rs:34-40` stub |
+| 58 | `contactListFlagsUpdate` | `i32 list_id, u32 flags` | `cell_methods/contact_list.rs:41-53` stub |
+| 59 | `contactListAddMembers` | `i32 list_id, member_array` | `cell_methods/contact_list.rs:54-60` stub |
+| 60 | `contactListRemoveMembers` | `i32 list_id, member_array` | `cell_methods/contact_list.rs:61-71` stub |
+| 73 | `who` | (likely WSTRING filter) | `cell_methods/player/interaction.rs:17-20` stub |
+
+### NetOut events with NO server handler (warn-arm only)
+
+Ghidra-confirmed via string registration but no msg_id arm in `dispatch.rs`
+and no cell-method arm in any per-interface dispatcher:
+
+| Ghidra string addr | event class | server-side gate required |
+|---|---|---|
+| `019b9b50` | `Event_NetOut_SendGMShout` | `access_level >= GameMaster` |
+| `019b9b80` | `Event_NetOut_Petition` | rate-limit + sender from session |
+| `019b30c0` | `Event_NetOut_ChatFriend` | self-add guard + size cap |
+| `019be840` | `Event_NetOut_ChatIgnore` | self-add guard + size cap |
+| `019b9a90` | `Event_NetOut_ChatOp` | per-channel op-bit (server-tracked) |
+| `019b9a38` | `Event_NetOut_ChatMute` | per-channel op-bit |
+| `019b9a64` | `Event_NetOut_ChatKick` | per-channel op-bit |
+| `019b9ab8` | `Event_NetOut_ChatBan` | per-channel op-bit |
+| `019b9ae4` | `Event_NetOut_ChatPassword` | per-channel op-bit |
+
+### Speaker flags (matches `python/base/Chat.py::getSpeakerFlags`)
+
+```
+SPEAKER_GM       = 0x01  -- set when c.access_level > 0
+SPEAKER_Petition = 0x02  -- enum-only, never set by Python reference; intentionally omitted
+SPEAKER_DND      = 0x04  -- set when c.dnd_message is Some
+```
+
+`dispatch.rs:131-141` computes these from `ConnectedClientState` exclusively —
+**never from any wire field**. This is the canonical "GM bit lives on the
+session, not the inbound packet" example in the codebase. Tests 1-4 at
+`dispatch.rs:588-660` regression-pin the byte-exact behavior.
+
+### Channel IDs (`python/Atrea/enums.py::EChannel`)
+
+```
+0  CHAN_SAY      -- spatial, AoI broadcast
+1  CHAN_EMOTE    -- spatial, AoI broadcast
+2  CHAN_YELL     -- spatial, wider AoI broadcast
+3  CHAN_TEAM     -- team only
+4  CHAN_SQUAD    -- squad only
+5  CHAN_COMMAND  -- guild/command
+6  CHAN_OFFICER  -- guild officer
+7  CHAN_SERVER   -- system broadcasts only -- NOT from clients
+8  CHAN_FEEDBACK -- system feedback
+9  CHAN_TELL     -- direct P2P (handled by BaseApp, not cell)
+10 CHAN_SPLASH   -- splash screen
+```
+
+Cell-side `chat::handle_chat_message` (`chat.rs:65-95`) gates broadcast to
+CHAN_SAY/EMOTE/YELL only. CHAN_TELL falls through to debug-log
+(tell-routing is unimplemented). The client cannot set CHAN_SERVER and have
+it broadcast through Cimmeria's current code, but if future PRs add
+CHAN_TEAM/SQUAD arms without a per-channel membership check, an attacker
+can chat into channels they're not a member of. → CAT-L-03.
+
+### Witness fan-out invariant
+
+`broadcast_to_witnesses` reads from `space_mgr.get_entity(sender_id).witnesses`
+(`cell/chat.rs:101-119`), which is server-computed AoI. NO client-supplied
+target list. This is the right pattern — preserve it on any future
+per-channel broadcast addition.

--- a/.claude/agent-memory/server-authority-enforcer/reference_combat_exploit_classes.md
+++ b/.claude/agent-memory/server-authority-enforcer/reference_combat_exploit_classes.md
@@ -1,0 +1,126 @@
+---
+name: reference-combat-exploit-classes
+description: Recurring server-authority gaps in the SGW combat/abilities path — what to look for when reviewing useAbility / respawn / setTarget / pet handlers
+metadata:
+  type: reference
+---
+
+# Combat / abilities exploit classes (CAT-C audit, 2026-05-31)
+
+Use when reviewing any cell-method handler that touches ability use,
+target selection, respawn, or pet control. Cross-link from
+[[reference-cell-method-entity-id-authority]].
+
+## Live caller-state preconditions are routinely missing
+
+The combat dispatch in `cell_methods/player/combat/mod.rs` (CALL_FOR_AID=67,
+USE_ABILITY=68, USE_ABILITY_ON_GROUND=69, RESPAWN=70) does **not** check
+that the caller is in the expected state before acting.
+
+- **`respawn` / `callForAid` do not check `BSF_DEAD`.** A live player at
+  any HP can send these and be teleported + healed to full + cooldowns
+  cleared + threatened_mobs wiped. `handle_respawn` in
+  `cell_methods/player/combat/respawn.rs` is the single home of this
+  bug — every entry point routes through it.
+- **`useAbility` does not check `BSF_MOVEMENT_LOCK`.** Caller validation
+  in `cell/abilities/use_ability/mod.rs:122-124` only consults
+  `is_dead_state`. When stun/fear/root land via the `cell/effects/`
+  framework, the cast gate will be wrong.
+- **`setCrouched` / `requestHolsterWeapon` don't check `is_dead`.** A
+  ragdolled player can still toggle visual state mid-Defeat-Window.
+
+**Validation idiom to recommend:** `entity.has_state_flag(BSF_X)` is the
+canonical "is this state present" check (refcount-aware, see
+`crates/entity/src/cell_entity.rs` set/unset/has helpers).
+
+## Client-supplied id parameters lack existence + space + AoI checks
+
+The wire path enforces `entity_id == session.player_eid` at
+`base/connect_loop/cell_arms.rs:64-71` (the framing layer overwrites
+the wire entity_id with the session's player). **But:**
+
+- **`setTargetID(target_id)` accepts any i32** with only `> 0` filter.
+  No existence check, no same-space check, no AoI membership check. The
+  server then broadcasts `onTargetUpdate(target_id)` to all AoI
+  witnesses — wire spam vector.
+- **`useAbility(ability_id, target_id)`** validates that the target
+  entity exists, is alive, and is in `max_range`. It does **not**
+  check faction/hostility, AoI membership, or LOS. PvP / friendly-fire
+  / shoot-through-walls is wide open.
+- **`callForAid(respawner_id)`** matches against the entire global
+  `space_mgr.respawners` table — no membership check against the list
+  the server sent in `onBeginAidWait`, no per-world filter.
+
+**Validation idiom to recommend:** the vendor handler at
+`cell_methods/player/vendor.rs:75-123` is the canonical pattern —
+server stashes the legitimate id (`player.vendor_entity` /
+`vendor.template_id`) when the interaction opens, and the inbound
+handler validates the client-supplied id matches the stashed one.
+The pattern is `Option<i32>` server-side, client supplies an id,
+server compares + rejects on mismatch. Use the same pattern for
+respawner_id (per-session "outstanding respawner offer" set),
+target_id (per-session AoI witness set), and pet_entity_id.
+
+## Cone AoE got hostility filtering right; single-target did not
+
+`cell/abilities/cone_aoe.rs:67-73` (`is_cone_effect`) and the
+`HOSTILE_FACTION` sentinel filter cone-AoE targets to NPCs with
+faction = 10. The same filter is missing on the single-target path
+(`cell/abilities/use_ability/mod.rs`). Pattern: every target
+acquisition path must consume the same hostility predicate.
+
+## Min-range is in the AbilityDef schema but not enforced
+
+`AbilityDef::min_range: i32` exists; only `max_range` is consulted in
+the validation block at `use_ability/mod.rs:152-169` and at
+`abilities/dispatch.rs:143-149` (ground-target). A future shotgun /
+grenade-arc ability with `min_range > 0` will silently fire
+point-blank.
+
+## Stubbed wire surfaces inherit security debt at implementation time
+
+- **AI-debug class** (`CombatDebug`, `HealDebug`, `AbilityDebug`,
+  `DebugAbilityOnMob`, `DebugBehaviorsOnMob`, `DebugPathsOnMob`,
+  `EnterErrorAIState`, `ExitErrorAIState`) — all stubs today. When
+  implemented, every one needs `session.is_gm` check. The wire
+  surface is registered (Ghidra RTTI strings present at 0x019b3d1c
+  etc.), the client emits them, the server's cell-method dispatch
+  routes them. No GM-check infrastructure exists in the SGWAbilityManager
+  or SGWCombatant interfaces today — must be added alongside any
+  implementation.
+- **Pet methods** (`PetInvokeAbility`, `PetAbilityToggle`,
+  `PetChangeStance`, cell methods 88-90) — stubs in
+  `cell_methods/player/social.rs:15-59`. When implemented, validate
+  `pet_entity_id` is owned by the calling player via a server-side
+  player→active_pet map (NOT trusted from the wire).
+- **`confirmationResponse`** (CONFIRMATION_RESPONSE=4) — handler parses
+  `(effect_id: i32, accepted: bool)` and logs. When the prompt-system
+  lands, the effect_id must match an outstanding server-issued prompt
+  for THIS session, with a TTL — otherwise replay attack via leaked
+  effect_id.
+
+## Auto-cycle tick is the canonical "do it right" example
+
+`crates/services/src/cell/service/ticks/auto_cycle.rs` shows the
+correct shape:
+
+- Reads `current_target_id` LIVE every tick — no stash.
+- Per-tick re-validates: target exists, alive, in range.
+- Out-of-range = skip without clearing (preserves loop intent).
+- Target gone = clear loop + broadcast un-arm.
+- Re-fires through `handle_use_ability_with_kill_credit` so quest
+  kill-count missions advance for AoE secondaries.
+
+Use this as the recommend-by-name pattern when proposing fixes for
+other periodic target-driven loops.
+
+## Wire format anchors
+
+- `useAbility`: cell method 68, `INT32 abilityId, INT32 targetId`. RTTI string at Ghidra `0x019b37c4`.
+- `useAbilityOnGroundTarget`: cell method 69, `INT32 abilityId, FLOAT x, FLOAT y, FLOAT z`. RTTI string at `0x019bb70c`.
+- `callForAid`: cell method 67, `INT32 respawnerID`. RTTI string at `0x0195f9c0`.
+- `respawn`: cell method 70, no args. RTTI string at `0x019b33ac`.
+- `setTargetID`: cell method 0 (SGWBeing interface), `INT32 targetId`. RTTI string at `0x019bf55c`.
+- `trainAbility`: cell method 77, `INT32 abilityId`. RTTI string at `0x019bf2a4`. (Well-validated — pattern to emulate.)
+
+Reference: `docs/protocol/cell-method-dispatch-table.md`.

--- a/.claude/agent-memory/server-authority-enforcer/reference_dialog_choice_exploit_shape.md
+++ b/.claude/agent-memory/server-authority-enforcer/reference_dialog_choice_exploit_shape.md
@@ -1,0 +1,82 @@
+---
+name: reference-dialog-choice-exploit-shape
+description: SGW DIALOG_BUTTON_CHOICE has no server-side "is this dialog open?" check; OnDialogChoice chains can be replay-forced
+metadata:
+  type: reference
+---
+
+# DialogButtonChoice / OnDialogChoice exploit shape
+
+The `DIALOG_BUTTON_CHOICE` cell method (method_index 75, SGWPlayer
+interface) carries `(dialog_id: i32, button_id: i32)` and the Rust
+handler in `crates/services/src/cell/cell_methods/player/interaction.rs`
+(arm starting around line 237) calls `fire_dialog_choice` unconditionally
+with the client-supplied `dialog_id`.
+
+**No server-side state tracks which dialogs are open for a player.**
+`CellEntity` carries `last_interaction_target: Option<u32>` (the NPC the
+player last clicked) but no `open_dialog_id`. The `available_interactions`
+map is a list of dialogs the player has been *offered* across all
+templates, not a single-element "currently open" pin.
+
+The chain engine's `OnDialogChoice { dialog_id }` matcher only filters on
+`dialog_id`, not `button_id` — `crates/content-engine/src/triggers.rs:287`.
+The `button_id` is stuffed into chain params and only chain *conditions*
+can validate it, if the author wrote one.
+
+Action surface reachable via `OnDialogChoice` includes (see
+`crates/content-engine/src/actions.rs:20–`): `GrantXP`, `GrantItem`,
+`Teleport`, `CrossWorldTeleport`, `AcceptMission`, `CompleteMission`,
+`AdvanceStep`, `AbandonMission`, `RollLootTable`, `SpawnEntity`,
+`TriggerChain`. Forging a single DIALOG_BUTTON_CHOICE packet for a
+dialog_id bound to any of these gets the side-effect without opening
+the dialog.
+
+## Related sibling exploit shapes
+
+- `INITIAL_RESPONSE` (method 76) — `handle_initial_response` scans
+  *all* templates' available_interactions for a matching dsm_id, not
+  just the template of `last_interaction_target`. Lets a player open
+  one NPC's dialog while interacting with a different NPC.
+- `INTERACT` (74) — has range check (MAX_INTERACT_DISTANCE = 5.0) but
+  no player liveness check (BSF_DEAD).
+- `accept_or_advance` (`cell/content/executor/mission.rs:27-100`) —
+  no prereq validation (level, faction, prior missions). Reachable
+  from any `OnDialogChoice`/`OnDialogOpen` chain with `AcceptMission`,
+  so the dialog-choice exploit composes with this gap.
+
+## Server-authoritative sources for fix
+
+- "Is dialog open for player?" — currently doesn't exist. Add
+  `CellEntity::open_dialog_id: Option<i32>`, set at
+  `send_dialog_display` time, clear on choice or new dialog.
+- "Is player alive?" — `crate::cell::combat::is_dead_state(e.state_field)`
+  already exists and is used in `INTERACT`'s hostile-reroute path.
+- "Does player own mission?" — `entity.missions.get_mission(mission_id)`
+  on the player's in-memory tracker.
+- "Mission prereqs ok?" — currently has NO server-side enforcement.
+  `space_mgr.mission_defs.get(mission_id)` returns a `MissionDef` that
+  would need to carry `min_level / required_faction / prereq_mission_ids`
+  fields — consult mission-systems-advisor.
+
+## Latent: unimplemented client→server message names
+
+All registered in client `register_NetOut_*` with `Direction: NetOut
+(client -> server)` per Ghidra decompile, but no Rust dispatch arm —
+fall through to the unhandled warn at `dispatch/router.rs:101`:
+
+- `MissionAdvance`, `MissionComplete`, `MissionAssign`, `MissionReset`
+- `MissionClear`, `MissionClearActive`, `MissionClearHistory`
+- `MissionList`, `MissionListFull`, `MissionDetails`, `MissionSetAvailable`
+- `ChosenRewards` (method 87 — has the constant + UNIMPLEMENTED log arm)
+- `DebugInteract` (clearly GM/debug by name)
+- `AbandonMission` (slash-cmd variant; distinct from method 52 MissionAbandon)
+- `ShareMission`, `ShareMissionResponse` (methods 53, 54 — payload parsed but UNIMPLEMENTED)
+
+These inherit no validation today; when wired up they need their own
+server-authority review. Routed through `SGWTextCommandMgr` for those
+with matching `Event_SlashCmd_*` registrations, meaning they're slash-
+command-emittable from console (= no UI affordance to hide).
+
+Links: [[reference-cell-method-entity-id-authority]]
+[[reference-auth-exploit-classes]]

--- a/.claude/agent-memory/server-authority-enforcer/reference_gm_auth_plumbing_gap.md
+++ b/.claude/agent-memory/server-authority-enforcer/reference_gm_auth_plumbing_gap.md
@@ -1,0 +1,81 @@
+---
+name: reference-gm-auth-plumbing-gap
+description: Cell-method dispatch has no access to access_level — systemic gap blocking GM auth on any future gm* handler
+metadata:
+  type: reference
+---
+
+## The systemic GM-auth plumbing gap in Cimmeria
+
+`access_level` lives ONLY on `ConnectedClientState.access_level`
+(`crates/services/src/base/mod.rs:117`). Sourced from
+`account.accesslevel` DB column via
+`crates/services/src/auth/handlers.rs:486-488`. Today consumed by
+exactly ONE site: the chat dispatch's `SPEAKER_GM` bit computation
+in `crates/services/src/base/dispatch.rs:131-133`.
+
+The cell-method dispatch entry point at
+`crates/services/src/cell/dispatch/router.rs:33` has signature
+`(entity_id, method_index, args, tx, space_mgr, engine)` — NO
+caller-identity parameter beyond entity_id. None of the per-
+interface dispatchers (`cell_methods::being::dispatch`,
+`cell_methods::ability_manager::dispatch`, ...) accept an
+access_level either.
+
+`grep access_level crates/services/src/cell` returns ZERO files —
+the cell layer literally has no access to the bit.
+
+### Why this matters
+
+The natural implementation path for adding `gmGiveItem`,
+`gmSpawnByCmd`, `gmKillTarget`, etc. (the ~120 GM cell methods) is:
+
+1. Add a new `match` arm in the appropriate `cell_methods/...` dispatch.
+2. Decode args from the byte slice.
+3. Apply effect to entity / DB.
+
+Step 0 should be: check `access_level >= GameMaster`. But there's
+nothing to check against — the access_level isn't in scope.
+
+### Required fix shape
+
+Plumb `access_level: u32` (or an enum) through:
+
+1. `BaseToCellMsg::CellMethodCall` — add the field; the base
+   already has it on `ConnectedClientState`.
+2. `dispatch_cell_method` signature — add the param.
+3. Each per-interface `cell_methods::*::dispatch` — add the param.
+4. Add a helper `fn require_gm(access_level: u32) -> Result<(), ()>`
+   at the top of every `gm*` handler.
+
+Without (1)-(3), step (4) cannot be added even if a contributor
+remembers to. This is structural.
+
+### Related concern: entity-class hardcode
+
+`crates/services/src/base/world_entry/play_character.rs:89-94`
+forces `class_id = 0x02 (SGWPlayer)` regardless of access_level.
+The TODO says: "Until we build a separate SGWGmPlayer index
+table, always use SGWPlayer (0x02) regardless of access_level."
+
+When that TODO is addressed, the SGWGmPlayer flat index space
+(80+ extra cell methods) opens up. If the access_level plumbing
+isn't done FIRST or AT THE SAME TIME, every gm* handler added
+will be unauthenticated by default. Couple the fixes.
+
+### Other validation locations on the GM surface
+
+- `cimmeria-commands` (the slash-command registry at
+  `crates/commands/src/registry.rs` + `permissions.rs`) DOES
+  enforce access_level — `CommandContext.access_level` is checked
+  in `execute()`. But that's for chat-typed `/spawn`, `/give`,
+  `/kill` commands, NOT for the wire `Event_NetOut_*` GM messages.
+  The two paths are completely separate.
+- The chat-command stubs at `crates/game/src/commands/gm_cmds.rs`
+  (spawn, teleport, kill, give, setlevel, shutdown) register with
+  `AccessLevel::GameMaster` / `Admin` — but they're TODO stubs
+  with no actual effect. When wired up they'll use the slash-
+  command path, not the wire cell-method path.
+
+So: TWO GM dispatch paths. The slash-command path has gating
+infrastructure. The wire cell-method path does not.

--- a/.claude/agent-memory/server-authority-enforcer/reference_gm_command_wire_spec.md
+++ b/.claude/agent-memory/server-authority-enforcer/reference_gm_command_wire_spec.md
@@ -1,0 +1,152 @@
+---
+name: reference-gm-command-wire-spec
+description: Authoritative wire shapes for SGW GM commands; SGWGmPlayer.def + Ghidra Event_NetOut_* anchors
+metadata:
+  type: reference
+---
+
+## SGW GM-command wire spec — extraction points
+
+The SGW client emits ~125 distinct `Event_NetOut_*` GM/debug events from
+`SGWTextCommandMgr` (slash command source). Each maps to a `gm*`-prefixed
+cell method or base method on `entities/defs/SGWGmPlayer.def` (parent:
+SGWPlayer). A small subset (`onWorldInstanceReset`, `resetMyAbilities`,
+`toggleCombatDebug`, `toggleCombatVerboseDebug`, `toggleHealDebug`,
+`perfStats`) is exposed on the regular SGWPlayer/SGWAbilityManager/SGWCombatant
+interfaces too — i.e., the wire indices for those land in the regular
+flat-index table.
+
+### File anchors
+
+- `entities/defs/SGWGmPlayer.def` — the GM entity class declaration.
+  Parent SGWPlayer. Adds 6 ClientMethods + 80+ CellMethods + 5
+  BaseMethods. Every GM-prefixed method shape (args, types) is
+  authoritative here.
+- `entities/defs/SGWPlayer.def` — has `<onWorldInstanceReset>` line
+  868, `<resetMyAbilities>` line 602, `<perfStats>` line 529 all
+  `<Exposed/>` — i.e., GM-shaped methods exposed on the regular
+  player flat-index table.
+- `entities/defs/interfaces/SGWAbilityManager.def:103-113` —
+  `bCombatDebug` and `bCombatVerboseDebug` properties + the
+  exposed `toggleCombatDebug` / `toggleCombatVerboseDebug` methods.
+- `entities/defs/interfaces/SGWCombatant.def` — `toggleHealDebug`
+  is here.
+
+### Ghidra anchors (SGW.exe)
+
+The full RTTI string scan for `Event_NetOut_*` GM commands lives
+in the binary at ~0x019b3xxx and 0x019bexxx (the NetOut event class
+RTTI block). The typed RTTI descriptors live at 0x01df3xxx-0x01df5xxx.
+
+Specific examples:
+- `019b373c` Event_NetOut_GiveItem
+- `019b3848` Event_NetOut_SetGodMode
+- `019b3820` Event_NetOut_Kill
+- `019b4340` Event_NetOut_WorldInstanceReset
+- `019b3bd8` Event_NetOut_Spawn / `019b3c00` Event_NetOut_Despawn
+- `019b3818` Event_NetOut_SetSpeed
+- `019b3794` Event_NetOut_GiveAbility / `019b36b0` GiveAllAbilities
+- `019b370c` Event_NetOut_GiveNaqahdah / `019b362c` GiveXp
+- `019b2ec8` Event_NetOut_SetHideGM
+- `019c33b0` gmGiveXp (method-name string)
+- `019c3498` gmSetGodMode (method-name string)
+
+The corresponding method-name strings ("gmGiveXp", "gmSetGodMode",
+etc.) live in a separate block near 0x019c3xxx — these are the
+flat-method-name lookup table used by the BigWorld dispatcher
+client-side.
+
+### Wire payload reference for hot ones
+
+(All args are little-endian; WSTRING is `u32 char_count + N×u16 LE`.)
+
+- `gmSetGodMode(UINT8 bTurnOn)`
+- `gmSetHealth(INT32 Amount, INT64 TargetId)` — same shape for
+  `gmSetHealthMax`, `gmSetFocus`, `gmSetFocusMax`.
+- `gmSetSpeed(FLOAT Multiplier)` — unbounded float
+- `gmSetLevel(INT32 aLevel)` — self only, no TargetId
+- `gmGiveXp(INT32 XpAmount)` / `gmGiveCash(INT32 Amount)` —
+  both signed; binary has the error string "Amount to be given
+  (or taken away) cannot be 0." confirming negatives are
+  intended in the Python reference.
+- `gmGiveItem(WSTRING DesignId, INT32 Quantity)`
+- `gmGiveRespawner(INT32 aRespawnerMobID)`
+- `gmGiveAbility(INT32 aAbilityID)` / `gmGiveAllAbilities()`
+- `gmGiveStargateAddress(WSTRING AddressId, INT64 TargetId,
+  UINT8 Hidden)`
+- `gmKillTarget(INT64 TargetId)`
+- `gmSpawnByCmd(WSTRING DesignId, FLOAT XOffset, FLOAT ZOffset)`
+- `gmDespawnByCmd(INT32 TargetID)`
+- `gmGoto(WSTRING aNameOrID)` / `gmGotoXYZ(FLOAT, FLOAT, FLOAT)`
+  / `gmGotoLocation(WSTRING WorldName, FLOAT X, Y, Z)`
+- `gmSummon(WSTRING aNameOrID)`
+- `gmShowIP(INT32 TargetID)` / `gmShowInventory(INT32 TargetID)`
+  / `gmShowPlayer(INT32 TargetID)`
+- `gmSetFlag(INT32 aFlagId, UINT8 aForceVal)`
+- `gmSetInstanceFlag(INT32 aFlagNumber, INT8 aFlagValue)`
+- `gmSetMobAttribute(INT32 TargetID, WSTRING Attribute,
+  WSTRING AttributeType, INT32 Value)` — reflection-style setter
+- `gmEmitBehaviorEventOnMob(INT32 aBehaviorEventId)`
+- `gmAddBehaviorEventSet(INT32)` / `gmRemoveBehaviorEventSet(INT32)`
+- `gmSetCallback(PYTHON aChangeList, UINT8 bSuccess, UINT32 aEntityId)`
+  — **PYTHON wire type is pickle deserialization**; today the Rust
+  cell-method decoder does not handle PYTHON at all so this is
+  unreachable, but future implementers must NEVER deserialize
+  pickled Python from client.
+- `gmGetMobAttribute(INT32 TargetID, WSTRING Attribute)`
+- `gmShowMobCount(INT32 SpaceID)` (cell) / `(WSTRING aAreaKey)` (base)
+- `gmDebugEvents(INT32 TargetId, INT32 InformLevel)`
+- `regenerateCoverLinks(FLOAT NormalLimit, UINT32 MaxLinks,
+  FLOAT MaxDistance)` — UINT32 MaxLinks is unclamped
+- `changeCoverWeight(FLOAT × 6)` / `changeCoverStanceWeight(WSTRING × 7)`
+- `loadConstants()` / `loadAbility(INT32)` / `loadAbilitySet(INT32)`
+  / `loadNACSI(INT32)` / `loadBehavior(INT32)` / `loadMOB(INT32)`
+  / `loadDialogSet(INT32)` / `loadItem(INT32)` / `loadMission(INT32)`
+- `testLOS(INT32 aSourceEntityID, INT32 aTargetEntityID)`
+- `toggleCombatLOS()` / `toggleCombatDebug()` / `toggleCombatVerboseDebug()`
+  / `toggleHealDebug()`
+- `onInvisible(UINT8 bTurnOn)` / `onXRayEyes(UINT8 bTurnOn)`
+  / `onPhysics(UINT8 bTurnOn)`
+- `sendGMShout(UINT8 isGlobal, WSTRING Text)` (cell variant) /
+  `sendGMShout(UINT8 ChannelID, UINT8 BroadcastScope, INT32 SpaceID,
+  WSTRING Text)` (base variant)
+- `setMobVariable(INT32 aVariable, INT32 aValue)`
+- `enterErrorAIState()` / `exitErrorAIState()`
+- `gmSetMobAbilitySet(INT32 aAbilitySetId)` /
+  `gmSetMobStance(INT32 aNewStance)`
+- `gmDHD(INT8 aGateAddress)`
+- `gmReloadOrganizations()` / `gmReloadInventory()` / `gmUsers()`
+- `gmSetHideGM(UINT8 bTurnOn)` — both cell and base variants
+- `gmPerfStatsByChannel(INT8 aOnOff)`
+- `gmShowInstanceFlag(INT32 aFlagNumber)` /
+  `gmShowNavigation(INT8 aOnOff)`
+- `gmRechargeItem(INT32 ItemId)`
+- `gmRemoveItem(ItemID itemID, INT16 quantity)` — INT16 signed
+  quantity is a footgun
+- `gmRemoveStargateAddress(WSTRING AddressId, INT64 TargetId)`
+- `gmMission*` family (Assign / Clear / ClearActive / ClearHistory /
+  List / ListFull / Details / Advance / Reset / Complete /
+  SetAvailable / Abandon)
+- `gmRespec()` / `Event_NetOut_RespecAbility` /
+  `Event_NetOut_ResetAbilities`
+
+### Mission GM variants on SGWGmPlayer.def lines 65-123
+
+`gmMissionAssign`, `gmMissionClear`, `gmMissionClearActive`,
+`gmMissionClearHistory`, `gmMissionList`, `gmMissionListFull`,
+`gmMissionDetails`, `gmMissionAdvance`, `gmMissionReset`,
+`gmMissionComplete`, `gmMissionSetAvailable`, `gmMissionAbandon` —
+all `Exposed`, all take a `WSTRING DesignID` and possibly
+additional integer args.
+
+### What's NOT in SGWGmPlayer.def but IS a GM event
+
+Some events appear in the Ghidra NetOut RTTI scan but not in the
+SGWGmPlayer.def excerpt — likely because they go through the
+SGWTextCommandMgr Python-side dispatch only (no exposed cell
+method on the entity). Examples: `Event_NetOut_GiveGearset`,
+`Event_NetOut_GiveInventory`, `Event_NetOut_GiveBlueprint`,
+`Event_NetOut_GiveTrainingPoints` (declared in .def but on
+SGWGmPlayer), `Event_NetOut_SetFaction`, `Event_NetOut_SetTechSkill`.
+The Python reference would be the next place to look for
+these shapes; needs x64dbg confirmation.

--- a/.claude/agent-memory/server-authority-enforcer/reference_mail_validation_locations.md
+++ b/.claude/agent-memory/server-authority-enforcer/reference_mail_validation_locations.md
@@ -1,0 +1,36 @@
+---
+name: reference-mail-validation-locations
+description: File/line anchors for mail validation entry points and gaps
+metadata:
+  type: reference
+---
+
+**Dispatcher** (decodes mail_id / container_id / slot_id from client bytes):
+`crates/services/src/cell/cell_methods/mail.rs`. Indices 43-51 (REQUEST_MAIL_HEADERS=43 … PAY_COD_FOR_MAIL=51).
+
+**Player-id resolution** (the canonical "refuse to fall back to 0" pattern for
+mail routing): `crates/services/src/cell/mail.rs:20-28` —
+`resolve_mail_player_id()` reads `space_mgr.get_entity(entity_id).player_id`
+and returns `None` (with `warn!`) if unset.
+
+**DB write paths** (currently only headers/body/archive/delete are wired):
+`crates/services/src/base/world_entry/methods/mail/mod.rs`
+- RequestHeaders: line 82-95 — `WHERE character_id = $1`, scoped.
+- RequestBody: line 155-185 — `WHERE mail_id = $1 AND character_id = $2`, scoped.
+- RequestBody read_time UPDATE: line 191-200 — **NOT scoped by character_id**
+  (CAT-G-07). Mitigated upstream today by the SELECT.
+- Delete: line 231 — `WHERE mail_id = $1 AND character_id = $2`, scoped.
+- Archive: line 275-280 — `WHERE mail_id = $1 AND character_id = $2`, scoped.
+
+**Wire serializers**: `crates/services/src/cell/mail.rs:143-209`
+(`serialize_on_mail_header_info`, `serialize_on_mail_read`,
+`serialize_on_mail_header_remove`). `onMailRead.ToText` is currently
+filled with the **reader's** name, not the recipient's (CAT-G-08).
+
+**Schema**: `db/sgw/Mail/Tables/sgw_gate_mail.sql` — columns: mail_id (PK),
+character_id (recipient), sender_id, subject, message, cash (bigint),
+sent_time, read_time, flags, item_id, sender_name. No FK constraints.
+
+**Stub (game crate)**: `crates/game/src/social/mail.rs` — `MailMessage` struct
+with `send()` and `collect_attachments()` as `todo!()`. Not wired to the
+dispatcher; safe to ignore for review purposes today.

--- a/.claude/agent-memory/server-authority-enforcer/reference_mail_wire_spec.md
+++ b/.claude/agent-memory/server-authority-enforcer/reference_mail_wire_spec.md
@@ -1,0 +1,40 @@
+---
+name: reference-mail-wire-spec
+description: Authoritative wire shapes for mail messages — extracted from SGWMailManager.def
+metadata:
+  type: reference
+---
+
+Source: `entities/defs/interfaces/SGWMailManager.def` (entity def is the
+data BigWorld code-gen reads, so it's authoritative for the wire shape;
+cross-checks against Ghidra `Event_NetOut_*` confirm field count).
+
+CellMethod indices (client → server):
+- 43 `requestMailHeaders(UINT8 bArchive)`
+- 44 `sendMailMessage(INT32 RecipientFlags, ARRAY<WSTRING> Recipients, WSTRING Subject, WSTRING Body, INT32 Cash, UINT8 bCOD, INT32 ItemId, INT32 ItemQuantity)`
+- 45 `archiveMailMessage(INT32 MailId)`
+- 46 `deleteMailMessage(INT32 MailId)`
+- 47 `returnMailMessage(INT32 MailId)`
+- 48 `requestMailBody(INT32 MailId)`
+- 49 `takeCashFromMailMessage(INT32 MailId)`
+- 50 `takeItemFromMailMessage(INT32 MailId, INT32 ContainerId, INT32 SlotId)`
+- 51 `payCODForMailMessage(INT32 MailId)`
+
+ClientMethod indices (server → client):
+- 76 `onMailHeaderInfo(UINT8 ResetCategory, UINT8 bArchive, ARRAY<MessageHeader> Headers, ARRAY<MessageAttachment> Attachments)`
+- 77 `onMailHeaderRemove(INT32 MailId)`
+- 78 `onMailRead(INT32 MailId, WSTRING BodyText, INT32 BodyId, WSTRING ToText)`
+- 79 `sendMailResult(UINT8 ResultCode, ARRAY<WSTRING> FailedRecipients, INT32 FailedRecipientFlags)`
+
+BaseMethod (notification fan-out):
+- `notifyPlayersOfNewMail(ARRAY<WSTRING> Recipients)`
+
+Notes for the auditor:
+- `payCODForMailMessage` has NO client-supplied price field — the COD
+  amount MUST come from `sgw_gate_mail.cash` (server side). If a future
+  PR widens this arg list, that's a CAT-G-05 regression.
+- `takeCashFromMailMessage` and `takeItemFromMailMessage` are two separate
+  indices that share the underlying mail row — they need shared atomicity
+  (CAT-G-04 — double-take race).
+- `returnMailMessage` only carries MailId. The return destination must be
+  resolved from `sender_id` (integer), not `sender_name` (free text).

--- a/.claude/agent-memory/server-authority-enforcer/reference_org_squad_duel_wire_spec.md
+++ b/.claude/agent-memory/server-authority-enforcer/reference_org_squad_duel_wire_spec.md
@@ -1,0 +1,132 @@
+---
+name: reference-org-squad-duel-wire-spec
+description: Authoritative wire shapes for SGW organization, squad, duel, PvP-leave client messages with .def + Ghidra anchors
+metadata:
+  type: reference
+---
+
+# CAT-M wire spec anchors
+
+Wire shapes for the 18 client→server messages in the Organization /
+Squad / Duel category. The .def files are the truth for arg ordering
+because the BigWorld entity codegen consumes them on both client and
+server. Ghidra `Event_NetOut_*` RTTI strings confirm the client emits
+these exact classes.
+
+## Org base methods (lifecycle / destructive)
+
+`entities/defs/interfaces/OrganizationMember.def:421-447` (`<BaseMethods>`,
+all `<Exposed/>`):
+
+- `organizationInvite(INT32 aOrganizationId, WSTRING aPlayerName)` — RTTI `0x019be900`
+- `organizationInviteByType(UINT8 aOrganizationType, WSTRING aPlayerName)` — RTTI `0x019be920`
+- `organizationKick(INT32 aOrganizationId, WSTRING aPlayerName)` — RTTI `0x019be990`
+- `organizationRankChange(INT32 aOrganizationId, WSTRING aPlayerName, UINT8 aRank)` — RTTI `0x019be9b0`
+
+All four have **no base-dispatch arm in Rust** today; they hit the
+catch-all warn at `crates/services/src/base/dispatch.rs:333-347`.
+
+## Org / squad cell methods (rosters, text, bank, loot)
+
+`entities/defs/interfaces/OrganizationMember.def`, `<CellMethods>` with
+`<Exposed/>` (cell method index in `crates/services/src/cell/cell_methods/organization.rs:7-18`):
+
+- `organizationInviteResponse(INT32 aRequestID, UINT8 aResponse)` — `INVITE_RESPONSE=8`, def:267-271
+- `organizationLeave(INT32 aOrganizationId)` — `LEAVE=9`, def:286-289
+- `BroadcastMinimapPing(INT32 aOrganizationId, VECTOR3 aLocation)` — `BROADCAST_MINIMAP_PING=10`, def:308-312
+- `strikeTeamResponse(INT32 aOrganizationId, UINT8 aResponse)` — `STRIKE_TEAM_RESPONSE=11`, def:329-333
+- `pvpOrganizationLeaveResponse(INT32 aOrganizationId, UINT8 aResponse)` — `PVP_LEAVE_RESPONSE=12`, def:336-340
+- `organizationMOTD(INT32 aOrganizationId, WSTRING aMOTD)` — `MOTD=13`, def:371-375
+- `organizationNote(INT32 aOrganizationId, WSTRING aNote)` — `NOTE=14`, def:377-381
+- `organizationOfficerNote(INT32 aOrganizationId, WSTRING aName, WSTRING aNote)` — `OFFICER_NOTE=15`, def:383-388
+- `organizationSetRankPermissions(INT32 aOrganizationId, INT32 aRank, INT32 aPermissions)` — `SET_RANK_PERMISSIONS=16`, def:390-395
+- `organizationSetRankName(INT32 aOrganizationId, INT32 aRank, WSTRING aName)` — `SET_RANK_NAME=17`, def:397-402
+- `squadSetLootMode(INT32 aLootMode)` — `SQUAD_SET_LOOT_MODE=18`, def:404-407
+  — **note: no aOrganizationId on the wire**; server must resolve squad from session
+- `organizationTransferCash(INT32 aOrganizationId, INT32 aCash)` — `TRANSFER_CASH=19`, def:409-413
+  — `aCash` is **signed**, must reject `<= 0`
+
+All twelve are stubs in `crates/services/src/cell/cell_methods/organization.rs:28-159`.
+
+## SGWPlayer cell methods (creation / duel)
+
+`entities/defs/SGWPlayer.def`, `<CellMethods>` with `<Exposed/>` (indices
+in `crates/services/src/cell/cell_methods/player/constants.rs`):
+
+- `onOrganizationCreation(WSTRING aOrganizationName)` — `ORG_CREATION=94`, def:877-880
+- `sendDuelResponse(INT8 aResponse)` — `SEND_DUEL_RESPONSE=102`, def:975-978
+  — **no challenger id**; server must hold pending-challenge state per session
+- `duelForfeit()` — `DUEL_FORFEIT=103`, def:1015-1017 — **no args**
+
+All three are stubs in `crates/services/src/cell/cell_methods/player/social.rs:61-101`.
+
+## SGWPlayer base method (duel challenge)
+
+`entities/defs/SGWPlayer.def`, `<BaseMethods>` with `<Exposed/>`:
+
+- `sendDuelChallenge(WSTRING aPlayerName, INT8 aSquadDuel)` — def:509-513
+
+**No base-dispatch arm in Rust** — hits the catch-all warn.
+
+## Permission and rank enums
+
+`entities/defs/enumerations.xml`:
+
+- `EOrganizationRank` (UINT8) lines 1892-1905: `None=0, Initiate=1, Member=2,
+  SeniorMember=3, Veteran=4, SeniorVeteran=5, Officer=6, SeniorOfficer=7, Leader=8`
+- `EOrganizationPermission` (UINT32 bitfield) lines 1907-1937:
+  - `Invite=2`, `Promote=4`, `Demote=8`, `Eject=16`
+  - `RosterNotes=32`, `OfficerNotes=64`, `RankNames=128`, `OfficerChat=256`
+  - `MOTD=1024`, `HistoryLog=2048`
+  - `DepositCash=262144`, `WithdrawCash=524288`
+  - `AlterPerms=8388608`, `TransferLeader=16777216`, `AllianceCmds=33554432`
+- `EOrganizationType` (UINT8) lines 1939-1946: `Squad=0, Team=1, Command=2`
+- `EDBErrorType` (INT32) lines 1948-1959 contains the rank-related error codes
+  the original Python reference returned (`Player_rank_too_low = -20072`,
+  `Invalid_org_rank = -20092`, etc.) — useful for the new Rust handlers to
+  mirror so client UI error display continues to work.
+
+## Pending-state properties already declared
+
+`entities/defs/interfaces/OrganizationMember.def:26-57` already declares
+the right per-session pending maps (`strikeTeamTimers`, `pendingPvPTimers`,
+`pendingGroups`, `pendingJoins`, `pendingInvitesByType`) as
+`CELL_PRIVATE` PYTHON-typed properties. The implementer can wire the
+state-machine-correlation checks (CAT-M-13, -16, -17, -18) against
+these without needing to add new entity-level state.
+
+## Duel marker
+
+`entities/defs/SGWDuelMarker.def:7-18`:
+
+- `duelDetectorID: CONTROLLER_ID`
+- `duelEntities: ARRAY<of>MAILBOX` — array of participant base mailboxes
+
+A `disconnect mid-duel` auto-forfeit path (CAT-M-15) must consult
+`duelEntities` from any active marker the disconnecting player is in.
+
+## Ghidra wire-class anchors (summary)
+
+| Message | RTTI string addr |
+|---|---|
+| `Event_NetOut_OrganizationCreation` | `0x0195fb88` |
+| `Event_NetOut_OrganizationInvite` | `0x019be900` |
+| `Event_NetOut_OrganizationInviteByType` | `0x019be920` |
+| `Event_NetOut_OrganizationInviteResponse` | `0x019be948` |
+| `Event_NetOut_OrganizationLeave` | `0x019be970` |
+| `Event_NetOut_OrganizationKick` | `0x019be990` |
+| `Event_NetOut_OrganizationRankChange` | `0x019be9b0` |
+| `Event_NetOut_OrganizationMOTD` | `0x019be9d4` |
+| `Event_NetOut_OrganizationNote` | `0x019be9f4` |
+| `Event_NetOut_OrganizationOfficerNote` | `0x019bea14` |
+| `Event_NetOut_OrganizationSetRankPermissions` | `0x019bea3c` |
+| `Event_NetOut_OrganizationSetRankName` | `0x019bea68` |
+| `Event_NetOut_OrganizationTransferCash` | `0x019bea90` |
+| `Event_NetOut_SquadSetLootMode` | `0x019beab8` |
+| `Event_NetOut_PvPOrganizationLeaveResponse` | `0x019bfbec` (also `0x019cb5d8`) |
+| `Event_NetOut_DuelChallenge` | `0x019b4448` |
+| `Event_NetOut_DuelResponse` | `0x0195fb58` |
+| `Event_NetOut_DuelForfeit` | `0x019b4478` |
+
+Reference: [[project-org-squad-duel-unimplemented]] for the trust-
+posture summary and the 18-finding checklist.

--- a/.claude/agent-memory/server-authority-enforcer/reference_trade_wire_spec.md
+++ b/.claude/agent-memory/server-authority-enforcer/reference_trade_wire_spec.md
@@ -1,0 +1,107 @@
+---
+name: reference-trade-wire-spec
+description: Authoritative wire shapes for the four client-callable trade RPCs and the two server-to-client trade callbacks
+metadata:
+  type: reference
+---
+
+**Authoritative source:** `entities/defs/SGWPlayer.def` (RPC signatures) plus
+`entities/defs/alias.xml` (FIXED_DICT payloads) plus
+`entities/defs/enumerations.xml` (lock-state and result enums).
+
+## Client→Server (Exposed RPCs — cell methods 104-107)
+
+- `tradeRequest(INT32 EntityId, LocalTradeProposal LocalProposal)` —
+  `SGWPlayer.def:1034-1038`, cell method index 104.
+- `tradeRequestCancel(INT32 EntityId)` — `SGWPlayer.def:1047-1050`, cell method
+  index 105.
+- `tradeUpdateProposal(INT32 EntityId, LocalTradeProposal LocalProposal)` —
+  `SGWPlayer.def:1053-1057`, cell method index 106. Note: the
+  `Event_NetOut_TradeProposal` C++ class name on the client is shortened from
+  the RPC name `tradeUpdateProposal`.
+- `tradeLockState(INT32 LocalVersionId, INT32 RemoteVersionId, INT8 LockState)` —
+  `SGWPlayer.def:1067-1072`, cell method index 107.
+
+## FIXED_DICT payloads
+
+`LocalTradeProposal` (sent client→server in `tradeRequest` and
+`tradeUpdateProposal`):
+
+```
+version    : INT32
+items      : ARRAY<LocalTradeItem>
+cash       : INT32          (naquadah delta)
+lockState  : INT8           (ETradeLockState enum)
+```
+
+`LocalTradeItem` (element in the items array):
+
+```
+instanceId : INT32          (server-side item-row primary key)
+slotId     : INT32
+```
+
+Note: no quantity field — quantity is server-resolved from the item row.
+
+`RemoteTradeProposal` (sent server→client in `onTradeState`) replaces the
+`LocalTradeItem` array with a full `InvItem` array; the client gets the rich
+item view of the partner's offer.
+
+## Enums
+
+`ETradeLockState` (INT8) — `entities/defs/enumerations.xml:1784-1791`:
+
+- 0 = `ETRADELOCKSTATE_None`
+- 1 = `ETRADELOCKSTATE_Locked`
+- 2 = `ETRADELOCKSTATE_LockedAndConfirmed`
+
+`ETradeResults` (INT8) — `entities/defs/enumerations.xml:1793-1803`:
+
+- 1 = `Completed`
+- (2, 3 not enumerated in the file? — verify if needed)
+- 4 = `Cancelled` (inferred from deprecated Python use)
+- 5 = `NoLocalCash`
+- 6 = `NoRemoteCash`
+- (NoLocalSpace, NoRemoteSpace also referenced — verify exact values from
+  enumerations.xml when implementing)
+
+## Server→Client callbacks (cell methods 144-145, defined but never emitted)
+
+- `onTradeState(INT32 EntityId, LocalTradeProposal LocalProposal,
+  RemoteTradeProposal RemoteProposal)` — `SGWPlayer.def:1378-1382`, method 144.
+- `onTradeResults(INT32 EntityId, INT32 Result)` — `SGWPlayer.def:1385-1388`,
+  method 145.
+
+Both are decoded by `crates/services/src/wire_log/decoders/generated.rs` and
+constant-defined in `crates/services/src/cell/client_methods/player.rs:96,98`
+but **no production code path in `crates/` emits them today**.
+
+## Non-Exposed server-internal RPCs (not client-callable, do NOT add to dispatch)
+
+- `tradeRequestFromEntity(INT32, RemoteTradeProposal)` —
+  `SGWPlayer.def:1041-1044`.
+- `updateTradeState(MAILBOX, INT32, RemoteTradeProposal)` —
+  `SGWPlayer.def:1060-1064`.
+- `updateTradeLockState(INT32, INT32, INT32)` — `SGWPlayer.def:1080-1084`.
+- `tradeCancel(INT32 EntityId)` — `SGWPlayer.def:1087-1089`.
+
+These are cell-to-cell or base-to-cell internal RPCs invoked by the *server*
+during trade orchestration. They should never accept a client-originated packet.
+
+## Ghidra anchors (for x64dbg follow-up)
+
+- Outbound emit class strings:
+  - `019d898c` `Event_NetOut_TradeRequestCancel`
+  - `019d89c0` `Event_NetOut_TradeLockState`
+  - `019d89f0` `Event_NetOut_TradeProposal` (this is `tradeUpdateProposal` on
+    the wire)
+  - `01e2c224` `.?AVEvent_NetOut_TradeRequest@@` (mangled type name)
+- Mercury method-name strings: `019c2f20` `tradeRequest`, `019c2f3c`
+  `tradeRequestCancel`, `019c2f5c` `tradeUpdateProposal`, `019c2f7c`
+  `tradeLockState`.
+- Client `SGWNetworkManager::EventHandler` vfunc destructors: `00d68330`,
+  `00d68350`, `00d68370`, `00d68390`.
+- UI verb strings (button-handler entry points): `01952a70` `requestTrade`,
+  `01952a58` `cancelTrade`, `01952a3c` `setTradeItem`, `019529b4`
+  `setTradeCash`, `01952944` `setTradeLockState`, `019529d0`
+  `removeTradeItem`. All wired into `00ad5b7c` (CEGUI_ButtonBase_3).

--- a/.claude/agent-memory/server-authority-enforcer/reference_world_space_gate_wire_spec.md
+++ b/.claude/agent-memory/server-authority-enforcer/reference_world_space_gate_wire_spec.md
@@ -1,0 +1,87 @@
+---
+name: reference-world-space-gate-wire-spec
+description: Wire shapes + dispatch indices + Ghidra anchors for CAT-O surface (gate / ring / region / world-instance / system-options / movie)
+metadata:
+  type: reference
+---
+
+Authoritative wire shapes and dispatch indices for the CAT-O surface,
+cross-referenced to entity defs, Ghidra symbols, and Rust handler files.
+
+## Cell method dispatch indices (client → server)
+
+| Method | Index | Def location | Rust dispatch |
+|---|---|---|---|
+| `onDialGate` | 35 | `entities/defs/interfaces/GateTravel.def:70-74` (INT32 target, INT32 source) | `crates/services/src/cell/cell_methods/gate_travel.rs:17-37` → `crates/services/src/cell/gate_travel.rs:35-108` |
+| `setRingTransporterDestination` | 91 | `SGWPlayer.def:848-852` (INT32 regionId, INT32 destinationId) | `crates/services/src/cell/cell_methods/player/world/mod.rs:207-228` → `crates/services/src/cell/ring_transport/runtime.rs:244-350` |
+| `onWorldInstanceReset` | 92 | `SGWPlayer.def:868-870` (no args, `<Exposed/>`) | `crates/services/src/cell/cell_methods/player/world/mod.rs:230-233` — **UNIMPLEMENTED STUB** |
+| `updateSystemOptions` | 93 | `SGWPlayer.def:872-875` (ARRAY of NameValuePair) | `crates/services/src/cell/cell_methods/player/world/mod.rs:235-238` → `handle_update_system_options` at lines 262-351 |
+| `triggerClientHintedGenericRegion` | 85 | `SGWPlayer.def:766-771` (INT32 id, UINT8 bEntering, VECTOR3 position) | `crates/services/src/cell/cell_methods/player/world/mod.rs:128-191` |
+| `cancelMovie` | 108 | `SGWPlayer.def:1104-1107` (WSTRING MovieName) | early-handled in `crates/services/src/base/connect_loop/cell_arms.rs:113-117` → `handle_cancel_movie` at `crates/services/src/base/world_entry_appearance.rs:721-741` |
+| `onStrikeTeamResponse` | 11 (org range) | (per `Organization.def` — not searched here) | `crates/services/src/cell/cell_methods/organization.rs:65-77` — **UNIMPLEMENTED STUB** |
+
+## Stub-only (no server arm, falls through to "Unhandled cell method" warn)
+
+| Method | Def | Status |
+|---|---|---|
+| `onSpaceQueuedResponse` | `SGWPlayer.def:524-527` (INT8 aAccept) | Not in dispatch |
+| `onSpaceQueueReadyResponse` | `SGWPlayer.def:519-522` (INT8 aAccept) | Not in dispatch |
+| `onSpaceQueueStatus` | `SGWPlayer.def:515-517` (no args) | Not in dispatch |
+
+## Server-side data sources
+
+| Quantity | Authority source |
+|---|---|
+| Stargate position / destination world | `space_mgr.stargates[address_id]` (loaded from `resources.stargates` at startup) — server-only |
+| Player's unlocked stargates | `sgw_player.known_stargates` (Postgres column) → `PlayerLoadData::known_stargates` (`crates/services/src/base/world_entry/methods/player_load/core.rs:60,217`) → shipped to client via `setupStargateInfo` at `crates/services/src/mercury/world_data/map_loaded.rs:175-181`. **NOT plumbed onto `CellEntity`** — gate handler can't consult it without an additional plumb. |
+| Ring-transporter pad layout | `space_mgr.ring_transporters` (loaded from DB at world load) |
+| Ring mission-gate | `RingTransporter::required_mission_id` (per pad) — checked in `handle_select_destination` at `runtime.rs:277-288` |
+| Player position | `space_mgr.get_entity(entity_id).position` — NOT consulted in gate / ring / region handlers (the trust gap in CAT-B-02/03/04) |
+| System-options apply allowlist | `crates/entity/src/cell_entity/system_options.rs:59-71` — closed match on `autoReload`, `reloadOnActivate` |
+| `ConnectedClientState.access_level` | Per-session GM bit, set at auth. **NOT plumbed into cell-method dispatch** (see [[reference_gm_auth_plumbing_gap]]). |
+
+## Ghidra anchors
+
+| Symbol | Address | Notes |
+|---|---|---|
+| `Event_NetOut_onDialGate` (string) | 019be588, 019ca724 | |
+| `register_NetOut_onDialGate` | 00d93060 | |
+| `SGWNetworkManager_VEvent_NetOut_onDialGate___EventHandler__vfunc_0` | 00d69030 | |
+| `Event_NetOut_DHD` (string) | 019be1c4, 019ca2b8 | |
+| `register_NetOut_DHD` | 00d8fe80 | Same server-side cell-method 35 as onDialGate |
+| `Event_NetOut_WorldInstanceReset` (string) | 019b4340 | |
+| `register_NetOut_WorldInstanceReset` | 00cbe5a0 | |
+| `Event_SlashCmd_WorldInstanceReset` (string) | 018429f4 | C++ client emits from slash-command — no client-side gate |
+| `Event_SlashCmd_DHD` (string) | 01841b98 | Same — slash-command path emits through `Event_NetOut_DHD` |
+| `Event_NetOut_SetRingTransporterDestination` cluster | 019b3ec8 area | (CAT-B-03 anchor) |
+| `Event_NetOut_TriggerClientHintedGenericRegion` | (standard NetOut shape) | (CAT-B-04 anchor) |
+
+## Trust-violation patterns specific to CAT-O
+
+1. **Destination authorization** — independent of source-position trust.
+   `handle_dial_gate` checks `target_address_id in space_mgr.stargates`
+   (any-world global catalog) but not `target_address_id in
+   player.known_stargates`. The destination-authorization fix and the
+   CAT-B-02 source-position fix must both ship; either alone is insufficient.
+
+2. **Chain-trigger debouncing** — `triggerClientHintedGenericRegion` has
+   no rate-limit or per-region debounce. Even after CAT-B-04's position
+   validation ships, a client at the right position can still rapid-fire
+   enter/exit across multiple regions to walk the chain engine through
+   mission steps faster than the design allows.
+
+3. **GM/player exposed-method confusion** — `onWorldInstanceReset` is on
+   `SGWPlayer.def`, not `SGWGmPlayer.def`. The naming implies GM but the
+   wire surface is fully exposed. Future implementer must add an explicit
+   `is_gm_session()` check; the dispatch layer won't enforce it for them.
+
+4. **Argument-discarded "safe today" handlers** — `cancelMovie` reads no
+   args from the payload, `updateSystemOptions` accepts only an allowlist
+   of 2 names. Both surfaces *will* become exploitable the moment any
+   contributor (a) ships a mission-gating cinematic that should not be
+   cancellable, or (b) adds a server-authoritative option to the apply
+   match. Comments in the def + handler should call this out by name.
+
+Links: [[reference_gm_auth_plumbing_gap]],
+[[reference_cell_method_entity_id_authority]],
+[[project_world_space_gate_audit_2026-05-31]].

--- a/.claude/agent-memory/server-authority-enforcer/trade-container-whitelist.md
+++ b/.claude/agent-memory/server-authority-enforcer/trade-container-whitelist.md
@@ -1,0 +1,23 @@
+---
+name: trade-container-whitelist
+description: Trade swap must whitelist source container (INV_MAIN only) — blacklist-only (INV_BUYBACK) is a dupe-strip exploit
+metadata:
+  type: feedback
+---
+
+PR #438's `base/world_entry/methods/trade/execute.rs::lock_items` rejected only `INV_BUYBACK` (16) as a source container. Every other container the player owns rows in — `INV_MISSION` (2), `INV_BANDOLIER` (3), `INV_HEAD`..`INV_ARTIFACT2` (4..14), `INV_CRAFTING` (15), `INV_BANK` (17), bank variants (18..20) — passed the gauntlet. The atomicity of the `FOR UPDATE` swap does NOT save you here; it guarantees serializability, not eligibility.
+
+**Why:** rule of thumb — any "what can move in this transaction" check on an inventory mutation must be a **whitelist of allowed containers**, not a blacklist of forbidden ones. New containers added in future PRs default to "can be traded" under a blacklist; they default to "cannot" under a whitelist. The latter is safe; the former is a future-bug-magnet.
+
+**How to apply:** when reviewing any new player-to-player item mutation path (trade, mail, drop, gift, account-share), enumerate the source containers and confirm the handler does `if !TRADEABLE_FROM.contains(&row.container_id) return Err(...)`. If the only check is `row.container_id != INV_BUYBACK` or `row.bound == false`, that's the dupe-strip shape.
+
+Canonical exploit chain:
+1. Player A in trade with player B (alt account).
+2. A's proposal includes `instance_id` of an INV_CHEST armor row.
+3. Base validates ownership: row.character_id == A, row.bound == false, row.container_id == 7 (not 16). Passes.
+4. UPDATE row SET character_id = B, container_id = INV_MAIN, slot_id = $new.
+5. Cell-side cached stats on A are stale until forced recompute → A keeps the armor stat bonuses locally while B has the actual item.
+
+Linked to [[trade-cancel-uses-completed-not-cancelled]] (the documented enum quirk) and [[trade-toctou-row-level-lock]] (the atomicity guarantee).
+
+Spec anchor: `entities/defs/alias.xml` `LocalTradeItem` + Python `cell/Trade.py:53-58` (item validation in `_validateProposal` — the Python equivalent did check `canTrade()` per-item, not just per-bag).

--- a/.claude/agent-memory/testing-validation-engineer/MEMORY.md
+++ b/.claude/agent-memory/testing-validation-engineer/MEMORY.md
@@ -1,0 +1,9 @@
+# Memory Index
+
+- [workflow_revert_audit.md](workflow_revert_audit.md) — Per-PR revert+run audit workflow: Edit prod code to revert, run test, confirm failure shape, Edit to restore (NOT git stash)
+- [feedback_revert_to_verify_regression_guards.md](feedback_revert_to_verify_regression_guards.md) — Always revert the fix locally + rerun the test before accepting a regression-guard claim; theatre is invisible without this step
+- [finding_external_junction.md](finding_external_junction.md) — PowerShell `New-Item -ItemType Junction` to link `external/` into fresh audit worktrees
+- [finding_self_skipping_asset_tests.md](finding_self_skipping_asset_tests.md) — Cooked-asset-dependent tests silently pass when assets absent — flag as CI coverage gap
+- [project_dispatcher_layering_gotcha.md](project_dispatcher_layering_gotcha.md) — Tests calling inner submodule dispatch bypass outer router; check arg count (5 vs 6 args)
+- [project_social_arm_shadow.md](project_social_arm_shadow.md) — social.rs has a SPEND_APPLIED_SCIENCE_POINTS arm shadowing crafting's — bool routing assertions are blind to this
+- [reference_logcapture_helper.md](reference_logcapture_helper.md) — `crate::test_support::LogCapture` for asserting which tracing event fired; required for routing tests where bool returns are ambiguous

--- a/.claude/agent-memory/testing-validation-engineer/feedback_revert_to_verify_regression_guards.md
+++ b/.claude/agent-memory/testing-validation-engineer/feedback_revert_to_verify_regression_guards.md
@@ -1,0 +1,25 @@
+---
+name: revert-to-verify-regression-guards
+description: When auditing a PR's regression guards, revert the fix locally and rerun the test before accepting it
+metadata:
+  type: feedback
+---
+
+When auditing a PR that claims to add regression guards, the only reliable validation is to revert the fix in the worktree (via git stash or surgical edit) and rerun the test. A test that passes whether the fix is in place or reverted is theatre, no matter how good the docstring reads.
+
+**Why:** PR #427 had two routing tests (`spend_applied_science_points_routes_to_crafting`, `craft_routes_to_crafting`) whose docstrings described exactly the bug shape they claimed to guard. Both passed cleanly with the outer-router fix reverted, because they called the inner submodule's dispatch directly and bypassed the outer router entirely. The bug was 100% invisible to the test suite until I pushed a LogCapture-based replacement to `dispatch.rs`'s test module.
+
+**How to apply:** For any test labeled "regression guard" in a PR review:
+
+1. Identify the *fix commit* the test claims to guard (usually the one immediately preceding the test commit).
+2. Stash unrelated working-tree changes (`git stash push <file>`).
+3. Revert the fix surgically — prefer `Edit` over `git revert` so the test commit stays intact and only the production code changes.
+4. Run only the named test: `cargo test -p <crate> --lib <test::path>`.
+5. If it passes with the fix reverted, the test is theatre. Restore the fix (`git checkout <file>`) and write a replacement.
+6. Push the replacement as a new commit on the PR branch.
+
+The high-value reverts to check: `if (X..=Y)` range narrowing (because submodules often have their own arms), `rows_affected() == 0` checks (because seed data variants can mask which path fires), `checked_mul` / bounds checks (because the dropped check might still panic under debug overflow checks).
+
+For live-DB tests where the local env can't run them, document the static-analysis reasoning explicitly in the audit comment instead of skipping the check. CI on a reverted branch is the fallback verification.
+
+Related: [[gotcha-inner-dispatch-bypasses-outer-router]], [[gotcha-social-arm-shadows-crafting-95]]

--- a/.claude/agent-memory/testing-validation-engineer/finding_external_junction.md
+++ b/.claude/agent-memory/testing-validation-engineer/finding_external_junction.md
@@ -1,0 +1,18 @@
+---
+name: finding-external-junction
+description: Fresh worktrees lack external/ — junction-link from the main repo before any cargo test that pulls in detour/recast/SDL
+metadata:
+  type: reference
+---
+
+`external/` is not in git (populated by `setup.ps1`). Newly-created worktrees fail to compile crates with C++ deps (cimmeria-entity → recast/detour) until the junction is created.
+
+**PowerShell incantation that works on Windows 11:**
+
+```powershell
+New-Item -ItemType Junction -Path "<worktree>\external" -Target "C:\Users\Steve\source\projects\Cimmeria\external"
+```
+
+**Why not `cmd /c mklink /J`:** the cmd subshell output goes to stdout but the working-directory state is lost between Bash tool calls, so when I ran it inside the worktree I couldn't observe what happened. PowerShell's `New-Item -ItemType Junction` is the more reliable form.
+
+**How to apply:** any time I create a temp audit worktree (e.g. `audit-prNNN`), follow up with the junction creation before kicking off any compile. cimmeria-services tests fail differently — they don't need `external/` directly but they transitively depend on cimmeria-entity which DOES.

--- a/.claude/agent-memory/testing-validation-engineer/finding_self_skipping_asset_tests.md
+++ b/.claude/agent-memory/testing-validation-engineer/finding_self_skipping_asset_tests.md
@@ -1,0 +1,17 @@
+---
+name: finding-self-skipping-asset-tests
+description: Integration tests that self-skip on missing cooked assets silently "pass" in CI — coverage gap to flag in audit
+metadata:
+  type: feedback
+---
+
+When an integration test under `crates/navmesh-extractor/tests/` calls `skip_if_missing(&dir, ...)` and returns early because the cooked Castle_CellBlock asset bundle isn't present, the test reports `ok` to cargo. CI then shows a green test that proved nothing.
+
+**Why this matters for revert+audit:** PR #436's `castle_cellblock_walks_static_mesh_actors` is the canonical regression guard for the StaticMeshComponent offset (4 vs 8). The agent verified locally that reverting offset 8 → 4 trips the test. But on a machine without the cooked assets (most CI runners, most reviewer machines), the test silently no-ops. The verification only works in the dev environment with `sgw/Stargate Worlds-QA/...` co-located.
+
+**How to apply:**
+1. In audit output, when a test self-skips on missing assets, note it as a coverage gap (CI doesn't run this regression guard).
+2. Suggest emitting a `tracing::warn!` or `eprintln!` with `SKIP` prefix that CI can grep for, AND/OR landing a smaller asset-free unit test that pins the offset constant directly (`assert_eq!(STATIC_MESH_COMPONENT_OFFSET, 8)`).
+3. If the agent reports they verified the guard locally, treat as VERIFIED-locally but note it's a low-confidence verification in CI.
+
+**Examples from audit:** PR #436 `castle_cellblock_walks_static_mesh_actors` and `castle_cellblock_extract_chunk_without_index_emits_no_geometry` both self-skipped. The non-asset unit tests in `crates/upk-objects/src/static_mesh.rs` (14 tests covering bounds/normals/kdop) all ran cleanly.

--- a/.claude/agent-memory/testing-validation-engineer/project_dispatcher_layering_gotcha.md
+++ b/.claude/agent-memory/testing-validation-engineer/project_dispatcher_layering_gotcha.md
@@ -1,0 +1,20 @@
+---
+name: gotcha-inner-dispatch-bypasses-outer-router
+description: Tests that call a cell-methods submodule's dispatch directly do NOT exercise the outer router's range, even if the docstring claims they do
+metadata:
+  type: project
+---
+
+In `crates/services/src/cell/cell_methods/player/`, dispatch is layered:
+- `dispatch.rs::dispatch` is the **outer** router (takes 6 args including `&ChainEngine`). It matches against constant ranges (`CALL_FOR_AID..=RESET_MY_ABILITIES`, `ORG_CREATION..=CANCEL_MOVIE`, etc.) and routes to submodule dispatchers.
+- Each submodule (`crafting.rs`, `social.rs`, `combat.rs`, `world.rs`, ...) has its own `dispatch` function (typically 5 args, sometimes 6). These are the **inner** dispatchers — invoked by the outer router based on the range arm.
+
+**Why:** Routing bugs almost always live in the *outer* router (wrong range, wrong arm order). The inner dispatchers usually have stable match arms once they exist. A test like `dispatch(1, X, &args, &tx, &mut mgr).await` written inside a submodule's `#[cfg(test)] mod tests { use super::*; ... }` block calls **the submodule's dispatch directly**, completely bypassing the outer router.
+
+**How to apply:** When auditing a PR that claims to fix a routing/range bug in `dispatch.rs`:
+
+1. Find the test. Check whether the `dispatch(...)` call has 5 or 6 arguments. 5-arg means it's calling the inner submodule's dispatch (testing arm coverage, not routing). 6-arg with `&ChainEngine` means it's calling the outer router (testing routing).
+2. Look at the test's imports: `use super::*` inside `submodule/mod.rs` brings in that submodule's `dispatch`. To call the outer router, the test must be in `dispatch.rs`'s test module or import explicitly with `use super::super::dispatch::dispatch`.
+3. To pin an outer-router fix, the test MUST live in `dispatch.rs`'s test module. The strong-shape test calls `outer::dispatch(1, METHOD, ...)` and asserts on *side effects that distinguish which inner branch was taken* — not on `handled: bool`, because multiple inner dispatchers may legitimately handle the same method index (see [[gotcha-social-arm-shadows-crafting-95]]).
+
+The canonical pattern for "right submodule routed" is `LogCapture::install()` + assert the submodule-distinctive log message fired. The negative-logging convention doc (`docs/architecture/negative-logging-convention.md`) describes the field-naming pattern.

--- a/.claude/agent-memory/testing-validation-engineer/project_social_arm_shadow.md
+++ b/.claude/agent-memory/testing-validation-engineer/project_social_arm_shadow.md
@@ -1,0 +1,30 @@
+---
+name: gotcha-social-arm-shadows-crafting-95
+description: cell::cell_methods::player::social::dispatch has a SPEND_APPLIED_SCIENCE_POINTS arm (95) that returns true — making bool-based routing tests for crafting/social split invisible
+metadata:
+  type: project
+---
+
+`crates/services/src/cell/cell_methods/player/social.rs:66` has an arm:
+```
+SPEND_APPLIED_SCIENCE_POINTS => {
+    if args.len() >= 4 { ... }
+    tracing::info!(entity_id, discipline_seq_id, "UNIMPLEMENTED: spendAppliedSciencePoints");
+    true
+}
+```
+
+This is a stub left from an earlier wiring attempt before the crafting submodule got its own arm. As of PR #427 it has not been removed.
+
+**Why this matters:** PR #427 fixed a routing bug where the outer router's range `(CRAFT..=RESPEC_CRAFTING)` (96..=100) dropped index 95 into the social arm. The "fix" widened it to `(SPEND_APPLIED_SCIENCE_POINTS..=RESPEC_CRAFTING)` (95..=100). But because **both** the crafting submodule AND the social submodule have arms for index 95 that return `true`, **any test asserting `handled == true` is blind to which branch was taken**. You can revert the fix and `assert!(handled)` still passes — the wrong handler runs, but it still returns true.
+
+**How to apply:**
+
+1. Any future cell-routing test for index 95 (and any other index where multiple submodules might have stub arms) must use `LogCapture` to assert WHICH submodule fired the log, not just whether `handled` was true.
+2. The crafting-side log is `"UNIMPLEMENTED: spendAppliedSciencePoints (Phase 2)"` (the `(Phase 2)` suffix is the distinguishing marker). Social's is `"UNIMPLEMENTED: spendAppliedSciencePoints"` (no suffix). Use `LogCapture::install().find_message(Level::INFO, "(Phase 2)")` to pin the crafting branch.
+3. As a follow-up clean-up issue worth filing: remove the social-side `SPEND_APPLIED_SCIENCE_POINTS` arm. It's dead code now that crafting owns the routing. Doing so would make a simple `assert!(handled)` test sufficient for the outer-router check.
+4. There may be other "shadowed" arms in this dispatcher tree. When auditing a routing-fix PR, grep the other submodule dispatchers for the same method constant to check for shadows.
+
+Reference: pushed `outer_dispatch_routes_spend_asp_to_crafting_not_social` in commit `fc821bd6` (PR #427) as the canonical example of a LogCapture-based routing pin.
+
+Related: [[gotcha-inner-dispatch-bypasses-outer-router]]

--- a/.claude/agent-memory/testing-validation-engineer/reference_logcapture_helper.md
+++ b/.claude/agent-memory/testing-validation-engineer/reference_logcapture_helper.md
@@ -1,0 +1,23 @@
+---
+name: logcapture-helper-location
+description: The LogCapture test helper for asserting which tracing event fired lives in crates/services/src/test_support.rs
+metadata:
+  type: reference
+---
+
+`crate::test_support::LogCapture::install()` returns a `LogCaptureGuard` that captures every `tracing::event!` call on the current thread. Drop the guard to restore the previous subscriber.
+
+API surface:
+- `install()` — returns the guard. **Must be called from a `#[tokio::test]` (current-thread) runtime, not multi_thread.** It panics if called inside a multi-thread runtime because `set_default` is thread-local.
+- `guard.find_event(level, message_substr, reason_value)` — finds the first event matching all three filters. Use this when the negative log carries a `reason: "..."` field (the project's convention per `docs/architecture/negative-logging-convention.md`).
+- `guard.find_message(level, message_substr)` — finds the first event matching level + substring, ignoring fields. Use when the log doesn't have a `reason` field.
+- `guard.all()` — returns every captured event (useful inside `assert!` failure messages to debug what *did* fire).
+
+Examples in the codebase:
+- `crates/services/src/base/character/delete_live_db_tests.rs` — `use crate::test_support::{require_db_or_skip, LogCapture, TestTransport};`
+- `crates/services/src/base/helpers/tests.rs` lines 195, 235, 272, 331, 362, 393, 447 — many use cases for negative-log assertions.
+- `crates/services/src/cell/cell_methods/player/dispatch.rs` (after commit `fc821bd6`) — example of using `find_message` to distinguish which dispatcher branch fired.
+
+Self-tests live at `crates/services/src/test_support.rs::log_capture_tests` if the helper's behavior is in doubt.
+
+Reference field names per the negative-logging-convention doc: `reason`, `entity_id`, `player_id`, etc. Stable across the test suite; renaming requires touching every guard.

--- a/.claude/agent-memory/testing-validation-engineer/workflow_revert_audit.md
+++ b/.claude/agent-memory/testing-validation-engineer/workflow_revert_audit.md
@@ -1,0 +1,20 @@
+---
+name: workflow-revert-audit
+description: Per-PR revert+run audit workflow that has caught test theatre on past PRs — the gold-standard verification method
+metadata:
+  type: feedback
+---
+
+The audit workflow:
+
+1. **Each open PR has its own worktree** at `.claude/worktrees/agent-<hash>` (locked, named after `gh pr view N --json headRefName`). PR #432 was an exception (no worktree pre-existed) — I created `audit-pr432` ad-hoc, junction-linked `external/`, ran verification, and pruned.
+2. **For each trap guard**: Edit the production code to revert (NOT git stash — use Edit tool with explicit `REVERTED for audit:` comment). Run the test. Confirm the failure shape matches the agent's claim. Use Edit to restore. End with `git diff --stat` showing only `.claude/settings.local.json` drift.
+3. **Each cargo test run that needs `LogCapture` requires `-- --test-threads=1`** (PR #433 matrix used this). The tracing subscriber install in `LogCapture::install()` races under in-process parallel tests.
+4. **Live-DB rollback tests should NOT be run unless local Postgres is up.** They self-skip via `require_db_or_skip!`. PR #438 had 7 of these — I validated by static read of assertion exactness rather than runtime revert.
+5. **Cooked-asset-dependent tests silently self-skip** when assets aren't present — `castle_cellblock_walks_static_mesh_actors` "passes" but actually returned early. Flag this in audit output.
+
+**Why:** The user explicitly warned "Don't trust the agents' self-reports that they verified their tests under revert — the prior round caught real theatre on PR #427 even though the agent claimed it had verified." Revert + run is the only audit method that surfaces theatre.
+
+**How to apply:** Run on highest-trap-risk PRs first (trading state machine, security bounds checks, dispatch routing matrices). Lower-risk PRs (pure deletions, asset-dependent tests) can be static-read for assertion exactness.
+
+Related: [[finding_log_capture_serial]], [[finding_external_junction]]

--- a/docs/security-audit/2026-05-31-server-authority/BRIEF.md
+++ b/docs/security-audit/2026-05-31-server-authority/BRIEF.md
@@ -1,0 +1,131 @@
+# Server-Authority Audit — Agent Brief
+
+You are auditing the Cimmeria SGW server emulator for server-authority / anti-cheat /
+anti-replay gaps. This brief is shared across all per-category agents.
+
+## Hard rules for evidence
+
+A finding may ONLY cite as authoritative:
+
+1. **Ghidra MCP** — decompiled SGW.exe / STBC.exe / AtreaRL.dll. See the inventory of
+   client-side `Event_NetOut_*` classes in `.scratch/audit/surface.md`.
+2. **Client install behavioral evidence** at `C:\Users\Steve\source\projects\sgw\Stargate Worlds-QA\`:
+   - `Working/binaries/SGWDebugLog.log` — most recent client-run debug log
+   - `Working/binaries/CrashDumps/` — crash dump tree (currently mostly empty)
+   - `Working/SGWGame/Logs/` — runtime log dir (mostly empty)
+   - `Common/xml/SGWShared/CookedData/*.xsd` — schema of cooked client data
+3. **Direct client code references** — the SGW client source isn't checked in, only the
+   compiled binary. So this means Ghidra-decompiled C++.
+
+A finding MAY NOT cite as authoritative:
+
+- The deprecated Python in `deprecated/python/`
+- The Rust server code in `crates/`
+- The PostgreSQL schema in `db/`
+- Any markdown docs in `docs/`
+
+You can REFERENCE these to identify where to look or what's currently implemented,
+but the *truth* about what the client sends / accepts must come from Ghidra or
+client-side behavioral evidence.
+
+## What "demonstrable + likely-exploitable theoretical" means
+
+A finding is reportable if either:
+
+- (a) **Demonstrable**: Ghidra shows the client constructing field X from local state
+  Y with no client-side bounds check, AND the Rust server reads X and acts on it
+  without server-side validation. The attack is: a modified or replayed client
+  sends X = `<adversary value>` and the server obeys.
+
+- (b) **Likely-exploitable theoretical**: The Rust handler trusts a client-supplied
+  field that obviously should be authoritative server-side (e.g. price, target
+  entity ID, currency type, slot index, GM flag). You may not have a full
+  Ghidra trace, but the trust violation is clear from the wire shape and
+  the absence of validation. Flag with "needs live debugger to confirm at
+  triage time."
+
+Don't file:
+
+- Speculative holes with no observable client trigger and no obvious wire shape.
+- Generic "what if attacker sends malformed bytes" without a specific bad value.
+- Code-quality issues that aren't security relevant.
+
+## What to produce per finding
+
+A markdown block in this format (write to `.scratch/audit/findings/<category>.md`,
+one per category):
+
+```
+### CAT-X-NN — <short title>
+
+**Severity**: Critical | High | Medium | Low
+**Class**: <attack class — e.g. "GM auth bypass", "TOCTOU", "missing range check">
+**Wire surface**: <client message name(s) — e.g. `Event_NetOut_UseAbility`>
+**Demonstrable / Likely-theoretical**: <one of the two>
+
+**Trust violation**
+<one paragraph — what the client sends, what the server trusts, why it's wrong>
+
+**Evidence**
+- Ghidra: `<addr>` `<symbol>` — <decoded payload shape OR observed client behavior>
+- Client behavioral log: <file:line OR "n/a">
+- Cross-ref to Rust handler (for the fix author, NOT as truth): `<file>:<line>`
+
+**Attack scenario**
+1. <step>
+2. <step>
+3. Observable effect on the server
+
+**Suggested remediation (one line)**
+<terse: "validate server-side X" or "drop client-supplied Y and recompute from Z">
+
+**Would benefit from x64dbg trace?**
+Yes / No — <one-line reason if yes>
+```
+
+## Output discipline
+
+- ONE markdown file per category at `.scratch/audit/findings/<category>.md`
+- File starts with a one-paragraph summary of the category's overall trust posture
+- Then lists findings in the format above, numbered CAT-X-01, CAT-X-02, etc.
+- At the END of the file, a "Not Filed" section listing things you considered but
+  decided didn't meet the bar, with a one-line "why not filed" each. This is the
+  user's "let me know what you decide not to do" deliverable.
+- DO NOT write any commits, edits, or PR comments. Findings are local-only.
+- DO NOT file GitHub issues — that batch step happens later in main thread.
+
+## Tools you have
+
+- Read / Glob / Grep / Bash — for surveying Rust code + ../sgw/ binaries
+- Ghidra MCP — `mcp__ghidra__*` tools. SGW.exe is open as the active program at
+  `C:/Users/Steve/source/projects/SGW/Stargate Worlds-QA/Working/binaries/SGW.exe`.
+  173,223 functions, 634,156 symbols available.
+
+Tools you should AVOID:
+- Edit / Write to source files (audit is read-only; only `.scratch/audit/**` writes)
+- Any git operations
+- Any GitHub gh commands
+
+## Scope of this audit
+
+Categories (one agent per category):
+
+- CAT-A: Auth / Session / Character lifecycle / Disconnect-LogOff
+- CAT-B: Movement / Teleport / Position / Crouched / WeaponState / Unstuck
+- CAT-C: Combat / Abilities / UseAbility / Pet abilities / Respawn / SetTarget
+- CAT-D: Inventory / Items / MoveItem / RequestAmmoChange / Bandolier / UseItem
+- CAT-E: Vendor / PurchaseItems / SellItems / BuybackItems / RepairItems / RechargeItems
+- CAT-F: Crafting / Craft / Alloy / Research / ReverseEngineer / TrainAbility
+- CAT-G: Mail / Send / Take / PayCOD / Archive / Delete
+- CAT-H: Trade P2P / TradeProposal / TradeLockState
+- CAT-I: Black Market / BMCreateAuction / BMPlaceBid / BMSearch
+- CAT-J: Mission / Dialog / Interact / DialogButtonChoice / MissionAdvance/Reset/Complete
+- CAT-K: Minigame / Start / End / Complete / Spectate
+- CAT-L: Chat / Contact list / sendPlayerCommunication / Petition / Who
+- CAT-M: Organization / Squad / Duel
+- CAT-N: GM debug commands (Set*/Give*/Show*/Spawn/Despawn/Kill/Goto*/Summon/etc.)
+- CAT-O: World / Space / GateTravel / RingTransporter / DHD / WorldInstanceReset
+
+Each agent gets its category. CAT-N (GM commands) is the largest and most critical —
+verify each Set*/Give*/Show*/Kill/Spawn/Summon path is gated by server-side GM check,
+NOT by hiding the UI affordance.

--- a/docs/security-audit/2026-05-31-server-authority/UMBRELLA.md
+++ b/docs/security-audit/2026-05-31-server-authority/UMBRELLA.md
@@ -1,0 +1,192 @@
+# Server-authority audit — full sweep [umbrella]
+
+Date: 2026-05-31
+Worktree branch: `worktree-server-authority-audit`
+
+> Tracking record for an exhaustive server-authority / anti-cheat / anti-replay
+> audit of every player-facing wire surface in the Cimmeria SGW server emulator.
+
+## Scope + methodology
+
+All findings are evidence-backed against authoritative sources only:
+
+- **Ghidra MCP** decompilation of the live SGW.exe client (`/SGW.exe`, 173,223 functions, 634,156 symbols, image base 0x00400000) — the actual bytes the client constructs and sends.
+- **`../sgw/` client install** at `C:\Users\Steve\source\projects\sgw\Stargate Worlds-QA\` — game data files (XSD schemas under `Common/xml/SGWShared/CookedData/`), client-generated logs.
+- **Compiled-binary RTTI evidence** — every `Event_NetOut_*` client message class confirmed via Ghidra string addresses (cited inline in each finding).
+
+Deliberately **NOT** treated as sources of truth:
+
+- The deprecated Python in `deprecated/python/` (referenced only where the wire shape can be cross-checked, never as authority).
+- The Rust server code in `crates/` (the *thing being audited*, cited only as fix-author cross-reference).
+- The PostgreSQL schema in `db/`.
+- Any markdown docs in `docs/`.
+
+Methodology: each category was audited by a dedicated `server-authority-enforcer` agent with read-only access. Each agent (a) extracted the inbound `Event_NetOut_*` wire surface from Ghidra, (b) traced the matching server handler in Rust, (c) flagged trust-boundary violations where the server reads client-supplied state and acts on it without server-side validation, and (d) filed only "demonstrable" or "likely-exploitable theoretical" findings (no pure speculation).
+
+## Stats
+
+- **Categories audited**: 15 (A through O)
+- **Total findings**: 177
+- **Severity breakdown**:
+  - **10 Critical** (Demonstrable + Latent-Critical-when-impl combined)
+  - **~35 High**
+  - **~50 Medium**
+  - **~55 Low / Latent-when-impl**
+
+## Six systemic cross-cutting patterns
+
+These recur across multiple categories and warrant focused attention before
+the per-finding work begins.
+
+### 1. `access_level` is not plumbed into cell-method dispatch
+
+**Lead finding**: CAT-N-03 (Critical, systemic).
+
+The `access_level` (GM / admin / player) lives on `ConnectedClientState` in the
+base layer. The cell-method dispatcher in `crates/services/src/cell/dispatch/router.rs`
+has no access to it. Every future `gm*` handler added to the cell layer will be
+unauthenticated-by-default. This blocks every GM-gating fix in CAT-N until it's
+addressed structurally.
+
+**Related findings**: CAT-L-06 (SendGMShout), CAT-N-01/02 (WORLD_INSTANCE_RESET / RESET_MY_ABILITIES exposed on regular SGWPlayer), CAT-O-04 (onWorldInstanceReset exposed on player).
+
+### 2. Auth-channel crypto + anti-replay foundation is wide open
+
+**Lead findings**: CAT-A-01 (Critical, plaintext SOAP), CAT-A-02 (High, zero-IV AES-CBC reuse), CAT-A-03 (High, no inbound replay/dedup on encrypted datagrams), CAT-A-05 (High, ticket no source-IP binding), CAT-B-05 (Medium, no anti-replay on position updates).
+
+The encrypted channel uses a fixed zero IV reused per packet (passive plaintext-structure leak) and has no inbound sequence/dedup wired on the game-packet path. **Every other anti-cheat finding in this audit assumes a secure channel that isn't actually secure.** Fix these *first*: per-handler validation can be bypassed by replaying captured packets if this layer doesn't hold.
+
+### 3. Wire surface live, handler stubbed — "future implementer ships the dupe"
+
+**Categories most affected**: CAT-G (mail), CAT-H (trade), CAT-I (black market), CAT-F (crafting), CAT-J (mission), CAT-K (minigame), CAT-L (chat), CAT-M (org/duel).
+
+Consistent pattern: the cell-method dispatcher returns `true` (handled) and logs
+`UNIMPLEMENTED:` while doing nothing. The wire surface is fully exposed, the validation
+contract is undocumented, and the next contributor to fill in the handler body will inherit
+all the trust violations by default. The audit findings serve as the *spec* for what
+guard-rails the implementation must include.
+
+Most acute for:
+- **Trade (CAT-H)** — 4 Critical-latent (TOCTOU, atomicity, disconnect, concurrent inventory mutation)
+- **Auction (CAT-I)** — 5 Critical-post-impl (no current-bid check, no atomicity, no expiry sweep)
+- **Mail (CAT-G)** — 5 High-latent (no validation contract; double-take race surface)
+- **Crafting (CAT-F)** — 3 Critical-latent (`craft`, `research`/`reverseEngineer`, `alloying`)
+- **Org/Duel (CAT-M)** — 1 Critical real (guild bank dupe via signed-int) + 7 High
+
+### 4. Position validation is absent on the inbound write path
+
+**Lead finding**: CAT-B-01 (Critical).
+
+`AVATAR_UPDATE_EXPLICIT` (system message 0x03) writes the client-supplied position to
+the cell entity with **zero validation** — no navmesh check (the helper `is_position_valid`
+exists but is unwired), no speed check, no Z-axis check, no cross-space sanity. Every
+per-tick movement is a free teleport. Downstream AoI, region triggers, quest gates,
+threat radius, navmesh distance — every higher-level system reads from this corrupt
+position.
+
+**Related findings**: CAT-B-09 (navmesh helper exists but unwired), CAT-B-06 (cross-space spaceId discarded).
+
+### 5. Content-engine chains can be reached by forging a single packet
+
+**Lead finding**: CAT-J-01 (Critical).
+
+`DIALOG_BUTTON_CHOICE` fires arbitrary content chains with no check that the dialog is
+actually open. Forge one `(dialog_id, button_id)` packet → reach chain actions like
+`GrantXP / GrantItem / Teleport / AcceptMission / CompleteMission`. Combined with CAT-J-04
+(no mission prereq validation on accept), this is the universal content-bypass exploit.
+
+### 6. Server-must-hold-pending-state — the response-without-correlation anti-pattern
+
+**Findings**: CAT-J-01 (DialogButtonChoice), CAT-M-13 (sendDuelResponse), CAT-M-16 (pvpOrganizationLeaveResponse), CAT-M-17 (strikeTeamResponse), CAT-M-18 (organizationInviteResponse), CAT-K-04/05 (minigame cancel/spectate), and the mail invite-response analogues (CAT-G when implemented).
+
+Pattern: a response message carries NO correlation id (no challenger id, no invite id, no pending-prompt id, etc.). The server MUST hold pending-state per-session for these, and reject responses that don't match. Naïve handler implementations that just decode the payload and act on it will be exploitable.
+
+## Per-category status
+
+| Category | Findings | Critical | High | Medium | Low | Findings file |
+|---|---:|---:|---:|---:|---:|---|
+| CAT-A — Auth / Session / Character lifecycle | 14 | 1 | 4 | 3 | 6 | [CAT-A-auth.md](findings/CAT-A-auth.md) |
+| CAT-B — Movement / Teleport / Position | 10 | 1 | 3 | 3 | 3 | [CAT-B-movement.md](findings/CAT-B-movement.md) |
+| CAT-C — Combat / Abilities | 15 | 0 | 4 | 4 | 7 | [CAT-C-combat-abilities.md](findings/CAT-C-combat-abilities.md) |
+| CAT-D — Inventory / Items | 9 | 0 | 3 | 4 | 2 | [CAT-D-inventory.md](findings/CAT-D-inventory.md) |
+| CAT-E — Vendor | 6 | 0 | 1 | 1 | 4 | [CAT-E-vendor.md](findings/CAT-E-vendor.md) |
+| CAT-F — Crafting / R&D | 8 | 3 (latent) | 1 (latent) | 2 | 2 | [CAT-F-crafting.md](findings/CAT-F-crafting.md) |
+| CAT-G — Mail | 8 | 0 | 5 (latent) | 1 | 2 | [CAT-G-mail.md](findings/CAT-G-mail.md) |
+| CAT-H — Trade (P2P) | 10 | 4 (latent) | 5 (latent) | 1 (latent) | 0 | [CAT-H-trade.md](findings/CAT-H-trade.md) |
+| CAT-I — Black Market | 6 | 5 (post-impl) | 1 | 0 | 0 | [CAT-I-black-market.md](findings/CAT-I-black-market.md) |
+| CAT-J — Mission / Dialog / Interaction | 9 | 1 | 2 | 2 | 4 | [CAT-J-mission-dialog.md](findings/CAT-J-mission-dialog.md) |
+| CAT-K — Minigame | 9 | 1 | 1 | 4 | 3 | [CAT-K-minigame.md](findings/CAT-K-minigame.md) |
+| CAT-L — Chat / Contact | 9 | 0 | 3 (latent) | 3 | 3 | [CAT-L-chat-contact.md](findings/CAT-L-chat-contact.md) |
+| CAT-M — Organization / Squad / Duel | 18 | 1 | 7 | 8 | 2 | [CAT-M-org-squad-duel.md](findings/CAT-M-org-squad-duel.md) |
+| CAT-N — GM / Debug / Cheat commands | 40 | 2 (incl. systemic) | 8 | 12 | 18 | [CAT-N-gm-commands.md](findings/CAT-N-gm-commands.md) |
+| CAT-O — World / Space / Gate / Ring | 6 | 0 | 3 | 2 | 1 | [CAT-O-world-space-gate.md](findings/CAT-O-world-space-gate.md) |
+| **Totals** | **177** | **~18** | **~46** | **~46** | **~57** | |
+
+## P0 / P1 / P2 triage
+
+### P0 — Foundational; fix before anything else
+
+These are systemic. Every other audit finding rides on top of them.
+
+1. **CAT-N-03** — Plumb `access_level` from base session state into cell-method dispatch context. (Critical, systemic, blocks every GM-gating fix in CAT-N.)
+2. **CAT-A-01** — Move SOAP auth to TLS. (Critical, exposes credentials + session keys.)
+3. **CAT-A-02 + CAT-A-03 + CAT-B-05** (crypto-and-replay bundle) — Per-packet IV derived from sequence number, wire `Channel::receive_packet` dedup into the inbound encrypted path, anti-replay sequence on position updates. (Without these, every per-handler fix is replay-bypassable.)
+4. **CAT-B-01 + CAT-B-09** — Server-side speed / navmesh / Z-axis validation on the `AVATAR_UPDATE_EXPLICIT` write path. The `is_position_valid` helper already exists; wire it.
+5. **CAT-J-01** — Track open-dialog state server-side; reject `DIALOG_BUTTON_CHOICE` unless caller has that dialog open with that button. (Without this, every content chain can be triggered by a single forged packet.)
+
+### P1 — Critical individual exploits (currently demonstrable)
+
+These are localized single-finding fixes.
+
+- **CAT-C-01** — `respawn`/`callForAid` heal non-dead player to full → effective combat-state reset + free heal.
+- **CAT-C-02** — `callForAid(respawner_id)` accepts any id → arbitrary teleport via respawner table.
+- **CAT-C-03** — `useAbility` has no faction/friendly-fire filter → PvP damage open + damage to vendors/quest-givers.
+- **CAT-C-04** — `useAbility` has no LOS / navmesh / AoI-membership check → shoot through walls.
+- **CAT-D-01** — Bandolier ammo TOCTOU keyed on `type_id` → same-type-swap ammo overwrite.
+- **CAT-D-02 + CAT-D-03** — `lootItem` no range/state recheck + no loot reservation → vacuum loot from 100 units.
+- **CAT-E-01** — Vendor REPAIR/RECHARGE wire-shape inversion: omit trailing 4 bytes → free repair/recharge.
+- **CAT-K-01** — Minigame `PlaceholderGame` instant-victory → bypass every mission with a minigame gate.
+- **CAT-M-09** — `organizationTransferCash` signed `INT32 aCash` → negative-amount sign-flip = guild-bank dupe.
+- **CAT-B-02 / B-03 / B-04** — onDialGate / ring transport / region trigger trust client claim with no source-position proof (combine with P0 #4).
+- **CAT-O-01** — `onDialGate` ignores `knownStargateAddresses` → any char dials any gate in catalog.
+- **CAT-O-03** — `triggerClientHintedGenericRegion` has no rate-limit → chain-fire region triggers across mission sequences at packet rate.
+
+### P2 — Guard-rail tests for stubbed handlers
+
+These are *latent* findings: dispatcher returns `true` while handler is stubbed.
+File now so the spec exists before the implementer ships the dupe.
+
+- **All of CAT-G (mail)** — sendMail, takeCash, takeItem, payCOD, returnMail.
+- **All of CAT-H (trade)** — full state machine, item lock, atomicity, disconnect handling.
+- **All of CAT-I (black market)** — bid/cancel/expiry/COD-to-seller cascade.
+- **CAT-F-03/04/05** (crafting) — material consumption atomicity, server-side outcome roll, alloying tier check.
+- **CAT-J-05/06** (mission) — ChosenRewards (offered-reward-set authority), ShareMission (ownership + group membership + recipient consent).
+- **CAT-K-02/04/05/06** (minigame) — debug commands GM-gating, cancel-actor auth, spectate perception, contact request gating.
+- **CAT-L-04/05/06/08** (chat) — contact list ownership, BroadcastMinimapPing org-membership, SendGMShout access_level, channel-op session-side bit tracking.
+- **CAT-M (whole category)** — rank-comparison invariants, transferCash positivity + atomic, response-correlation per session.
+- **CAT-O-04** (world-instance-reset on player entity).
+- **All of CAT-N** — every `gm*` command needs access_level + bounds checks at implementation time.
+
+## Live-debugger triage
+
+A subset of findings flag "would benefit from x64dbg trace" for confirmation under a real client connection. These are noted per-finding (e.g. CAT-D-01 bandolier race window timing, CAT-D-09 wire-width confirmation). They can be batched into a debugger session when the user is available — issues will be tagged so they're surfaced as a group.
+
+## Specialist consults
+
+Each finding's "Suggested remediation" line tags the appropriate specialist agent at fix time:
+
+- `combat-systems-advisor` — combat math, threat lifecycle, BSF_InCombat semantics, focus restoration
+- `items-systems-advisor` — bandolier state, stack semantics, container ACL, vendor state machine, material consumption
+- `movement-physics-advisor` — speed validation primitive, navmesh containment, LOS raycast
+- `movement-teleport-advisor` — BASEMSG_FORCED_POSITION + AoI refresh, ring/DHD/gate canonical primitives
+- `social-systems-engineer` — mail/trade/auction state machines, item locks, guild ranks, duel handshake
+- `mission-systems-advisor` — chain pipeline, mission prereq model, reward selection authority
+- `minigame-systems-advisor` — SmartFoxServer 1.x protocol, ticket exchange, per-game result schema
+- `network-security-auth` — TLS migration, IV derivation, replay window wiring, dev-mode bypass gate
+
+## How to triage from here
+
+1. Land the **P0 bundle** as a coordinated change set. Per-handler fixes from P1/P2 are bypassable without P0.
+2. **P1 individual exploits** as separate small PRs — each has localized fixes.
+3. **P2 guard-rails**: file as tests/specs against the stub handlers so the implementing PR has a failing test that proves the trust violation is closed.
+4. Use the per-category child issues as the working list — each lists its findings with checkboxes.

--- a/docs/security-audit/2026-05-31-server-authority/findings/CAT-A-auth.md
+++ b/docs/security-audit/2026-05-31-server-authority/findings/CAT-A-auth.md
@@ -1,0 +1,668 @@
+# CAT-A — Auth / Session / Character lifecycle
+
+**Overall trust posture**: The auth-handshake path applies several correct
+server-authority disciplines: the inbound baseAppLogin's `account_id` field is
+parsed-and-discarded (the trusted account_id comes from the ticket map);
+deleteCharacter and requestCharacterVisuals both filter by `account_id` so
+players cannot mutate or enumerate other accounts' characters; PlayCharacter's
+spawn position is read server-side from `sgw_player` (not from the wire);
+CreateCharacter's archetype/alignment/gender/bodyset/starting-position are all
+derived server-side from a static `chardef_lookup` table keyed by the
+client-supplied `CharDefId`; starting abilities/items come from
+`resources.char_creation_*` tables, not from the client; and the GM-relevant
+`access_level` for in-world dispatch lives on the server-side
+`ConnectedClientState` row sourced from the auth ticket (which sources from
+the `account.accesslevel` column). The login itself, however, is wide open in
+several places that matter outside a closed LAN deployment:
+
+1. The HTTP SOAP auth (Phases 1 + 2) runs **plaintext HTTP** — credentials
+   (as SHA-1 hex, which the server accepts as the password), the session_key,
+   and the ticket all traverse the wire unencrypted. Anyone on-path can replay
+   either the SOAP request or the Phase 3 UDP packet.
+2. The Phase 3 ticket has no source-IP binding, no nonce, and no per-attempt
+   challenge — possession of the ticket = full session.
+3. AES-256-CBC encryption uses a hard-coded all-zero IV reused across every
+   packet for the lifetime of the channel. Identical plaintext blocks produce
+   identical ciphertext blocks, leaking message structure to a passive
+   observer.
+4. There is no per-sequence inbound dedup on encrypted game packets — the
+   per-channel `Channel::receive_packet` window is wired only on the outbound
+   ACK path; the inbound dispatch in `connect_loop::encrypted` runs decrypt →
+   parse → dispatch with no replay check, so any captured ciphertext can be
+   re-injected and re-dispatched.
+5. The Phase 3 handler does not consult `TICKET_TTL` — only a 10s reaper
+   thread enforces it, so a ticket can be consumed up to ~10s past its 30s
+   nominal expiry.
+6. No rate limiting / lockout on Phase 1 — brute-force-by-SHA1 is unimpeded.
+7. Password equality uses `String::!=` (variable time) — a millisecond-scale
+   timing oracle, exploitable across the unencrypted SOAP channel.
+8. CreateCharacter has no profanity / reserved-word filter; names like
+   `Admin`, `GM_*`, etc. parse through unchanged.
+
+The CharDef → starting-state derivation, account-id ownership filters, and
+ConnectedClientState-rooted access_level are the load-bearing correctness
+properties — none of those are wire-trust violations. Everything below is
+either a wire-trust gap or an encryption/replay/credential-handling gap, not
+a CharDef/visuals/ownership gap.
+
+---
+
+### CAT-A-01 — Phase 1/2 auth SOAP runs plaintext HTTP; credentials, session_key, and ticket all sniffable
+
+**Severity**: Critical
+**Class**: missing transport security
+**Wire surface**: `POST /SGWLogin/UserAuth`, `POST /SGWLogin/ServerSelection`
+**Demonstrable / Likely-theoretical**: Demonstrable
+
+**Trust violation**
+The auth service binds an axum `TcpListener` and serves the SOAP login
+endpoints over plain HTTP (no `rustls`, `TlsAcceptor`, or any TLS termination
+in front). The client's `password` field is a 40-char hex SHA-1 of the
+plaintext password and is accepted directly by `validate_credentials` —
+possession of the hash is functionally equivalent to possession of the
+password (it's the only thing the wire protocol needs). Phase 2's response
+includes the `SessionKey` (64-char hex AES-256 key) and `Ticket` (20-char
+hex) in plaintext XML. Anyone with passive network capture between client
+and server captures: (a) a reusable credential, (b) the AES key for the
+client's entire in-world session, and (c) the ticket needed to claim the
+session via Phase 3.
+
+**Evidence**
+- Ghidra: `0x019d0030` `ServerConnection::authenticate: Unexpected key! (%s, wanted %s)` — the client emits `authenticate` carrying the SessionKey it got from Phase 2, and the server's encrypted-channel logic relies on that exact key on both sides. SessionKey is XML-encoded in the Phase 2 SOAP response (`0x01b26028` `SessionKey`).
+- Client behavioral log: n/a — the protocol is HTTP-by-design per `crates/services/src/auth/handlers.rs` (no TLS in scope).
+- Cross-ref to Rust handler (for the fix author, NOT as truth): `crates/services/src/auth/service.rs:135` (`TcpListener::bind`), `crates/services/src/auth/handlers.rs:172-181` (XML response with cleartext SessionKey/Ticket).
+
+**Attack scenario**
+1. Attacker is on-path between the client and the auth server (open Wi-Fi,
+   ISP, compromised router).
+2. Captures the Phase 1 POST body — extracts `Password=<40 hex chars>` and
+   `AccountName=<user>`.
+3. Captures the Phase 2 response — extracts `SessionKey=<64 hex chars>` and
+   `Ticket=<20 hex chars>`.
+4. Either: (a) reuses the captured `Password` hash anytime to log in as the
+   user (the wire protocol accepts the hash; no challenge-response), or (b)
+   races the legitimate client to the Phase 3 UDP endpoint, claims the
+   ticket, and runs the in-world session under the captured session_key.
+5. Observable effect on the server: the legitimate client either fails Phase
+   3 (ticket already consumed) or is duplicate-evicted by the attacker's
+   later login.
+
+**Suggested remediation (one line)**
+Terminate Phases 1/2 behind TLS (axum + rustls or a reverse proxy); migrate the password column off raw SHA-1 to a salted PBKDF2/argon2 with a challenge-response wire protocol so the hash is not itself a reusable credential.
+
+**Would benefit from x64dbg trace?**
+No — the protocol is unambiguous from Ghidra strings and the Rust handler. A
+network capture in a real session would confirm but adds nothing beyond what
+the code states.
+
+---
+
+### CAT-A-02 — AES-CBC encryption uses a hard-coded all-zero IV reused for every packet
+
+**Severity**: High
+**Class**: cryptographic misuse — IV reuse
+**Wire surface**: every encrypted Mercury packet (post-Phase 3)
+**Demonstrable / Likely-theoretical**: Demonstrable
+
+**Trust violation**
+`MercuryEncryption::from_session_key` constructs the per-session encryption
+context with `iv: [0u8; 16]` and never advances it. Every packet sent on the
+channel encrypts under `AES-256-CBC(key, iv=0, padded_plaintext)`. With a
+fixed IV, two packets whose first plaintext block is identical produce
+identical first ciphertext blocks — and because the SGW wire protocol begins
+many message families with stable preambles (msg_id + WORD_LENGTH +
+entity_id, repeating heartbeat bundles, fixed AVATAR_UPDATE_EXPLICIT layout,
+etc.), a passive observer can recover substantial plaintext structure
+without breaking AES at all. Combined with CAT-A-01 (key is sniffable
+anyway), this is a defense-in-depth gap rather than the primary break, but
+the design is wrong: AES-CBC requires a unique IV per encryption.
+
+**Evidence**
+- Ghidra: n/a — encryption is server-side; the matching C++ behaviour is referenced in the Rust source comment ("matches the C++ `EncryptionFilter::setKey()`").
+- Client behavioral log: n/a.
+- Cross-ref to Rust handler (for the fix author, NOT as truth): `crates/mercury/src/encryption.rs:78-84` (`from_session_key` hard-codes the zero IV).
+
+**Attack scenario**
+1. Attacker passively captures the encrypted bundle stream from any client.
+2. Identifies recurring 16-byte ciphertext prefixes — these correspond to
+   message-family preambles whose plaintext is dictionary-known.
+3. Cross-references against the (also-sniffable) AES key from CAT-A-01 to
+   fully decrypt; or, even without the key, performs pattern-matching to
+   classify message families and time them against game events.
+4. Observable effect on the server: no direct effect, but information
+   disclosure compounds with any other gap (replay, ticket capture, etc.).
+
+**Suggested remediation (one line)**
+Generate a fresh random 16-byte IV per packet and prepend it to the
+ciphertext (then HMAC over IV‖ciphertext); the per-packet IV cost is
+trivial vs. the kept-forever key-reuse leak.
+
+**Would benefit from x64dbg trace?**
+No — the misuse is on the server side; behaviour is unambiguous from the Rust source.
+
+---
+
+### CAT-A-03 — No inbound packet replay / dedup on the encrypted game-packet path
+
+**Severity**: High
+**Class**: missing replay protection
+**Wire surface**: every encrypted Mercury packet from a connected client
+**Demonstrable / Likely-theoretical**: Demonstrable
+
+**Trust violation**
+The per-channel `Channel::receive_packet` implementation in
+`crates/mercury/src/channel/mod.rs:412` does maintain an RX window with
+duplicate-drop semantics (`if self.rx_window[offset].is_none() { … }`), but
+**that method is never called for inbound encrypted game packets** — a
+workspace-wide grep for `receive_packet` returns zero hits in
+`crates/services`. The actual game-packet path in
+`connect_loop/encrypted/mod.rs::handle_encrypted_datagram` only (i) decrypts,
+(ii) parses, (iii) queues an ACK for the client's reliable sequence number,
+and (iv) dispatches the bundle. There is no check that the client's
+`pkt.seq_id` has not already been processed; a captured ciphertext blob can
+be re-injected verbatim by any on-path attacker and the server will
+re-dispatch every message in the bundle.
+
+**Evidence**
+- Ghidra: n/a — the Mercury wire format and 28-bit sequence space are described in `docs/drafts/spec/mercury-wire-format.md` and confirmed by `crates/mercury/src/packet`. The server's omission is on the receive side.
+- Client behavioral log: n/a.
+- Cross-ref to Rust handler (for the fix author, NOT as truth): `crates/services/src/base/connect_loop/encrypted/mod.rs:99-105` (queues ACK without dedup), `crates/mercury/src/channel/mod.rs:412-468` (the unwired `receive_packet` dedup window).
+
+**Attack scenario**
+1. Attacker captures one ciphertext datagram from any client (e.g. a UseItem
+   bundle that consumes a stack item, or a PurchaseItems, or a GM-shout from
+   a moderator).
+2. Re-injects the same datagram against the same UDP endpoint, optionally
+   multiple times.
+3. Server decrypts (succeeds — HMAC valid), parses, dispatches every
+   contained message a second time.
+4. Observable effect: depending on the captured message family, double
+   item-consume (CAT-D class), double purchase, repeated chat broadcast,
+   repeated GM-action, repeated character delete, etc.
+
+**Suggested remediation (one line)**
+Plumb every inbound packet through `Channel::receive_packet` (or an
+equivalent per-session received-sequence set) and drop datagrams whose
+`seq_id` has already been processed; the dedup window is already
+implemented, it just isn't called on the receive path.
+
+**Would benefit from x64dbg trace?**
+No — the omission is observable purely in the server source. A
+proof-of-concept replay using the existing `cimmeria-wireclient` chaos
+harness would confirm but the code-level evidence is already sufficient.
+
+---
+
+### CAT-A-04 — Phase 3 baseAppLogin does not enforce TICKET_TTL — ~10s reaper lag is the only gate
+
+**Severity**: Medium
+**Class**: stale-credential acceptance
+**Wire surface**: Phase 3 UDP `baseAppLogin` (msg_id 0x00, flags 0x41)
+**Demonstrable / Likely-theoretical**: Demonstrable
+
+**Trust violation**
+`PendingLogin` carries a `created: Instant` and the auth service defines
+`TICKET_TTL = 30s`, but the actual enforcement only happens in the 10-second
+background reaper (`crates/services/src/auth/service.rs:160`). The Phase 3
+consumer `handle_login` performs `pending_logins.lock().remove(ticket)`
+without checking `login.created.elapsed() < TICKET_TTL`. Consequence: a
+ticket older than 30s but younger than the reaper's next sweep is still
+consumable — up to ~40s old in the worst case. This widens the attacker's
+race window after a CAT-A-01-style ticket capture: the attacker has not 30s
+but as much as 40s to win the race to Phase 3.
+
+**Evidence**
+- Ghidra: n/a.
+- Client behavioral log: n/a.
+- Cross-ref to Rust handler (for the fix author, NOT as truth): `crates/services/src/base/login/mod.rs:44-57` (`pending_logins.remove(ticket)` with no elapsed check), `crates/services/src/auth/service.rs:157-162` (reaper is the only TTL enforcer).
+
+**Attack scenario**
+1. Attacker captures a ticket from a CAT-A-01 SOAP sniff at T=0.
+2. Legitimate client is slow to Phase 3 (e.g. firewall, DNS, retry) — at
+   T=31s no Phase 3 has happened.
+3. Attacker's Phase 3 packet at T=35s arrives. Reaper last ran at T=30s and
+   next runs at T=40s. The ticket is still in the map.
+4. `handle_login` succeeds; attacker now owns the session for the
+   legitimate user.
+
+**Suggested remediation (one line)**
+Add `if login.created.elapsed() >= TICKET_TTL { return Ok(()); }` in
+`handle_login` right after the `remove()`, before any session setup.
+
+**Would benefit from x64dbg trace?**
+No — purely a server-side check omission.
+
+---
+
+### CAT-A-05 — Phase 3 ticket has no source-IP binding; capture-from-anywhere = full session
+
+**Severity**: High
+**Class**: missing session binding
+**Wire surface**: Phase 3 UDP `baseAppLogin`
+**Demonstrable / Likely-theoretical**: Likely-exploitable theoretical (needs network capture to confirm)
+
+**Trust violation**
+`PendingLogin` stores only `(account_id, access_level, ticket, session_key,
+created)`. The client_ip observed at Phase 2 (`addr.ip()` in
+`handle_server_selection`) is logged but discarded — it is not stored in the
+PendingLogin record, and `handle_login` does not compare the inbound UDP
+source address against an expected IP. Combined with CAT-A-01 (plaintext
+ticket on the wire), this means any attacker who observes a ticket from any
+network location can replay it from any other source address.
+
+**Evidence**
+- Ghidra: n/a.
+- Client behavioral log: n/a.
+- Cross-ref to Rust handler (for the fix author, NOT as truth): `crates/services/src/auth/mod.rs:99-110` (PendingLogin struct, no source_ip field), `crates/services/src/auth/handlers.rs:251-262` (Phase 2 stores PendingLogin without binding `addr`).
+
+**Attack scenario**
+1. Attacker captures Phase 2 response from an off-path vantage (e.g. mirror
+   port at an ISP, BGP hijack of a tiny prefix, or a captured PCAP shared
+   among adversaries).
+2. Sends Phase 3 from a completely different network (different country,
+   different ASN).
+3. Server accepts — no IP comparison — and creates the session bound to the
+   attacker's UDP address. The legitimate client's later Phase 3 either
+   fails ("ticket already consumed") or duplicate-evicts the attacker
+   AFTER the attacker has had time to perform an action.
+
+**Suggested remediation (one line)**
+Store `peer_ip` in `PendingLogin` at Phase 2 and reject `handle_login` when
+the inbound UDP source IP does not match (with a strict-vs-permissive knob
+for NAT'd clients if needed).
+
+**Would benefit from x64dbg trace?**
+No — server-side check omission. A two-host PoC is the natural test.
+
+---
+
+### CAT-A-06 — No rate-limiting / lockout on Phase 1 credential check — credential stuffing is unimpeded
+
+**Severity**: Medium
+**Class**: missing brute-force defense
+**Wire surface**: `POST /SGWLogin/UserAuth`
+**Demonstrable / Likely-theoretical**: Demonstrable
+
+**Trust violation**
+`handle_user_auth` runs through `validate_credentials` synchronously on each
+request and emits a `LoginEvent` audit record on failure, but there is no
+per-IP, per-account, or global throttle. An attacker can hammer the SOAP
+endpoint at full server CPU and never trigger a slowdown or account lock.
+Combined with the wire protocol's stable SHA-1 hash format (CAT-A-01), an
+offline rainbow table / leaked-credential list is fully effective.
+
+**Evidence**
+- Ghidra: n/a.
+- Client behavioral log: n/a.
+- Cross-ref to Rust handler (for the fix author, NOT as truth): `crates/services/src/auth/handlers.rs:117-144` (credential check with no throttle); workspace-wide grep for `rate_limit|lockout` in `crates/services` returns no matches.
+
+**Attack scenario**
+1. Attacker scripts POST requests to `/SGWLogin/UserAuth` with a known
+   account_name + a wordlist of SHA-1 hashes.
+2. Server processes each request at full speed; no failure threshold pauses
+   or blocks the attacker.
+3. On hit, the success returns a valid Phase 1 SID — attacker proceeds to
+   Phase 2 + Phase 3 normally.
+
+**Suggested remediation (one line)**
+Add a per-(IP, account_name) sliding-window failure counter that backs off
+exponentially and triggers an account lock after N failures within a window;
+emit `LoginEvent` with a `rate_limited` outcome.
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-A-07 — Password comparison uses variable-time `String::!=` — timing oracle
+
+**Severity**: Low
+**Class**: side-channel — timing attack
+**Wire surface**: `POST /SGWLogin/UserAuth`
+**Demonstrable / Likely-theoretical**: Likely-exploitable theoretical (timing leak; would require careful measurement, especially over a plaintext HTTP path)
+
+**Trust violation**
+`validate_credentials` compares the stored password hash against the
+client-supplied hash using `row.password.to_uppercase() != client_password_hash.to_uppercase()` —
+this is `std::String`'s `PartialEq`, which short-circuits on the first
+mismatching byte. The comparison happens AFTER the DB round-trip (which
+dominates the wall-clock), but the difference between "first byte mismatch"
+and "37th byte mismatch" is measurable over many samples. For a 40-char
+SHA-1 hex string, this leaks the password hash one nibble at a time.
+
+**Evidence**
+- Ghidra: n/a.
+- Client behavioral log: n/a.
+- Cross-ref to Rust handler (for the fix author, NOT as truth): `crates/services/src/auth/handlers.rs:481`.
+
+**Attack scenario**
+1. Attacker knows the target account_name.
+2. Performs many calibrated Phase 1 requests with crafted password hashes,
+   binary-search-style measuring server response time per prefix.
+3. Over ~40 × 16 ≈ 640 measurements (in practice many more, to denoise),
+   recovers the stored hash one nibble at a time.
+4. Recovered hash is itself a reusable credential per CAT-A-01.
+
+**Suggested remediation (one line)**
+Use `subtle::ConstantTimeEq` (or the `constant_time_eq` crate) for the hash
+comparison, and convert both sides to bytes before the compare.
+
+**Would benefit from x64dbg trace?**
+No — pure timing channel on the server.
+
+---
+
+### CAT-A-08 — Developer-mode bypass: any-credentials login with access_level=99 if DB is absent
+
+**Severity**: High (if reachable in deployed env) / Low (if dev-only)
+**Class**: configuration footgun — admin bypass
+**Wire surface**: `POST /SGWLogin/UserAuth`
+**Demonstrable / Likely-theoretical**: Demonstrable
+
+**Trust violation**
+When `state.developer_mode = true` AND `state.db = None`,
+`handle_user_auth` short-circuits the credential check and returns
+`(account_id=1, access_level=99)` for any submitted account_name/password
+combination (subject only to format-validation: 40-char hex password, valid
+account-name characters). The same flag also bypasses the protocol-digest
+client-version check. Access_level 99 is the highest privilege the server
+recognises — that account is full GM. The default for `developer_mode` is
+`false`, but the dual condition (developer_mode AND no DB) is an easy
+operator mistake: any deployment that forgets to wire the Postgres pool
+turns into a wide-open admin server.
+
+**Evidence**
+- Ghidra: n/a.
+- Client behavioral log: n/a.
+- Cross-ref to Rust handler (for the fix author, NOT as truth): `crates/services/src/auth/handlers.rs:107-145` (developer_mode protocol-digest bypass + no-DB credential bypass at access_level 99).
+
+**Attack scenario**
+1. Operator deploys with `developer_mode=true` (left over from local dev)
+   and a misconfigured DATABASE_URL that fails the connection.
+2. AuthService starts with `state.db = None`.
+3. Any attacker hits `/SGWLogin/UserAuth` with any account_name + a valid
+   40-hex password string and gets `(account_id=1, access_level=99)`.
+4. Phase 2 + 3 proceed normally; the attacker is in-world as a full GM.
+
+**Suggested remediation (one line)**
+Refuse to start the AuthService when `developer_mode=true` and the DB pool
+is `None` simultaneously — both conditions in production should be a fatal
+startup error, not a silent open door. Failing that, log an
+operator-visible WARN-level alert on every developer-mode credential
+acceptance.
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-A-09 — `Channel` per-session inbound dedup state exists but is never wired to the live game-packet path
+
+**Severity**: Medium
+**Class**: defense-in-depth missing, related to CAT-A-03
+**Wire surface**: every encrypted Mercury packet
+**Demonstrable / Likely-theoretical**: Demonstrable
+
+**Trust violation**
+`ConnectedClientState` carries `channel: Mutex<cimmeria_mercury::channel::Channel>`
+(initialised at Phase 3 in `crates/services/src/base/login/mod.rs:186`),
+which contains the full `rx_window` + `expected_rx_seq` machinery
+described in spec §1.7. Today only the **outbound ACK side** is wired
+(`channel.process_acks(...)` in `encrypted/mod.rs:117`). The inbound
+`channel.receive_packet(...)` is never called — duplicates aren't dropped,
+out-of-window packets aren't logged, and the carefully-built RX window
+sits dead. This is the same root cause as CAT-A-03 but worth filing
+separately because the fix is "wire the existing implementation up",
+not "design replay protection from scratch".
+
+**Evidence**
+- Ghidra: n/a.
+- Client behavioral log: n/a.
+- Cross-ref to Rust handler (for the fix author, NOT as truth): `crates/mercury/src/channel/mod.rs:412-468` (the unused `receive_packet` dedup path), `crates/services/src/base/login/mod.rs:186` (Channel is created but never sees inbound packets).
+
+**Attack scenario**
+Same as CAT-A-03 — the per-session `Channel` already has the data
+structure to detect a replayed `seq_id`; the bug is that the receive
+loop bypasses it.
+
+**Suggested remediation (one line)**
+In `handle_encrypted_datagram`, before dispatching the bundle, call
+`state.channel.lock().receive_packet(pkt.clone())?` and drop the bundle
+if the call returns `Ok(None)` and the packet is reliable (i.e. it was
+a duplicate that the RX window already saw, not a buffered-ahead one).
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-A-10 — CreateCharacter has no profanity / reserved-word filter; "Admin", "Moderator", "GM_*" are creatable
+
+**Severity**: Low
+**Class**: missing impersonation defense
+**Wire surface**: `Event_NetOut_CreateCharacter` (Account base method 0xC3)
+**Demonstrable / Likely-theoretical**: Demonstrable
+
+**Trust violation**
+`validate_character_name` enforces length (3–20), ASCII letters/digits/space/
+hyphen/apostrophe only, no leading/trailing/consecutive whitespace. There is
+no profanity or reserved-word filter. A normal user can create characters
+named `Admin`, `Moderator`, `GM Sam`, `Customer Service`, etc. — these
+appear in chat and on the wire as legitimate-looking entities and are an
+impersonation / social-engineering vector even though the actual
+`access_level` is still 0.
+
+**Evidence**
+- Ghidra: `0x019bbdb0` `Event_NetOut_CreateCharacter` — the client emits CreateCharacter carrying the Name WSTRING; client-side validation does not filter reserved names (the client passes whatever the UI text field contains).
+- Client behavioral log: n/a.
+- Cross-ref to Rust handler (for the fix author, NOT as truth): `crates/services/src/base/character_create.rs:495-515` (validate_character_name).
+
+**Attack scenario**
+1. Attacker creates a character named `Admin` or `Moderator <ServerName>`.
+2. The character appears in chat as if it were staff; the attacker uses it
+   to phish other players ("I'm a GM, send me your password to verify").
+3. Observable effect on the server: no direct game-state corruption, but a
+   real-world impersonation channel.
+
+**Suggested remediation (one line)**
+Add a reserved-prefix/reserved-name list (`["admin", "moderator", "gm", "cs", "support", "system", "cimmeria", ...]`) and reject case-insensitively in `validate_character_name`.
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-A-11 — onClientVersion / versionInfoRequest does not enforce a server-side minimum client version
+
+**Severity**: Low
+**Class**: defense-in-depth — modded/old client tolerance
+**Wire surface**: `Event_NetOut_versionInfoRequest`, `Event_NetOut_onClientVersion` (Account base method 0xC7)
+**Demonstrable / Likely-theoretical**: Demonstrable
+
+**Trust violation**
+`onClientVersion` (0xC7) is dispatched in `account_arms.rs:150-152` as
+nothing more than `tracing::debug!(...)`. `versionInfoRequest` is handled by
+`handle_version_info_request` which serves invalid-keys deltas but does NOT
+compare a client-reported version to a minimum. The only version gate is
+the Phase 1 SOAP `ProtocolDigest` MD5, which a modded client can hard-code.
+After Phase 1, the server accepts any client version — including a modded
+client that disables client-side bounds checks, disables UI lockouts on GM
+buttons, etc.
+
+**Evidence**
+- Ghidra: client emits `Event_NetOut_onClientVersion` at the standard NetOut emit site; the payload carries a version blob that the server reads but does not validate against a floor.
+- Client behavioral log: n/a.
+- Cross-ref to Rust handler (for the fix author, NOT as truth): `crates/services/src/base/connect_loop/account_arms.rs:150-152` (no-op accept).
+
+**Attack scenario**
+1. Attacker modifies SGW.exe (or AtreaRL.dll wrapper) to disable client-side
+   UI lockouts on debug/CHEAT-class messages (Goto, Spawn, SetGodMode, etc.).
+2. Logs in normally — the modded client passes Phase 1 because the
+   ProtocolDigest matches; passes onClientVersion because the server doesn't
+   check.
+3. Sends GM-class messages from a non-GM account — those are gated
+   server-side per CAT-N, but defense-in-depth was supposed to start here.
+
+**Suggested remediation (one line)**
+Parse and enforce a minimum client version in `onClientVersion`; reject
+clients below the floor with `LOGGED_OFF`.
+
+**Would benefit from x64dbg trace?**
+No — the server-side omission is the issue, not the client behaviour.
+
+---
+
+### CAT-A-12 — `restoreClientAck` (0x0B) is consumed silently; no validation that a restore was actually pending
+
+**Severity**: Low
+**Class**: protocol-state ambiguity
+**Wire surface**: System message 0x0B (`restoreClientAck`, CONSTANT_LENGTH=4)
+**Demonstrable / Likely-theoretical**: Demonstrable
+
+**Trust violation**
+The wire framing code in `encrypted/mod.rs:500-501` correctly reads
+`restoreClientAck` as CONSTANT_LENGTH=4 and advances the offset, but there
+is no match arm for `0x0B` in the dispatcher — it falls through to the
+`_` wildcard at `mod.rs:444` and is logged at trace. The 4 bytes of payload
+are never inspected, and the server doesn't verify that the client is
+acknowledging an actual outstanding `RESTORE_CLIENT` — a stale or
+maliciously-injected `restoreClientAck` would be silently accepted. In the
+current server this is dead code on both sides (no `RESTORE_CLIENT` is ever
+sent), but the silent-accept means any future addition of a restore
+sequence would have to remember to bolt validation on; today's behavior
+silently drops the evidence.
+
+**Evidence**
+- Ghidra: the spec annotation in the Rust source cites `ghidra://SGW.exe@0x00dd8bc9` as the sole emitter (writes literal `i32 = 0`). The client always sends a zero-int payload.
+- Client behavioral log: n/a.
+- Cross-ref to Rust handler (for the fix author, NOT as truth): `crates/services/src/base/connect_loop/encrypted/mod.rs:444-446` (the wildcard arm consumes 0x0B without any state check).
+
+**Attack scenario**
+1. Attacker sends a `restoreClientAck` (4 bytes, all-zero) on any encrypted
+   channel that they own.
+2. Server silently consumes it.
+3. Today's observable effect: none — no server logic is gated on
+   restoreClientAck. **The finding is filed as a noise-class warning**: any
+   future work that wires `RESTORE_CLIENT` (e.g. for snapshot-resume) must
+   validate that an ack arrives only when one was solicited.
+
+**Suggested remediation (one line)**
+Either explicitly drop `0x0B` with a `warn!` if no restore was solicited,
+or add a guarded state machine in `ConnectedClientState` (`pending_restore: Option<...>`) and validate against it.
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-A-13 — Phase 3 ticket consumption is not atomic with eviction of an existing session for the same account
+
+**Severity**: Low
+**Class**: TOCTOU on session swap
+**Wire surface**: Phase 3 UDP `baseAppLogin`
+**Demonstrable / Likely-theoretical**: Likely-exploitable theoretical (race-window narrow but extant)
+
+**Trust violation**
+`handle_login` performs three separate lock acquisitions on the `connected`
+map: (1) scan-for-existing-session-by-account_id, (2) send LOGGED_OFF to the
+old session, (3) insert the new session. Between steps 1 and 3 another
+thread (e.g. a concurrent `handle_log_off` or the tick loop's
+`destroy_client_entities`) can mutate the connected map. The eviction logic
+also assumes the old session's `account_id` is still on the entry — it is,
+but the lock is dropped twice. In normal operation the duplicate-eviction
+flow works, but a hostile client can race: (a) initiate Phase 3 from one
+network endpoint, (b) before the LOGGED_OFF send completes, fire another
+Phase 3 from a different endpoint. The two new sessions can both register
+because the second one's scan in step (1) doesn't see the first one (it's
+still being set up). One of the sessions is then orphaned in the connected
+map but with cancelled-tick-loop status.
+
+**Evidence**
+- Ghidra: n/a.
+- Client behavioral log: n/a.
+- Cross-ref to Rust handler (for the fix author, NOT as truth): `crates/services/src/base/login/mod.rs:67-113` (multi-step eviction with intervening lock drops).
+
+**Attack scenario**
+1. Attacker holds two valid (captured) tickets for the same account.
+2. Fires Phase 3 from two source ports nearly simultaneously.
+3. Both pass the "no existing session" check; both insert a connected
+   state. One wins the entity_to_addr race; the other holds a zombie
+   connected entry that the tick loop may or may not clean up.
+4. Observable effect: account_id appears in `clients` twice;
+   `destroy_client_entities` and account_id-keyed lookups elsewhere
+   (chat, friends) get an ambiguous answer.
+
+**Suggested remediation (one line)**
+Hold the `connected` lock across the entire scan-evict-insert sequence
+(refactor `handle_login` to acquire once and structure the eviction
+work as data extraction inside the lock + side effects outside).
+
+**Would benefit from x64dbg trace?**
+No — repro is a two-socket Rust test.
+
+---
+
+### CAT-A-14 — Authentication (0x01) message is parsed-and-discarded; the server does not verify the client knows the session key
+
+**Severity**: Low
+**Class**: defense-in-depth — handshake completeness
+**Wire surface**: System message 0x01 (`authenticate`, WORD_LENGTH)
+**Demonstrable / Likely-theoretical**: Demonstrable
+
+**Trust violation**
+The first message in every post-Phase-3 bundle is the client's
+`authenticate` (0x01). The C++ reference server (per the in-code comment)
+"ignores this message — entity creation happens on ENABLE_ENTITIES (0x08)
+so the client's entity system is ready." The current Rust implementation
+mirrors that: `encrypted/mod.rs:145-156` skips the message and advances the
+offset. This is correct vs. the C++ behaviour, but it does mean the
+**possession of the AES key** is the only thing proving the client knows
+the session_key — there is no challenge-response that the client must
+satisfy with the session_key as input. Combined with the all-zero IV
+(CAT-A-02) and the absence of inbound replay protection (CAT-A-03), there
+is no mechanism that distinguishes a legitimate client from a
+captured-key replayer.
+
+The Ghidra string `ServerConnection::authenticate: Unexpected key! (%s, wanted %s)`
+at `0x019d0030` confirms the client SIDE does compare keys, but the
+server-side comparison is absent.
+
+**Evidence**
+- Ghidra: `0x019d0030` `ServerConnection::authenticate: Unexpected key! (%s, wanted %s)` — invoked from `ServerConnection_authenticate` at `0x00dd85b6`. The client validates that the SessionKey it sees in the inbound stream matches the one Phase 2 returned. The server has no symmetric check.
+- Client behavioral log: n/a.
+- Cross-ref to Rust handler (for the fix author, NOT as truth): `crates/services/src/base/connect_loop/encrypted/mod.rs:142-156` (authenticate is consumed without inspection).
+
+**Attack scenario**
+1. Attacker captures Phase 2 ticket + session_key (CAT-A-01).
+2. Wins the Phase 3 race (CAT-A-05).
+3. Sends a valid encrypted bundle. Server decrypts (HMAC valid since the
+   attacker has the key); the `authenticate` field is consumed without
+   inspection; subsequent messages dispatch normally.
+4. Observable effect: full session takeover with no proof-of-key beyond
+   the HMAC verification, which is implicit in successful decryption.
+
+**Suggested remediation (one line)**
+Parse the `authenticate` payload and verify it carries the same session
+fingerprint Phase 2 produced (e.g. an HMAC over a server-issued nonce);
+treat a mismatch as `disconnect_reason = "auth_mismatch"`. The HMAC over
+the AES key already exists — the gap is the explicit fingerprint check.
+
+**Would benefit from x64dbg trace?**
+Yes — capturing the exact bytes the client puts in the authenticate
+WSTRING would lock the spec for the fix author.
+
+---
+
+## Not Filed
+
+- **AVATAR_UPDATE_EXPLICIT (0x03) accepted on the encrypted channel before world entry** — checked; the handler in `encrypted/mod.rs:214` requires `player_entity_id` to be `Some`, which is only set in `play_character.rs:131-133`. Pre-world-entry packets are dropped, not dispatched. Properly gated.
+- **deleteCharacter has no confirmation prompt server-side** — the spec/protocol does not require one (it's a UX decision in the client). The account-id ownership check at the SQL layer (`WHERE player_id = $1 AND account_id = $2`) is the load-bearing defense and is present.
+- **requestCharacterVisuals as enumeration vector** — the SQL filters by `account_id` (handler line 184), so it cannot leak other accounts' characters even with a guessed player_id. Not filed.
+- **Phase 3 baseAppLogin embeds an `account_id` field in the wire payload** — parsed-and-discarded at `login/mod.rs:242` (`_account_id`). The trusted account_id comes from the ticket map. Correct shape; no finding.
+- **CharDefId trust** — chardef_lookup is a static server-side table; an out-of-range CharDefId returns None and the handler rejects the create. Properly server-derived. Not filed.
+- **Starting inventory / abilities** — pulled from `resources.char_creation_abilities` and `resources.items.container_sets` server-side, not from the client payload. Properly server-derived.
+- **`access_level` desync between `account.accesslevel` and `sgw_player.access_level`** — the only **authorization-load-bearing** consumer is `ConnectedClientState.access_level` (sourced from auth ticket = account row). The `PlayerLoadData.access_level` (sourced from sgw_player row) flows out to the client as a property (informational) but is never used for an auth decision. Two sources of truth, but the authorization-affecting one is the correct one. Borderline — filed as a documentation concern, not a security finding.
+- **LogOff/Disconnect from another session** — both arrive on the encrypted channel keyed by the inbound UDP `addr`; an attacker cannot inject these on behalf of a different session without decrypting that session's channel (which is the same problem as session takeover, already covered by CAT-A-01/03/05/14).
+- **Python console on port 8989** — referenced in the audit prompt as something `network-security-auth` knows about. Workspace grep for `8989`, `python_console`, `Python.*Console` returns no hits in `crates/`. Either retired or never implemented in the Rust port; nothing to file. If the surface is added later, treat it as a separate audit pass.
+- **0x0D channelSetup** — per the comment in `encrypted/mod.rs:511-517`, 0x0D as a literal msg_id never appears on the wire (it's reserved for the high-bit entity-message namespace). The audit-prompt's "channelSetup" name appears in `wire_log/client_names.rs:206` as a stale label. No live surface to audit.
+- **Mercury HMAC-MD5 strength** — MD5 is broken for collision resistance but HMAC-MD5 remains acceptable for integrity in 2026 (no practical key recovery). Not filed as a primary finding; lumped into the CAT-A-01/02 "modernize the crypto stack" remediation.

--- a/docs/security-audit/2026-05-31-server-authority/findings/CAT-B-movement.md
+++ b/docs/security-audit/2026-05-31-server-authority/findings/CAT-B-movement.md
@@ -1,0 +1,649 @@
+# CAT-B — Movement / Teleport / Position
+
+## Trust posture summary
+
+The movement subsystem trusts the client to be the authoritative source of
+position, velocity, direction, and "I'm standing on object X" claims. Inbound
+`AVATAR_UPDATE_EXPLICIT` (0x03) writes the client-supplied position vector
+straight into the cell's authoritative `CellEntity::position` with no speed,
+distance, navmesh, vertical-bounds, or rate validation — every per-tick
+position update is a free teleport for an attacker. A `is_position_valid`
+navmesh helper exists but is never called from the write path. Several
+client-hinted region/destination handlers (`onDialGate`,
+`setRingTransporterDestination`, `triggerClientHintedGenericRegion`) accept
+target IDs without verifying the player is physically near the source pad /
+region, turning them into one-shot teleports that bypass intermediate
+geography. Player-initiated `setMovementType` is correctly NPC-only-guarded
+(no exploit), `Unstuck` (cell method 71) is a logged stub today, and the
+GM-prefixed `gmGoto*` / `gmSummon` Cheats methods have no server handler
+(fall through to `warn!`). The base layer correctly substitutes the
+session's `player_entity_id` for the client-supplied entityId prefix on
+cell-method calls (line 122/134 of `cell_arms.rs`), so cross-entity
+spoofing through that channel is blocked. The dominant exploit shape is
+"send a single 0x03 packet with arbitrary world-space coordinates and the
+server obeys" — every higher-level system that depends on player position
+(AoI, region triggers, navmesh distance, gating quests) is downstream of
+this primitive and is corrupted in turn.
+
+---
+
+### CAT-B-01 — `AVATAR_UPDATE_EXPLICIT` writes client position with no validation
+
+**Severity**: Critical
+**Class**: Speed hack / teleport / position spoofing
+**Wire surface**: System message `0x03` (`AVATAR_UPDATE_EXPLICIT`)
+**Demonstrable / Likely-theoretical**: Demonstrable
+
+**Trust violation**
+The client sends a 40-byte payload containing `[spaceId:u32][vehicleId:u32]
+[pos:3×f32][vel:3×f32][dir:3×i8][flags:u8][cells:3×u8][updateId:u8]`. The
+server reads pos/vel/dir from offsets 8–34, looks up the player's
+`entity_id` from session state (good), and forwards the values to the cell
+via `BaseToCellMsg::EntityMove`. The cell handler at
+`crates/services/src/cell/service/base_messages/mod.rs:138-167` calls
+`space_mgr.update_entity_position(entity_id, position, direction, velocity)`
+which unconditionally writes the new position and updates the spatial grid
+(`crates/services/src/cell/space_manager/entities.rs:147-177`). There is no
+delta cap, no `last_position → new_position` distance check, no navmesh
+reachability check, no Z-axis cap, no rate limit, no comparison to the
+last server-confirmed position. A modified client can send a single 0x03
+packet with `pos = (0, 0, 0)` or any other coordinate in any world and the
+server's authoritative spatial state will reflect it on the next tick.
+AoI, region triggers, gating quests, threat radius — every downstream
+system reads from this state.
+
+**Evidence**
+- Ghidra: `019d08b8` — string literal `avatarUpdateExplicit` confirms the
+  client-side message name; the 0x03 system-message payload shape is
+  pinned by the spec-cited `messages.cpp` table.
+- Client behavioral log: n/a (continuous 10 Hz traffic — the canonical
+  movement signal).
+- Cross-ref to Rust handler (for the fix author):
+  `crates/services/src/base/connect_loop/encrypted/mod.rs:211-281` (parse +
+  forward), `crates/services/src/cell/service/base_messages/mod.rs:138-167`
+  (apply), `crates/services/src/cell/space_manager/entities.rs:147-177`
+  (write).
+
+**Attack scenario**
+1. Stand at any reachable position to establish a baseline.
+2. Send one 0x03 packet with `pos = (any_x, any_y, any_z)` for the
+   destination world's coordinate range.
+3. Server overwrites the entity position. Next AoI tick fires
+   `EnteredAoI`/`LeftAoI` from the new location — the attacker now sees
+   and interacts with entities at the spoofed position (loot, NPCs,
+   regions). Quest regions can be flipped from anywhere on the map.
+
+**Suggested remediation (one line)**
+Reject `EntityMove` when `||new_pos − last_server_pos|| / (server_tick_dt)`
+exceeds the entity's class-derived max speed, AND when
+`!is_position_valid(new_pos)`; pre-bake a `last_server_pos` snapshot
+keyed off the *server's* tick clock — never client-supplied timestamps.
+Consult `movement-physics-advisor` for the canonical speed-validation
+primitive shape.
+
+**Would benefit from x64dbg trace?**
+No — the trust violation is fully demonstrable from the Rust handler alone;
+the 0x03 framing is already pinned by the wire-format constants in
+`encrypted/mod.rs:485-503`.
+
+---
+
+### CAT-B-02 — `onDialGate` ignores `source_address_id`, teleports from anywhere
+
+**Severity**: High
+**Class**: Authoritative location bypass / world teleport
+**Wire surface**: Cell method 35 (`onDialGate`) — `Event_NetOut_OnDialGate`
+**Demonstrable / Likely-theoretical**: Demonstrable
+
+**Trust violation**
+The handler at `crates/services/src/cell/gate_travel.rs:35-108` takes a
+client-supplied `(target_address_id, source_address_id)` pair, validates
+that `target_address_id` is a known stargate, then issues
+`CellToBaseMsg::GateTravel` to the destination. `source_address_id` is
+explicitly unused (prefixed `_source_address_id`, line 38). There's no
+check that the player is physically near any stargate, let alone the one
+they claim to be using. A player can stand anywhere in the world and dial
+any cross-world stargate — bypassing the in-world walk to the source
+gate, any mission gating tied to "reach gate X first" content actions,
+and any region-trigger entry conditions on the source pad. Combined with
+[[CAT-B-01]], a player can send a single 0x03 to spawn-bump themselves
+into a world they shouldn't have access to without ever having to walk
+to a gate or have completed the unlock quest.
+
+**Evidence**
+- Ghidra: client emits `onDialGate` via the standard `Event_NetOut_*` path
+  (no Cheats prefix); the cell method index 35 is the documented GateTravel
+  interface (see `crates/services/src/cell/cell_methods/gate_travel.rs:7`).
+- Client behavioral log: n/a (player-driven UI event).
+- Cross-ref to Rust handler:
+  `crates/services/src/cell/cell_methods/gate_travel.rs:9-40` (dispatch),
+  `crates/services/src/cell/gate_travel.rs:35-108` (handle).
+
+**Attack scenario**
+1. Player creates a low-level character on the starter world.
+2. Without walking to any stargate, send `onDialGate(target=2, source=0)`
+   where target=2 is a stargate to an end-game world that requires
+   completion of multiple unlock missions.
+3. Server validates the target exists in `space_mgr.stargates`, calls
+   `handle_gate_travel`, persists the destination world to `sgw_player`,
+   and ships RESET_ENTITIES + new world entry. Attacker is now on the
+   end-game world with no mission gating.
+
+**Suggested remediation (one line)**
+Validate that the player's current position is within an interaction
+radius (e.g., 5m) of the source stargate's pad position before dispatching
+`GateTravel`; fail closed if the source-gate position is unknown, and
+log-and-reject if the player isn't standing on it. Route the redesign
+back to `movement-teleport-advisor` to confirm whether a region-trigger
+ack should be the gating signal instead.
+
+**Would benefit from x64dbg trace?**
+No — the unused `_source_address_id` parameter is a code-level proof.
+
+---
+
+### CAT-B-03 — `setRingTransporterDestination` accepts any source ring globally
+
+**Severity**: High
+**Class**: Authoritative location bypass / ring teleport
+**Wire surface**: Cell method 91 (`setRingTransporterDestination`) — `Event_NetOut_SetRingTransporterDestination`
+**Demonstrable / Likely-theoretical**: Demonstrable
+
+**Trust violation**
+`handle_select_destination` at
+`crates/services/src/cell/ring_transport/runtime.rs:244-350` accepts
+`(source_region_id, destination_region_id)` from the client and validates:
+(a) `source` exists and is `Idle`, (b) `destination` is in
+`source.destination_ids`, (c) `destination` is not the source itself.
+It does **not** validate that the player is physically standing on the
+source ring's pad — there's no entity-position check against the source
+region's `RingRegion::x/y/z` or its `point_set_id` containment. The
+related `triggerClientHintedGenericRegion` (see [[CAT-B-04]]) is what
+normally sets `player.ring_source_id` when the player walks onto the pad,
+but `handle_select_destination` doesn't consult `ring_source_id` either —
+it overwrites it on line 332. A player can send
+`setRingTransporterDestination(source=any_idle_ring, dest=any_valid_dest)`
+from anywhere in the world and the FSM will run, locking the source
+ring's state into `SendWait`, and (when auto-start fires) eventually
+running the full transport ceremony.
+
+**Evidence**
+- Ghidra: `019b3ec8` cluster confirms the `Event_NetOut_SetRingTransporterDestination`
+  vtable (`00ae9ed0`, `00ae9ff0`) and `SGWNetworkManager::EventHandler<...>`
+  (`00d68c30`) — emit path is the standard cell-method dispatch.
+- Client behavioral log: n/a (UI-driven destination selector).
+- Cross-ref to Rust handler:
+  `crates/services/src/cell/cell_methods/player/world/mod.rs:207-228`
+  (dispatch arm), `crates/services/src/cell/ring_transport/runtime.rs:244-350`
+  (handle), `crates/services/src/cell/ring_transport/transporter/mod.rs:245-256`
+  (`validate_destination` — note: doesn't check player position).
+
+**Attack scenario**
+1. Discover ring-region IDs via `onRingTransporterList` (server broadcasts
+   the list when any player interacts with a ring, which AoI replays).
+2. Without standing on any ring pad, send
+   `setRingTransporterDestination(source=Castle_pad, dest=Asuras_pad)`.
+3. Server runs `validate_destination` — passes because Castle is Idle and
+   Asuras is a valid destination. Source enters `SendWait`, destination
+   `RecvWait`. The auto-start kicks in via
+   `should_auto_start`, and the player gets teleported to Asuras without
+   walking to the Castle ring pad. Combined with the mission-gate check
+   that's *also* anchored only to the source ring's
+   `required_mission_id` (which the player may or may not have completed),
+   this is a cross-world teleport from arbitrary coordinates.
+
+**Suggested remediation (one line)**
+Before `enter_send_wait`, verify `player.ring_source_id ==
+Some(source_region_id)` — i.e., the player's region-trigger state shows
+they actually walked onto the pad — and reject otherwise; treat any other
+state as a protocol-level error. Consult `movement-teleport-advisor` on
+whether to additionally distance-check against `RingRegion::x/y/z`.
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-B-04 — `triggerClientHintedGenericRegion` discards client position, trusts region_id
+
+**Severity**: High
+**Class**: Region-trigger spoofing / chain-event injection
+**Wire surface**: Cell method 85 (`triggerClientHintedGenericRegion`) — `Event_NetOut_TriggerClientHintedGenericRegion`
+**Demonstrable / Likely-theoretical**: Demonstrable
+
+**Trust violation**
+The handler at
+`crates/services/src/cell/cell_methods/player/world/mod.rs:128-191`
+reads a client-supplied `(region_id, b_entering, x, y, z)` payload. The
+position triple `(x, y, z)` is parsed and immediately discarded
+(prefixed `_x`, `_y`, `_z` — lines 132-134). The handler looks up the
+region by id, fires the `enter_region` / `exit_region` content chain
+event for the region's `tag`, and forwards to the ring transport FSM
+if the region matches a ring pad. There is no validation that the
+player's *actual* position (from the server-tracked
+`CellEntity::position`) is inside the region's bounds. A malicious
+client can send `triggerClientHintedGenericRegion(region=N,
+b_entering=true, 0, 0, 0)` from anywhere to claim entry into any
+loaded region — firing every content chain bound to
+`enter_region::<tag>` for arbitrary regions (quest-region triggers,
+mission-advance triggers, content-engine actions). The ring forwarding
+also fires `RingTransporter::region_triggered(entering=true,
+entity_id)` which is what sets `player.ring_source_id` — meaning this
+single handler is sufficient to *also* prepare the ring-transporter
+exploit described in [[CAT-B-03]] without a position check.
+
+**Evidence**
+- Ghidra: client-emit path identical to other cell methods (standard
+  `Event_NetOut_*` shape); spec source is
+  `entities/defs/interfaces/SGWPlayer.def`.
+- Client behavioral log: n/a (continuous as the player walks).
+- Cross-ref to Rust handler:
+  `crates/services/src/cell/cell_methods/player/world/mod.rs:128-191`,
+  `crates/services/src/cell/ring_transport/runtime.rs:375-409`
+  (`handle_region_trigger` — region_triggered call).
+
+**Attack scenario**
+1. Enumerate loaded region IDs by entering the world normally and
+   observing `triggerClientHintedGenericRegion` round-trips, OR
+   bruteforce u32 region_ids until log-grep shows `region_tag` was
+   resolved.
+2. Send `triggerClientHintedGenericRegion(region=<mission_region_id>,
+   b_entering=true, 0, 0, 0)` from a safe far-away spot.
+3. Server fires `fire_enter_region` and the chain engine advances the
+   mission as if the player walked into the trigger area. Repeat for
+   chained quest steps to skip-flag content; combine with the ring
+   exploit path to short-circuit cross-world travel.
+
+**Suggested remediation (one line)**
+Before firing the chain event, validate the player's
+`space_mgr.get_entity(entity_id).position` actually intersects the
+region's geometry (bounding-box for simple regions; point-in-polygon for
+named-region shapes), and drop the client's `(x,y,z)` entirely — the
+server already has the canonical position.
+
+**Would benefit from x64dbg trace?**
+No — the discarded `_x`/`_y`/`_z` is a code-level proof.
+
+---
+
+### CAT-B-05 — `EntityMove` has no anti-replay / dedup of position updates
+
+**Severity**: Medium
+**Class**: Replay attack / position rewind
+**Wire surface**: System message `0x03` (`AVATAR_UPDATE_EXPLICIT`)
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+The 0x03 message is parsed and dispatched on the **unreliable** path
+(`FLAG_RELIABLE` not set on send — see comment at
+`crates/services/src/mercury/aoi/update.rs:14-18`). Because the message
+is unreliable, the Mercury channel's `rx_window` dedup (which protects
+reliable traffic at `crates/mercury/src/channel/mod.rs:442-456`) does
+not apply. The payload carries an `updateId:u8` at the tail (offset 39
+of the 40-byte payload — see comment at line 212 of `encrypted/mod.rs`)
+that the server reads as part of the constant-length consumption but
+never validates against any per-client sequence counter. A captured
+position packet can be replayed at the server later — when the player
+has moved elsewhere — to rewind their authoritative position to the
+captured value. Combined with [[CAT-B-01]] (no movement validation),
+replay → rewind is a one-packet primitive.
+
+**Evidence**
+- Ghidra: `019d08b8` `avatarUpdateExplicit` — emit path is one packet per
+  position update; the SGW client doesn't sign or chain them.
+- Client behavioral log: n/a.
+- Cross-ref to Rust handler:
+  `crates/services/src/base/connect_loop/encrypted/mod.rs:211-281`
+  (no `updateId` validation; field at `payload[39]` is read by the
+  constant-length consumer but never inspected).
+
+**Attack scenario**
+1. Attacker (or a passive observer in possession of pre-encryption
+   packets) captures a 0x03 packet for player P at position A.
+2. Player P walks across the world to position B.
+3. Attacker (sharing a session key, or testing from the same client)
+   re-injects the captured 0x03. Server writes position A back over
+   position B, jerking the avatar back and re-firing AoI/region
+   triggers as if the rewind were legitimate.
+
+**Suggested remediation (one line)**
+Track the last accepted `updateId` per session in
+`ConnectedClientState`; reject 0x03 when `updateId <= last_seen`
+(wrapping rules per the client's update-counter spec), so replays are
+silently dropped.
+
+**Would benefit from x64dbg trace?**
+Yes — confirming the `updateId` field semantics (monotonic? wrapping?
+reset on world transition?) in the running client would tighten the
+remediation; the comment at `encrypted/mod.rs:212` is the only current
+documentation.
+
+---
+
+### CAT-B-06 — Client spaceId in 0x03 ignored — no cross-space sanity check
+
+**Severity**: Medium
+**Class**: Position smuggling / space-grid corruption
+**Wire surface**: System message `0x03` (`AVATAR_UPDATE_EXPLICIT`)
+**Demonstrable / Likely-theoretical**: Demonstrable
+
+**Trust violation**
+The 0x03 payload's first 4 bytes are `spaceId` (per the comment block at
+`crates/services/src/base/connect_loop/encrypted/mod.rs:212`). The
+server reads `payload[0..4]` and discards it ("not used here -- client
+confirms which space"). The position written to the cell is interpreted
+in whatever space the entity is *currently* assigned to on the server
+side. If the server's notion of the player's space ever diverges from
+the client's (e.g., after a gate-travel race where the cell's
+`CreateEntity` reply arrives late, or after instance reset), the client
+might be sending coordinates valid for one world while the server
+writes them into another space's spatial grid — corrupting the grid
+with out-of-range coordinates and breaking AoI for every player in
+that space. There's no check that the client-supplied `spaceId`
+matches `space_mgr.entity_space.get(&entity_id)`.
+
+**Evidence**
+- Ghidra: client emits `spaceId` as the first u32 — see Ghidra wire
+  shape in `encrypted/mod.rs:211-213`.
+- Client behavioral log: n/a.
+- Cross-ref to Rust handler:
+  `crates/services/src/base/connect_loop/encrypted/mod.rs:224`
+  ("`payload[0..4] = spaceId (not used here -- client confirms which
+  space)`").
+
+**Attack scenario**
+1. Trigger a gate-travel; race the `BaseToCellMsg::CreateEntity` reply.
+2. Send a flood of 0x03 packets with the old world's `spaceId` while the
+   cell's `entity_space` map still points to the old space. The first
+   packets get written to the old space (server reads
+   `entity_space[entity_id]`, which is still the old value); subsequent
+   ones — once the new space binding lands — get written to the new
+   space. Coordinates valid for one world land in the other's grid.
+3. Spatial grid degrades; AoI distance checks return nonsense; nearby
+   players may see ghosts or miss real entities.
+
+**Suggested remediation (one line)**
+Read the spaceId from the payload and drop the message unless it equals
+`space_mgr.entity_space.get(&entity_id)`; log a `warn!` on mismatch so
+race conditions are observable.
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-B-07 — Cell-method `entityId` prefix is read then ignored — defense-in-depth gap
+
+**Severity**: Low
+**Class**: Defense-in-depth / wire-shape hardening
+**Wire surface**: Every cell-method call (0x80–0xBF range)
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+The cell-method dispatcher at
+`crates/services/src/base/connect_loop/cell_arms.rs:86-89` reads a
+4-byte `entity_id_from_client` from the wire (always present per the
+comment block), but then **substitutes** `player_eid` from the session
+state when forwarding to the cell (lines 122 and 134). This is the
+correct behavior for security — but the value parsed off the wire is
+never compared to `player_eid`, so a client sending an `entityId`
+prefix that doesn't match its session's player is silently accepted.
+Today this is harmless (the substitution catches it) but the lack of
+the cheap check means a malicious-but-curious client can experiment
+with the wire format without ever surfacing the protocol violation in
+the server logs. A future refactor that, for any reason, started
+trusting `entity_id_from_client` (e.g., to support GM-spoofed entity
+calls) would silently re-open this. The two-line guard (warn + drop
+on mismatch) is a regression-resistant pin for the substitution
+invariant.
+
+**Evidence**
+- Cross-ref to Rust handler:
+  `crates/services/src/base/connect_loop/cell_arms.rs:86-89` (parse) +
+  `:122, :134` (substitute).
+
+**Attack scenario**
+1. Send `cell method N` with `entityId = 0xDEADBEEF` (a foreign player's
+   id). Server silently accepts the message and dispatches the method
+   against the attacker's own `player_eid` — no protocol-level error
+   surfaces in logs.
+2. Detection: attacker discovers via empirical wire-shape probing that
+   the prefix is unverified, which is the first step in finding the
+   "what if a future refactor uses this?" gap.
+
+**Suggested remediation (one line)**
+Compare `entity_id_from_client` to `player_eid` and `warn!`-log + drop on
+mismatch.
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-B-08 — `Unstuck` cell method is a no-op stub — UX gap, not security today
+
+**Severity**: Low
+**Class**: Future-implementation hazard
+**Wire surface**: Cell method 71 (`unstuck`) — `Event_NetOut_Unstuck`
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+At `crates/services/src/cell/cell_methods/player/combat/mod.rs:114-117`,
+the `UNSTUCK` arm logs `UNIMPLEMENTED: unstuck` and returns. No state
+is mutated; no exploit exists today. Flagging because: (a) Unstuck is
+the canonical example of "server must compute the destination from the
+navmesh" — when this is implemented, the implementer must NOT take the
+target position from the client; (b) when implemented, Unstuck must
+have a server-side cooldown (otherwise it's just another teleport
+primitive at zero cost) and must reject during combat (no escape from
+threat). Filing as a pre-emptive pin so the future PR catches review.
+
+**Evidence**
+- Ghidra: `019b4374` `Event_NetOut_Unstuck` confirms the client
+  emit path; the handler stub is at the cited Rust line.
+- Cross-ref to Rust handler:
+  `crates/services/src/cell/cell_methods/player/combat/mod.rs:114-117`.
+
+**Attack scenario**
+(N/A today — handler is a no-op.) Future risk: if implemented without
+server-computed destination + cooldown + combat-state gate, every player
+gets a 0-cooldown teleport-to-safe-position primitive.
+
+**Suggested remediation (one line)**
+When implementing, anchor the destination to a navmesh sample around the
+last server-confirmed safe position (NOT a client-supplied target), add
+a server-side cooldown of ≥30 s, and reject when `BSF_IN_COMBAT` is set;
+route the design to `movement-teleport-advisor`.
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-B-09 — Navmesh `is_position_valid` exists but is unused on the inbound write path
+
+**Severity**: Medium
+**Class**: Defense-in-depth / navmesh containment
+**Wire surface**: System message `0x03` (`AVATAR_UPDATE_EXPLICIT`)
+**Demonstrable / Likely-theoretical**: Demonstrable
+
+**Trust violation**
+`SpaceManager::is_position_valid` at
+`crates/services/src/cell/space_manager/spatial.rs:53-67` returns
+`true` when the position lies on the walkable navmesh of the entity's
+space. The function is defined; it loads navmeshes at space-startup
+(`crates/services/src/cell/space_manager/lifecycle.rs:26-47`); and it
+returns `true` (fail-open) when no navmesh is loaded. But it is
+**never called** from `update_entity_position` (the inbound write
+path), so a client can send positions deep underwater, inside walls,
+clipping into NPC spawn rooms, above ceilings, or under terrain, and
+the server accepts them as authoritative. This is a sibling to
+[[CAT-B-01]] but distinct because the *fix* is local: the validator
+already exists. Wiring it into the inbound path is one conditional
+plus a rejection (or snap-to-nearest, depending on policy).
+
+**Evidence**
+- Cross-ref to Rust handler:
+  `crates/services/src/cell/space_manager/spatial.rs:53-67`
+  (`is_position_valid` defined);
+  `crates/services/src/cell/space_manager/entities.rs:147-177`
+  (`update_entity_position` — no call to `is_position_valid`).
+
+**Attack scenario**
+1. Send 0x03 with `pos = (x, y_underground_terrain, z)` for a known
+   underground vault containing high-value loot spawns.
+2. Server writes the position. AoI tick fires `EnteredAoI` for loot
+   NPCs the player wouldn't normally see; quest regions inside the
+   bound geometry fire from the spoofed position.
+3. Repeat for any out-of-bounds region of interest.
+
+**Suggested remediation (one line)**
+In `update_entity_position`, call `is_position_valid(entity_id,
+&new_pos)`; on `false`, reject the move (or snap to the last
+confirmed valid position) and `warn!`-log; route the snap-vs-reject
+policy choice through `movement-physics-advisor`.
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-B-10 — 0x02 / 0x04 / 0x05 avatar variants are silently dropped — protocol gap
+
+**Severity**: Low
+**Class**: Protocol completeness / wire-format hardening
+**Wire surface**: System messages `0x02` (`AVATAR_UPD_IMPLICIT`), `0x04`
+(`AVATAR_UPDW_IMPLICIT`), `0x05` (`AVATAR_UPDW_EXPLICIT`)
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+At `crates/services/src/base/connect_loop/encrypted/mod.rs:484-491`, the
+constant-length payload widths for 0x02 (36 bytes), 0x04 (36), and 0x05
+(40) are honored so the bundle scanner advances correctly, BUT the
+dispatcher (lines 193-447) has no match arm for those ids. They fall
+through to `_ => tracing::trace!(... "Unhandled client message")` at
+line 444. A modern SGW client emits 0x02 (implicit) updates routinely
+between 0x03 (explicit) batches per the BigWorld implicit/explicit
+split. The server therefore sees only a subset of the position
+traffic, and a hostile client could deliberately emit only 0x02 to
+keep its position appearing stationary to the server while moving
+freely on the client's view — combined with [[CAT-B-01]] this isn't
+itself a teleport primitive (the server's position view would just
+stale), but it confounds any future server-side movement-validation
+heuristic that relies on the per-tick delta being well-defined.
+
+**Evidence**
+- Cross-ref to Rust handler:
+  `crates/services/src/base/connect_loop/encrypted/mod.rs:484-491`
+  (parse), `:444` (silent fall-through).
+
+**Attack scenario**
+Combined with future speed-hack detection (when added), an attacker can
+*delay* tripping the detector by sending 0x02 (which the server
+silently drops, leaving its position view static) interleaved with
+infrequent 0x03 small-delta packets. Without 0x02 being processed,
+the server can't reconstruct a continuous track to compare against.
+
+**Suggested remediation (one line)**
+Decide explicitly whether 0x02/0x04/0x05 are no-ops (then promote the
+`trace!` to a `debug!` with the parsed position so they're loggable) or
+proper position updates (then dispatch to `EntityMove` like 0x03).
+Document the policy in `docs/protocol/`.
+
+**Would benefit from x64dbg trace?**
+Yes — confirming the client's actual 0x02/0x04/0x05 emit cadence in a
+running session would tighten this triage (the implicit/explicit split
+semantics matter for the right answer).
+
+---
+
+## Not Filed
+
+- **GotoXYZ / Goto / GotoLocation / Summon (`gm`-prefixed Cheats cell
+  methods)**: Client-side strings exist (`019c3658` `gmGoto`,
+  `019c366c` `gmGotoLocation`, `019c3688` `gmGotoXYZ`, `019c3710`
+  `gmSummon`); the SGW.exe emits them via `Event_NetOut_*` from
+  Cheat-bound slash commands. The Rust server has **no handler** for
+  these method indices — they fall through to the `Unhandled cell
+  method` warn-arm at `crates/services/src/cell/dispatch/router.rs:101-106`.
+  Not exploitable today. CAT-N (GM commands) owns the broader
+  GM-gating concern; flagging here as a sibling-only note. If/when
+  these are implemented, this is the canonical example of a method
+  that MUST be gated on `client_state.access_level == GM`.
+
+- **`SetMovementType` cell method (index 1, SGWBeing)**: Routed at
+  `crates/services/src/cell/cell_methods/being.rs:65-104`, but the
+  downstream `broadcast_movement_type` at
+  `crates/services/src/cell/abilities/messaging.rs:209-222` early-
+  returns with a `warn!` when the entity is a player (which is the
+  case for any client-driven call after `cell_arms` substitution).
+  Effectively NPC-only; not exploitable today. A future change that
+  drops the `is_player` guard would re-open this.
+
+- **`SetCrouched` cell method (index 5, SGWCombatant)**: Sets/clears
+  the `BSF_CROUCHING` state-field bit at
+  `crates/services/src/cell/cell_methods/combatant.rs:31-58`. No
+  server-side accuracy buff, no cooldown-relevant behavior, no AoI
+  fan-out fires; pure cosmetic state announcement. Confirmed against
+  the codebase that no ability/effect modifier reads `BSF_CROUCHING`.
+
+- **`ChangeWeaponState` (`Event_NetOut_ChangeWeaponState`)**: Comment
+  at `crates/services/src/cell/cell_methods/player/world/mod.rs:520-525`
+  marks this as "dead scaffolding (the 2009 client never shipped one — the
+  archaeology agent confirmed `Event_NetOut_ChangeWeaponState` is dead
+  scaffolding)". No emit path in SGW.exe per Ghidra (only
+  `Event_NetOut_ChangeWeaponState` RTTI and the
+  `register_NetOut_ChangeWeaponState` stub — no caller). Cannot fire.
+
+- **`Physics` (`Event_NetOut_Physics`)**: Ghidra confirms the
+  `Event_NetOut_Physics` class exists with handler at `00d686f0` (a
+  vfunc-0 destructor); no `Event_NetOut_Physics::vfunc_2` emit-into-
+  bundle function is callable (no slash-command or UI emit). Likely
+  dev-only / never wired. The Rust server has no handler. Not
+  exploitable today.
+
+- **`onPlayerTeleport` (method 116)**: Server → client direction only
+  (`crates/services/src/cell/client_methods/player::ON_PLAYER_TELEPORT`).
+  Client-side handler is the streaming-load waiting flag — does not
+  move the avatar (the comment at
+  `crates/services/src/mercury/aoi/update.rs:57-59` is explicit).
+  No inbound from client; nothing to validate. The "known footgun" in
+  the brief — "streaming load hint, not authoritative" — is
+  already correctly modeled in code: `FORCED_POSITION` (0x31) is the
+  authoritative snap, paired with onPlayerTeleport as the hint. Server
+  composes both in `build_teleport_bundle`
+  (`crates/services/src/base/world_entry/teleport.rs:151-176`).
+
+- **AoI `aoi_radius` widening / cheat**: A client cannot change its own
+  `aoi_radius` (server uses the `CellEntity` default of 100.0; clients
+  send no `aoi_radius` field). AoI is server-driven from the entity's
+  position alone. This is correctly server-authoritative. Filing
+  [[CAT-B-01]] (the position primitive) already covers any radius-
+  amplification consequences.
+
+- **Cell-boundary handoff (central question 7)**: Cimmeria is
+  single-cell today (one cell process per space, see
+  `crates/services/src/cell/`); there's no cell-to-cell handoff to
+  exploit. When sharding is introduced later, the right place to
+  audit is the handoff message in `crates/services/src/cell/messages/`
+  — not in scope for today's audit.
+
+- **`WorldInstanceReset` (cell method 92)**: `UNIMPLEMENTED` stub at
+  `crates/services/src/cell/cell_methods/player/world/mod.rs:230-233`.
+  Belongs to CAT-O (World / Space / Gate). Future-implementation
+  hazard, but not actionable here.
+
+- **Velocity-vector spoofing in 0x03**: The velocity triple at
+  payload[20..32] is stored on `CellEntity.velocity` at
+  `crates/services/src/cell/space_manager/entities.rs:174` and
+  re-broadcast verbatim to AoI witnesses via `build_avatar_update`
+  (`crates/services/src/mercury/aoi/update.rs:21-50`). A client can
+  set arbitrary velocity for visual effect on witnesses, but the
+  server never *uses* the velocity for any authoritative computation
+  — distance checks use position only. Pure visual; not security-
+  relevant. Promote to CAT-B-NN if a future feature reads velocity
+  for cooldown/damage modulation.
+
+- **Direction (yaw/pitch/roll) spoofing in 0x03**: Same as velocity —
+  stored, re-broadcast to witnesses, never used authoritatively. Not
+  filed.

--- a/docs/security-audit/2026-05-31-server-authority/findings/CAT-C-combat-abilities.md
+++ b/docs/security-audit/2026-05-31-server-authority/findings/CAT-C-combat-abilities.md
@@ -1,0 +1,710 @@
+# CAT-C — Combat / Abilities — Findings
+
+**Overall trust posture (CAT-C):** The combat dispatch surface enforces the
+session→player binding at the framing layer (`base/connect_loop/cell_arms.rs`
+substitutes the session's `player_eid` for any client-supplied `entity_id`
+prefix), and the QR/damage formula is fully server-side with no
+`damage_override` field on the wire. Cooldown timing uses server-tracked
+`Instant` (not client timestamps), and ammo is decremented server-side from
+the bandolier slot — there is no client-supplied quantity. `trainAbility` is
+validated end-to-end (archetype tree, level gate, prerequisites,
+already-known no-op) before the base-side debit. AoE secondary damage is
+correctly gated on primary-commit and clamped to the attacker's space.
+
+That said, **CAT-C has multiple high-severity server-authority gaps** in
+the player-controlled paths that drive ability resolution:
+
+1. **No "is dead" guard on `respawn` or `callForAid`**. A live player can
+   send these messages and be teleported + healed to full.
+2. **`callForAid` accepts any `respawnerID` from the global table**, with
+   no membership check against the player's current world or any
+   access-list — turning the Defeat Window into an arbitrary teleporter
+   to any respawn point in the database.
+3. **No friendly-fire / faction / hostility check on single-target
+   `useAbility`**. Players can damage other players, friendly NPCs
+   (vendors, quest givers), and any in-range entity by id — PvP is
+   undesigned today but the wire path is fully open.
+4. **No LOS / navmesh / aggro-list validation on `useAbility` target
+   selection**. The only target gate is "exists, alive, within range" —
+   a modified client can fire through walls, at entities not in its AoI,
+   at AI mobs leashed behind doors, etc.
+5. **No "caller is stunned / movement-locked" guard on `useAbility`**.
+   `BSF_MOVEMENT_LOCK` and future stun flags are ignored on the fire
+   path — a stunned player can still cast.
+6. **`setTargetID` accepts any i32 with no validation** (target exists,
+   in AoI, same space, alive). The stored id then drives the auto-cycle
+   tick's re-fire target.
+7. **`useAbilityOnGroundTarget`'s ground point is unchecked for
+   distance from the attacker** — a player can ground-click anywhere
+   on the map; secondary targets are filtered by the click radius, but
+   the click itself is never validated against the attacker's location.
+   Also no NaN/Infinity guard on the floats.
+8. **Min-range is never enforced** — abilities with a `min_range` (e.g.,
+   shotgun-style or grenade-arc weapons) can be fired point-blank with
+   damage applying.
+9. **`requestHolsterWeapon` and `setCrouched` have no in-combat / dead-state
+   guard** — a dead player can toggle their visual state, breaking
+   appearance invariants.
+10. **AI-debug client messages (`CombatDebug`, `HealDebug`, `AbilityDebug`,
+    `DebugAbilityOnMob`, `EnterErrorAIState`, etc.) are entirely
+    unimplemented** server-side. They are dispatchable wire surfaces
+    today (the client emits them, the server's router accepts the
+    method index range, the per-interface handlers either no-op them
+    or return false). When implementation lands, every one needs an
+    explicit `is_gm` session check — these reveal mob internals and
+    debug AI state that must be GM-only.
+11. **`confirmationResponse` is parsed but the `effect_id` and
+    `accepted` flag are only logged.** Future use must validate the
+    effect_id against an outstanding server-issued prompt for this
+    player; today it's harmless but the wire shape is in place.
+12. **Pet methods (`PetInvokeAbility`, `PetAbilityToggle`,
+    `PetChangeStance`) are stubbed.** When implemented, pet ownership
+    must be validated against a server-side pet→owner table before any
+    pet ability fires; today the stubs accept arbitrary `pet_entity_id`
+    from the client and log them.
+
+The auto-cycle loop driver (`service/ticks/auto_cycle.rs`) **does**
+properly read `current_target_id` live, re-validates range and target
+aliveness per tick, and routes through the kill-credit wrapper. That's
+the well-built end of CAT-C and the canonical pattern other handlers
+should follow.
+
+---
+
+### CAT-C-01 — `respawn` / `callForAid` heal a non-dead player to full
+
+**Severity**: High
+**Class**: Missing state precondition (server fails to gate on "actor is dead")
+**Wire surface**: `Event_NetOut_Respawn` (cell method 70), `Event_NetOut_callForAid` (cell method 67)
+**Demonstrable / Likely-theoretical**: Demonstrable
+
+**Trust violation**
+A client at any HP can send `respawn` (no args) or `callForAid(respawner_id)`.
+The cell-method dispatcher routes both to `handle_respawn`, which
+unconditionally resets `HEALTH` and `FOCUS` to `max`, clears every state
+flag (including `BSF_IN_COMBAT` and `BSF_MOVEMENT_LOCK`), drops all
+ability cooldowns, snaps the player to a respawner position, and
+re-broadcasts an `onStateFieldUpdate(0)` to lift the dead-cursor.
+**Nothing in the handler checks that `BSF_DEAD` is set on the calling
+entity.** A live player who is on a 60-second ability cooldown, taking
+DoT damage, low on HP, or in combat can use this as a panic button that
+resets every combat state and teleports them out.
+
+**Evidence**
+- Ghidra: `0x0195f9c0` `Event_NetOut_callForAid`, `0x019b33ac` `Event_NetOut_Respawn` — client RTTI strings registered via `register_NetOut_callForAid` / `register_NetOut_Respawn`. Wire format per `docs/protocol/cell-method-dispatch-table.md:272`: `callForAid` carries `INT32 respawnerID`; `respawn` carries no args. The client emits these from the Defeat Window UI on death OR from the auto-respawn timer, but the wire path has no "is-dead" predicate — any in-game key remap (or modified client) can fire them at will.
+- Client behavioral log: n/a (client always emits these from the Defeat Window, so live log won't show abuse; abuse requires a tweaked client).
+- Cross-ref to Rust handler (for the fix author, NOT as truth): `crates/services/src/cell/cell_methods/player/combat/mod.rs:30-37` (CALL_FOR_AID dispatch), `:108-112` (RESPAWN dispatch), `crates/services/src/cell/cell_methods/player/combat/respawn.rs:73-264` (`handle_respawn` body — no `BSF_DEAD` precondition).
+
+**Attack scenario**
+1. Player is in combat at 5 HP, ability on 30s cooldown, BSF_IN_COMBAT set, threatened by 3 NPCs.
+2. Client sends `respawn()` (0xBA + 0xBD encoding for cell method 70 takes no args beyond the entity prefix).
+3. Server: heals to full HP/Focus, clears all state flags (including IN_COMBAT and MOVEMENT_LOCK), clears all cooldowns, snaps to nearest respawner.
+4. Observable effect: every cooldown timer resets, player is at full HP at a safe respawn point, all aggro is broken via the `threatened_mobs.clear()` + state-flag reset.
+
+**Suggested remediation (one line)**
+Reject the call when `!is_dead_state(entity.state_field)`; log at `warn!`. Consult `combat-systems-advisor` if there's a design intent to allow non-dead respawn (suicide button) — if so, the path must at minimum incur a death first, not a free heal.
+
+**Would benefit from x64dbg trace?**
+No — the wire format is documented, the handler code is the trust violation, no debugger needed.
+
+---
+
+### CAT-C-02 — `callForAid` accepts any `respawner_id` from the global table
+
+**Severity**: High
+**Class**: Missing access-list validation (arbitrary teleport)
+**Wire surface**: `Event_NetOut_callForAid` (cell method 67)
+**Demonstrable / Likely-theoretical**: Demonstrable
+
+**Trust violation**
+`callForAid(respawnerID)` is supposed to be the player's chosen
+respawn point from the list the server pushed in `onBeginAidWait`
+(damage_apply/mod.rs:411-416 — server sends the per-world filtered
+respawner list). The cell-method handler passes the client-supplied
+`respawner_id` straight to `resolve_respawn_target`, which does
+`space_mgr.respawners.iter().find(|r| r.respawner_id == respawner_id)`
+across the **entire global respawner table** (loaded via
+`load_respawners` from `resources.respawners`). There is no
+membership check against the list the server actually offered, no
+world-name match against the dying player's current world, no
+per-faction or per-mission gating. A client that sends any positive
+`respawnerID` known to exist in the DB gets teleported there.
+
+**Evidence**
+- Ghidra: `0x0195f9c0` `Event_NetOut_callForAid`. Wire shape `docs/protocol/cell-method-dispatch-table.md:272` — `INT32 respawnerID`.
+- Client behavioral log: n/a (live client only sends UI-chosen ids).
+- Cross-ref to Rust handler: `crates/services/src/cell/cell_methods/player/combat/respawn.rs:281-329` (`resolve_respawn_target` — does not constrain the respawner_id to the player's current `onBeginAidWait` list or to the player's world; only falls back through priority levels if the id is not found).
+
+**Attack scenario**
+1. Player dies in Castle_CellBlock (the tutorial world). Server sends `onBeginAidWait` listing only Castle_CellBlock respawners.
+2. Client ignores the listed ids and sends `callForAid(respawnerID = 12345)` where 12345 is a respawner in, say, the endgame world Othala.
+3. Server resolves 12345 against the global table → returns `(Othala, [x,y,z])`.
+4. Observable effect: the cross-world branch fires `GateTravel { target_world_name: "Othala", position: ... }`, teleporting the dead-character into endgame content. Combined with CAT-C-01 (live-player respawn), this is a free teleport to anywhere in the game world a respawner exists.
+
+**Suggested remediation (one line)**
+Validate `respawner_id` is in the per-world list returned by `respawners_for_world(dying_player_world)` and matches an outstanding `onBeginAidWait` offer recorded on the player session — drop anything else with a `warn!`. Same authoritative list both `onBeginAidWait` and the validator should consume.
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-C-03 — `useAbility` allows player→player damage (no friendly-fire / faction check)
+
+**Severity**: High
+**Class**: Missing faction/hostility gate
+**Wire surface**: `Event_NetOut_UseAbility` (cell method 68)
+**Demonstrable / Likely-theoretical**: Demonstrable
+
+**Trust violation**
+`handle_use_ability` validates: ability exists, ability is known, ability
+not on cooldown, target exists, target alive, target in range. It does
+**not** check target faction or `target.is_player`. The downstream
+`apply_damage_to_target` will gladly subtract HEALTH from any entity id —
+another player, a vendor NPC (faction 0), a quest-giver, a friendly
+escort mob — using the full QR + armor pipeline. SGW is PvE-only by
+design today (`cone_aoe.rs:24` documents the assumption), but the wire
+path doesn't enforce that. The cone-AoE path correctly scans only NPCs
+with `HOSTILE_FACTION`; the **single-target path has no such filter**.
+
+**Evidence**
+- Ghidra: `0x019b37c4` `Event_NetOut_UseAbility`. Wire `INT32 abilityId, INT32 targetId` (`docs/protocol/cell-method-dispatch-table.md:274`).
+- Client behavioral log: n/a.
+- Cross-ref to Rust handler: `crates/services/src/cell/abilities/use_ability/mod.rs:139-171` (validation block — no `is_player` or faction check); `crates/services/src/cell/abilities/damage_apply/mod.rs:50-545` (no hostility filter, damage applies regardless of target type).
+
+**Attack scenario**
+1. Player A enables auto-target of player B (or just looks up B's entity_id via the AoI fan-out / wire-log).
+2. Client sends `useAbility(ability_id = <ranged weapon>, target_id = B_entity_id)`.
+3. Server: range check passes (they're in the same instance), alive check passes, fires the full damage pipeline against player B.
+4. Observable effect: B's HEALTH stat decrements, `onEffectResults` shows up on B's client (and on A's, plus AoI witnesses). At lethal damage, B is sent to the Defeat Window. Same attack works against any neutral or friendly NPC — vendors, mission contacts.
+
+**Suggested remediation (one line)**
+Add a `target_is_attackable(attacker, target, ability)` gate in `handle_use_ability` before `apply_damage_to_target`: reject when `target.is_player` (until a real PvP/duel state machine lands) or when target faction is not in the attacker's hostile-to-me set. Route through the same `HOSTILE_FACTION` sentinel as cone AoE for now; consult `combat-systems-advisor` for the long-term faction model.
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-C-04 — `useAbility` target has no LOS / navmesh / AoI membership check
+
+**Severity**: High
+**Class**: Missing visibility/reachability gate
+**Wire surface**: `Event_NetOut_UseAbility` (cell method 68)
+**Demonstrable / Likely-theoretical**: Demonstrable
+
+**Trust violation**
+The only spatial check between attacker and target is `position.distance_to`
+against the ability's `max_range`. There is no:
+- **Line-of-sight check** — the attacker can shoot through walls.
+- **Navmesh-reachability check** — the attacker can hit a target standing
+  in an inaccessible volume (under-the-map collision, locked rooms).
+- **AoI membership check** — the attacker can hit an entity that is NOT
+  in their AoI witness list (so the client wouldn't normally even know
+  about it), as long as it's in the same coordinate space and within
+  `max_range`. The wire-log can leak entity ids of mobs outside AoI
+  during transient frames (entity creation/destruction); a modified
+  client can stash those ids and fire on them later.
+
+**Evidence**
+- Ghidra: `0x019b37c4` `Event_NetOut_UseAbility` — payload is `INT32 abilityId, INT32 targetId`, no LOS bit.
+- Client behavioral log: n/a.
+- Cross-ref to Rust handler: `crates/services/src/cell/abilities/use_ability/mod.rs:139-171` — only `entity.position.distance_to(&target.position)` is consulted; `crates/services/src/cell/abilities/damage_apply/mod.rs` proceeds without re-validating LOS.
+
+**Attack scenario**
+1. Player observes the AoI fan-out of a mob behind a door (e.g., the mob spawned, then the player left AoI but kept the id).
+2. Walks within `max_range` of the door's coordinates (but the mob is unreachable from the player's pathing graph).
+3. Client sends `useAbility(weaponAbility, mobBehindDoor)`.
+4. Server: range check passes, mob isn't dead, fires.
+5. Observable effect: mob takes damage and dies through a wall. Variant: shooting at a target standing in a sniper-only nest, an unreachable balcony, or inside a quest objective area whose door isn't opened yet.
+
+**Suggested remediation (one line)**
+Add an LOS check (raycast against the cell's static-collision data) and an AoI membership check (`target_eid` must be in `attacker.witnesses` or a 1-frame transition set) before any damage applies. Consult `movement-physics-advisor` for the LOS primitive — navmesh-reachability is overkill for a per-fire check but LOS is mandatory.
+
+**Would benefit from x64dbg trace?**
+Yes — confirming the client-side ability button isn't itself gating these (i.e., whether it's a "client wouldn't send this" vs. "client would happily send this") would tighten the severity case. The fact that the auto-cycle tick re-uses `current_target_id` LIVE strongly suggests the client never lets go of the stash even when LOS breaks, but a debugger trace would pin it.
+
+---
+
+### CAT-C-05 — `useAbility` has no caller-stunned / `BSF_MOVEMENT_LOCK` guard
+
+**Severity**: Medium
+**Class**: Missing caller-state precondition
+**Wire surface**: `Event_NetOut_UseAbility` (cell method 68), `Event_NetOut_useAbilityOnGroundTarget` (cell method 69)
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+The caller-side validation in `handle_use_ability` only checks
+`is_dead_state(entity.state_field)` (i.e., `BSF_DEAD` bit). It does
+not check `BSF_MOVEMENT_LOCK` (set on death, future stuns, fear, root)
+or any other "you can't act" condition. When stun/fear/root effects
+are wired up (the `cell/effects/` framework already exists),
+`useAbility` will need a corresponding gate. Today the gap is dormant
+because no effect script sets `BSF_MOVEMENT_LOCK` on a live entity
+outside the death path — but stun is in the design.
+
+**Evidence**
+- Ghidra: `0x019b37c4` `Event_NetOut_UseAbility`.
+- Client behavioral log: n/a.
+- Cross-ref to Rust handler: `crates/services/src/cell/abilities/use_ability/mod.rs:122-124` (`is_dead_state` check, no `BSF_MOVEMENT_LOCK` check); `crates/services/src/cell/combat/state.rs:46-51` (`BSF_MOVEMENT_LOCK` is documented as multi-source for "future stun/fear effects").
+
+**Attack scenario**
+1. NPC casts a stun on player → server sets `BSF_MOVEMENT_LOCK` (with the planned effect framework).
+2. Client sends `useAbility(weaponAbility, target)` during the stun window.
+3. Server: only checks `BSF_DEAD`; stun bit is set but not consulted; ability fires normally.
+4. Observable effect: stunned player still attacks. Variant: rooted player still uses abilities, fearful player still casts.
+
+**Suggested remediation (one line)**
+Add `if entity.has_state_flag(BSF_MOVEMENT_LOCK) || entity.has_state_flag(<stun-bit>) { return false; }` to the caller-state validation block; consult `combat-systems-advisor` for the canonical "cast-blocking" state-flag set.
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-C-06 — `setTargetID` accepts any i32 with no existence/space/AoI validation
+
+**Severity**: Medium
+**Class**: Server stores unvalidated client input that drives later authoritative behavior
+**Wire surface**: `Event_NetOut_SetTargetID` (cell method 0 — SGWBeing interface)
+**Demonstrable / Likely-theoretical**: Demonstrable
+
+**Trust violation**
+`cell_methods/being.rs:20-63` accepts `target_id: INT32` from the
+client and stores it as `entity.current_target_id` with the only
+filter being `target_id > 0 ? Some(target_id) : None`. No check that
+the entity exists, is in the player's AoI, is in the same space, or
+is alive. The stored value drives the auto-cycle loop driver
+(`service/ticks/auto_cycle.rs`), which does re-validate per tick
+(target exists, alive, in range) — so the immediate damage is gated
+elsewhere. But the server also **broadcasts `onTargetUpdate(target_id)`
+to every AoI witness** (being.rs:46-61), so an attacker can publish
+that they "target" an arbitrary entity id, including ids the
+witnesses can't see — useful for griefing UI ("Player X is targeting
+you" when X has no actual line on the witness), for social-engineering
+duels, or for fingerprinting the entity ID space (poke a range of
+ids, see which broadcasts the server lets through).
+
+**Evidence**
+- Ghidra: `0x019bf55c` `Event_NetOut_SetTargetID`. Wire `INT32 targetId` per `docs/protocol/cell-method-dispatch-table.md:48`.
+- Client behavioral log: n/a.
+- Cross-ref to Rust handler: `crates/services/src/cell/cell_methods/being.rs:19-63` — stores `target_id` and fans out to witnesses, no existence check.
+
+**Attack scenario**
+1. Client sends `setTargetID(arbitrary_i32)` where `arbitrary_i32` is any positive id (does not have to exist on the server).
+2. Server: stores `entity.current_target_id = Some(arbitrary_i32)`, broadcasts `onTargetUpdate(arbitrary_i32)` to AoI witnesses.
+3. Observable effect: witnesses' clients receive a "this player is now targeting entity X" packet for an entity they cannot see. Combined with the auto-cycle tick's re-validation, the player's auto-fire never actually triggers (the tick filters invalid targets), but the broadcast still went out — wire-spam, UI confusion, light info disclosure.
+
+**Suggested remediation (one line)**
+Reject (or store `None`) when `target_id > 0` and the entity is not present in `space_mgr` OR not in the player's AoI; only broadcast `onTargetUpdate` for ids that survive that filter.
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-C-07 — `useAbilityOnGroundTarget` doesn't validate ground point or guard against NaN/Inf
+
+**Severity**: Medium
+**Class**: Missing input validation on client-supplied floats
+**Wire surface**: `Event_NetOut_useAbilityOnGroundTarget` (cell method 69)
+**Demonstrable / Likely-theoretical**: Demonstrable
+
+**Trust violation**
+The handler reads `[x, y, z]` directly from the wire as three f32s
+(`cell_methods/player/combat/mod.rs:60-63`) and passes them straight to
+`handle_use_ability_on_ground`, which uses them as the AoE center. There
+is no check that the ground point is:
+- Within `max_range` of the attacker (the **target** is range-checked
+  against the attacker, but the **click point** is not).
+- Within the world's MinX/MaxX/MinY/MaxY/MinZ/MaxZ bounds.
+- Finite (no NaN, no Infinity). NaN comparisons fall through to false
+  in the in-radius check, so the practical effect is "no targets in
+  radius" → primary cast still commits cooldown/ammo. Infinity drives
+  the cone-AoE math to produce NaN target lists. Both are denial-of-
+  service-flavor inputs more than damage cheats.
+
+The biggest behavioral consequence: the player can ground-click at
+any coordinate, and as long as a real hostile NPC sits near the
+attacker's position (within the ability's `max_range` of the attacker),
+the cast commits and damages NPCs within the **click point's radius**
+even when the click point is far from the attacker. This is mild
+because the actual damaged targets must be within the click's
+`Radius` NVP (which is small — typical 5-10m) and within the click
+point itself, so the "wrong click point" attack is bounded. But
+combined with a faulty radius lookup or a 1-shot AoE ability with
+no falloff, it's a cheap aimbot helper.
+
+**Evidence**
+- Ghidra: `0x019bb70c` `Event_NetOut_useAbilityOnGroundTarget`. Wire `INT32 abilityId, FLOAT x, FLOAT y, FLOAT z` per `docs/protocol/cell-method-dispatch-table.md:275`.
+- Client behavioral log: n/a.
+- Cross-ref to Rust handler: `crates/services/src/cell/abilities/dispatch.rs:81-273` (`handle_use_ability_on_ground` — only target-vs-attacker range is checked, click-vs-attacker is not; no NaN/Inf or world-bounds guard).
+
+**Attack scenario**
+1. Client sends `useAbilityOnGroundTarget(grenadeAbility, x=1000000.0, y=0.0, z=0.0)`.
+2. Server: collects in-radius hostiles centered at (1000000, 0, 0) → empty.
+3. `primary_in_range` is false → call falls through to `handle_use_ability(target_id=0)` → cooldown/ammo consumed, no damage. Minor — just spammed-cast cost.
+4. NaN variant: client sends `x = NaN`. `dx*dx + dy*dy + dz*dz` is NaN, `<= radius_sq` is false everywhere → no targets caught → benign. **But:** `if primary_in_range { ... }` evaluates target_in_range via `attacker.position.distance_to(&target.position)` (no NaN involvement) — so this path is fine. The danger is future code that consumes `ground[]` for navmesh queries or world-edge checks downstream — NaN propagation will silently break invariants there.
+
+**Suggested remediation (one line)**
+Reject the call when any component of `ground[]` is non-finite (`!x.is_finite()`), and reject when `attacker.position.distance_to_xyz(ground) > max_range + ability_radius` (the click must be within reach + AoE radius of the attacker).
+
+**Would benefit from x64dbg trace?**
+Yes — confirming the client-side aim system would never produce a click outside reach would let us deprioritize, but the wire format permits it.
+
+---
+
+### CAT-C-08 — `useAbility` does not enforce `min_range`
+
+**Severity**: Low
+**Class**: Missing range-band enforcement
+**Wire surface**: `Event_NetOut_UseAbility` (cell method 68), `Event_NetOut_useAbilityOnGroundTarget` (cell method 69)
+**Demonstrable / Likely-theoretical**: Demonstrable
+
+**Trust violation**
+`AbilityDef` carries a `min_range: i32` field but the validation block in
+`handle_use_ability` only consults `max_range`. Abilities authored with
+a positive `min_range` (shotgun-style spread weapons or grenade arcs
+where point-blank fire is meant to be unavailable) can be fired with
+the muzzle touching the target. The damage formula has no compensating
+falloff inside the min-range band, so this typically produces
+maximum-damage point-blank shots from weapons designed to require
+spacing.
+
+**Evidence**
+- Ghidra: `0x019b37c4` `Event_NetOut_UseAbility`.
+- Client behavioral log: n/a.
+- Cross-ref to Rust handler: `crates/services/src/cell/abilities/use_ability/mod.rs:152-169` (only `max_range` consulted); `crates/entity/src/abilities/...` `AbilityDef::min_range` exists in the schema. Same gap in `dispatch.rs:143-149` for the ground-target path.
+
+**Attack scenario**
+1. Client equips a shotgun-style ability with `min_range = 5` (designed to require 5m spacing).
+2. Walks into the target at point-blank range (0.5m).
+3. Fires.
+4. Observable effect: full damage applies; UI may even allow the firing because the client-side animation cones don't gate.
+
+**Suggested remediation (one line)**
+Add `if d.min_range > 0 && dist < d.min_range as f32 { send onErrorCode(InsideMinRange); return false; }` to the range-check block alongside the existing `max_range` check.
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-C-09 — `setCrouched` / `requestHolsterWeapon` have no caller-state guard
+
+**Severity**: Low
+**Class**: Missing dead-state precondition
+**Wire surface**: `Event_NetOut_SetCrouched` (cell method 5 — SGWCombatant interface), `Event_NetOut_RequestHolsterWeapon` (cell method 7)
+**Demonstrable / Likely-theoretical**: Demonstrable
+
+**Trust violation**
+A dead player can send `setCrouched(true|false)` and the server flips
+the `BSF_CROUCHING` bit on the entity and broadcasts
+`onStateFieldUpdate`. Same for `requestHolsterWeapon` — a dead player
+can toggle the holster visual mid-Defeat-Window, firing a
+`RefreshAppearance` to all AoI witnesses. Neither matches Python ref
+behavior (`SGWBeing.py:746-770` — both are gated on alive).
+Observable surface is cosmetic (state-field bit flips on a corpse,
+weapon visual flips on a ragdoll), but the state-flag refcount
+machinery is not re-evaluated post-respawn cleanly when these
+mid-death toggles happened — the same-world respawn does
+`clear_all_state_flags` which would catch this, but cross-world
+respawn destroys the entity entirely so any cross-bit invariants
+across that window are out of scope.
+
+**Evidence**
+- Ghidra: `Event_NetOut_SetCrouched`, `Event_NetOut_RequestHolsterWeapon` (RTTI strings present, not enumerated above but listed in surface inventory).
+- Client behavioral log: n/a.
+- Cross-ref to Rust handler: `crates/services/src/cell/cell_methods/combatant.rs:31-94`. The `SET_CROUCHED` arm has no `is_dead_state` check. The `REQUEST_HOLSTER_WEAPON` arm doesn't either.
+
+**Attack scenario**
+1. Player dies, is in Defeat Window.
+2. Client sends `requestHolsterWeapon(0)` (draw weapon) while ragdolled.
+3. Server: clears `weapon_holstered`, fires `RefreshAppearance` to all AoI witnesses.
+4. Observable effect: weapon mesh attaches to the ragdolled corpse. Cosmetic but indicates the dead-state guard is missing.
+
+**Suggested remediation (one line)**
+Reject `SET_CROUCHED` and `REQUEST_HOLSTER_WEAPON` when `is_dead_state(entity.state_field)` is true; mirror the Python reference's alive-only gate.
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-C-10 — AI-debug client messages are unimplemented; future implementation must be GM-gated
+
+**Severity**: Medium (forward-looking — gap exists when handlers land)
+**Class**: GM-gated wire surface with no handlers (today) and no skeleton ACL gate
+**Wire surface**: `Event_NetOut_CombatDebug`, `Event_NetOut_CombatDebugVerbose`, `Event_NetOut_HealDebug`, `Event_NetOut_AbilityDebug`, `Event_NetOut_DebugAbilityOnMob`, `Event_NetOut_DebugBehaviorsOnMob`, `Event_NetOut_DebugPathsOnMob`, `Event_NetOut_EnterErrorAIState`, `Event_NetOut_ExitErrorAIState`
+**Demonstrable / Likely-theoretical**: Likely-theoretical (no implementation today, but the wire surface is live)
+
+**Trust violation**
+The client emits all of these (Ghidra-confirmed RTTI strings at
+`0x019b2fe8`, `0x019b3020`, `0x019b305c`, `0x019b3d1c`, `0x019b44a8`,
+etc.). Server-side: `cell_methods/ability_manager.rs` has stubbed
+`TOGGLE_COMBAT_DEBUG` and `TOGGLE_COMBAT_VERBOSE_DEBUG` as no-ops;
+`combatant.rs` has `TOGGLE_HEAL_DEBUG` as a stub; the rest don't have
+handlers wired at all (the cell-method dispatch returns `false` and
+the router warn-logs as "Unhandled cell method call"). When these are
+implemented (and they will be — they're useful for live debugging
+mob AI), every one of them needs an explicit `is_gm` session check.
+They reveal mob internal state (current behavior, threat list,
+nav-path), and EnterErrorAIState / ExitErrorAIState would let a
+client force mobs into broken AI states (deadlock, lockout) — a
+denial-of-service against world content.
+
+The forward-looking risk: the existing handler patterns in
+CAT-N's GM commands DO check the GM flag, so the template is in
+place — but the AI-debug commands sit in the CAT-C interface space
+(SGWAbilityManager and SGWCombatant), which today has NO
+GM-check infrastructure at all. The team needs to drop the GM check
+in alongside the implementation, not after.
+
+**Evidence**
+- Ghidra: RTTI strings for every listed event confirmed present (queries above).
+- Client behavioral log: n/a (debug commands aren't fired by normal play).
+- Cross-ref to Rust handler: `crates/services/src/cell/cell_methods/ability_manager.rs:22-25` (no-op stubs for combat-debug toggle), `combatant.rs:59-62` (no-op stub for heal-debug toggle), rest unimplemented.
+
+**Attack scenario** (when handlers land without GM gating)
+1. Client sends `Event_NetOut_DebugBehaviorsOnMob(mob_id)`.
+2. Server (hypothetical future handler): responds with the mob's full behavior tree state — current node, transition history, scheduled actions.
+3. Observable effect: information disclosure of mob AI internals. Variant: `EnterErrorAIState(mob_id)` forces a mob into the error state, allowing the player to disable any encounter mob at will.
+
+**Suggested remediation (one line)**
+File a "GM-gate the AI-debug interfaces" tracker now and add a regression test that any handler dispatched from method indices in the CombatDebug / HealDebug / AbilityDebug / Debug*Mob / *ErrorAIState ranges must read `session.is_gm` server-side before doing work.
+
+**Would benefit from x64dbg trace?**
+No — the surface is fully Ghidra-derivable.
+
+---
+
+### CAT-C-11 — Pet methods are stubbed; pet ownership must be validated at implementation time
+
+**Severity**: Medium (forward-looking)
+**Class**: Stubbed handlers that will accept arbitrary entity ids
+**Wire surface**: `Event_NetOut_PetInvokeAbility`, `Event_NetOut_PetAbilityToggle`, `Event_NetOut_PetChangeStance` (cell methods 88-90)
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+`cell_methods/player/social.rs:15-59` parses `pet_entity_id` from the
+wire and logs it as `UNIMPLEMENTED`. When the handlers land, they must
+enforce that the client-supplied `pet_entity_id` is actually owned by
+the calling player — server-side, via a `player→active_pet` mapping —
+not by trusting the wire id. Otherwise a player can `petInvokeAbility`
+on **any pet in the world** (which is shared across multiple players in
+group encounters), forcing other people's pets to attack arbitrary
+targets, change stance, etc.
+
+**Evidence**
+- Ghidra: `Event_NetOut_PetInvokeAbility` at `0x019b42a4` (RTTI string confirmed).
+- Client behavioral log: n/a.
+- Cross-ref to Rust handler: `crates/services/src/cell/cell_methods/player/social.rs:15-59` — all three pet methods parse the wire `pet_entity_id` but do nothing with it.
+
+**Attack scenario** (when handlers land without ownership gating)
+1. Client sends `petInvokeAbility(pet_entity_id = other_player_pet, ability_id, target_id)`.
+2. Server (hypothetical future handler): dispatches the ability on the named pet.
+3. Observable effect: another player's pet starts attacking your target — griefing, faction-tag exploits.
+
+**Suggested remediation (one line)**
+At implementation time, validate `pet_entity_id == session.player.active_pet_eid` (or membership in the player's pet roster) before any pet behavior fires; reject otherwise. Same template as the vendor-template-id validation pattern in `cell_methods/player/vendor.rs:75-123`.
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-C-12 — `confirmationResponse` is parsed but unused; future use needs prompt validation
+
+**Severity**: Low (forward-looking)
+**Class**: Wire surface in place, handler is a debug log
+**Wire surface**: `Event_NetOut_ConfirmEffect` (CONFIRMATION_RESPONSE cell method 4)
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+The handler reads `(effect_id: i32, accepted: bool)` and logs them
+(`cell_methods/ability_manager.rs:26-32`). The intended use (per the
+field comment "Respond to a confirmation prompt") is the server-side
+"are you sure you want to engage in this risky action?" pattern —
+e.g., confirming a destructive trade, joining PvP, or accepting a
+duel. When this lands, the server must verify the `effect_id` matches
+an outstanding server-issued prompt for **this specific player**,
+and the prompt must have a TTL — otherwise a client can replay an
+old prompt-confirm to bypass guard rails on a new action with a
+guessable / leaked `effect_id`.
+
+**Evidence**
+- Ghidra: `0x019b4610` `Event_NetOut_ConfirmEffect` (RTTI string).
+- Client behavioral log: n/a.
+- Cross-ref to Rust handler: `crates/services/src/cell/cell_methods/ability_manager.rs:26-33`.
+
+**Attack scenario** (when handlers land without prompt validation)
+1. Server pushes "are you sure you want to drop this?" prompt with `effect_id = 12345` for player A.
+2. Player A's session leaks the effect_id (wire-log, friend who saw it on screen).
+3. Player B replays `confirmationResponse(12345, accepted=true)` to bypass their OWN unrelated prompt with a matching id (if the id space is global/guessable).
+4. Observable effect: confirmed action goes through without the prompt's intended guard.
+
+**Suggested remediation (one line)**
+At implementation time, keep a per-session set of outstanding `(effect_id, action)` tuples; reject `confirmationResponse` whose `effect_id` is not in the calling player's outstanding set; expire entries after a short TTL.
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-C-13 — Auto-cycle target switch broadcasts to witnesses regardless of validity
+
+**Severity**: Low
+**Class**: Information disclosure / wire spam
+**Wire surface**: `Event_NetOut_SetTargetID` (cell method 0)
+**Demonstrable / Likely-theoretical**: Demonstrable
+
+**Trust violation**
+`setTargetID` always fans `onTargetUpdate` to every AoI witness
+(being.rs:46-61), even when the target id is `0` (deselect, which the
+server correctly clears to `None`) or a non-existent id (which the
+server happily broadcasts before any validation). A client can spam
+`setTargetID(any_id)` to flood witnesses' wire and UI with bogus
+target-update packets. The auto-cycle tick later filters invalid
+targets, so no actual damage results, but the broadcast cost is
+unbounded per inbound packet.
+
+**Evidence**
+- Ghidra: `0x019bf55c` `Event_NetOut_SetTargetID`.
+- Client behavioral log: n/a.
+- Cross-ref to Rust handler: `crates/services/src/cell/cell_methods/being.rs:30-62` — the broadcast loop runs on the unvalidated `target_id`.
+
+**Attack scenario**
+1. Client sends `setTargetID(random_i32)` 100 times per second.
+2. Server: writes 100×N witness packets per second per player (N = AoI witness count). Per-target-update CPU is small but bandwidth and per-witness client overhead is real.
+3. Observable effect: wire bandwidth spike, witness clients render a target-update flicker for every spurious id.
+
+**Suggested remediation (one line)**
+Rate-limit `setTargetID` (e.g., one per 100 ms per player) and skip the broadcast when the resolved id is `None` or fails the existence/space/AoI check from CAT-C-06.
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-C-14 — `respawn` always replenishes Focus, not just Health
+
+**Severity**: Low
+**Class**: Over-restoration on respawn
+**Wire surface**: `Event_NetOut_Respawn` (cell method 70), `Event_NetOut_callForAid` (cell method 67)
+**Demonstrable / Likely-theoretical**: Demonstrable
+
+**Trust violation**
+`handle_respawn` at `respawn.rs:142-148` sets both `HEALTH` and `FOCUS`
+back to their `max` values. Combined with CAT-C-01 (no dead check), a
+live player who has burned through their focus pool firing channelled
+abilities can `respawn()` to instantly refill the focus bar without
+paying the time-to-regen cost. Even with CAT-C-01 fixed, the design
+question is whether respawn should refund Focus or just Health —
+the python reference's `_doDoRevive` resets Health but the Focus
+treatment depends on the class. Today it's unconditional and bypasses
+class-specific regen mechanics.
+
+**Evidence**
+- Ghidra: `0x019b33ac` `Event_NetOut_Respawn`, `0x0195f9c0` `Event_NetOut_callForAid`.
+- Client behavioral log: n/a.
+- Cross-ref to Rust handler: `crates/services/src/cell/cell_methods/player/combat/respawn.rs:142-148`.
+
+**Attack scenario**
+1. Player burns 100% of focus pool casting a high-cost ability.
+2. Client sends `respawn()` (gated by CAT-C-01 fix not yet shipped).
+3. Server: refills both HEALTH and FOCUS to max.
+4. Observable effect: full Focus refund mid-fight (assuming CAT-C-01 is not yet fixed). Once CAT-C-01 IS fixed, this is a moot point because only dead players hit this path, and at that point the design question is whether dead-respawn should refund focus.
+
+**Suggested remediation (one line)**
+Consult `combat-systems-advisor` on whether respawn should restore Focus by archetype-specific rules; in the interim, only restore Health and let the post-respawn regen tick refill focus naturally.
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-C-15 — `useAbility` consumes ammo even when target is dead-but-still-in-space
+
+**Severity**: Low
+**Class**: Mild ammo-waste / quality-of-life seam (not exploit shape, but pin)
+**Wire surface**: `Event_NetOut_UseAbility` (cell method 68)
+**Demonstrable / Likely-theoretical**: Demonstrable
+
+**Trust violation**
+`handle_use_ability` checks `combat::is_dead_state(target.state_field)`
+and returns `false` early without consuming ammo (use_ability/mod.rs
+:142-150). That's correct. **But:** when target is `-1` (no-target /
+self-buff) the function bypasses the target validation entirely and
+fires — including consuming ammo for ranged abilities. A client that
+sends `useAbility(rangedAbility, -1)` consumes one ammo round per
+fire and emits all the cooldown/sequence packets but applies no
+damage. This isn't really exploitable (the player just wastes their
+own ammo) but it's a wire-shape that future grief-prevention should
+think about — chained with the auto-cycle tick, a corrupted
+`current_target_id = -1` could quietly drain ammo every cooldown
+elapse.
+
+**Evidence**
+- Ghidra: `0x019b37c4` `Event_NetOut_UseAbility`.
+- Cross-ref to Rust handler: `crates/services/src/cell/abilities/use_ability/mod.rs:488-501` (no-target branch consumes ammo, returns true).
+
+**Attack scenario**
+1. (Self-griefing or accidental) `current_target_id = -1` persists from a deselect glitch.
+2. Auto-cycle tick re-fires `handle_use_ability(ability, target_id=-1)` every cooldown.
+3. Server: consumes ammo, fires no-damage burst, restarts cooldown.
+4. Observable effect: player's ammo drains over time with no damage output.
+
+**Suggested remediation (one line)**
+For weapon ranged abilities (`required_ammo > 0`), reject calls with `target_id <= 0` unless the ability is explicitly authored as a no-target self-buff. Mirrors the auto-cycle tick's `current_target_id` precondition.
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+## Not Filed
+
+- **"Server-trusted hit/miss roll"** — the QR roll is deterministic via a
+  server-derived seed (`pseudo_random_seed(entity_id, ability_id, effect_seq)`)
+  and the formula is fully server-side. The client never supplies a roll
+  result. Cleanly server-authoritative.
+- **"Damage formula could be exploited via stat-buff spam"** — buffs
+  apply through server-side stat mutations, and the DAMAGE / PENETRATION /
+  QR_MOD reads pull from `attacker.stats` (server state) not client args.
+  Out of scope for CAT-C.
+- **"`requestAmmoChange` validation"** — covered in CAT-D (inventory).
+  The bandolier whitelist + slot-id keying are already in place per the
+  reviewed handler at `cell_methods/inventory/bandolier.rs:518-712`.
+- **"Cone AoE width / orientation spoofing"** — cone is anchored at
+  attacker, oriented toward primary target — both server state. No
+  client-supplied cone params. Solid.
+- **"Auto-cycle target-switch race"** — the tick re-reads
+  `current_target_id` live every 100 ms and re-validates target
+  existence + range; a target switch during cooldown is handled
+  correctly via the existing test `auto_cycle_tick_refires_at_live_current_target`.
+- **"`useAbility` rate-limit"** — the server-side cooldown gates this;
+  no separate rate-limit needed at the wire layer for the single-target
+  path. Pickable to file if a per-IP burst guard becomes desirable
+  later for DoS prevention, but not a server-authority gap.
+- **"Channel cancellation on dead caster"** — `cancel_channels_from_attacker`
+  is called inside `handle_use_ability` at the same-ability switch
+  point. If the caster dies mid-channel, the death path
+  (`apply_death_transition`) is responsible — out of scope for CAT-C
+  (cross-system, channel lifecycle is `cell/effects/` territory).
+- **"`requestHolsterWeapon` while in pending swap"** — the bandolier
+  slot-swap choreography (`pending_slot_swap_at`) is the gate, already
+  in place at `bandolier.rs:226-237` for ability fire. Holster toggle
+  during swap is cosmetic and reverts on the tick.
+- **"`setMovementType` server authority"** — that's CAT-B
+  (movement). The setMovementType handler stores the cached byte and
+  fans out; the cell method does not give the player movement
+  authority that movement-physics-advisor doesn't already audit.
+- **"AoE primary's `primary_in_range` bypass"** — looked at this
+  closely. The check `attacker.position.distance_to(&target.position) <= max_range`
+  is the same single-target gate, just applied per-target. No bypass
+  shape under the current code; the **click point itself** not being
+  range-checked is filed as CAT-C-07 because it's separate.
+- **"Negative ammo via fire-during-reload race"** — the existing
+  `reload_complete_at.is_some()` gate at use_ability/mod.rs:291
+  is the documented fix; the comment cross-refs why this is the right
+  shape. Already pinned.

--- a/docs/security-audit/2026-05-31-server-authority/findings/CAT-D-inventory.md
+++ b/docs/security-audit/2026-05-31-server-authority/findings/CAT-D-inventory.md
@@ -1,0 +1,573 @@
+# CAT-D — Inventory / Items — Findings
+
+**Overall trust posture.** The MoveItem and RemoveItem core paths are surprisingly
+well-defended: per-player and per-container `pg_advisory_xact_lock` plus
+`FOR UPDATE` row locks plus a UNIQUE INDEX on `(character_id, container_id, slot_id)`
+make the inventory-mutation flow concurrency-safe at the SQL boundary, and
+ownership is uniformly keyed off `character_id = $player_id` (server-resolved).
+The cell-method dispatcher in `connect_loop::cell_arms` correctly substitutes
+the server-trusted `player_eid` for the wire-supplied `entity_id` prefix, so
+cross-player actor spoofing on cell methods is blocked at the framing layer.
+
+The serious gaps are around (1) bandolier ammo persistence using the
+**type_id** as its TOCTOU guard instead of the unique inventory **item_id**
+— the textbook same-type-swap ammo-duplication shape mentioned in the agent
+brief; (2) `lootItem` having no range/state recheck (the only gate is the
+in-memory `looting_entity` pin which is set by a range-checked `interact()`
+but never re-validated for distance, line-of-sight, alive-state, or that the
+corpse hasn't moved between window-open and item-take); (3) zero
+loot-reservation / group-loot enforcement (any witness who can get the
+`interact()` to succeed claims the whole drop); (4) zero protection against
+dropping `bound` (no-drop) items; (5) `requestAmmoChange` accepts any
+positive ammo type for "custom items the loader skipped" — a forged item_id
+referencing an unmapped weapon bypasses the whitelist entirely.
+
+GetItemInfo / requestItemData are emitted by the client (RTTI present) but
+not handled server-side at all — info-disclosure attempts no-op. RepairItem
+(singular, inventory dispatch index 40) is `UNIMPLEMENTED` and logs only;
+the real repair flow is the vendor-domain `repairItems` (CAT-E). GMRemoveItem
+(GM-only spawn/destroy variant) has no server handler.
+
+---
+
+### CAT-D-01 — Bandolier ammo persistence keyed by `type_id`, not `item_id` — same-type-swap dupe
+
+**Severity**: High
+**Class**: TOCTOU / Same-type swap ammo overwrite
+**Wire surface**: `Event_NetOut_RequestAmmoChange`, `Event_NetOut_RequestActiveSlotChange`,
+  cell-tick reload completion → `CellToBaseMsg::BandolierAmmoUpdate`
+**Demonstrable / Likely-theoretical**: Demonstrable
+
+**Trust violation**
+The cell sends `BandolierAmmoUpdate { player_id, slot_id, expected_item_id, current_ammo, cur_ammo_type }`
+expecting the SQL helper to refuse the write if the slot's instance has
+been swapped. The field is named `expected_item_id` and the wire-comment in
+`CellToBaseMsg::BandolierAmmoUpdate` says it "guards against TOCTOU" — but
+the cell populates it from `BandolierItem.item_id`, which is documented in
+`crates/entity/src/cell_entity/mod.rs:743-745` as "Item design ID" (i.e. the
+`type_id`, not the unique `sgw_inventory.item_id` row id). The base-side
+SQL guard at `crates/services/src/base/world_entry/methods/inventory/ammo.rs:25-29`
+binds it against `type_id = $5`. When a player has two distinct bandolier
+instances of the same weapon **type** (e.g., two pistols, different ammo
+loads), any swap between them satisfies the `(slot_id, type_id)` predicate
+even though it's the wrong row, and the in-flight UPDATE scribbles one
+instance's ammo onto the other. This is the **bandolier-ammo-via-same-type-swap
+TOCTOU** the agent brief calls out by name as the canonical SGW exploit shape.
+
+**Evidence**
+- Ghidra: `019b430c` `Event_NetOut_RequestAmmoChange` + `019be2bc`
+  `Event_NetOut_RequestActiveSlotChange` — client wire surfaces that
+  drive the swap. Reload-completion ticks also produce the same
+  `BandolierAmmoUpdate` shape server-side.
+- DB schema: `db/sgw/Inventory/Tables/sgw_inventory.sql:6-22` — `item_id`
+  is the unique sequence-default PK ("the inventory instance"); `type_id`
+  is the design id ("the item type"). The unique index
+  `sgw_inventory_unique_slot` is on `(character_id, container_id, slot_id)`,
+  NOT on `type_id`, so two same-type instances are perfectly representable
+  (in different slots).
+- Cross-ref to Rust (for fix author): `crates/services/src/base/world_entry/methods/inventory/ammo.rs:25-36`
+  (the SQL) and `crates/services/src/cell/cell_methods/inventory/bandolier.rs:39-46`
+  / `:645-653` (the cell senders).
+
+**Attack scenario**
+1. Player A has two pistols of `type_id = 3241` in bandolier slots 0 and 1.
+   Slot 0's instance (item_id=A) has 15 rounds of ammo type X; slot 1's
+   instance (item_id=B) has 0 rounds of ammo type Y.
+2. Player fires from slot 0 down to 5 rounds. `bandolier_ammo_dirty` marks
+   slot 0. The cell decides to flush at the next swap/logout boundary.
+3. Player swaps to slot 1 (RequestActiveSlotChange). The cell snapshots
+   slot 0's state at swap time, then sends `BandolierAmmoUpdate { slot_id=0,
+   expected_item_id=3241, current_ammo=5, cur_ammo_type=X }`.
+4. Before the base processes that message, the player executes a MoveItem
+   that swaps slot 0's row (item_id=A, ammo=5) with the main-bag instance
+   of a *third* pistol of same type 3241 (item_id=C, ammo=30).
+5. Base processes the queued `BandolierAmmoUpdate`. WHERE
+   `(character_id, container_id=3, slot_id=0, type_id=3241)` matches —
+   but it now matches item_id=C, not A. The write overwrites C's
+   `ammo=30, cur_ammo_type=...` with `ammo=5, cur_ammo_type=X`.
+6. Player swaps back. Slot 0 now has the formerly-30-round pistol with
+   ammo=5; the formerly-5-round one (A) was moved away with its old
+   ammo=15 unchanged. Net: 15 + 30 → 15 + 5 isn't a dupe, but the
+   inverse direction (snapshot the LOW state, race a swap that brings a
+   HIGH-ammo instance into the slot, then race a reload completion that
+   brings a 5→full FULL state forward) lets an attacker shape arbitrary
+   ammo writes onto arbitrary same-type instances. Per the agent brief's
+   own articulation, this is the "ammo duplication via same-type swap
+   TOCTOU" shape.
+
+**Suggested remediation (one line)**
+Add a `sgw_inventory.item_id` field (instance id) to the `BandolierAmmoUpdate`
+message and change the SQL `WHERE` to key on the unique row id rather than
+`type_id`. Consult items-systems-advisor on whether the cell-side
+`BandolierItem` struct should also carry the instance id explicitly (it
+currently only carries the design id), and whether renaming the
+mis-described `expected_item_id` field is worth the churn.
+
+**Would benefit from x64dbg trace?**
+Yes — verifying the live race window between a `requestAmmoChange` and an
+adjacent MoveItem requires watching the Mercury bundle order under a real
+client connection; pure unit/live-DB tests can only prove the SQL key is
+wrong (they can't reproduce the racing client ordering).
+
+---
+
+### CAT-D-02 — `lootItem` does not recheck range, line-of-sight, or alive-state
+
+**Severity**: High
+**Class**: Missing range/state recheck on stateful action
+**Wire surface**: cell method 84 (`lootItem`) — index dispatched from
+  `Event_NetOut_LootItem` / `register_NetOut_LootItem` at Ghidra `00d935a0`
+**Demonstrable / Likely-theoretical**: Likely-theoretical (no client trace
+  for the abuse, but the missing checks are obvious from the handler)
+
+**Trust violation**
+`handle_loot_item` in `crates/services/src/cell/interactions/loot.rs:87` gates
+solely on `space_mgr.get_entity(entity_id).looting_entity` — set previously
+by `handle_interact` only after a 5-unit distance check. After the pin is
+set, the looter is free to walk arbitrarily far from the corpse, get
+crowd-controlled, or even die, and still drain the loot list one item per
+`lootItem(index)` packet. The corpse is identified by `looting_entity`, so
+the looter has effectively a permanent pointer at it until the corpse
+despawns. There is no per-`lootItem` distance recheck, no alive-check on
+the looter, no LoS check, no faction check, and no recheck that the
+corpse is still interactable (`INT_NormalLoot` still set).
+
+**Evidence**
+- Ghidra: `00d935a0` `register_NetOut_LootItem` data ref → typed emit info
+  at `00d93680` — the wire surface is just `lootItem(index : INT32)`.
+- Behavioral log: n/a (no observable client-side restraint in the wire
+  shape; the client UI's "loot all" button is the only natural caller).
+- Cross-ref to Rust (for fix author): `crates/services/src/cell/interactions/loot.rs:87-145`
+  and `crates/services/src/cell/interactions/dispatch.rs:172-184` for the
+  preceding `interact()` distance check.
+
+**Attack scenario**
+1. Player A kills a high-value mob; `handle_interact()` pins
+   `looting_entity = corpse_eid` after the 5-unit range check.
+2. Player A runs 100 units away, into a safe area / out of LoS.
+3. Player A spams `lootItem(index)` for each remaining drop. Each one
+   succeeds because the handler only checks `looting_entity.is_some()`.
+4. Observable effect: a player can vacuum corpses without ever needing
+   to stand near them — useful for kiting champions across hostile
+   terrain, looting from inside a vehicle/transporter, looting after
+   dying (looter has no alive-check), or looting an instance you've
+   been kicked from but were briefly pinned to.
+
+**Suggested remediation (one line)**
+Recheck `(distance(player, looting_entity_pos) <= MAX_INTERACT_DISTANCE)` AND
+`player.is_alive()` AND `corpse.interaction_type_flags & INT_NORMAL_LOOT != 0`
+at the top of `handle_loot_item`, before touching the loot list.
+
+**Would benefit from x64dbg trace?**
+No — the missing checks are static; the test that fails on revert is a
+live-DB integration test that drives `handle_interact` then walks the
+player and asserts `handle_loot_item` rejects.
+
+---
+
+### CAT-D-03 — Zero loot-reservation / group-loot ownership on corpse drops
+
+**Severity**: High
+**Class**: Loot fairness / ownership
+**Wire surface**: `Event_NetOut_LootItem` (cell method 84)
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+The corpse-side `LootItem` rows carry only `(design_id, quantity, index)`
+— no `killer_player_id`, no `reserved_until`, no group-mode discriminator,
+no per-item per-player claim. Any player who can pass the `interact()`
+distance check is then free to drain the entire loot pile via `lootItem`
+calls. This contradicts every standard MMO loot model (FFA, Round-Robin,
+Master Looter, Need-Before-Greed, Group). The repo has `SquadSetLootMode`
+in CAT-M, implying a loot-mode setting exists at the squad/social layer,
+but nothing wires that mode into the corpse's loot dispatch.
+
+**Evidence**
+- `crates/entity/src/cell_entity/mod.rs:725-739` — `LootItem` struct has
+  no ownership / reservation fields.
+- `crates/services/src/cell/interactions/loot.rs:122-145` — handler
+  removes by `index` only; no claim check.
+- `Grep loot_reservation|loot_owner|reserved_for|killer|group_loot` over
+  `crates/services/src/cell/interactions/`: zero matches.
+
+**Attack scenario**
+1. Player A is in a fireteam pulling a champion. Their squad's
+   `SquadSetLootMode` is set to "Round Robin" or similar in the UI.
+2. The champion dies. Player B (any nearby witness, not in the squad)
+   walks into 5-unit range of the corpse.
+3. B's `interact()` succeeds (no faction/squad/raid-membership gate),
+   pinning `looting_entity` on B. B sends `lootItem(0..n)` for every drop.
+4. Observable effect: the squad gets zero of the drops; B vacuums the
+   corpse with no consent. With CAT-D-02 stacked, B can do this from
+   100+ units away.
+
+**Suggested remediation (one line)**
+Stamp the killer's player_id (and squad_id when in a group) onto the
+`LootItem` row at drop generation, and reject `lootItem` calls from
+non-eligible looters with a wire-visible reason; consult
+items-systems-advisor for the exact reservation matrix (FFA / RR / NBG /
+ML) that matches the legacy design intent.
+
+**Would benefit from x64dbg trace?**
+No — the missing field/state is static.
+
+---
+
+### CAT-D-04 — `RemoveItem` accepts any positive quantity from the client with no bound-item gate
+
+**Severity**: Medium
+**Class**: Missing server-side authorization on destructive action
+**Wire surface**: `Event_NetOut_RemoveItem` (cell method 36, `removeItem`)
+**Demonstrable / Likely-theoretical**: Demonstrable
+
+**Trust violation**
+The cell-side `handle_remove_item` (item_ops.rs:27) reads
+`(item_id: i32, quantity: i16-as-i32)` straight off the wire and forwards
+to base. Base's `handle_remove_inventory_item` only checks
+`quantity > 0`, `character_id = $player_id`, and `quantity ≤ stack_size`
+— there is **no** check that the item is unbound (`bound = false`), no
+mission-protection check (mission-pinned quest items can be silently
+deleted), and no rate-limit on how often `removeItem` can be issued. Per
+the legacy python `SGWPlayer.removeItem` (`deprecated/python/cell/SGWPlayer.py:2137`)
+this matches a player-driven "drop item" UI affordance, but the python
+also exposed it without a bound check; the wire surface is therefore
+fully trusted to gate destruction client-side. A modified client can
+delete the player's own quest tokens, breaking missions in
+content-engine-dependent ways. (No cross-player effect — `character_id =
+$1` clamp is intact.)
+
+**Evidence**
+- Ghidra: `019be770` `Event_NetOut_RemoveItem` → `register_NetOut_RemoveItem`
+  at `00d94560`. Wire payload is `(item_id : INT32, quantity : INT16)`.
+- Behavioral log: n/a.
+- Cross-ref to Rust (for fix author): `crates/services/src/cell/cell_methods/inventory/item_ops.rs:27-60`
+  and `crates/services/src/base/world_entry/methods/inventory/core/remove_instance.rs:26-100`.
+
+**Attack scenario**
+1. Player has a `bound = true` quest token in mission bag (container 2).
+2. Modified client sends `Event_NetOut_RemoveItem(item_id, 1)`.
+3. Server deletes the row, fires `onRemoveItem`. Mission is now
+   unable to advance because the chain's `RemoveItem` action will
+   no-op (no instance to consume) and `OnItemUse` events never fire.
+4. Observable effect: durable self-griefing or, if mission rewards
+   include re-grants, abuse of the re-grant loop (combined with vendor
+   sells, etc).
+
+**Suggested remediation (one line)**
+Reject `removeItem` when the source row has `bound = true` (or when its
+`type_id`'s row in `resources.items` flags it as mission-pinned /
+no-drop); consult items-systems-advisor for the canonical bound /
+no-drop predicate.
+
+**Would benefit from x64dbg trace?**
+No — bug is static.
+
+---
+
+### CAT-D-05 — `useItem` accepts an unvalidated `target_id` and forwards it through the outbox + cell
+
+**Severity**: Medium
+**Class**: Unvalidated trust on side-channel field
+**Wire surface**: `Event_NetOut_UseItem` (cell method 39, `useItem`)
+**Demonstrable / Likely-theoretical**: Demonstrable (the field is read but
+  currently discarded by chain code — fix-it-now-or-it-bites-later shape)
+
+**Trust violation**
+The wire payload is `(item_id : INT32, target_id : INT32)`. The cell handler
+(`item_ops.rs:144-153`) forwards `target_id` verbatim to base.
+`handle_use_inventory_item` plumbs it into `CellOutboxPayload::ItemUsed`
+and dispatches as `BaseToCellMsg::ItemUsed { ..., target_id }`. The cell's
+`fire_item_use` (`content/event_dispatch/inventory.rs:28-73`) currently
+sets `target_entity: None` in the trigger event, **so the field is
+functionally dead today**. But (a) it's persisted in `cell_event_outbox`
+across a server restart, and (b) any future content action that pulls
+`target_id` out of `ItemUsed` will inherit the trust violation: the
+client supplies an arbitrary entity id with zero ownership / range /
+perception check. If a future chain uses `target_id` to e.g. apply a
+buff or trigger an effect, the player can target arbitrary entities
+(including other players, NPCs in a different cell, or invalid IDs).
+
+**Evidence**
+- Ghidra: `019be70c` `Event_NetOut_UseItem` → `register_NetOut_UseItem`
+  at `00d94020`. Wire shape `(item_id, target_id)`.
+- Cross-ref to Rust (for fix author): `crates/services/src/cell/cell_methods/inventory/item_ops.rs:137-174`
+  and `crates/services/src/base/world_entry/methods/inventory/core/use_instance.rs:80-263`,
+  outbox enqueue at `:230-252`.
+
+**Attack scenario**
+1. A future content action `ApplyEffectToTarget` is added that reads
+   `target_id` from `ItemUsed`.
+2. Player crafts a `useItem(consumable_with_that_chain, target_id=other_player_eid)`.
+3. The chain fires `ApplyEffectToTarget(other_player_eid, ...)` with no
+   range / LoS / perception / faction check; the effect is applied
+   server-side.
+4. Observable: a "useItem" affordance becomes a cross-player effect
+   delivery vector.
+
+**Suggested remediation (one line)**
+Either drop `target_id` at the cell decoder and pass `None` to base, or
+validate against the player's perception list + range gate at the cell
+handler before forwarding — match the validation shape `handle_interact`
+already enforces.
+
+**Would benefit from x64dbg trace?**
+No — static.
+
+---
+
+### CAT-D-06 — `requestAmmoChange` falls through to "any positive ammo_type" when the weapon's `item_defs` cache row is missing
+
+**Severity**: Medium
+**Class**: Missing whitelist on edge case
+**Wire surface**: `Event_NetOut_RequestAmmoChange` (cell method 42)
+**Demonstrable / Likely-theoretical**: Demonstrable
+
+**Trust violation**
+`handle_request_ammo_change` (`bandolier.rs:518-712`) validates
+`ammo_type` against the weapon definition's `allowed_ammo_types` set,
+but only **if** `space_mgr.item_defs.get(&item_id).cloned()` returns
+`Some`. The comment at lines 558-561 acknowledges that "`None` means the
+cache had no entry (custom item the loader skipped), in which case we
+accept any positive ammo_type." This is a wide-open hole: any
+`type_id` that the loader doesn't populate into `item_defs` becomes a
+whitelist-bypass vector. The hole is multiplied by the upstream lookup
+being keyed on `item_id` (which `requestAmmoChange` carries) — so the
+attacker controls which cache lookup happens. A forged or
+loader-missing-by-design item type will silently pass through the
+otherwise-correct whitelist.
+
+**Evidence**
+- Cross-ref to Rust (for fix author): `crates/services/src/cell/cell_methods/inventory/bandolier.rs:555-619`.
+  Specifically the comment block at 555-561 acknowledges the fall-through
+  semantics; the resulting `if let Some(def) = weapon_def.as_ref()` block
+  at 606-617 is the gate that's bypassed when the cache miss occurs.
+- DB schema: `db/sgw/Inventory/Tables/sgw_inventory.sql:20` —
+  `cur_ammo_type` only has `CHECK (cur_ammo_type >= 0)`, so a forged
+  positive ammo_type WILL persist on commit if it gets that far. The
+  cell-side rejection at line 545 (`ammo_type <= 0`) is the only
+  remaining gate.
+
+**Attack scenario**
+1. Find a weapon `type_id` whose `resources.items` row exists but isn't
+   loaded into the `item_defs` runtime cache at server startup (e.g., a
+   data-load skip due to mis-named asset, a never-shipped weapon design
+   that's in the seed but not in the loader's filter, or an item that
+   becomes craftable after a hot-reload but isn't refreshed in cache).
+2. Modified client sends `requestAmmoChange(item_id=that_weapon's_instance,
+   ammo_type=arbitrary_positive_value)`.
+3. Cell's `if let Some(def) = weapon_def.as_ref()` is skipped; only the
+   `ammo_type > 0` check remains.
+4. Server persists `cur_ammo_type = arbitrary_positive_value` via
+   `BandolierAmmoUpdate`. The client UI may render incorrectly (per
+   the existing TODO comment); downstream damage-type resolution may
+   apply effects from a subtype the player shouldn't have been able to
+   pick.
+
+**Suggested remediation (one line)**
+On `item_defs` cache miss, reject `requestAmmoChange` outright (warn-log
+"unknown weapon type") rather than fall through to accept; consult
+items-systems-advisor on whether the cache should be backfilled
+lazily from `resources.items` or whether the cache-miss is a fatal
+content-loading error.
+
+**Would benefit from x64dbg trace?**
+No — the fall-through is in the code comment block at 555-561.
+
+---
+
+### CAT-D-07 — `MoveItem` allows the client to move items into the buyback container (16)
+
+**Severity**: Medium
+**Class**: Container ACL — wire-controlled `target_container_id`
+**Wire surface**: `Event_NetOut_MoveItem` (cell method 38)
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+`bag_max_slots(target_container_id)` returns nonzero for container 16
+(`INV_BUYBACK`, 12 slots). The MoveItem handler accepts any
+`target_container_id > 0` with `bag_max_slots(...) > target_slot_id` — it
+does not maintain a whitelist of "containers a player is allowed to
+move INTO via MoveItem." The only secondary gate is
+`item_allows_container(pool, type_id, target_container_id)` which
+consults the per-item `container_sets` array; if any seeded item has
+`16` in its `container_sets`, the client can manually move that item
+into the buyback container outside the normal vendor flow. Buyback rows
+have special semantics (price, expiry) — landing a player-owned item
+there outside a sell flow creates dangling state. INV_BANK (17),
+INV_AUCTION (18), INV_TEAM_BANK (19), INV_COMMAND_BANK (20) are NOT
+reachable because `bag_max_slots(17..=20)` returns 0 (default match arm),
+so the slot-range check at move.rs:79 rejects.
+
+**Evidence**
+- `crates/services/src/base/resources/mod.rs:28-38` — `bag_max_slots(16) = 12`
+  (the buyback container) but no flag distinguishes "system-managed" from
+  "player-movable" containers.
+- `crates/services/src/base/world_entry/methods/inventory/move_/mod.rs:64-91`
+  — only checks `target_container_id > 0` and `slot_id` range; no
+  player-movable whitelist.
+- `crates/entity/src/inventory.rs:13-32` — defines `INV_BANK..INV_COMMAND_BANK`
+  constants which are NOT in `bag_max_slots`'s match (return 0, so they're
+  already blocked). Buyback is at 16 in both lists, but listed in
+  `bag_max_slots` (so it IS reachable).
+
+**Attack scenario**
+1. Find any item whose `resources.items.container_sets` includes 16
+   (any seed row with that — verify against `db/resources/Items/Seed/`).
+2. Modified client sends `moveItem(item_id, target_container_id=16,
+   target_slot_id=N, quantity=1)`.
+3. Server moves the player's item into the buyback container outside
+   the vendor sell path. Subsequent vendor open / buyback-reload logic
+   sees the row and treats it as a buyback entry without the
+   accompanying `sgw_buyback`-style price row.
+4. Observable: the item appears in the buyback UI without a sell having
+   happened; depending on how the buyback price/expiry are stored,
+   either the player can "buy back" the item for free (dupe) or the
+   row becomes inaccessible (item-loss). Either is a content-state
+   corruption.
+
+**Suggested remediation (one line)**
+Add a `target_container_id ∈ {1, 2, 3, 4..=14, 15}` whitelist to the move
+handler (player-movable containers only); system-managed containers
+(16 buyback, 17 bank, etc.) should be mutated only by their owning
+service paths; consult items-systems-advisor on the canonical "what's
+movable by the player" rule.
+
+**Would benefit from x64dbg trace?**
+No — static check against the seed `container_sets` data is sufficient
+to confirm the existence of an item that triggers the bypass.
+
+---
+
+### CAT-D-08 — `MoveItem` stack-split copies durability/charges/bound without re-validating against the source
+
+**Severity**: Low
+**Class**: Bound-flag drift on split
+**Wire surface**: `Event_NetOut_MoveItem` split path (`quantity < stack_size`)
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+The split branch (move/mod.rs:289-369) INSERTs a new row carrying
+`source.bound`, `source.durability`, `source.charges`. For *consumable
+stacks* this is fine — splitting a stack of slappacks doesn't change
+their bound-ness — but for a stack that legitimately had a bind-on-pickup
+applied via a chain action between the FOR-UPDATE read and the split's
+INSERT, the new row would carry the **pre-bind** bound flag if a race
+fits in the gap. The advisory lock makes this hard to hit in practice
+(per-player serialization), so this is filed as a Low; flagged primarily
+so future refactors that loosen the lock don't accidentally regress
+this.
+
+**Evidence**
+- `crates/services/src/base/world_entry/methods/inventory/move_/mod.rs:326-341`
+  — the split insert binds `source.bound, source.durability,
+  source.charges` from the row read at line 162.
+
+**Suggested remediation (one line)**
+None required today (per-player advisory lock closes the race). If the
+lock is ever scoped down or removed, refactor the split to RETURNING-style
+re-read or copy the durability/charges/bound straight from a
+`SELECT ... FOR UPDATE` of the row that's about to be inserted-from.
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-D-09 — `RemoveItem` quantity decoded as `i16` then sign-extended to `i32` — no upper-bound clamp on cell side
+
+**Severity**: Low
+**Class**: Wire-decoding integer-width mismatch (defense in depth)
+**Wire surface**: `Event_NetOut_RemoveItem`
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+The cell-side decoder at `item_ops.rs:34-35` reads `quantity` as `i16`
+then sign-extends to `i32`. The base-side validates `quantity > 0` and
+`quantity ≤ source.stack_size`. The `i16` lift is fine in practice because
+stack sizes never exceed `i16::MAX`, but the wire shape per the legacy
+python (`SGWPlayer.py:2137` `removeItem(itemId, quantity)`) is an i32
+quantity, not i16. If a future content path raises `stack_size > i16::MAX`,
+the wire decode silently truncates / wraps and the player removes a
+different quantity than they asked for. The base-side `quantity <= source.stack_size`
+catches *invalid* values but not *truncated* ones — a player sending
+quantity=70000 (legitimate for a large craft stack) would arrive at the
+base as quantity = 4464 (70000 - 65536). Self-grief mostly, but the
+wire shape is wrong relative to the legacy convention.
+
+**Evidence**
+- `crates/services/src/cell/cell_methods/inventory/item_ops.rs:34-35`.
+- `deprecated/python/cell/SGWPlayer.py:2137` `removeItem(itemId, quantity)`
+  uses an unannotated int; the def-file shape is i32 to match other
+  inventory methods (`useItem` carries i32 itemID + i32 target_id).
+
+**Suggested remediation (one line)**
+Decode `quantity` as `i32` (read 4 bytes) instead of `i16`; verify the
+wire-shape against `entities/defs/SGWInventoryManager.def` before
+landing — the .def is the actual schema, items-systems-advisor can
+confirm.
+
+**Would benefit from x64dbg trace?**
+Yes — a single intercepted `removeItem` packet shows the field width
+unambiguously. The decision tree is "what does the client actually send?"
+not "what should it send?".
+
+---
+
+## Not Filed (considered but did not meet the bar)
+
+- **Player can swap bandolier slots while stunned / mid-cast** — combat
+  state has no defense in `handle_request_active_slot_change`. Reason
+  not filed: the legacy convention doesn't appear to enforce a
+  slot-swap stun gate either, and combat-systems-advisor owns the
+  stun-vs-action-eligibility matrix. Worth a heads-up to that advisor
+  but not a server-authority finding per se.
+
+- **`useItem` doesn't decrement charges/uses on the cell side** — the
+  consume path is the chain's `Action::RemoveItem`. Reason not filed:
+  this is the intended decoupling (per the module comment block at
+  use_instance.rs:1-22) and the agent brief's "no double-consume"
+  invariant is upheld — `remove_item` + `UseInventoryItem` don't both
+  run on the same instance; the chain decides.
+
+- **`requestAmmoChange` carries no slot id, ambiguates when same item_id
+  in multiple slots** — already handled by the
+  `multiple slots hold this item_id → reject` branch at
+  `bandolier.rs:580-598`. Reason not filed: defense exists. The
+  underlying protocol shape is awkward but the cell does the right
+  thing.
+
+- **`GetItemInfo` / `requestItemData` info disclosure** — the Ghidra RTTI
+  shows the class exists (`019b3090` / `019bccb0`) but no
+  `register_NetOut_*` symbol, no handler index, and the Rust
+  dispatcher has no arm. The client builds the typeinfo but doesn't
+  emit. Reason not filed: no observable wire surface today; if a
+  future patch exposes `getItemInfo(targetPlayerId)` then re-audit.
+
+- **GMRemoveItem** — listed in CAT-N; in this category we observe that
+  no server-side handler exists, so the GM destruction path is
+  currently unwired. Reason not filed: CAT-N owns GM-gating; nothing
+  to authorize here yet.
+
+- **`RepairItem` (cell method 40, singular)** — handler logs
+  "UNIMPLEMENTED" and returns. Reason not filed: there's no trust
+  violation in code that does nothing; flag for review at
+  implementation time. Worth a comment in the handler that it must be
+  vendor-gated when implemented.
+
+- **`ListItems` (cell method 37)** — passes server-resolved `player_id`
+  through to a self-only `SELECT ... WHERE character_id = $player_id`.
+  Reason not filed: validation is uniformly applied; the wire payload
+  carries no targetable field, so info-disclosure is structurally
+  impossible.
+
+- **`LootItem` index out-of-range** — handler rejects unknown index
+  cleanly (loot.rs:139-143). Reason not filed: defense exists.
+
+- **`MoveItem` source-item ownership** — gated by `character_id = $1`
+  on the FOR-UPDATE source query at move.rs:162-169. Reason not filed:
+  defense exists.
+
+- **Bandolier `requestActiveSlotChange` slot-range** — explicitly
+  range-checked against `bag_max_slots(3)` at bandolier.rs:119-130 with
+  a saturating_sub guard against `i32::MIN`. Reason not filed: defense
+  exists.

--- a/docs/security-audit/2026-05-31-server-authority/findings/CAT-E-vendor.md
+++ b/docs/security-audit/2026-05-31-server-authority/findings/CAT-E-vendor.md
@@ -1,0 +1,416 @@
+# CAT-E — Vendor (PurchaseItems / SellItems / BuybackItems / RepairItems / RechargeItems)
+
+**Overall trust posture: GOOD with two real exploit-shaped holes and several
+softer issues.** The vendor stack consistently treats the client's wire payload
+as a request, not a result — for every flow the server (a) looks up the vendor
+template via the player's server-side `vendor_entity` (not a client field), (b)
+recomputes price authoritatively from `resources.item_list_items.naquadah` (and
+for repair, scales by current `durability`), (c) wraps the mutation +
+cash-balance update in a Postgres transaction with `FOR UPDATE` locks, and (d)
+balances are read with `FOR UPDATE` before the debit. The known holes:
+
+- **CAT-E-01** (High) — The cell dispatcher routes `REPAIR_ITEMS` and
+  `RECHARGE_ITEMS` to a "free" code path whenever the trailing
+  `vendor_template_id` is absent from the client payload. The free path
+  performs durability=100 / charges=full UPDATEs with **no payment, no vendor
+  template check**, and no equivalence to the paid handler. The PURCHASE / SELL
+  / BUYBACK arms in the same dispatcher reject a missing template id; the
+  REPAIR / RECHARGE arms do not. A client that simply omits the trailing 4
+  bytes on its `repairItems` packet gets free durability restore on every
+  carried item. This is a wire-shape inversion: the *absence* of a client
+  field selects the free flow.
+- **CAT-E-02** (Medium) — `player.vendor_entity` is set by the Interact path
+  and **never cleared** — not on cell→base disconnect, not on
+  `OpenVendorStore`-close, not on death, not on instance/zone transfer. There
+  is also no distance / proximity / line-of-sight check between the player
+  entity and the vendor entity at op time. A player who once interacted with
+  vendor A can submit purchase/sell/buyback/repair packets while standing
+  arbitrarily far away (other side of the map, in another instance if the
+  entity persists, after combat / death). The current `vendor_context`
+  validation only rejects when the vendor entity has despawned.
+
+The other findings are: a freely-readable `repair_ratio: f32` arrives on the
+single-item `RepairItem` path (currently UNIMPLEMENTED in the cell handler —
+flagged so it doesn't ship), buyback rows are not bound to the vendor that
+sold them and have no expiration window, and the buyback unit price is stored
+in the inventory row's `flags` column where it would survive any future bug
+that lets a client edit `flags` via a different mutation path.
+
+---
+
+### CAT-E-01 — Missing trailing `vendor_template_id` selects free repair / free recharge
+
+**Severity**: High
+**Class**: Wire-shape inversion / missing-field bypass — server-authority bypass that grants a free service
+**Wire surface**: `Event_NetOut_RepairItems`, `Event_NetOut_RechargeItems`
+**Demonstrable / Likely-theoretical**: Likely-exploitable theoretical (needs live debugger to confirm at triage time)
+
+**Trust violation**
+The wire payload for cell methods 78–82 (PURCHASE_ITEMS … RECHARGE_ITEMS) is:
+`u32 count, (i32 item_id, i32 quantity)[count], [i32 trailing_template_id]`.
+The trailing `template_id` is parsed via `read_trailing_template_id`, which
+returns `Some(_)` if 4 trailing bytes remain and `None` otherwise. In the
+cell dispatcher, PURCHASE / SELL / BUYBACK reject `None` with a "missing
+vendor_template_id" warn and `return true` — they require the field. REPAIR
+and RECHARGE accept `None` and pass it through to the base handler. The
+base handler `handle_repair_inventory_items` / `handle_recharge_inventory_items`
+treats `Some(id)` as the paid path (cost computed from
+`resources.item_list_items.naquadah` and debited from `sgw_player.naquadah`)
+and `None` as a **free path** that simply runs `UPDATE sgw_inventory SET
+durability = 100 …` / `charges = ri.charges …` against every owned item in
+the request list. The free path has no template lookup, no `naquadah`
+balance check, and no `tx.begin()` cost debit. A modified client (or
+replayed-with-truncation client) that sends a `repairItems` packet without
+the trailing 4 bytes restores every item's durability to 100 for free; the
+same for `rechargeItems`.
+
+**Evidence**
+- Ghidra: string `0x019c2cf8` = `"repairItems"`, registered as wire method
+  name in `register_NetOut_onStrikeTeamResponse` at xref `00dc290d`; the
+  EventHandler constructor for `Event_NetOut_RepairItems` lives at
+  `0x00d6cfa0` (called from the registration at `00dc295b`). RTTI string
+  `.?AVEvent_NetOut_RepairItems@@` at `0x01e2b984`. The client emits a
+  message whose typed payload is a `(item_id, quantity)[]` array plus —
+  per the matching server parser — an optional trailing template id. Whether
+  this trailing field is **always** present on the client emit needs an
+  x64dbg trace of the actual emit site (the registration only proves the
+  *registration*; the constructor of the typed payload was not traced in
+  this audit) — flagging as likely-theoretical.
+- Client behavioral log: n/a
+- Cross-ref to Rust handler (for the fix author, NOT as truth):
+  `crates/services/src/cell/cell_methods/player/vendor.rs:189-256` (the
+  dispatcher arm that yields `validated_template_id = None` for REPAIR /
+  RECHARGE but rejects `None` for PURCHASE / SELL / BUYBACK), and
+  `crates/services/src/base/world_entry/methods/vendor/repair.rs:122-135` +
+  `crates/services/src/base/world_entry/methods/vendor/recharge.rs:32-45`
+  (the wrapper functions that branch to free vs. paid on `Option<i32>`).
+  Items-systems-advisor: the vendor state machine should make the free
+  repair path reachable only from a "free-repair NPC" (e.g., training
+  area / mission reward), not from any vendor's `repairItems` invocation.
+
+**Attack scenario**
+1. Player interacts with a paid repair vendor (`OpenVendorStore` runs;
+   `player.vendor_entity` is set; UI loads the vendor's `repair_item_list`).
+2. Adversary sends `cellMethod 81` (REPAIR_ITEMS) with payload
+   `count=N, (item_id, 0) × N` and **omits the trailing 4-byte template id**.
+3. Cell dispatcher `vendor::dispatch` reads `validated_template_id = None`
+   (the `Some(client_id)` arm requires a non-empty trailing read; absent
+   bytes drop through to the `None => None` arm), builds
+   `CellToBaseMsg::RepairInventoryItems { vendor_template_id: None, .. }`.
+4. Base handler `handle_repair_inventory_items(None)` falls through past
+   the `if let Some(...) = vendor_template_id` arm and executes
+   `UPDATE sgw_inventory SET durability = 100 WHERE character_id = $1 AND
+   item_id = ANY($2) AND container_id = ANY(VENDOR_FILTER_BAGS) AND
+   stack_size = 1 AND durability < 100` — no payment.
+5. Observable effect on the server: every requested item's durability
+   restored to 100, no `sgw_player.naquadah` row mutated, no
+   `onCashChanged` packet emitted to the witness. The same shape works for
+   RECHARGE_ITEMS — restoring `charges` for free. Repeatable indefinitely.
+
+**Suggested remediation (one line)**
+Reject `None` `validated_template_id` for REPAIR_ITEMS and RECHARGE_ITEMS at
+the cell dispatcher (mirror the PURCHASE / SELL / BUYBACK arms), and route the
+free-repair / free-recharge code paths through a distinct cell method index
+that is only invoked by trusted server-side flows (mission-grant, GM, etc.) —
+not by `repairItems` / `rechargeItems` from the wire.
+
+**Would benefit from x64dbg trace?**
+Yes — confirm at the actual `Event_NetOut_RepairItems` / `RechargeItems`
+emit site (the typed payload's serializer) whether the trailing
+`template_id` is encoded in **all** code paths, including the
+`free repair from non-vendor context` UI path. If the client always packs
+the trailing id, the exploit requires a modified client; if it ever omits
+the trailing id (e.g., from a self-repair hotkey), the exploit is reachable
+from an unmodified client.
+
+---
+
+### CAT-E-02 — `vendor_entity` is never cleared; no proximity / line-of-sight check
+
+**Severity**: Medium
+**Class**: Stale session / missing proximity check — server-authority gap in vendor session lifecycle
+**Wire surface**: All five — `Event_NetOut_PurchaseItems`, `SellItems`, `BuybackItems`, `RepairItems`, `RechargeItems`
+**Demonstrable / Likely-theoretical**: Likely-exploitable theoretical (needs live debugger to confirm at triage time)
+
+**Trust violation**
+The cell-side `vendor_context` looks up the vendor session via
+`player.vendor_entity` (a server-side `Option<u32>` set by the
+Interact→vendor path). It is **set** at `crates/services/src/cell/interactions/vendor.rs:20`
+and is never written elsewhere. No code clears it on disconnect, on
+`CancelMovie`, on death, on respawn, on instance / world transfer, or on a
+"close vendor store" UI message (there is no such message). The cell-side
+op also performs no proximity check between the player's current position
+and the vendor entity's position, and no line-of-sight or "is the player
+even in the same space" check. The only validation against arbitrary
+operation is `validate_template_id`, which catches the case where the
+vendor entity despawned (template_id reads as `None`) — but for any
+persisting vendor entity, the player can purchase / sell / buyback / repair
+at any range as long as they ever interacted with that vendor.
+
+**Evidence**
+- Ghidra: n/a (this is a server-side stateful gap; the client's emit is
+  uncontrolled but the gating is meant to be server-authoritative)
+- Client behavioral log: n/a
+- Cross-ref to Rust handler (for the fix author, NOT as truth):
+  `crates/services/src/cell/interactions/vendor.rs:18-21` (the only
+  assignment site of `vendor_entity`); `crates/services/src/cell/cell_methods/player/vendor.rs:75-88`
+  (`vendor_context` reads it without proximity check); the missing
+  inverse is anywhere that should clear it. Items-systems-advisor: the
+  vendor state machine in SGW's spec almost certainly requires
+  player-in-range and a server-side "store open" turn-of-state that
+  decays on disconnect / respawn — the current implementation models
+  the open state as a never-decaying pointer.
+
+**Attack scenario**
+1. Player interacts with vendor A (cell-side `vendor_entity` set, vendor
+   open UI loads on client).
+2. Player walks 1 km away (or dies and respawns, or zones, or
+   disconnects+reconnects if `vendor_entity` survives the reload — flag
+   for verification).
+3. Adversary sends a well-formed `purchaseItems` packet with the
+   correct vendor A `template_id`.
+4. Server-side `vendor_context` returns `Some(VendorSession { ..,
+   server_template_id: Some(A) })` because vendor A is still alive in
+   the cell. `validate_template_id` accepts.
+5. Observable effect on the server: purchase / sell / repair runs at
+   arbitrary distance from the vendor entity. In PvP / instance content
+   this lets a player buy ammo / repair mid-fight without seeking
+   shelter at a vendor.
+
+**Suggested remediation (one line)**
+Clear `player.vendor_entity` on (a) cell-side disconnect, (b) any other
+Interact target, (c) respawn / death, and add a server-side range check
+between the player's position and the vendor entity's position at the top
+of `vendor_context` (and a same-space check if vendor entities can leak
+across spaces).
+
+**Would benefit from x64dbg trace?**
+Yes — confirm whether the live client's UI ever emits a vendor packet
+after the player has moved out of vendor-UI range, to distinguish
+"adversary must use a modified client" from "the legitimate client emits
+this naturally on UI lag."
+
+---
+
+### CAT-E-03 — `RepairItem` (singular, client-supplied `repair_ratio: f32`) is wired but UNIMPLEMENTED on the cell side
+
+**Severity**: Low (latent — not currently reachable)
+**Class**: Latent client-trust seam — would-be exploit awaiting wiring
+**Wire surface**: `Event_NetOut_RepairItem` (singular; per surface inventory CAT-D)
+**Demonstrable / Likely-theoretical**: Likely-exploitable theoretical, currently latent
+
+**Trust violation**
+`crates/services/src/cell/cell_methods/inventory/item_ops.rs:176-186`
+parses a `repairItemRequest` packet as `(i32 item_id, f32 repair_ratio)`
+and logs `UNIMPLEMENTED`. The matching base-side handler
+`handle_repair_inventory_item` (called via `CellToBaseMsg::RepairInventoryItem`)
+*does* exist and accepts the client-supplied `repair_ratio: f32` as the
+authoritative repair amount: it clamps to `[0.0, 1.0]`, rounds to integer
+points, and adds to `durability` — **with no naquadah debit at all**. If
+the cell-side wiring is ever completed (the message routing from
+`repairItemRequest` → `CellToBaseMsg::RepairInventoryItem` is currently
+missing), the handler would let any client supply
+`repair_ratio = 1.0` and fully repair any owned item without paying.
+
+**Evidence**
+- Ghidra: not investigated (latent — no `Event_NetOut_RepairItem` xref
+  trace performed because the cell handler is a no-op today). Flag for
+  re-audit if a future PR wires the cell→base path.
+- Client behavioral log: n/a
+- Cross-ref to Rust handler (for the fix author, NOT as truth):
+  `crates/services/src/cell/cell_methods/inventory/item_ops.rs:184`
+  (`UNIMPLEMENTED: repairItemRequest`) and
+  `crates/services/src/base/world_entry/methods/vendor/repair.rs:22-104`
+  (the function that *would* be called).
+
+**Attack scenario**
+1. (Hypothetical, gated by future wiring.) Adversary sends
+   `repairItemRequest(item_id=X, repair_ratio=1.0)`.
+2. Cell-side handler forwards to base as
+   `CellToBaseMsg::RepairInventoryItem { repair_ratio: 1.0, .. }`.
+3. Base handler runs `UPDATE sgw_inventory SET durability = LEAST(100,
+   durability + round(1.0 * 100))` — no cost, no balance check.
+
+**Suggested remediation (one line)**
+Before wiring the cell-side path, make `handle_repair_inventory_item` debit
+naquadah computed from `(repair_ratio, item template's repair cost)` inside
+a transaction, OR drop `repair_ratio` from the wire and have the server
+compute it (the client should not assert how much it pays for).
+
+**Would benefit from x64dbg trace?**
+No — the seam is on the server side; the issue is the *handler shape*, not
+the client emit.
+
+---
+
+### CAT-E-04 — Buyback price stored in `sgw_inventory.flags`; recoverable independent of vendor identity
+
+**Severity**: Low
+**Class**: Cross-cutting state coupling — buyback queue not bound to the originating vendor
+**Wire surface**: `Event_NetOut_BuybackItems`
+**Demonstrable / Likely-theoretical**: Likely-exploitable theoretical (minor — outcomes are server-favorable in current shape)
+
+**Trust violation**
+When a player sells items at vendor A, the sell handler moves the items
+to `container_id = 16` (INV_BUYBACK) and stores the sell unit price in
+the row's `flags` column. The buyback handler later reads `flags AS
+unit_price` and charges the player that amount to retrieve the item. The
+buyback handler's query is keyed on `(character_id, item_id IN $items,
+container_id = 16, flags > 0)` — it is **not** keyed on the originating
+vendor's template id. This means:
+
+- A player can sell at vendor A (a high-sell-price vendor) and buy back at
+  vendor B (any other open vendor). The buyback price is the original
+  vendor-A sell price, but the operation is performed in vendor-B's
+  session. This violates the spec assumption that buyback is per-vendor.
+- The buyback row persists in `sgw_inventory` indefinitely — across
+  logouts, instance transfers, and any time window. There is no
+  expiration / decay. Real SGW likely had a per-session buyback window.
+- Because the unit price lives in `flags`, any future bug that lets a
+  client mutate the `flags` column on an INV_BUYBACK row (via MoveItem,
+  ammo edit, etc.) would let them buy a row back for an arbitrary
+  unit price. The buyback handler accepts whatever `flags` says
+  without an upper bound. Today no client path writes `flags` for
+  INV_BUYBACK rows so this is latent.
+
+The exploit shape today is "buy back at the wrong vendor", which is not
+server-favorable (player still pays the original sell price for their own
+item). The risk is the indefinite persistence + the side channel.
+
+**Evidence**
+- Ghidra: n/a (server-side schema-coupling concern)
+- Client behavioral log: n/a
+- Cross-ref to Rust handler (for the fix author, NOT as truth):
+  `crates/services/src/base/world_entry/methods/vendor/buyback/mod.rs:80-108`
+  (the buyback query — no `vendor_template_id` filter, no time filter),
+  `crates/services/src/base/world_entry/methods/vendor/sell/mod.rs:222-227`
+  (the sell-side `flags = row.unit_price` UPDATE). Items-systems-advisor:
+  the spec'd vendor state machine likely has buyback bound to the sell
+  session and expiring on session close — verify before re-platforming.
+
+**Attack scenario**
+1. (Spec-divergence, not a direct dupe.) Player sells item X at vendor A
+   for 100 naquadah. INV_BUYBACK row exists with `flags = 100`.
+2. Player logs out, logs back in three days later, walks to vendor B.
+3. Submits `buybackItems(item_id=X, qty=1)` with vendor B's template id.
+4. Handler accepts (no vendor binding); debits 100 naquadah; restores
+   item X to INV_MAIN.
+5. Observable effect: spec drift; potentially detectable via a future
+   audit that asserts "buyback retrieval at same vendor as sell."
+
+**Suggested remediation (one line)**
+Store the originating vendor template id and sell timestamp on the
+INV_BUYBACK row (extend schema or repurpose another column), filter the
+buyback query by `template_id = current_vendor AND timestamp > now() -
+buyback_window`, and audit any future code path that mutates
+`sgw_inventory.flags` to ensure it cannot touch INV_BUYBACK rows.
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-E-05 — `INV_BUYBACK` capacity (12) silently aborts sell; client-side reconciliation needed
+
+**Severity**: Low (UX / availability, not direct exploit)
+**Class**: Server-authority-correct but client-trust adjacent — sell silently aborts when buyback full
+**Wire surface**: `Event_NetOut_SellItems`
+**Demonstrable / Likely-theoretical**: N/A — not exploit-shaped; flagged for completeness
+
+**Trust violation**
+The sell handler reserves INV_BUYBACK slots via `reserve_free_inventory_slots`
+and aborts the whole transaction with a warn when there are not enough free
+buyback slots. INV_BUYBACK has capacity 12. The client likely does not know
+this server-side limit; the abort surfaces as a silent no-op on the client
+(no error packet is sent to the wire — `tracing::warn!` is server-side only).
+A player whose buyback is full will see "sell did nothing" with no
+explanation, which is not an exploit but is a server-authority correctness
+question if the client UI is showing the sale completed. Not filing as a
+finding but documenting for the items-systems-advisor review.
+
+**Evidence**: server-only, no Ghidra needed.
+
+---
+
+### CAT-E-06 — Buyback handler accepts arbitrary `vendor_template_id` in the message payload but never uses it for filtering
+
+**Severity**: Low (informational — see CAT-E-04)
+**Class**: Wire field is present but ignored — defense-in-depth gap
+**Wire surface**: `Event_NetOut_BuybackItems`
+**Demonstrable / Likely-theoretical**: Likely-exploitable theoretical (latent, not a direct exploit today)
+
+**Trust violation**
+`handle_buyback_vendor_items` accepts `vendor_template_id: i32` as a
+required parameter (rejects `None` at the cell dispatcher), but the
+function body uses it only for `tracing::instrument` fields and for the
+`handle_open_vendor_store` callback at the end. The buyback query is not
+filtered by `vendor_template_id`. So while the cell dispatcher correctly
+verifies that the client's claimed template id matches the player's
+opened vendor (via `validate_template_id`), the base handler then
+discards that information. This is the same shape as CAT-E-04 — the
+finding is the same, but emphasising that a *future* validation that
+relies on `vendor_template_id` reaching the SQL layer would not work
+because the field is dropped.
+
+**Evidence**
+- Cross-ref to Rust handler (for the fix author, NOT as truth):
+  `crates/services/src/base/world_entry/methods/vendor/buyback/mod.rs:38`
+  (`vendor_template_id: i32` parameter), `line 80-108` (query without
+  template filter). Items-systems-advisor: see CAT-E-04 remediation.
+
+**Suggested remediation (one line)**
+See CAT-E-04 — if buyback should be per-vendor, the SQL filter is the
+right place to enforce it.
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+## Not Filed
+
+- **Client-supplied `(item_id, quantity)` array in PURCHASE_ITEMS** — the
+  `item_id` is actually a `store_index` (server-recomputed via
+  `ROW_NUMBER() OVER (ORDER BY item_id) - 1` on the vendor's
+  `item_list_items`), and `quantity` is a multiplier capped at 9,999 with
+  overflow/negativity guards. `cash_cost` and `grant_quantity` are both
+  recomputed from DB via `checked_mul`. The server never reads a price
+  from the client. Not filing — this is the correct shape.
+- **Client-supplied price field in any vendor message** — searched for it,
+  doesn't exist. The wire only carries `(item_id/index, quantity)` and
+  optional trailing `template_id`. Not filing.
+- **Currency type validation (naqahdah vs. training points etc.)** —
+  vendor purchases always debit `sgw_player.naquadah`; there is no
+  multi-currency selector on the wire today. Not filing in CAT-E; flag
+  for CAT-F if crafting / R&D has training-point or expertise spending.
+- **Faction / reputation discount computed client-side** — no such discount
+  is present in any vendor handler today; the `naquadah` field in
+  `resources.item_list_items` is the price, multiplied only by the
+  client's requested quantity (server-side `checked_mul`). Not filing.
+- **`PurchaseItems` slot reservation race against concurrent
+  `MoveItem`** — purchase reserves free INV_MAIN slots inside the same
+  `tx.begin()` that takes the `sgw_player.naquadah` `FOR UPDATE` and the
+  per-row inventory locks via `consume_design_quantity`'s `FOR UPDATE`.
+  Slot reservation is part of the locked window. The TOCTOU is contained.
+  Not filing.
+- **Free repair sets durability = 100 instead of an item-cost-weighted
+  partial repair** — by design (the free path is meant for content-driven
+  repair sources). The exploit is *whether the free path is reachable
+  from the wire*, which is CAT-E-01. Not filing separately.
+- **Sell handler doesn't notify the cell of the moved item** — the buyback
+  handler comment explicitly documents that `InventoryItemGranted` is
+  not emitted on buyback (the item id is reused). Sell does enqueue
+  `InventoryItemRemoved` to the outbox. Correct shape. Not filing.
+- **`repair_ratio: f32` floor-clamp via `.max(1)`** — the server clamps
+  silly client values (NaN, negative, > 1.0) before use. The trust
+  violation is that the client supplies the ratio at all — flagged as
+  CAT-E-03 (latent, not currently reachable). Not refiling the float
+  edge cases separately.
+- **Vendor handler returns silently on DB error (no error packet to
+  client)** — observability gap, not server-authority. Out of scope.
+- **`paid_repair` UPDATE row-count check returns `r.rows_affected() !=
+  item_ids.len()` as a rollback condition** — this is the correct
+  pessimistic shape; not a finding.
+- **`reserve_free_inventory_slots` runs an unbounded loop scanning slots**
+  — capacity-bounded by `bag_max_slots` and gated by the prior duplicate
+  check. Performance concern at scale, not an exploit. Out of scope.

--- a/docs/security-audit/2026-05-31-server-authority/findings/CAT-F-crafting.md
+++ b/docs/security-audit/2026-05-31-server-authority/findings/CAT-F-crafting.md
@@ -1,0 +1,743 @@
+# CAT-F — Crafting / R&D / Training
+
+**Overall trust posture: MIXED — TrainAbility is well-implemented; everything
+else is a stub waiting to ship as an exploit chain.** The TrainAbility flow
+(cell method 77) is the one path in this category that actually mutates state,
+and its server-side validation chain is strong: cell-side checks ability_def
+existence, player_id presence, already-known, archetype-tree membership,
+level requirement, and per-prereq known-ability; the base then re-validates
+under a Postgres `WHERE training_points > 0 AND NOT abilities @> [ability_id]`
+guard, making double-debit on concurrent or replayed packets impossible. The
+five other handlers in this category (`spendAppliedSciencePoints` 95,
+`craft` 96, `research` 97, `reverseEngineer` 98, `alloying` 99,
+`respecCrafting` 100) are all Phase-1 stubs that log "UNIMPLEMENTED" and
+return `true` — they are NOT exploitable today because no state mutates,
+but the dispatch path is wired, the wire shapes are accepted, and the
+implementer who fills in Phase 2 inherits a hostile attack surface:
+every one of these RPCs trusts the client to name a blueprint id, a
+discipline id, or — worst of all — to name **the inventory item_ids
+that will be consumed**. The set of mandatory server-authority checks
+when Phase 2 lands is large and easy to skip a few of; the findings
+below enumerate the must-haves derived from the Ghidra-confirmed wire
+shapes and the deprecated-Python reference implementation.
+
+A separate authority gap is also flagged on TrainAbility itself: the
+**trainer-NPC interaction requirement was dropped** in the Rust port.
+The original Python required `self.trainerEntity is not None` AND
+`distanceTo(trainerEntity) <= MAX_INTERACT_DISTANCE` before honoring
+`trainAbility`; the Rust handler does not. A client that has any
+in-archetype-tree ability they qualify for can train it from anywhere
+on the map without ever interacting with a trainer NPC — there is no
+proximity, no "trainer-open" session state, no NPC↔ability list match.
+This is the same authority gap class as the vendor `vendor_entity`
+non-clearing finding in CAT-E (CAT-E-02), and the fix shape is the same:
+gate the action on a server-tracked `active_trainer_entity` field set
+by the interact path and validated on the train RPC. Filed as CAT-F-01
+because the train-anywhere shape is reachable today.
+
+---
+
+### CAT-F-01 — TrainAbility skips trainer-NPC interaction and distance check
+
+**Severity**: Medium
+**Class**: Missing context check — client can invoke trainer-RPC without standing at a trainer
+**Wire surface**: `Event_NetOut_TrainAbility` (cell method 77, payload `INT32 abilityId`)
+**Demonstrable / Likely-theoretical**: Likely-exploitable theoretical (needs live debugger to confirm at triage time)
+
+**Trust violation**
+The Python reference at `deprecated/python/cell/SGWPlayer.py:1347` gates
+`trainAbility` on two server-tracked conditions:
+- `self.trainerEntity is not None` — i.e. the player previously invoked
+  `interact()` on a trainer NPC and the cell stored a back-reference.
+- `self.trainerEntity().entity().distanceTo(self.position) <=
+  Constants.MAX_INTERACT_DISTANCE` — proximity at the moment of the train
+  RPC, not just at the moment of the original interact.
+
+The Rust port at `crates/services/src/cell/cell_methods/player/vendor.rs:491`
+drops both checks. It validates archetype-tree membership, level, and
+prerequisites — all of which it can do off the cached entity state — but
+does not consult any `active_trainer_entity` field, and there is no such
+field on the entity struct (parallel to `vendor_entity` for the vendor
+flow). A client that knows any ability id that exists in their archetype
+tree and that they meet level + prereq for can send `trainAbility` from
+anywhere in the world (different map cell, mid-combat, while falling, or
+from a malicious replay of an old packet) and the server will debit a
+training point and grant the ability.
+
+This is not a "free training points" exploit — the player still needs to
+have earned the TPs and meet the archetype/level/prereq gates — but it
+fully removes the trainer NPC from the gameplay loop, which is also the
+content gate for "this trainer hasn't been unlocked for your faction yet"
+and "you have to physically visit the trainer in the world." Both of
+those are content-team design constraints the auth layer is supposed to
+preserve, and right now it doesn't.
+
+**Evidence**
+- Ghidra: `019cf940`+ (`Event_NetOut_TrainAbility` registration) — payload
+  is a single INT32 abilityId per `entities/defs/SGWPlayer.def` (method
+  77 exposed declaration). Client emits only the abilityId; the trainer
+  identity is server-side state.
+- Python ref: `deprecated/python/cell/SGWPlayer.py:1347-1361` —
+  trainer-presence + distance gate documented as a contract the cell
+  enforces, with `onError("Not interacting with a trainer entity")` /
+  `onError("You are too far away to interact with that")` feedback.
+- Cross-ref to Rust handler: `crates/services/src/cell/cell_methods/player/vendor.rs:491`
+  (no trainer-presence check; no distance check).
+- Companion struct that should hold the trainer back-ref: see how
+  `vendor_entity` is stored on the entity in
+  `crates/services/src/cell/interactions/vendor.rs:20` — the trainer flow
+  needs a parallel `trainer_entity: Option<u32>` field set by
+  `try_open_trainer` at `crates/services/src/cell/interactions/trainer.rs:55`.
+
+**Attack scenario**
+1. Player walks up to an in-world trainer once during a normal session,
+   triggering `try_open_trainer` and receiving `onTrainerOpen` with the
+   abilities they're eligible for.
+2. Player walks away (or zones out, or dies) — there is no server-side
+   `trainer_entity = None` on any of these transitions because the field
+   doesn't exist.
+3. Player or a replay tool sends `trainAbility(abilityId)` from anywhere
+   for any ability that's in their archetype tree and that they meet
+   level + prereq for — the server validates the static gates and
+   forwards `CellToBaseMsg::TrainAbility` to the base, which debits 1 TP
+   and grants the ability.
+4. Observable effect: ability granted, TP debited, `onKnownAbilitiesUpdate`
+   broadcast, no trainer NPC ever consulted. Content team's "you must
+   visit the trainer" gameplay invariant is broken.
+
+**Suggested remediation (one line)**
+Add `trainer_entity: Option<u32>` on the cell entity, set by `try_open_trainer`,
+cleared on death/zone/disconnect/distance-out, and require it set + within
+`MAX_INTERACT_DISTANCE` before forwarding the cell→base TrainAbility message;
+also validate that the requested ability_id is in `trainer_abilities[(list_id,
+archetype_id)]` for the open trainer, not just in `archetype_ability_trees`.
+
+**Would benefit from x64dbg trace?**
+No — the wire shape is single-INT32 and the trust violation is on a
+server-side state field the Rust port hasn't added yet.
+
+---
+
+### CAT-F-02 — `spendAppliedSciencePoints` will trust client's discipline_id when Phase 2 lands
+
+**Severity**: High (latent — Phase 1 is no-op; first Phase 2 impl that lands without these checks is critical)
+**Class**: Future-implementer trap — full ASP/discipline mutation path is wired through with stub handler
+**Wire surface**: `Event_NetOut_SpendAppliedSciencePoint` (cell method 95, payload `INT32 aDisciplineSeqId`)
+**Demonstrable / Likely-theoretical**: Likely-exploitable theoretical (Phase 2 will ship the mutation; the brief explicitly asks "what should the server validate?")
+
+**Trust violation**
+The Phase 1 handler at `crates/services/src/cell/cell_methods/player/crafting.rs:23`
+accepts the message, parses the 4-byte `discipline_id`, logs
+`"UNIMPLEMENTED: spendAppliedSciencePoints (Phase 2)"`, and returns `true`
+(handled). When Phase 2 implements the mutation, the implementer must
+faithfully port every check from `deprecated/python/cell/Crafter.py:154`
+(`spendAppliedSciencePoints`):
+
+1. **ASP balance check** — `self.appliedSciencePoints >= 1` — must be a
+   server-authoritative read of `sgw_player.applied_science_points`, NOT
+   a trust of any client-side cached value.
+2. **Discipline exists** — `DefMgr.get('discipline', disciplineId)` —
+   resources lookup against `discipline` table; rejects client-invented
+   IDs.
+3. **Already-known guard** — `disciplineId not in self.disciplines` —
+   silent no-op on duplicates (a replayed packet must not debit twice).
+4. **Racial paradigm gate** — `racialParadigms[discipline.racialParadigm.id]
+   >= discipline.racialParadigmLevel` — server-authoritative read of the
+   player's paradigm levels.
+5. **Prerequisite disciplines** — every entry in `discipline.requiredDisciplines`
+   must already be in the player's `disciplines` AND at expertise >= 50.
+6. **Atomic** — decrement ASP + learn discipline + insert initial
+   expertise=1 row in a single Postgres transaction, with the discipline
+   uniqueness derived from a `WHERE NOT (discipline_ids @> ARRAY[$1])`
+   guard so two concurrent or replayed packets debit at most once.
+
+The wire shape carries ONLY `aDisciplineSeqId`. Every other field in
+the validation chain — ASP balance, paradigm level, prerequisite
+expertise — must come from server-authoritative state. A Phase 2 impl
+that reads any of these from a client-supplied or client-cached value
+is a critical exploit (infinite disciplines via 0-cost spend, or
+bypassing the paradigm/prereq gates).
+
+Filing this finding now because the brief explicitly asks for the
+validation checklist that Phase 2 must satisfy and because the Phase 1
+stub already returns `true` — a next-iteration patch that adds the DB
+write without the gates would slip through review as "wire it up to
+the DB."
+
+**Evidence**
+- Wire shape: `entities/defs/SGWPlayer.def:916-919` (`spendAppliedSciencePoints
+  <Arg> INT32 <ArgName> aDisciplineSeqId </ArgName>`). Confirmed by Ghidra
+  `Event_NetOut_SpendAppliedSciencePoint` registration at `019db48c`.
+- Python ref: `deprecated/python/cell/Crafter.py:154-188` — full validation
+  chain in source.
+- Cross-ref to Rust stub: `crates/services/src/cell/cell_methods/player/crafting.rs:23-43`.
+
+**Attack scenario** (post-Phase-2, assuming a partial impl)
+1. Attacker sends `spendAppliedSciencePoints(disciplineId=<any>)` —
+   choosing an id that they don't qualify for (high paradigm prereq,
+   or prereq disciplines they don't know).
+2. Phase 2 impl that omitted the paradigm or prereq check (an easy
+   mistake — Python's `learnDiscipline` is permissive on its own; the
+   gates live in `spendAppliedSciencePoints` not in `learnDiscipline`)
+   debits ASP, learns the discipline, sends `onUpdateDiscipline` and
+   `onEntityProperty(AppliedSciencePoints, ...)`.
+3. Attacker now has a discipline that the content-design team intended
+   to gate behind paradigm/prereq progression — they can craft items
+   the design intended to be out-of-reach.
+
+**Suggested remediation (one line)**
+Phase 2 implementer must port all six checks from
+`deprecated/python/cell/Crafter.py:154`, with ASP read + decrement +
+discipline + expertise row insert in a single Postgres transaction
+guarded by `WHERE applied_science_points >= 1 AND NOT (discipline_ids
+@> ARRAY[$1])` (parallel to the TrainAbility pattern at
+`crates/services/src/base/world_entry/methods/progression/mod.rs:456`).
+
+**Would benefit from x64dbg trace?**
+No — the wire shape is single-INT32; the audit is on the server-side
+validation completeness, not the wire decoding.
+
+---
+
+### CAT-F-03 — `craft` will trust client-supplied item_ids for material consumption
+
+**Severity**: Critical (latent — Phase 1 is no-op; this is the bug that will eat the most reviewer-cycles when Phase 2 lands)
+**Class**: Future-implementer trap — client picks the consumption set; server must validate ownership, type, quantity, bag location
+**Wire surface**: `Event_NetOut_Craft` (cell method 96, payload `INT32 aCraftId, ARRAY<ItemID> aItems, INT32 aQuantity`)
+**Demonstrable / Likely-theoretical**: Likely-exploitable theoretical (the wire shape carries client-named item_ids; the brief flags this exact concern as central question 1)
+
+**Trust violation**
+The Ghidra-confirmed wire payload for `craft` (cell method 96) is three
+fields: a blueprint id, an **array of item_ids** the client says it
+wants to consume, and a quantity (Ghidra:
+`Event_NetOut_Craft` emitter at `00e47b10`, with named args
+`aCraftId`/`aItems`/`aQuantity`). The .def-level shape is confirmed at
+`entities/defs/SGWPlayer.def:921-926`.
+
+Every one of the three client fields is adversarial:
+
+1. **`aCraftId` (blueprint id)** — must be checked against the player's
+   server-authoritative `sgw_player.blueprint_ids` array. A client can
+   send any int32 — the server must reject any blueprint not in the
+   known list.
+2. **`aItems` (array of item_ids)** — every item_id must be:
+   - **Owned**: the row in `sgw_inventory` belongs to this player. A
+     client that sends a friend's item_id (or one it's seen in a trade
+     window, or a random scan) MUST be rejected.
+   - **In main or crafting bag**: the Python at
+     `deprecated/python/cell/Crafter.py:212-215` requires
+     `bagId in (INV_Main, INV_Crafting)` — equipped items, bandolier
+     items, mail-attached items, etc. are NOT eligible.
+   - **Of a type matching the blueprint's component set**: server
+     looks up the blueprint's component requirements from
+     `resources.blueprints_components` keyed by `(blueprint_id,
+     component_set_id)` and confirms the supplied item types cover
+     the requirement. (Python: lines 218-231.)
+   - **Sufficient stack quantity**: `sum(item.quantity for item in
+     items if item.typeId == component.item.id) >= component.quantity *
+     quantity_requested`. (Python: lines 233-239.)
+3. **`aQuantity`** — must be ≥ 1. Must be sanity-bounded (no `i32::MAX`
+   that overflows the multiplication on the quantity-sufficient check).
+   Must produce only as many outputs as the recipe permits, server-side.
+
+If Phase 2 ships without ALL of these, the exploits are immediate:
+
+- **Dupe via friend's item_id**: pass an item_id you don't own; the
+  server "consumes" it and produces the output. The friend still has
+  the item (it was never in your row); you have a free crafted item.
+- **Dupe via equipped item_id**: pass your own equipped weapon's
+  item_id; if the bag-location check is missing, you "consume" the
+  weapon for crafting AND still have it equipped (the equipment slot
+  reference doesn't decrement). Free output + weapon retained.
+- **Recipe-bypass via wrong type**: if the type check is missing,
+  pass low-tier scrap item_ids against a high-tier blueprint; you
+  get the high-tier output for the cheap materials.
+- **Quantity-bypass**: pass `aQuantity = 999999`; if the
+  type-sufficient check uses int multiplication without overflow
+  guard or doesn't recompute the deduction, you produce 999999 outputs
+  while consuming the items only once.
+- **Forbidden-blueprint bypass**: pass any `aCraftId`; if the
+  blueprint-known check is missing, you craft items you never learned
+  the recipe for.
+
+Filing this now because the brief explicitly asks "Can client provide
+arbitrary material item_ids that they don't own?" and "Can client claim
+a recipe they don't know?" — the answer to both today is "the handler
+is a stub, so trivially no; the answer post-Phase-2 depends on whether
+the implementer remembers all four item-id checks."
+
+The Rust persistence layer is partially in place: `blueprint_ids` is
+loaded into in-memory `CraftingState` (see
+`crates/services/src/base/crafting/persistence.rs:39`), and
+`sgw_inventory` rows include `bag_id`; the data is available. The risk
+is the cell→base coordination: cell must lock the item rows it intends
+to consume (`FOR UPDATE` against `sgw_inventory`) BEFORE running the
+type-and-quantity-sufficient check, and the produce-output INSERT must
+be in the same transaction as the consume-input UPDATE/DELETE. A
+disconnect or concurrent request between read and write is a dupe
+window.
+
+**Evidence**
+- Ghidra: `00e47b10` `Event_NetOut_Craft` emit site — wire field order
+  is aCraftId (INT32), aItems (array of INT32 item_ids), aQuantity (INT32).
+- Ghidra: `00aaa370` — Lua binding `requestCraftBlueprintProduct` that
+  invokes the emit (proves the client-side path).
+- Def file: `entities/defs/SGWPlayer.def:921-926`.
+- Python ref (full validation chain): `deprecated/python/cell/Crafter.py:191-254`.
+- Resources schema: `db/resources/Entities/Tables/blueprints.sql`,
+  `db/resources/Entities/Tables/blueprints_components.sql` — server has
+  the data needed for recipe validation.
+- Cross-ref to Rust stub: `crates/services/src/cell/cell_methods/player/crafting.rs:45-57`.
+
+**Attack scenario** (post-Phase-2, assuming the implementer misses item-ownership)
+1. Attacker is in a party with a friend whose inventory the attacker
+   has scrolled past (item_ids leak in `onUpdateItem` broadcasts to
+   nearby clients in some flows — verify against CAT-D findings).
+2. Attacker sends `craft(aCraftId=<known blueprint>, aItems=[friend's
+   item_id, friend's item_id, ...], aQuantity=1)`.
+3. Server (missing ownership check) finds the item_ids in `sgw_inventory`,
+   confirms types match the blueprint, and runs the consume. The
+   DELETE/UPDATE on `sgw_inventory` happens against the FRIEND's rows
+   (since the cell didn't gate by player_id).
+4. Attacker receives the crafted output; friend's inventory is silently
+   drained. Observable effect: friend's items disappear; attacker gets
+   free output.
+
+**Suggested remediation (one line)**
+Phase 2 implementer must validate (a) `aCraftId ∈
+sgw_player.blueprint_ids` for `player_id`, (b) every `aItems` entry has
+`sgw_inventory.player_id = $caller_player_id` AND `bag_id IN
+(INV_Main, INV_Crafting)`, (c) the (type, quantity_sum) tuple satisfies
+the `blueprints_components` requirement for some component_set_id, and
+(d) consume + produce in a single `BEGIN…COMMIT` with `FOR UPDATE` on
+all input rows. Reject (not partially-consume) on any failure.
+
+**Would benefit from x64dbg trace?**
+Yes — confirm the per-item `ItemID` wire encoding matches the
+`ItemID = INT32` alias before Phase 2 lands; the .def says INT32 but
+the alias.xml resolution should be confirmed end-to-end against an
+actual `craft()` packet at runtime to avoid an off-by-N parse on the
+array.
+
+---
+
+### CAT-F-04 — `research` and `reverseEngineer` will trust client-named item_ids; outcome must be server-rolled
+
+**Severity**: Critical (latent — Phase 1 is no-op)
+**Class**: Future-implementer trap — same as CAT-F-03 plus server-side RNG requirement
+**Wire surface**: `Event_NetOut_Research` (method 97, `ItemID aItemId, ARRAY<ItemID> aKickers`), `Event_NetOut_ReverseEngineer` (method 98, `ItemID aItemId`)
+**Demonstrable / Likely-theoretical**: Likely-exploitable theoretical
+
+**Trust violation**
+Two related flows share the same client-named-item-id pattern as `craft`:
+
+1. **`research(aItemId, aKickers[])`** — client says which item to
+   research and which kicker items to add. Both consume on success.
+   The expertise gain is a random roll: Python
+   `deprecated/python/cell/Crafter.py:277-345` computes
+   `chance = 100 - currentExpertise + 5 * len(kickers)` and rolls
+   `random() * 100 < chance`. **This roll MUST happen server-side.** If
+   any part of it is exposed to the client (or worse, the client tells
+   the server "I rolled successfully"), the player gets free expertise
+   on every research.
+2. **`reverseEngineer(aItemId)`** — client says which item to RE.
+   Server consumes the item and rolls a discovery quantity per
+   component (Python lines 364-414). Same RNG concern.
+
+For both: the consume-input check is the same gate set as `craft`
+(ownership, bag location, item type, sufficient quantity), AND for
+research the kickers must have `type.kicker == true` AND for both the
+researched/RE'd item must have `type.researchable == true` /
+`type.reverseEngineerable == true`. These are resources lookups, not
+client-supplied.
+
+Failure modes if Phase 2 ships a partial impl:
+- Missing researchable/reverseEngineerable type flag → can RE any
+  item, including ones the design intended as terminal (e.g. quest
+  items, soulbound gear).
+- Missing kicker `type.kicker` check → use random valuable items as
+  kickers; they get consumed but they shouldn't have been eligible,
+  inflating the success chance.
+- Trusting any client-asserted RNG state (timestamp seed, "roll
+  result" field) → guaranteed-success exploit.
+- The Python `randint(0, len(disciplines))` and `randint(0,
+  len(blueprints))` patterns are off-by-one bugs in the original
+  (inclusive upper bound) — Rust implementers must use a half-open
+  range like `rng.gen_range(0..n)`, not port the bug. Note this is
+  cosmetic, not security-relevant, but it's a porting trap.
+
+**Evidence**
+- Def file: `entities/defs/SGWPlayer.def:928-937`.
+- Python ref: `deprecated/python/cell/Crafter.py:277-345` (research),
+  `364-414` (reverseEngineer).
+- Cross-ref to Rust stub: `crates/services/src/cell/cell_methods/player/crafting.rs:59-67`.
+
+**Attack scenario** (post-Phase-2, missing researchable check)
+1. Attacker sends `research(aItemId=<quest item id>, aKickers=[])`.
+2. Server (missing researchable type check) finds the item, confirms
+   ownership, consumes it.
+3. Observable effect: quest item destroyed (potentially blocking the
+   player's own progression as collateral damage, OR — if the RE roll
+   returns components for a quest item — letting them turn quest items
+   into reverse-engineered "blueprints" they shouldn't get).
+
+**Suggested remediation (one line)**
+Same item-ownership/bag/type/quantity guards as CAT-F-03, plus
+`item.type.researchable` / `item.type.kicker` /
+`item.type.reverseEngineerable` resource-table checks; the outcome
+roll must use a server-side RNG seeded from non-client state, with
+no client-supplied "seed" or "result" field accepted from the wire.
+
+**Would benefit from x64dbg trace?**
+No — the wire shape is fully documented in the .def and
+straightforward. The risk is server-side validation completeness, not
+wire decoding.
+
+---
+
+### CAT-F-05 — `alloying` will trust client-supplied currentTier + lowerTier item_ids and tier metadata
+
+**Severity**: Critical (latent — Phase 1 is no-op)
+**Class**: Future-implementer trap — multi-item recipe with tier-progression rules
+**Wire surface**: `Event_NetOut_Alloy` (cell method 99, payload `INT32 aCraftId, ItemID aCurrentTierItemId, ARRAY<ItemID> aLowerTierItems`)
+**Demonstrable / Likely-theoretical**: Likely-exploitable theoretical
+
+**Trust violation**
+Alloy is craft's cousin but with two distinct material inputs:
+- `aCurrentTierItemId` (single ItemID) — the "primary" component, must
+  match the alloy blueprint's expected current-tier type.
+- `aLowerTierItems` (ARRAY<ItemID>) — N "elementary" components from
+  the tier *below* the current item's tier, with `N` determined by the
+  elementary items' quality (`Constants.ALLOYING_ELEMENTARY_COUNTS[quality]`
+  in the Python at `Crafter.py:485`).
+
+The Python validation chain (`Crafter.py:431-505`) is the longest in
+this category and is the most likely to be partially-ported:
+
+1. Blueprint known (`blueprintId in self.blueprints`) — server-side
+   ownership check on blueprints.
+2. Blueprint is an alloy blueprint (`blueprint.alloy is True`) —
+   prevents using a crafting blueprint id in this RPC and bypassing
+   the alloying-specific tier rules.
+3. All items exist and are owned by the player (current-tier item +
+   every elementary).
+4. All items are in main or crafting bag.
+5. Current-tier item type matches the blueprint's single-component
+   requirement (line 469).
+6. Current-tier item quantity >= requirement quantity.
+7. Elementary count matches `ALLOYING_ELEMENTARY_COUNTS[quality]` for
+   the elementary's quality (line 484-489) — note: quality is taken
+   from the **first elementary's type**, not from a client field,
+   which is good — but the implementer must take it from a
+   server-side type lookup, NOT from any client-supplied "tier"
+   field.
+8. Every elementary has `type.tier == currentTier.type.tier - 1`
+   (line 493-497) — server-side type lookup again, not client-asserted.
+
+Failure shapes if Phase 2 lands without these:
+- Skipping check #2 (`blueprint.alloy`) lets a client send a craft
+  blueprint id to `alloying()` and bypass the tier-decrement chain
+  entirely, "alloying" any blueprint without the elementary-tier
+  cost.
+- Skipping check #5/#6 lets the client substitute the wrong primary
+  type as long as it's some item they own.
+- Skipping check #7/#8 lets the client send arbitrary "elementary"
+  items (e.g. low-quality stack components for a high-tier alloy)
+  and produce the high-tier alloy for cheap.
+- Same dupe-via-friend's-item_id concern as CAT-F-03 if ownership is
+  missed.
+
+The Python source itself contains a real bug at line 469: `if
+requirement['item'].id != component.typeId is None` is a precedence
+error (`x != y is None` parses as `(x != y) and (y is None)`) that
+silently always returns False, meaning the original Python *never
+actually validated* current-tier type. The Rust port must implement
+the check correctly (compare type ids directly), not faithfully port
+the bug. Filing this as a watch-out because a "match Python behavior"
+approach would inherit the broken check.
+
+**Evidence**
+- Def file: `entities/defs/SGWPlayer.def:939-944`.
+- Ghidra: `Event_NetOut_Alloy` registration at `019db404` (`.PBV..._VEvent_NetOut_Alloy_…`
+  vftable at `01e2c55c` confirms the typed payload class exists).
+- Python ref: `deprecated/python/cell/Crafter.py:431-513`. Note the
+  precedence bug at 469 + 473 that the Rust port MUST fix, not copy.
+- Cross-ref to Rust stub: `crates/services/src/cell/cell_methods/player/crafting.rs:69-81`.
+
+**Attack scenario** (post-Phase-2 missing the `blueprint.alloy` flag check)
+1. Attacker has any blueprint known — including non-alloy ones.
+2. Attacker sends `alloying(aCraftId=<non-alloy blueprint>,
+   aCurrentTierItemId=<cheap item they own>, aLowerTierItems=[])`.
+3. Server (missing alloy-flag check) treats the request as valid,
+   consumes the cheap current-tier item, produces the non-alloy
+   blueprint's output — completely bypassing the elementary-tier
+   material cost the non-alloy blueprint normally requires.
+
+**Suggested remediation (one line)**
+Phase 2 implementer must implement all eight Python-style guards with
+the `blueprint.alloy` check as #2 (a `WHERE blueprint_id = $1 AND
+is_alloy = true` against `resources.blueprints`), and tier comparison
+against server-side `resources.item_list_items.tier`, NOT any
+client-supplied tier field; consume + produce in one transaction.
+
+**Would benefit from x64dbg trace?**
+Yes — the elementary count is dynamic (`ALLOYING_ELEMENTARY_COUNTS[quality]`)
+and an x64dbg trace would confirm the actual array length the client
+emits at runtime, which is helpful for the receiver's bound check on
+parse.
+
+---
+
+### CAT-F-06 — Phase-1 stubs return `true` (handled) for every craft RPC with no idempotency guard
+
+**Severity**: Low (latent infrastructure risk)
+**Class**: Wire-shape acceptance without state-change — silent drop today, partial-state risk on Phase 2
+**Wire surface**: All five crafting RPCs: methods 95–100
+**Demonstrable / Likely-theoretical**: Likely-exploitable theoretical (Phase 2 risk; documented for the implementer)
+
+**Trust violation**
+Today, the dispatch arms at
+`crates/services/src/cell/cell_methods/player/crafting.rs:23-86` all
+return `true` (handled) after logging "UNIMPLEMENTED". The client
+treats `true` as "the server accepted the call"; the absence of a
+follow-up `onUpdateDiscipline` / `onUpdateItem` / `onCraftingStarted`
+is the only signal the client gets that nothing happened.
+
+That's not exploitable today (no state changes), but it does mean
+the dispatch IS wired and the message IS being accepted. The Phase-2
+risk is: an implementer adds a partial side-effect — e.g. sets
+`craftingBlueprintId` on the entity, or starts a `craftTimer`, or
+emits `onCraftingStarted` to the client — *before* completing all
+the ownership/recipe/quantity validation. If the validation fails
+*after* that partial mutation, the player is "stuck in busy" (no
+output, but the busy state preventing further crafts), or worse,
+the in-memory mutation desyncs from the DB.
+
+The right shape is: every craft RPC's first commit-point must be the
+atomic DB transaction that consumes the materials AND produces the
+output AND updates the in-memory crafting state — no in-memory or
+in-flight mutation before validation completes.
+
+Additionally, the `respecCrafting` (method 100) stub at line 83
+accepts the message with zero validation; when Phase 2 lands, the
+implementer must validate the player has enough naquadah for the
+respec cost (`onCraftingRespecPrompt CostToRespec`) BEFORE clearing
+disciplines, and the deduct + clear must be atomic.
+
+**Evidence**
+- All five stub arms: `crates/services/src/cell/cell_methods/player/crafting.rs:23-86`.
+- All return `true` (line 42, 56, 61, 66, 80, 85) — dispatcher treats
+  this as "handled".
+- Python ref for `respecCrafting`: `deprecated/python/cell/SGWPlayer.py`
+  (search `respecCrafting` — confirms the naquadah deduct + clear-disciplines
+  flow).
+
+**Attack scenario** (Phase 2 partial-mutation shape, hypothetical)
+1. Phase 2 implementer adds `craftingBlueprintId = aCraftId` and
+   `entity.busy = true` at the top of the `craft` handler — before
+   running the material-ownership check.
+2. Attacker sends `craft(aCraftId=<known>, aItems=[<non-owned ids>],
+   aQuantity=1)`.
+3. The ownership check fails, the handler returns. But `busy = true`
+   was already set; no rollback. The player is locked out of crafting
+   until disconnect.
+4. Observable effect: griefing self-DoS, or — if combined with a
+   forced disconnect — abandoned `busy = true` rows that survive
+   reconnect.
+
+**Suggested remediation (one line)**
+Phase 2 implementers: validation must complete BEFORE any
+in-memory mutation, busy-flag set, or `onCraftingStarted` emit; all
+state changes (consume input, produce output, set timer, update
+in-memory state) live in one atomic block.
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-F-07 — No "busy" / induction-timer state tracked in Rust today
+
+**Severity**: Medium (latent — emerges with Phase 2)
+**Class**: Missing server-tracked rate limit — concurrent-request dupe via missing busy flag
+**Wire surface**: All craft / research / alloying RPCs (methods 96, 97, 98, 99)
+**Demonstrable / Likely-theoretical**: Likely-exploitable theoretical
+
+**Trust violation**
+The Python reference decorates `craft`/`research`/`reverseEngineer`/
+`alloying` with `@mustBeIdle`, which checks
+`deprecated/python/cell/SGWBeing.py:25` for `self.busy == False`
+before invoking the body. The `busy` flag is set when a crafting
+induction timer (3-second wait) starts and cleared on completion.
+
+The Rust port has no `busy` field on the entity, no induction-timer
+infrastructure, and no equivalent gate. When Phase 2 lands the
+mutation logic, two concurrent or rapidly-replayed craft packets will
+both pass the ownership + recipe checks and both consume materials.
+If they target different stacks, the player consumes 2× the
+materials. If they target the same stack via the same item_id, the
+DB row-locking will save them, but the in-memory state will desync
+(both fired `onCraftingStarted` to the client).
+
+Worse: research and reverseEngineer roll their outcome randomly.
+Without a busy gate, an attacker can fire 100 concurrent `research`
+packets on the same item_id (the DB DELETE will succeed only once,
+but if validation isn't ordered correctly, an attacker can get
+multiple `onExpertiseGained` rolls per consumed item) — the exact
+shape depends on the implementation but the absence of a per-player
+"one craft at a time" gate is the root.
+
+**Evidence**
+- Python ref: `deprecated/python/cell/SGWBeing.py:25-38` (`mustBeIdle`
+  decorator definition) and `deprecated/python/cell/SGWPlayer.py`
+  (lines 1620-1641 — `@mustBeIdle` applied to all four craft RPCs).
+- Rust audit (no `busy` field):
+  `crates/services/src/cell/space_manager/mod.rs` and the entity
+  struct have no `busy: bool` or `craft_timer: Option<…>`. Confirmed
+  via `grep -i "pub busy" crates/services` returning no matches.
+
+**Attack scenario**
+1. Attacker has materials sufficient for ONE craft of blueprint X.
+2. Attacker sends 100 `craft(aCraftId=X, ...)` packets in quick
+   succession (replay tool or scripted client).
+3. Phase 2 impl (missing busy gate) validates each packet against
+   in-memory inventory at packet-receive time. If the DB consume
+   uses `WHERE quantity >= $needed` row-locks correctly, only one
+   succeeds — but a partial impl that decrements in-memory state
+   before issuing the DB DELETE could see the in-memory count drop
+   to 0 between the validation and the DELETE for 99 of the 100
+   packets, each of which "produces" the output before the DB
+   reflects the consume.
+4. Observable effect: depending on the impl gap, attacker either
+   gets multiple craft outputs for one material set, or the
+   in-memory/DB inventories desync until next relog.
+
+**Suggested remediation (one line)**
+Add a per-entity `crafting_busy: Option<CraftTimer>` field (parallel
+to Python's `busy + craftTimer`) set at the top of the validated
+handler (after material lock, before output emit) and cleared by the
+timer-completion callback; reject any `craft`/`research`/`alloying`
+RPC where `crafting_busy.is_some()`.
+
+**Would benefit from x64dbg trace?**
+No — this is a server-side state-machine design gap.
+
+---
+
+### CAT-F-08 — TrainAbility cell-side accepts request even when player_level field is stale
+
+**Severity**: Low
+**Class**: TOCTOU / stale-cache risk on a non-critical validation
+**Wire surface**: `Event_NetOut_TrainAbility` (method 77)
+**Demonstrable / Likely-theoretical**: Likely-exploitable theoretical (narrow window; depends on grant_xp ordering)
+
+**Trust violation**
+The cell-side level check at
+`crates/services/src/cell/cell_methods/player/vendor.rs:583` reads
+`entity.level as i32` from in-memory cell state. The base-side
+progression handler at
+`crates/services/src/base/world_entry/methods/progression/mod.rs:163`
+updates `state.player_level` AFTER the DB persist succeeds, and the
+cell receives `BaseToCellMsg::LevelUpdate` separately.
+
+There's a narrow window where:
+- A `grant_xp` is in-flight in the base→cell→DB pipeline.
+- The cell's `entity.level` is the OLD (pre-level-up) value because
+  the `BaseToCellMsg::LevelUpdate` hasn't been processed yet.
+- A `trainAbility` arrives for an ability that requires the NEW
+  level.
+- The cell rejects with "level too low" even though the player has,
+  authoritatively, just gained the level.
+
+This is *not* an attack vector — it just rejects a legit train
+attempt — but the inverse is the concern: if the cell→base sequence
+for level decreases (death penalty, respec, GM `SetLevel`) updates
+in-memory level AFTER the cell already accepted a `trainAbility`,
+the cell might forward a TrainAbility for an ability that the
+player *no longer qualifies for*. The base re-validates only
+`training_points > 0`, not level. So a respec that decreases level
+mid-flight could let a TrainAbility for a now-too-high ability
+slip through.
+
+This is narrow enough that it's a low-severity informational, not
+an exploit shape — but it should be filed because the fix is cheap
+(re-validate level on the base side, parallel to the existing
+`training_points > 0` gate).
+
+**Evidence**
+- Cell-side level read: `crates/services/src/cell/cell_methods/player/vendor.rs:583`.
+- Base-side handler with no level re-check:
+  `crates/services/src/base/world_entry/methods/progression/mod.rs:400`
+  (no `WHERE level >=` clause in the UPDATE).
+- Resources table `archetype_ability_tree` has `level` per entry,
+  so the base could JOIN to re-validate.
+
+**Attack scenario**
+1. GM (or a respec flow) reduces the player's level from 10 to 5.
+2. The cell's in-memory `entity.level` is still 10 because the
+   level-update message hasn't reached the cell yet (or the cell
+   has crashed and is mid-recovery).
+3. Attacker (or any client) sends `trainAbility(<requires_level_8>)`.
+4. Cell validates 10 >= 8, forwards `CellToBaseMsg::TrainAbility`.
+5. Base validates `training_points > 0` AND `NOT abilities @>
+   [ability_id]` — both pass — and grants the ability.
+6. Observable effect: player now has an ability they don't qualify
+   for at their current level.
+
+**Suggested remediation (one line)**
+In `handle_train_ability` at
+`crates/services/src/base/world_entry/methods/progression/mod.rs:456`,
+join against `resources.archetype_ability_tree` and add `AND level <=
+(SELECT level FROM sgw_player WHERE player_id = $2)` (or pre-fetch
+the required level and pass it through the `CellToBaseMsg::TrainAbility`
+variant for the base to compare against the row).
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+## Not Filed
+
+- **"Stub returns true" considered as Critical** — the brief asks for
+  exploit-shaped findings; today's stubs don't mutate state, so the
+  "client thinks it worked but server did nothing" desync is a UX
+  bug, not an exploit. Documented as CAT-F-06 at Low for the Phase
+  2 implementer; not duplicated as a separate Critical.
+- **Python `randint(0, len(list))` off-by-one** — original Python
+  research/RE has `randint(0, len(disciplines))` (inclusive upper
+  bound) — a porting trap rather than an exploit. Flagged inline in
+  CAT-F-04; not a standalone finding.
+- **`respecCrafting` cost validation** — wire payload is empty
+  (`<respecCrafting><Exposed/></respecCrafting>`); cost comes from
+  `onCraftingRespecPrompt` server→client and is a server-side
+  resources lookup. Today the handler is a no-op stub; future
+  implementer's risk is captured in CAT-F-06 (validation-before-mutation
+  discipline). Not a separate finding.
+- **`onUpdateDiscipline` / `onUpdateKnownCrafts` wire shape** — these
+  are server→client, not in our adversarial-input scope. The
+  generated decoders exist at
+  `crates/services/src/wire_log/decoders/generated.rs:1327` for
+  observability only.
+- **`GiveBlueprint` / `GiveAppliedSciencePoints` / `GiveTrainingPoints`
+  / `GiveRacialParadigmLevels` / `GiveExpertise` GM commands** — these
+  are in CAT-N's scope (GM debug commands); already enumerated in the
+  surface inventory under CAT-N. None are wired in Rust today; their
+  authentication will be audited under CAT-N.
+- **`gainAppliedSciencePoints` / `updateCraftingFlags` BASE-side methods**
+  — these are server-internal RPCs invoked by content-engine actions
+  (level-up, mission rewards), not client-facing. Trust-boundary
+  analysis is internal-RPC scope, not adversarial-client scope.
+- **Concurrency safety of `CraftingState` load/save (existing
+  persistence layer)** — the `load_crafting_state` / `save_crafting_state`
+  in `crates/services/src/base/crafting/persistence.rs` are already
+  transactional and use `RowNotFound` to guard silent-no-op saves.
+  No exploit shape applies until a writer calls them (Phase 2).
+- **Wire-format truncation handling** — the stubs check `args.len() >=
+  4` before parsing. The error path is `warn!` + `return true`. A
+  client that sends 0 bytes on craft (msg 96) gets a warn-log but no
+  exploit shape today; future Phase 2 must keep the length check as
+  the first gate, not the last.
+- **Cell `_space_mgr` parameter is `&mut` but unused (`_space_mgr`)**
+  in the stub. This is fine for Phase 1; Phase 2 will use it. Not a
+  finding.

--- a/docs/security-audit/2026-05-31-server-authority/findings/CAT-G-mail.md
+++ b/docs/security-audit/2026-05-31-server-authority/findings/CAT-G-mail.md
@@ -1,0 +1,348 @@
+# CAT-G — Mail (server-authority audit)
+
+## Trust posture summary
+
+The SGW mail surface is **functionally unimplemented** server-side for every
+mutating operation that touches currency or items: `sendMailMessage`,
+`takeCashFromMailMessage`, `takeItemFromMailMessage`, `payCODForMailMessage`,
+and `returnMailMessage` are all stubbed (`tracing::info!("UNIMPLEMENTED: …")`)
+in `crates/services/src/cell/cell_methods/mail.rs`. Only header listing
+(`requestMailHeaders`), body reads (`requestMailBody`), `archiveMailMessage`,
+and `deleteMailMessage` execute against the DB.
+
+This is a security-relevant state for two reasons:
+
+1. The dispatcher's no-op stubs return `true` (handled), so the client gets
+   no `sendMailResult` failure path. A future implementer who fills in the
+   handler bodies inherits a wire surface that already accepts every
+   client-asserted field (recipient list, cash, COD flag, item_id, item
+   quantity, mail_id-on-take, mail_id-on-pay-COD) **with no validation
+   plumbed in**. The decoder structure in `cell/cell_methods/mail.rs`
+   reads `mail_id` / `container_id` / `slot_id` straight out of the LE
+   bytes and forwards them; there is no model for "validate the mail
+   belongs to the caller before the take/pay/return executes" anywhere
+   in the file. Whoever wires the send/take/COD paths next will, by
+   default, build a TOCTOU-shaped duplication exploit unless they
+   re-derive the invariants from scratch.
+2. The implemented surface (headers / body / archive / delete) correctly
+   scopes by `character_id = $player_id` where `player_id` is
+   server-resolved via `resolve_mail_player_id()` (cell/mail.rs:20-28),
+   which refuses to fall back to 0 — that defends against the "send
+   ops with player_id=0 sentinel" foot-gun. The `entity_id` carried in
+   the cell-method 4-byte prefix is parsed but immediately discarded in
+   favor of `player_eid` from the connected-client session record
+   (base/connect_loop/cell_arms.rs:64-89,121-138), so a client cannot
+   route a mail op against another player's mailbox via spoofed
+   entity_id.
+
+The dominant finding for this category is therefore "an entire mail vertical
+will land as an exploit chain the moment it is implemented" — the audit
+flags the missing-validation surface so it gets caught at implementation
+time rather than after merge. Two secondary findings cover the unread-time
+UPDATE shape and the `ToText` field mis-fill.
+
+---
+
+### CAT-G-01 — sendMailMessage handler is unimplemented but dispatcher reports "handled"
+
+**Severity**: High (latent — becomes Critical when handler body is filled in without validation)
+**Class**: Missing handler / silent client trust
+**Wire surface**: `Event_NetOut_SendMailMessage` (CellMethod index 44)
+**Demonstrable / Likely-theoretical**: Demonstrable (the absence of any server-side `INSERT INTO sgw_gate_mail` path is observable)
+
+**Trust violation**
+The client emits `Event_NetOut_SendMailMessage` carrying eight client-asserted
+fields: `RecipientFlags: INT32`, `Recipients: ARRAY<WSTRING>`, `Subject:
+WSTRING`, `Body: WSTRING`, `Cash: INT32`, `bCOD: UINT8`, `ItemId: INT32`,
+`ItemQuantity: INT32` (per `entities/defs/interfaces/SGWMailManager.def:56-66`).
+The server-side dispatcher accepts the method (returns `true`), logs
+`UNIMPLEMENTED: sendMailMessage`, and silently drops the bundle. There is
+no server-side debit of sender cash, no inventory removal, no recipient-
+name resolution, no recipient-mailbox-full check, no bounded recipient-array
+length check, no `INSERT INTO sgw_gate_mail`. The next implementer inherits
+a wire shape where every field is whatever the client wrote.
+
+**Evidence**
+- Ghidra: `019bf2e0` / `019caf68` — string `Event_NetOut_SendMailMessage`; client emits via `SGWNetworkManager::EventHandler<Event_NetOut_SendMailMessage>` (vtable at `01e2bb20`); the field list comes from the entity def (authoritative for wire shape since it is the data the BigWorld code-gen reads).
+- Client behavioral log: n/a (mail send is a UI path; no log emitted by the QA client without a UI-triggered send).
+- Cross-ref to Rust handler (for fix author): `crates/services/src/cell/cell_methods/mail.rs:32-35` — `SEND_MAIL_MESSAGE` arm is a single `tracing::info!("UNIMPLEMENTED: sendMailMessage")` plus `return true`.
+
+**Attack scenario** (once implemented without validation)
+1. Modified client crafts `Event_NetOut_SendMailMessage` with `Recipients = ["self_alt_char"]`, `Cash = i32::MAX`, `ItemId = <equipped weapon's item_id>`, `ItemQuantity = 1`, `bCOD = 0`.
+2. Server inserts the mail row and (in a naive implementation) credits the recipient on take without ever debiting the sender, or removes the item from the sender then writes the recipient row, but uses `type_id` instead of `item_id` and grants the alt a clone of the source weapon.
+3. Observable effect: cash dupe, item dupe, or cross-account transfer with no audit trail.
+
+**Suggested remediation (one line)**
+Before implementing `sendMailMessage`, file the validation contract: (a) recipient names resolved via DB, not client; (b) `Cash` clamped non-negative and atomically debited from `sgw_player.naquadah` in the same transaction as the `INSERT INTO sgw_gate_mail`; (c) attachment item moved by `item_id` (the row PK), never by `type_id`; (d) `Recipients` array bounded to e.g. 10 entries; (e) per-recipient mailbox-full check before insert; (f) atomic-or-rollback semantics on partial failure; (g) send a `sendMailResult` packet on every code path (success and per-recipient failure list).
+
+**Would benefit from x64dbg trace?**
+Yes — to lock down the exact wire byte layout (in particular WSTRING length-prefix encoding and the ARRAY<WSTRING> serialization for `Recipients`) before implementation, so the eventual decoder doesn't drift from the client.
+
+---
+
+### CAT-G-02 — takeCashFromMailMessage handler is unimplemented; no atomicity model defined
+
+**Severity**: High (latent — becomes Critical when filled in without atomicity)
+**Class**: Missing handler / future TOCTOU on currency mutation
+**Wire surface**: `Event_NetOut_TakeCashFromMailMessage` (CellMethod index 49)
+**Demonstrable / Likely-theoretical**: Demonstrable (no withdraw path exists)
+
+**Trust violation**
+The client emits `Event_NetOut_TakeCashFromMailMessage` with a single
+client-supplied `MailId: INT32` (per `SGWMailManager.def:85-88`). The server
+logs `UNIMPLEMENTED: takeCashFromMailMessage` and returns. There is no
+ownership check, no debit/credit, no zeroing of the `cash` column to prevent
+re-take, and no transactional guard against the take-cash + take-item
+double-claim window (see CAT-G-04).
+
+**Evidence**
+- Ghidra: `019bf380` — string `Event_NetOut_TakeCashFromMailMessage`; registered NetOut handler at `00d68150` family.
+- Client behavioral log: n/a.
+- Cross-ref to Rust handler: `crates/services/src/cell/cell_methods/mail.rs:68-74`.
+
+**Attack scenario** (once implemented without atomicity)
+1. Client sends `takeCashFromMailMessage(mail_id=N)` twice in rapid succession before the server's "set cash=0" UPDATE has committed.
+2. Server reads `cash=500` twice, credits player twice (`+1000`), then both UPDATEs zero the row.
+3. Observable effect: cash dupe equal to the attachment value × concurrency.
+
+**Suggested remediation (one line)**
+Implement as a single `UPDATE sgw_gate_mail SET cash=0 WHERE mail_id=$1 AND character_id=$2 AND cash>0 RETURNING cash` and credit the player only if `rows_affected == 1` and `RETURNING cash > 0` — the row-level lock + conditional `cash>0` makes the second concurrent request a no-op.
+
+**Would benefit from x64dbg trace?**
+No — the wire shape is trivially a single INT32; the work is purely server-side design.
+
+---
+
+### CAT-G-03 — takeItemFromMailMessage handler is unimplemented; no inventory-full / ownership / item_id checks
+
+**Severity**: High (latent — Critical when implemented naively)
+**Class**: Missing handler / future item dupe via TOCTOU
+**Wire surface**: `Event_NetOut_TakeItemFromMailMessage` (CellMethod index 50)
+**Demonstrable / Likely-theoretical**: Demonstrable
+
+**Trust violation**
+The client sends `MailId: INT32`, `ContainerId: INT32`, `SlotId: INT32`
+(per `SGWMailManager.def:89-94`). The dispatcher decodes all three from
+client bytes and logs UNIMPLEMENTED. `ContainerId` and `SlotId` are
+client-asserted destination coordinates for the moved item — these MUST
+be validated against the caller's actual container/slot table and against
+inventory-full at the destination, not blindly used. The mail row's
+`item_id` is the authoritative source PK and must be the key for the
+move, not the (mail_id, type_id) pair (see the canonical TOCTOU pattern
+recorded for inventory mutations — bandolier same-type swap).
+
+**Evidence**
+- Ghidra: `019bf3a8` — string `Event_NetOut_TakeItemFromMailMessage`; registered NetOut handler at `00d68210`.
+- Client behavioral log: n/a.
+- Cross-ref to Rust handler: `crates/services/src/cell/cell_methods/mail.rs:75-89`.
+
+**Attack scenario** (once implemented without item_id-keyed move + inventory-full check)
+1. Client sends `takeItemFromMailMessage(mail_id, container_id=<bandolier>, slot_id=<an occupied slot of same type>)`.
+2. Naive implementation overwrites the destination slot's item record using `type_id` matching, losing or cloning the equipped weapon's item row.
+3. Observable effect: ammo dupe / item overwrite / item dupe.
+
+**Suggested remediation (one line)**
+Move the item by `sgw_gate_mail.item_id` (DB row PK) into a `(container_id, slot_id)` validated against the caller's owned containers and against destination slot vacancy in a single transaction; null out `sgw_gate_mail.item_id` in the same UPDATE; consult `social-systems-engineer` for the mail-item state machine and item-lock invariants shared with trade/auction.
+
+**Would benefit from x64dbg trace?**
+Yes — to confirm whether the client's `ContainerId` is an int matching `sgw_player_containers.container_id` or a logical bandolier slot index, since the spec doesn't disambiguate.
+
+---
+
+### CAT-G-04 — Mail attachment double-take: take-cash + take-item flows are not coupled
+
+**Severity**: High (latent — emerges as soon as both handlers are filled in independently)
+**Class**: TOCTOU / cross-handler race on the same row
+**Wire surface**: `Event_NetOut_TakeCashFromMailMessage` + `Event_NetOut_TakeItemFromMailMessage`
+**Demonstrable / Likely-theoretical**: Likely-theoretical (both are unimplemented today; the dispatcher decoders treat them as two unrelated handlers; if implemented as two independent UPDATEs they will race)
+
+**Trust violation**
+The two take-paths share one DB row (`sgw_gate_mail.cash` + `sgw_gate_mail.item_id`).
+A correctly-implemented mail system must coordinate them: either by
+zeroing both columns in a single UPDATE on first-take, or by an
+explicit "claim" semaphore (e.g., `flags` bit "attachments_collected").
+The current dispatcher decodes the two as unrelated indices (49 vs 50)
+and forwards independently; nothing in the codebase yet ties them
+together. A future implementer who writes one path and then the other
+without re-reading both at the same time will produce a race in which
+a fast client sends both back-to-back and the server processes them
+against two reads of the same row.
+
+**Evidence**
+- Ghidra: `Event_NetOut_TakeCashFromMailMessage` at `019bf380`, `Event_NetOut_TakeItemFromMailMessage` at `019bf3a8` — two distinct client events with no shared client-side guard against double-emission. Client code path is per-attachment UI button.
+- Cross-ref to Rust handler: `crates/services/src/cell/cell_methods/mail.rs:68-89` — two independent arms; no shared `with_mail_lock(mail_id, ...)` pattern.
+
+**Attack scenario** (after independent implementation)
+1. Mail has both cash=500 and item_id=X attached.
+2. Client sends both `takeCashFromMailMessage(N)` and `takeItemFromMailMessage(N, c, s)` in the same Mercury bundle.
+3. If handlers commit in two transactions and the cash-zero UPDATE races with the item-null UPDATE, one or both can succeed without the other; worse, a third take-cash request in the same bundle could find cash still set.
+
+**Suggested remediation (one line)**
+Both handlers should `BEGIN; SELECT ... FOR UPDATE; UPDATE; COMMIT` on the same row, and the per-attachment fields should be cleared in the same statement — or introduce a `flags` bit `ATTACHMENTS_COLLECTED` that gates both takes and is set in the same UPDATE that moves the last attachment.
+
+**Would benefit from x64dbg trace?**
+No — pure server-side state-machine design.
+
+---
+
+### CAT-G-05 — payCODForMailMessage handler is unimplemented; client can later supply $0 COD
+
+**Severity**: High (latent — Critical if implementer trusts a client-supplied amount)
+**Class**: Missing handler / price-from-client-not-from-row
+**Wire surface**: `Event_NetOut_PayCODForMailMessage` (CellMethod index 51)
+**Demonstrable / Likely-theoretical**: Likely-theoretical (handler unimplemented today, but the def shows the client only sends `MailId`)
+
+**Trust violation**
+The wire-defined args list for `payCODForMailMessage` is `MailId: INT32`
+only (per `SGWMailManager.def:95-98`) — meaning the COD amount itself
+is NOT client-supplied; it must come from the row's `cash` column
+(re-purposed as COD when the `bCOD` flag was set at send time). If
+the future implementer instead reads any payload-supplied price (e.g.
+by widening the args list to match a "natural" expectation), the
+client can claim attachments for free.
+
+**Evidence**
+- Ghidra: `019bf3d0` — string `Event_NetOut_PayCODForMailMessage`; registered NetOut handler at `00d68230`. Entity-def args list (single INT32) at `entities/defs/interfaces/SGWMailManager.def:95-98`.
+- Cross-ref to Rust handler: `crates/services/src/cell/cell_methods/mail.rs:90-95`.
+
+**Attack scenario** (after implementation that trusts client price)
+1. Modified client sends `payCODForMailMessage(mail_id)` with a widened payload that includes `client_cod_amount=0`.
+2. If the server reads the client-supplied amount instead of `sgw_gate_mail.cash`, the claimer pays $0 and receives the attachment; the original sender is credited $0.
+3. Observable effect: COD bypass / fraud across the player economy.
+
+**Suggested remediation (one line)**
+The COD amount must be read from `sgw_gate_mail.cash WHERE mail_id=$1 AND character_id=$caller AND (flags & COD_FLAG) <> 0` and used as the authoritative price; the caller's cash must be debited and the sender's credited atomically with the attachment move, in one DB transaction with row-level locks; reject if the claimer has insufficient cash before any write.
+
+**Would benefit from x64dbg trace?**
+No — the wire shape (single INT32) is fixed by the def.
+
+---
+
+### CAT-G-06 — returnMailMessage handler is unimplemented; future bug-shape is attachment-loss or original-sender substitution
+
+**Severity**: Medium (latent — Critical only if implementer ignores `sender_id` resolution)
+**Class**: Missing handler / future trust-on-client-for-sender
+**Wire surface**: `Event_NetOut_ReturnMailMessage` (CellMethod index 47)
+**Demonstrable / Likely-theoretical**: Demonstrable that the handler is missing.
+
+**Trust violation**
+`returnMailMessage(MailId)` reads only the client-supplied mail_id (per
+`SGWMailManager.def:75-78`). The destination of the return is the row's
+`sender_id` column — never a client-supplied identifier. A future
+implementer who reaches for `sgw_gate_mail.sender_name` (a free-form
+WSTRING that may be stale or never validated at send-time, depending on
+how Send is implemented) instead of `sender_id` will route the return
+to the wrong character. Additionally, if the return path moves
+attachments back to the original sender without atomicity (item move +
+cash credit + delete original row), the attachments can be lost on a
+partial failure.
+
+**Evidence**
+- Ghidra: `019bf360` — string `Event_NetOut_ReturnMailMessage`; registered NetOut handler at `00d681d0`.
+- Cross-ref to Rust handler: `crates/services/src/cell/cell_methods/mail.rs:52-58`.
+
+**Attack scenario**
+1. Player A receives mail from Player B (cash+item attached). A modifies their client to send `returnMailMessage(N)`.
+2. If the return implementation creates a new mail row addressed to `sender_name` (string-keyed) and another character with that name (or a near-collision via Unicode normalization) exists, the attachments can be redirected.
+3. Observable effect: cross-account attachment redirection if `sender_name` is taken as authority instead of `sender_id`.
+
+**Suggested remediation (one line)**
+Implement return as `INSERT ... SELECT` keyed on `sender_id` (integer PK) of the original mail row, never on `sender_name`; wrap the original-row delete and the new-row insert in a single transaction; reject if `sender_id IS NULL` (system mail).
+
+**Would benefit from x64dbg trace?**
+No — wire shape is single INT32.
+
+---
+
+### CAT-G-07 — RequestMailBody read_time UPDATE lacks character_id filter (defense-in-depth)
+
+**Severity**: Low
+**Class**: Defense-in-depth gap on a multi-statement query
+**Wire surface**: `Event_NetOut_RequestMailBody` (CellMethod index 48)
+**Demonstrable / Likely-theoretical**: Likely-theoretical (mitigated upstream by the SELECT, but the UPDATE alone is unscoped)
+
+**Trust violation**
+In `crates/services/src/base/world_entry/methods/mail/mod.rs:191-200`
+the read-time stamp UPDATE is:
+
+```sql
+UPDATE sgw_gate_mail SET read_time = $1 WHERE mail_id = $2 AND read_time = 0
+```
+
+— **no `character_id = $player_id` filter**. The UPDATE is currently
+gated by the preceding SELECT (which IS scoped by `character_id`)
+returning `Some`, so today this is unreachable for foreign mailboxes.
+But it's a TOCTOU-shaped gap: if the SELECT scoping is ever refactored
+away (e.g. a future change reads "headers cache" first), the UPDATE
+will silently mark other players' mail as read.
+
+**Evidence**
+- Decoder in `cell/cell_methods/mail.rs:59-67` accepts `mail_id` from client bytes with no validation.
+- Cross-ref to Rust handler: `crates/services/src/base/world_entry/methods/mail/mod.rs:155-200`.
+
+**Attack scenario** (regression-shaped)
+1. A future refactor moves the SELECT into a cache lookup or drops the `AND character_id = $2` clause.
+2. Client iterates `mail_id` from 1..N and force-marks every player's unread mail as read.
+3. Observable effect: cross-mailbox griefing (unread-flag denial of service) — does not leak content, just resets the visual unread indicator.
+
+**Suggested remediation (one line)**
+Add `AND character_id = $3` to the UPDATE and bind `player_id` — the UPDATE then defends itself, independent of the SELECT.
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-G-08 — onMailRead `ToText` filled with caller's own name (info leak nil, but spec drift)
+
+**Severity**: Low (information-quality drift, not a security issue)
+**Class**: Spec/wire mismatch
+**Wire surface**: `onMailRead` server→client response (ClientMethod index 78)
+**Demonstrable / Likely-theoretical**: Demonstrable
+
+**Trust violation**
+The wire `onMailRead.ToText` field is documented as "recipient name"
+in `entities/defs/interfaces/SGWMailManager.def:42` (and in
+`crates/services/src/cell/mail.rs:182-201`). The handler at
+`base/world_entry/methods/mail/mod.rs:202-209` fills it from
+`lookup_player_name()`, which returns the **reader's** name (i.e.
+the caller's own player_name), not the recipient the mail was
+originally addressed to. For self-read mail the value is correct
+incidentally. For any future cross-account or system-mail case
+where reader != recipient, the field is wrong.
+
+This is not a security finding by itself (the reader is shown their
+own name in their own mail UI; no foreign data leaks). It is filed
+because a future implementer will look at this code, conclude
+"ToText is already wired", and not notice that it doesn't actually
+reflect the original `Recipients` array. When the client UI uses
+ToText for "Reply To" semantics, the wrong field can populate the
+reply target.
+
+**Evidence**
+- Entity def: `entities/defs/interfaces/SGWMailManager.def:42` says `ToText` is recipient.
+- Cross-ref to Rust handler: `crates/services/src/base/world_entry/methods/mail/mod.rs:202-209` — uses caller's own name.
+
+**Attack scenario**
+None directly exploitable today.
+
+**Suggested remediation (one line)**
+Populate `ToText` from the original mail row's stored recipient name
+once `sendMailMessage` persists `Recipients` (add column `recipient_name`
+to `sgw_gate_mail` or use the existing `character_id`→`sgw_player.player_name`
+join), and revisit the field's intended meaning with social-systems-engineer.
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+## Not Filed
+
+- **`b_archive` not applied as filter in RequestMailHeaders query.** Headers SELECT does not filter by archive flag — returns all mail regardless of client's `bArchive` byte. This is a functional/UX bug (archive folder shows inbox content), not a security issue: it doesn't leak foreign-player data because `character_id = $player_id` is enforced.
+- **`onMailHeaderInfo` always emits empty `MessageAttachments` array.** `serialize_on_mail_header_info` hard-codes `attachments count = 0u32` regardless of the row's `cash` / `item_id`. Feature gap (attachments UI cannot show on header), not a security issue.
+- **`if args.len() >= 4` decoder silently drops malformed cell-method args.** Every short-payload mail handler returns without acknowledging the bad packet to the client. Not exploitable — the client has no observable signal it can act on; only operator-side logging is affected, and the dispatcher's framing layer upstream already enforces packet integrity.
+- **`lookup_player_name` two-mutex lookup race.** `entity_to_addr` is released before `connected` is acquired. Worst case is an empty player_name string in `onMailRead.ToText` if disconnect interleaves. Not exploitable; covered by CAT-G-08 from a separate angle.
+- **`sgw_gate_mail` lacks a `recipient_name` column or any uniqueness on `(character_id, sent_time)`.** Schema-level gap that will matter for sendMailMessage but is upstream of any current handler. Out of scope for category G's per-handler audit; route to the social-systems-engineer when send is implemented.
+- **Read_time `cash` truncation warning at headers query** (`mod.rs:100-107`). DB column is `bigint`, wire is `i32`. The clamp+warn path is correct; no exploit.
+- **Entity-id from client decoded then discarded.** `cell_arms.rs:87-88` reads `entity_id_from_client` but `cell_arms.rs:121-138` forwards `player_eid` from the connected session. Server-authority is intact; the read is for diagnostic logging only. Filing the absence-of-bug for context, not as a finding.

--- a/docs/security-audit/2026-05-31-server-authority/findings/CAT-H-trade.md
+++ b/docs/security-audit/2026-05-31-server-authority/findings/CAT-H-trade.md
@@ -1,0 +1,731 @@
+# CAT-H — Trade (P2P) — Findings
+
+## Overall trust posture
+
+**The Rust server has no trade implementation at all.** All four client-callable
+trade RPCs (`tradeRequest`, `tradeRequestCancel`, `tradeUpdateProposal`,
+`tradeLockState`) dispatch to a single `match` arm in
+`crates/services/src/cell/cell_methods/player/social.rs` that decodes the leading
+4–9 header bytes, logs `UNIMPLEMENTED:`, and returns `true` (handled). The handler
+never decodes the `LocalTradeProposal` payload (item list + cash + lockState), never
+allocates a `TradeTransaction`, never validates the partner exists / is in range /
+is alive / is a player, never locks items, never emits the corresponding
+server-to-client `onTradeState` (method 144) or `onTradeResults` (method 145), and
+never persists or reconciles anything to inventory.
+
+This is a "wire exposed but unimplemented" posture — the same shape that, in MMO
+history, has produced silent dupe vectors when the handler is filled in piecewise
+without the dedicated state machine, because the wire shape encourages the author
+to trust the client's view of "what I put in the window" rather than building a
+server-authoritative escrow. The Python reference at
+`deprecated/python/cell/Trade.py` shows how the original implementers attempted it
+(version-numbered proposals, lock-state re-arming, in-place inventory mutation on
+confirm), and that reference itself contains several invariant gaps (no item lock,
+no disconnect handling, no `canTrade` check, no atomicity) that would carry over
+verbatim into a naive Rust port.
+
+The wire definition in `entities/defs/SGWPlayer.def:1033-1072` plus
+`entities/defs/alias.xml:355-379` (the `LocalTradeProposal`/`RemoteTradeProposal`
+FIXED_DICTs) confirms that every client-supplied trade field is fully
+attacker-controlled: `instanceId` (the item DB row id), `slotId`, `cash` (naquadah
+delta), `version`, `lockState`, and the trade partner `EntityId` — all
+client-asserted, none of them currently validated against any server-side state.
+
+The bulk of the findings below are therefore "what the server WILL need to validate
+when the handler is implemented." Because no handler exists today, the
+**demonstrable** attack is degenerate: the bytes are consumed and ignored, no item
+movement occurs, no dupe results. The **likely-exploitable theoretical** findings
+all become demonstrable the moment a developer fills in the match arms without the
+named server-side invariant. Treat this category as "the handler authors will need
+these explicit guardrails before the trade UI is unblocked client-side." I list
+them so the implementer can pre-load the regression-guard list rather than
+discovering each vector by review round-trip.
+
+A cross-disciplinary consult with `social-systems-engineer` is strongly recommended
+before any of these are filled in — trade state machines, item-lock invariants, and
+deadlock-on-disconnect are their domain.
+
+---
+
+### CAT-H-01 — Entire trade RPC surface is silently consumed, no server-authoritative state machine exists
+
+**Severity**: High (foundational — every subsequent finding rides on this)
+**Class**: Missing handler / silent ack
+**Wire surface**: `Event_NetOut_TradeRequest`, `Event_NetOut_TradeProposal`,
+`Event_NetOut_TradeLockState`, `Event_NetOut_TradeRequestCancel`
+**Demonstrable / Likely-theoretical**: Demonstrable (the unimplemented stub is the
+present behavior; the danger is the next PR that fills it in piecewise)
+
+**Trust violation**
+The four `Exposed` trade methods on `SGWPlayer.def` (lines 1034, 1047, 1053, 1067)
+are dispatched by `crates/services/src/cell/cell_methods/player/social.rs:103-149`
+to a `match` arm that logs `UNIMPLEMENTED:` and returns `true` (handled). The
+handler decodes only the leading INT32 (target EntityId, or LocalVersionId for
+tradeLockState) and never touches the rest of the wire payload. There is no
+`TradeTransaction` struct anywhere in `crates/` (grep for
+`trade_transaction|TradeTransaction|trade_session` returns zero matches outside the
+deprecated Python reference). No server-side trade response is ever emitted:
+`onTradeState` (method 144) and `onTradeResults` (method 145) are defined as
+constants in `crates/services/src/cell/client_methods/player.rs:96,98` and decoded
+by `wire_log/decoders/generated.rs` but no production code path emits them.
+
+**Evidence**
+- Ghidra: `019d898c`, `019d89c0`, `019d89f0` — strings
+  `Event_NetOut_TradeRequestCancel`, `Event_NetOut_TradeLockState`,
+  `Event_NetOut_TradeProposal` (the `TradeRequest` variant is name-mangled into the
+  vftable type strings at `01e2c224`, `01e37fb8`).
+  `00d68330` `SGWNetworkManager_VEvent_NetOut_TradeRequest___EventHandler__vfunc_0`
+  + sibling vfunc destructors at `00d68350`/`00d68370`/`00d68390` confirm the
+  client wires all four into the standard `SGWNetworkManager::EventHandler<T>`
+  Mercury emit pipeline. The client UI verbs (`requestTrade`, `cancelTrade`,
+  `setTradeItem`, `setTradeCash`, `setTradeLockState`, `removeTradeItem`) at
+  `01952a70`, `01952a58`, `01952a3c`, `019529b4`, `01952944`, `019529d0` are wired
+  into a button handler at `00ad5b7c` (CEGUI button-base 3), confirming UI is
+  fully present.
+- `entities/defs/SGWPlayer.def:1034-1072` — the four `<Exposed/>` trade methods'
+  signatures (the wire shape, authoritative).
+- `entities/defs/alias.xml:356-379` — `LocalTradeProposal`/`RemoteTradeProposal`
+  FIXED_DICT payload shapes.
+- Client behavioral log: n/a (trade UI requires a partner online; not exercised in
+  the most recent `SGWDebugLog.log`).
+- Cross-ref to Rust handler (for the fix author, NOT as truth):
+  `crates/services/src/cell/cell_methods/player/social.rs:103-149`.
+
+**Attack scenario**
+1. Player A clicks Trade on Player B in the client UI.
+2. Client emits `tradeRequest(B.entityId, LocalTradeProposal{version:1,
+   items:[], cash:0, lockState:0})`.
+3. Server logs `UNIMPLEMENTED: tradeRequest` and returns. No `onTradeState`
+   reply is sent.
+4. Observable effect on the server: nothing. Observable effect on Player A:
+   client likely hangs in the "waiting for partner" UI state, because the
+   client-side state machine in `Trade@@` (Ghidra) is expecting an
+   `onTradeState` callback from the server. Player B is never told a trade was
+   requested.
+
+This is benign today **only because the handler stub does nothing else**. The
+moment any subsequent PR fills in even part of this surface (e.g. "emit
+`onTradeState` so the UI doesn't hang") without the full escrow state machine, the
+class of exploits in CAT-H-02 through CAT-H-09 become live.
+
+**Suggested remediation (one line)**
+Do not begin filling in any of the four `match` arms in `social.rs` until the
+server-side `TradeTransaction` (escrow with item-lock table, version-counter
+arbiter, disconnect rollback) exists and is unit-tested; route the redesign back
+to `social-systems-engineer`.
+
+**Would benefit from x64dbg trace?**
+Yes — trace the client's `Trade@@` state machine through `requestTrade` →
+`onTradeState` round-trip to pin the exact serializer for `LocalTradeProposal`
+(item array element count, endian, FIXED_DICT framing) so the Rust handler decodes
+it byte-exact when implemented.
+
+---
+
+### CAT-H-02 — `tradeRequest` will trust client-supplied target `EntityId` without same-space / range / alive / is-player check
+
+**Severity**: High (when handler is implemented)
+**Class**: Missing target validation
+**Wire surface**: `Event_NetOut_TradeRequest` (cell method 104)
+**Demonstrable / Likely-theoretical**: Likely-theoretical (handler is a stub today;
+the trust violation becomes demonstrable on first fill-in)
+
+**Trust violation**
+`tradeRequest` takes an arbitrary client-supplied INT32 EntityId
+(`SGWPlayer.def:1036`). The Rust stub at `social.rs:104-108` reads the id and logs
+it; no validation against `space_mgr.find_entity(id)`, no class check (is it an
+`SGWPlayer`?), no spatial proximity check, no `isAlive`/`isInCombat` filter, and no
+"target is not already trading" check. The deprecated Python at
+`deprecated/python/cell/SGWPlayer.py:1685-1700` (the reference for what the design
+once enforced) imposed: same-space, `distanceTo(self.position) >
+MAX_INTERACT_DISTANCE`, `partner.isTrading()`, `partner is SGWPlayer`, and
+`entityId != self.entityId`. None of those are wired in Rust yet.
+
+**Evidence**
+- Ghidra: `019d89f0` `Event_NetOut_TradeProposal` (and the `Trade@@` C++ class
+  whose vftable mentions `setTradeItem`/`setTradeCash`) — the client supplies the
+  EntityId from the local target selection. There is no client-side enforcement
+  that the target is in range; the UI button just emits whatever target id is
+  currently selected.
+- `entities/defs/SGWPlayer.def:1036` — `INT32 EntityId` is the only target field;
+  client-controlled.
+- Cross-ref to Rust handler: `crates/services/src/cell/cell_methods/player/social.rs:103-109`.
+
+**Attack scenario**
+1. Adversary selects a target via Tab and notes the entity id.
+2. Adversary walks across the map, well past `MAX_INTERACT_DISTANCE`.
+3. Adversary emits `tradeRequest(remote_target_id, LocalTradeProposal{...})`.
+4. If the future handler accepts without range check: the trade window opens
+   regardless of distance, enabling long-range dupe-coordination (one mule
+   character stays in town, the other roams; items move freely).
+5. Worse variants: send `tradeRequest` with the EntityId of a vendor NPC, a mob,
+   a corpse, or the player's own id (self-trade — see CAT-H-08).
+
+**Suggested remediation (one line)**
+On handler implementation, gate with `space_mgr.find_entity(target).is_player() &&
+in_same_space && distance <= MAX_INTERACT_DISTANCE && target.is_alive() &&
+!target.is_trading() && target != self.entity_id` before allocating the
+`TradeTransaction`.
+
+**Would benefit from x64dbg trace?**
+No — wire shape is fully known from the .def.
+
+---
+
+### CAT-H-03 — `tradeUpdateProposal` payload (item list, cash, lockState) is fully decoded client-side and currently never validated server-side; will be the primary dupe surface once handler exists
+
+**Severity**: Critical (when handler is implemented)
+**Class**: TOCTOU / missing item-ownership re-check / missing item-lock invariant
+**Wire surface**: `Event_NetOut_TradeProposal` (cell method 106 — note: the wire
+name is `tradeUpdateProposal` despite the `Event_NetOut_TradeProposal` class
+naming)
+**Demonstrable / Likely-theoretical**: Likely-theoretical (stub today)
+
+**Trust violation**
+The `LocalTradeProposal` FIXED_DICT (`entities/defs/alias.xml:363-370`) carries
+`{INT32 version, ARRAY<LocalTradeItem{INT32 instanceId, INT32 slotId}> items,
+INT32 cash, INT8 lockState}` — all four fields client-supplied. The Rust stub at
+`social.rs:123-133` reads only the leading INT32 (the partner EntityId, before the
+payload starts) and discards the rest. When implemented, the handler MUST:
+
+1. Verify each `instanceId` resolves to an item row currently owned by the caller
+   (server-side inventory query, not client claim).
+2. Verify the item is not bind-on-acquire / bind-on-equip-bound to the caller
+   (`ITEM_FLAG_BindOnAcquire = 4`, `ITEM_FLAG_BindOnEquip = 8` per
+   `deprecated/python/Atrea/enums.py:794-795`). The Python reference at
+   `cell/Trade.py:49` punts on this with a literal `TODO: Do we need a separate
+   canTrade() ?`. Answer: yes — and the canonical SGW client-side flag must be
+   re-checked server-side.
+3. Verify each item is **not currently locked in another transaction** (vendor
+   sale in flight, mail attach in flight, another trade in flight, currently
+   equipped — see CAT-H-07).
+4. Verify the same `instanceId` does not appear twice in the items array (the
+   Python reference at `cell/Trade.py:53-55` warns and skips dupes; a Rust port
+   should *reject the whole proposal*, not silently filter, because the silent
+   filter means the client and server disagree on what's in the window).
+5. Verify `cash` is non-negative and `cash <= self.inventory.naquadah` at this
+   instant.
+6. Verify `version == server_known_version + 1` — single-step monotonic.
+7. Re-check (1)/(5) at lock-confirm time, because the player can drop / use / sell
+   the item *between* `tradeUpdateProposal` and `tradeLockState` if the item is
+   not locked at proposal time.
+
+The crucial dupe-prevention invariant (3) — **lock items into escrow at
+proposal-update time** — is absent from the Python reference and would be absent
+from a naive Rust port that copies it. The deprecated reference at
+`cell/Trade.py:67-74` only removes items from inventory at the *confirm* step
+(after both sides lock and confirm). Between proposal and confirm, the items are
+duplicatable via concurrent vendor-sell, mail-attach, drop, or use.
+
+**Evidence**
+- `entities/defs/alias.xml:355-370` — `LocalTradeProposal` FIXED_DICT contents,
+  every field client-supplied.
+- `entities/defs/SGWPlayer.def:1053-1057` — Exposed RPC signature.
+- Ghidra: `019d89f0` `Event_NetOut_TradeProposal`; the `Trade@@` C++ class on the
+  client (mangled type `.?AVTradeState@@` at `01de9594` and the UI verbs
+  `setTradeItem`/`removeTradeItem` at `01952a3c`/`019529d0`) constructs the
+  `items` array from the local inventory model — fully attacker-modifiable.
+- Cross-ref to Rust handler: `crates/services/src/cell/cell_methods/player/social.rs:123-133`.
+
+**Attack scenario** (assuming a naive future implementation that copies the Python
+reference's lock-at-confirm semantics)
+1. A and B initiate trade. A puts InstanceId I (a rare item) into the proposal
+   and locks. Server records: A's window contains I.
+2. A simultaneously opens vendor UI and emits `SellItems(I, …)`. Vendor handler
+   (if it doesn't query the trade-lock table — there isn't one yet) sells I and
+   credits A with naquadah.
+3. A confirms the trade. Server attempts `inventory.removeItem(I, quantity, True)`
+   — fails because I no longer exists.
+4. If the server bails out gracefully: B does not receive I, trade voids — OK.
+5. If the server proceeds with the partial transfer of remaining items + cash but
+   does not re-validate (this is the dupe-shape pattern history shows in nearly
+   every "missing item lock" trade exploit): B's inventory may be credited with a
+   phantom InstanceId, or A's removed-items list silently shrinks while B's
+   credited-items list does not — duplicating I.
+
+The shape is similar to the **stack duplication via disconnect-timing** trap from
+the SGW exploit notes (in `social-systems-engineer`'s domain). Without an explicit
+escrow / item-lock table, this is unavoidable.
+
+**Suggested remediation (one line)**
+On handler implementation, lock each `instanceId` into a server-side escrow table
+at `tradeUpdateProposal` time (not at confirm time), and reject any concurrent
+vendor / mail / use / drop / move on a locked instanceId.
+
+**Would benefit from x64dbg trace?**
+Yes — confirm byte-exact `LocalTradeProposal` framing (ARRAY-of-FIXED_DICT
+length-prefix shape) before authoring the decoder, so the Rust handler doesn't
+mis-frame the array bound (a length-confusion bug could itself become a dupe
+vector).
+
+---
+
+### CAT-H-04 — `tradeLockState` `localVersionId` / `remoteVersionId` enforcement absent in stub; partial-lock acceptance is the classic dupe path
+
+**Severity**: High (when handler is implemented)
+**Class**: Version-counter desync / replay
+**Wire surface**: `Event_NetOut_TradeLockState` (cell method 107)
+**Demonstrable / Likely-theoretical**: Likely-theoretical (stub today)
+
+**Trust violation**
+`tradeLockState(INT32 LocalVersionId, INT32 RemoteVersionId, INT8 LockState)` —
+the stub at `social.rs:135-149` reads all three but does nothing. When
+implemented, the invariant (the only invariant that keeps "lock state" honest
+relative to "proposal state") is:
+
+- `LocalVersionId == server.knownLocalVersion(self)`. If they don't match, the
+  client is trying to lock a stale proposal — reject and reset the partner's
+  lock-state to None (the Python reference at `cell/Trade.py:196-199` warns and
+  returns False; a Rust port must do the same plus reset partner lock).
+- `RemoteVersionId == server.knownRemoteVersion(partner)`. The client must
+  acknowledge the partner's latest proposal version. The Python reference at
+  `cell/Trade.py:203-204` *silently downgrades* lockState to None in this case —
+  that's a UX leniency but it's also a partial-lock attack: a client can emit
+  `tradeLockState(localVersion=N, remoteVersion=N-1, lockState=Locked)` to assert
+  Locked on a stale partner proposal; the silent-downgrade behavior means the
+  server transitions to a not-quite-locked state that's still observable on the
+  partner side. Reject, don't downgrade.
+- `LockState` must be a valid `ETradeLockState` enum value (0=None, 1=Locked,
+  2=LockedAndConfirmed; `entities/defs/enumerations.xml:1784-1791`). The Python
+  reference rejects out-of-range values; the Rust stub does no enum-bound check
+  and would happily forward any signed 8-bit value into the state machine.
+
+**Evidence**
+- `entities/defs/SGWPlayer.def:1066-1072` — Exposed RPC signature, all three INT32
+  / INT8 fields client-supplied.
+- `entities/defs/enumerations.xml:1784-1791` — three legal `ETradeLockState`
+  values.
+- Ghidra: `01944d80` `#ferror in function 'setTradeLockState'`, `01952944`
+  `setTradeLockState` — the client UI verb that emits this RPC. The state machine
+  in the client (lock button → `setTradeLockState`) trusts whatever the server
+  echoes back via `onTradeState`, so a divergence here is "client-visible weird
+  UI" not "client-side rejection".
+- Cross-ref to Rust handler: `crates/services/src/cell/cell_methods/player/social.rs:135-149`.
+
+**Attack scenario** (assuming naive future implementation)
+1. A puts items+cash into the proposal, server-known LocalVersion = 5.
+2. A emits `tradeLockState(LocalVersion=5, RemoteVersion=3, LockState=2/Confirmed)`
+   while B's actual current proposal is at version 7.
+3. Server, if it silently downgrades the lock as the Python reference does,
+   records "A is Confirmed" but with stale remote view.
+4. B (the partner), seeing A as locked-and-confirmed, may also confirm. If the
+   server's `confirm()` step (`cell/Trade.py:231-273`) does not re-check that
+   `proposal.lockState == LockedAndConfirmed && partner.lockState ==
+   LockedAndConfirmed && both saw each other's latest version`, the transaction
+   fires on B's stale view.
+
+**Suggested remediation (one line)**
+On handler implementation, reject (not downgrade) on any version mismatch, and at
+`confirm()` re-verify both proposals' `lockState == LockedAndConfirmed && both
+mutual versions are current` before any inventory mutation.
+
+**Would benefit from x64dbg trace?**
+No — wire shape and enum values are fully known.
+
+---
+
+### CAT-H-05 — No transactional rollback exists for trade confirm; partial-transfer dupe is unavoidable without a single-commit invariant
+
+**Severity**: Critical (when handler is implemented)
+**Class**: Atomicity violation / partial-commit dupe
+**Wire surface**: `Event_NetOut_TradeLockState` (the confirm transition fires
+inventory mutation)
+**Demonstrable / Likely-theoretical**: Likely-theoretical (no confirm handler
+exists today)
+
+**Trust violation**
+The Python reference at `deprecated/python/cell/Trade.py:265-273` performs four
+non-atomic steps:
+
+```python
+p1.removeItems()           # 1. A's items leave A's inventory
+p2.removeItems()           # 2. B's items leave B's inventory
+p1.player.inventory.addItems(p2Items)   # 3. A gets B's items
+p2.player.inventory.addItems(p1Items)   # 4. B gets A's items
+```
+
+If any step after (1) raises, A's items are gone and B never received them — but
+also B's items may have been removed (between 2 and 3) and never delivered. A
+modified server, or any panic / DB disconnect / process kill between (1) and (4),
+produces a dupe (items credited to neither party but possibly already removed)
+or a loss (items removed from A but never added to B). The naquadah (cash) move
+is not even shown — the Python reference does it implicitly via `removeItems` of
+the cash quantity (since cash is fungible) but with the same atomicity gap.
+
+When the Rust handler is written, this must be a single DB transaction with
+rollback, executed against the inventory tables in
+`db/sgw/` (the player-inventory-item table layouts; see `db/database.sql`). The
+deprecated reference is **not safe to port directly** — it was acknowledged
+unsafe in the original codebase (see also `deprecated/python/cell/Trade.py`
+absence of any `begin`/`commit`/`rollback`).
+
+**Evidence**
+- `deprecated/python/cell/Trade.py:265-273` — the four-step non-atomic confirm
+  sequence (reference only; the *truth* is the absence of any Rust impl).
+- No transactional commit boundary in `crates/services/src/cell/cell_methods/player/social.rs`
+  because no handler exists.
+- Ghidra: the client side does not arbitrate the confirm; it simply emits
+  `tradeLockState(…, LockState=2 LockedAndConfirmed)` and waits for `onTradeResults`
+  (method 145). The server is sole arbiter of the commit boundary.
+
+**Attack scenario**
+1. A and B fully fill the trade and both lock-and-confirm.
+2. Server begins the confirm sequence: A's items removed.
+3. Server is killed (operator pulls a kill switch, OOM, network partition
+   between cell and base, anything that interrupts the four-step sequence).
+4. On recovery, A's items are gone from A's inventory and B never received them.
+5. Variant: with appropriate timing or a chunked DB write that partially commits,
+   the items may be present in both A's and B's inventory — a clean dupe.
+
+**Suggested remediation (one line)**
+Implement confirm as a single `BEGIN/COMMIT` with all four mutations (A's items
+out, B's items in, B's items out, A's items in, both naquadah deltas) in one
+transaction, with `ROLLBACK` on any error and *no* partial-success path; pair
+with an outbox so `onTradeResults` is sent only after commit.
+
+**Would benefit from x64dbg trace?**
+No — this is purely a server-side invariant.
+
+---
+
+### CAT-H-06 — Disconnect during trade has no rollback; items in escrow are lost or duplicated depending on which side dropped
+
+**Severity**: Critical (when handler is implemented)
+**Class**: Disconnect-timing dupe (canonical MMO dupe shape)
+**Wire surface**: implicit — Mercury connection drop after a `tradeLockState`
+LockedAndConfirmed but before the server commits both sides
+**Demonstrable / Likely-theoretical**: Likely-theoretical (no handler; the named
+exploit pattern is from the SGW agent memory)
+
+**Trust violation**
+This is the named **stack duplication via disconnect-timing** pattern from the
+agent memory: "During trade, a client that disconnects between the
+item-transfer commit and the counterparty-credit commit can cause one side to
+keep the item and the other to gain it. Trade flows must be transactional
+end-to-end with a rollback on disconnect."
+
+The Rust server has no disconnect→trade-cancel hook. There is no
+`TradeTransaction` to be canceled, but more importantly, when the handler is
+written, the disconnect path in `crates/services/src/base/` and
+`crates/services/src/cell/` must call into the trade module to fail-fast any
+in-progress trade, return locked items to their original owner, and emit a
+synthetic `tradeRequestCancel` to the surviving partner so their UI clears.
+
+There is currently no test surface (no live-DB chain-replay test, no Mercury
+session test) covering "A locks, B locks, A disconnects" — because there's no
+handler to test.
+
+**Evidence**
+- `crates/services/src/cell/cell_methods/player/social.rs:103-149` — stub, no
+  disconnect interaction.
+- No grep matches for `trade_transaction|TradeTransaction|trade_session` outside
+  the deprecated Python reference, confirming no escrow object exists on which a
+  disconnect cleanup could fire.
+- Agent memory: the SGW exploit-pattern catalog explicitly names this shape.
+
+**Attack scenario**
+1. A and B fully fill the trade. Both lock.
+2. A confirms (`tradeLockState(..., LockedAndConfirmed)`).
+3. Server transitions to commit. B has not yet sent the second confirm.
+4. A force-kills the network (pulls cable, kill SGW.exe, exploits a `LogOff`
+   timing — see CAT-A for `LogOff`/Disconnect interaction surface).
+5. If the server commits A's removeItems but the disconnect aborts before B's
+   addItems: A loses items, B never gets them. *Loss variant.*
+6. If the server emits `onTradeResults(Completed)` to B optimistically and a
+   queued / outbox-style replay re-fires the commit on reconnect (see also the
+   `Mercury session replay` pattern in `docs/architecture/`): A's items are
+   added to B's inventory while A's session, on reconnect, re-claims them via
+   the outbox. *Dupe variant.*
+
+**Suggested remediation (one line)**
+On handler implementation, wire `cell.on_player_disconnect(entity_id)` into a
+trade-cancel callback that locks the trade transaction with a server-side
+mutex, returns escrow items, and emits a one-shot `tradeRequestCancel`-equivalent
+to the partner — ensure the outbox **never** re-fires a `tradeLockState` or
+`onTradeResults` after the disconnect-cancel.
+
+**Would benefit from x64dbg trace?**
+Yes — observe the client's behavior on receiving `onTradeResults(Cancelled)`
+after a partial-confirm, to confirm the client cleans up its local view (no
+ghost items shown / no UI hang).
+
+---
+
+### CAT-H-07 — Items in the trade window are not locked against concurrent inventory operations (use / drop / sell / move / mail-attach)
+
+**Severity**: Critical (when handler is implemented)
+**Class**: TOCTOU dupe via concurrent inventory mutation
+**Wire surface**: any concurrent `MoveItem`, `UseItem`, `RemoveItem`, `LootItem`,
+`SellItems`, `MailAttachItem`, `RequestAmmoChange`, etc., issued while the same
+`instanceId` is present in the trade window
+**Demonstrable / Likely-theoretical**: Likely-theoretical (stub today)
+
+**Trust violation**
+A trade implementation that does not lock the item rows it references in the
+proposal window opens every other inventory mutation handler as a dupe surface.
+The deprecated Python at `cell/Trade.py:67-74` calls `inventory.removeItem` only
+at `confirm()` time — leaving an arbitrarily long window during which:
+
+- `SellItems` (CAT-E) could sell the proposed item.
+- `UseItem` (CAT-D) could consume a stackable proposed item.
+- `MoveItem` (CAT-D) could move it (and depending on bandolier semantics, also
+  manipulate the ammo row — see the `ammo_dup_via_same_type_swap_toctou` pattern
+  in the agent memory).
+- `MailSendMessage` with item attachment (CAT-G) could attach and ship the same
+  instanceId.
+
+A robust Rust implementation must add an "item-lock" guard that lives on the
+`InventoryItem` row (or a side table keyed on `item_id` — never `type_id` per the
+`bandolier_ammo_key_by_item_id_not_type_id` invariant) and is checked by **every**
+mutation path. The current Rust impl has no such table.
+
+**Evidence**
+- No matches for `item_lock|inventory_lock|escrow|trade_lock` in `crates/services/src/`.
+- Cross-ref to siblings' handlers (for fix author):
+  - `crates/services/src/cell/cell_methods/player/social.rs:123-133` (the
+    tradeUpdateProposal stub that should be locking).
+  - `crates/services/src/base/world_entry/methods/vendor/` (sells).
+  - `crates/services/src/cell/cell_methods/player/inventory.rs` (move / use /
+    remove — exact location varies; the audit cross-referenced via the file
+    inventory map at top of CAT-D-inventory).
+- Ghidra: client-side has no awareness of locking — the inventory UI happily
+  allows MoveItem on an item that is also in the trade window. The race is
+  unmistakable.
+
+**Attack scenario**
+1. A puts InstanceId I (stack of 99 ammo) into the trade window.
+2. A simultaneously emits `UseItem(I)` (it's consumed; `RequestAmmoChange`-style
+   load).
+3. A emits `tradeLockState(..., Confirmed)`. B confirms.
+4. Server confirm: `inventory.removeItem(I, 99, True)` — fails because the stack
+   is now 98 or 0.
+5. Naive future handler proceeds with partial transfer: B gains 99 ammo, A only
+   lost 98. Dupe.
+6. Variant with two items: I1 (proposed) and I2 (used). A successfully tricks
+   the partial-failure path into transferring I1 while keeping it. Dupe.
+
+**Suggested remediation (one line)**
+Implement an item-lock table keyed by `instance_id` (not `type_id`), checked by
+every inventory-mutation handler; on lock conflict, the *competing* operation
+fails fast with a typed error (not the trade).
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-H-08 — Self-trade (player trading with own EntityId) is not explicitly rejected; dupe surface if any handler short-circuits the partner lookup
+
+**Severity**: High (when handler is implemented)
+**Class**: Self-target dupe
+**Wire surface**: `Event_NetOut_TradeRequest`, `Event_NetOut_TradeProposal`
+**Demonstrable / Likely-theoretical**: Likely-theoretical (stub today)
+
+**Trust violation**
+`tradeRequest(EntityId, ...)` takes the partner's entity id. The Rust stub at
+`social.rs:103-109` does no `target_entity_id != self_entity_id` check. The
+deprecated Python at `cell/SGWPlayer.py:1685-1687` does reject self-trade, but
+the Rust port may forget. The dupe shape: if the server's "find partner" lookup
+returns `self`, and the confirm step does
+`p1.removeItems(); p1.addItems(p1Items)`, then any non-atomic ordering between
+remove and add can dupe (or worse, the lookup-returns-self case may make
+`p1Items == p2Items` so adding the same set back after removing produces an
+identity — but if there's any rounding / quantity-cap / per-type-stack overflow
+in `addItems` the second add can silently truncate while the cash credit went
+through).
+
+**Evidence**
+- `entities/defs/SGWPlayer.def:1036` — INT32 EntityId, no constraint.
+- `crates/services/src/cell/cell_methods/player/social.rs:104-109` — no self-id
+  check.
+- `deprecated/python/cell/SGWPlayer.py:1685-1687` — the prior-art rejection
+  (informational).
+
+**Attack scenario**
+1. Adversary patches the client (or scripts a raw Mercury emitter) to send
+   `tradeRequest(self.entity_id, LocalTradeProposal{items:[I1, I2], cash:N})`.
+2. Future naive handler creates a `TradeTransaction(self, self)`, allocates
+   proposals for both sides keyed by `entity_id` — and in the
+   `TradeTransaction.proposals` dict (Python reference at
+   `cell/Trade.py:122-126`) the dict literal collapses two identical keys to
+   one entry. The confirm step then operates on a degenerate transaction
+   (likely panics or silently completes with no transfer).
+3. Variants depending on Rust implementation: any path that increments cash
+   twice, any path that does
+   `inventory.add(other.items); inventory.remove(self.items)` in either order
+   when `self == other` could dupe or lose items.
+
+**Suggested remediation (one line)**
+First-line check in `tradeRequest` and `tradeUpdateProposal` handlers:
+`if target_entity_id == self_entity_id { reject; return }`.
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-H-09 — Bind-on-acquire / bind-on-equip items can be placed in the trade window; `canTrade` invariant is missing from both reference and Rust
+
+**Severity**: Medium (when handler is implemented — bypasses an item-progression
+constraint, not a dupe per se)
+**Class**: Missing item-flag enforcement
+**Wire surface**: `Event_NetOut_TradeProposal`
+**Demonstrable / Likely-theoretical**: Likely-theoretical (stub today)
+
+**Trust violation**
+SGW items carry `ITEM_FLAG_BindOnAcquire = 4` and `ITEM_FLAG_BindOnEquip = 8`
+(`deprecated/python/Atrea/enums.py:794-795`). These flags are the SGW analog of
+WoW's "soulbound" — the item should not be transferable once it's bound to the
+acquirer. The deprecated Python `cell/Trade.py:48-51` punts on this with:
+
+```python
+# TODO: Do we need a separate canTrade() ?
+if not item.canSell():
+    warn(..., "Sent unsellable item in proposal")
+    continue
+```
+
+`canSell()` is not the same as `canTrade()`. An item may be sellable to a vendor
+(it has a sale price set) but bound to the player (not tradable). Conversely,
+some items may be tradable but not sellable. The conflation in the reference is
+a bug that would carry into a naive Rust port. The Rust stub does no flag check
+at all (no decode of `InvItem` flags from the proposal payload, since the
+payload is not decoded).
+
+**Evidence**
+- `deprecated/python/Atrea/enums.py:794-795` — bind-flag definitions.
+- `deprecated/python/cell/Trade.py:48-51` — the explicit `TODO` in the reference.
+- No matches for `bind|canTrade|notrade|soulbound` in `crates/services/`.
+
+**Attack scenario**
+1. A has a high-end raid item with `ITEM_FLAG_BindOnAcquire`.
+2. A puts it in the trade window with player B.
+3. Naive handler (copying `canSell()` semantics from the Python reference): the
+   item passes the sellable check, gets included, transfers to B.
+4. Observable: a bind-on-acquire item now belongs to B. Progression bypass.
+5. Compounding factor: if B equips and rebinds it, the audit trail of who
+   originally acquired it is lost.
+
+**Suggested remediation (one line)**
+On handler implementation, add a real `can_trade(item)` predicate that returns
+false for any `ITEM_FLAG_BindOnAcquire`-set item and any
+`ITEM_FLAG_BindOnEquip`-set item that has actually been equipped; reject the
+*entire* proposal on first violation (do not silently filter).
+
+**Would benefit from x64dbg trace?**
+No — flag enforcement is server-only.
+
+---
+
+### CAT-H-10 — `tradeUpdateProposal` "no active trade session" workaround in the deprecated reference opens an out-of-band escrow vector if copied
+
+**Severity**: Medium (only if a Rust port copies the Python workaround verbatim)
+**Class**: State-machine bypass
+**Wire surface**: `Event_NetOut_TradeProposal`
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+The deprecated Python at `cell/SGWPlayer.py:1785-1790` contains:
+
+```python
+# WORKAROUND: We need to start a trade session here as the 0.8384 QA client
+# doesn't send a tradeRequest RPC at all
+if not self.isTrading():
+    if not self.beginTrading(entityId):
+        self.client.onTradeResults(entityId, Atrea.enums.Cancelled)
+        return
+```
+
+This means `tradeUpdateProposal` can implicitly *start* a trade with an arbitrary
+EntityId — bypassing the more-restrictive `tradeRequest` flow (which in some
+implementations should require partner accept, distance check at request time,
+etc.). The QA client behavior is a workaround for a missing client-side packet,
+but as a server invariant it's a bypass: an adversary that skips `tradeRequest`
+entirely and goes straight to `tradeUpdateProposal` is implicitly granted a
+trade session.
+
+If a Rust port copies this workaround (which is reasonable on the assumption that
+the 0.8384 QA client we're targeting still doesn't send `tradeRequest`), then
+every range / alive / partner-not-already-trading check that lives in
+`beginTrading` must be invoked here too, and the partner must be notified of the
+implicit trade-start (otherwise the partner sees an `onTradeState` for a trade
+they never agreed to — a UI grief vector at minimum, a phishing surface at
+worst, e.g. "click here to confirm" social-engineering against a partner who
+didn't initiate).
+
+**Evidence**
+- `deprecated/python/cell/SGWPlayer.py:1785-1790` — the explicit workaround
+  comment, with reference to the 0.8384 QA client.
+- The client behavioral log dir
+  `C:\Users\Steve\source\projects\sgw\Stargate Worlds-QA\Working\binaries\SGWDebugLog.log`
+  contains no trade-flow evidence (UI not exercised in the captured run).
+- Ghidra: confirm the QA build does/doesn't emit `tradeRequest` is needed via
+  x64dbg trace; the static decompile is consistent with the client *being able to*
+  emit it (the EventHandler is wired) but not whether the actual UI path does.
+
+**Attack scenario**
+1. Adversary scripts: `tradeUpdateProposal(victim_id, {items:[I1], cash:0, version:1, lockState:0})`.
+2. Naive Rust port copies the Python workaround: `beginTrading(victim_id)` is
+   invoked, victim receives an `onTradeState` for a trade they did not request.
+3. Victim, if they accidentally click "lock" while the window has their attention
+   (which a clever adversary could time with another UI event), confirms.
+4. Adversary's prior `tradeLockState(..., Confirmed)` was already queued. Commit
+   fires.
+
+**Suggested remediation (one line)**
+On handler implementation, if the QA client really doesn't send `tradeRequest`,
+make `tradeUpdateProposal`'s implicit-begin go through the **exact same**
+validation gates as `tradeRequest` (distance, alive, is-player, not-already-trading,
+not-self), and require partner-side `onTradeRequestFromEntity` ack before the
+window opens on the victim's screen.
+
+**Would benefit from x64dbg trace?**
+Yes — first, confirm the 0.8384 QA client's actual emit sequence on "Trade"
+button-press, so we know whether to gate or to drop the workaround.
+
+---
+
+## Not Filed
+
+- **"Trade-from-banker / vendor / mailbox window dupe"** — the
+  `EInteractionType.Trade = 10` value in `entities/defs/enumerations.xml:855`
+  is only the dialog-type token, not a code path that bypasses player-to-player
+  trade. Not filed because the wire surface is the same four RPCs already
+  covered above.
+- **"`Event_NetIn_TradeState` / `Event_NetIn_TradeResults` server→client
+  spoofability"** — these are inbound on the client, not the server. Out of
+  scope for a server-authority audit (the trust direction is wrong — client
+  trusts the server here, and a malicious server isn't the threat model).
+- **"`tradeRequestFromEntity` / `updateTradeState` / `updateTradeLockState` /
+  `tradeCancel` as base-entity RPCs"** — these (`SGWPlayer.def:1041-1064,
+  1080-1089`) lack the `<Exposed/>` flag, so they are server-internal
+  base-to-cell or cell-to-cell RPCs, not client-callable. They are not part of
+  the inbound wire surface and so cannot carry a client trust violation.
+- **"Currency overflow on naquadah field in `LocalTradeProposal.cash`"** — the
+  INT32 cash field could be MAX_INT and a naive add to partner's naquadah could
+  overflow; not filed as a distinct finding because it folds into CAT-H-03's
+  enumerated server-side re-checks (the "cash <= self.inventory.naquadah at
+  this instant" check covers the upper bound; overflow on the partner side is
+  a CAT-D inventory concern, not a CAT-H trade concern). Cross-ref to
+  CAT-D-inventory for currency-overflow handling.
+- **"Trade window opens cross-space (different cells / different worlds)"** —
+  same-space enforcement is part of CAT-H-02; not split out separately.
+- **"`tradeRequestCancel(target_id)` where target is not the actual partner"** —
+  the stub at `social.rs:111-121` reads target_id but the Python reference at
+  `cell/SGWPlayer.py:1768-1774` doesn't even use it (`self.cancelTrading(entityId)`
+  cancels whatever trade `self` is in). Not filed as distinct — folds into the
+  general "use server-tracked partner id, not client-supplied" idiom in
+  CAT-H-02.
+- **"Replay attack on `tradeLockState`"** — the per-tick authenticate-token and
+  the 512-entry dedup hash from spec §1.7 are framing-layer concerns handled
+  upstream of the cell dispatcher. Not filed as a CAT-H finding because the
+  dedup is not trade-specific; the trade handler relies on the framing layer
+  for replay rejection. (The implementer should still verify the framing-layer
+  check is applied to cell-method packets, not just base-method packets.)
+- **"Stack-size manipulation in `LocalTradeItem`"** — the `LocalTradeItem`
+  FIXED_DICT (`alias.xml:356-361`) carries only `instanceId` and `slotId`, *not*
+  quantity. Quantity is looked up server-side from the actual item row. So this
+  is not a trust-violation surface — the dupe shape would have to come from a
+  TOCTOU on the item row (covered by CAT-H-07), not from a client-asserted
+  quantity. Filed as "not a distinct finding" precisely *because* the wire is
+  correctly shaped here.

--- a/docs/security-audit/2026-05-31-server-authority/findings/CAT-I-black-market.md
+++ b/docs/security-audit/2026-05-31-server-authority/findings/CAT-I-black-market.md
@@ -1,0 +1,638 @@
+# CAT-I — Black Market / Auction House (server-authority audit)
+
+## Trust posture summary
+
+The SGW Black Market / Auction House surface is **fully unimplemented**
+server-side. Every CellMethod under `SGWBlackMarketManager` (indices 61–66 —
+`BMSearch`, `BMCreateAuction`, `BMPlaceBid`, `BMCancelAuction`,
+`BMStartWatchingItem`, `BMStopWatchingItem`) is a stub that decodes a
+fixed slice of `args` with `i32::from_le_bytes`, emits a
+`tracing::info!("UNIMPLEMENTED: …")`, and returns `true` to the dispatcher
+(handler at `crates/services/src/cell/cell_methods/black_market.rs:14-80`).
+No DB tables back the surface (no `auctions` / `bm_listings` / `bm_bids`
+in `db/database.sql` or anywhere under `db/`), no `ON_BM_*` client method
+is ever invoked by the server, no item lock, no currency deduction, no
+listing-belongs-to-caller check, no expiry sweep, no COD-to-seller
+cascade.
+
+This is a security-relevant state for two reasons:
+
+1. The wire surface is **fully exposed** — Ghidra confirms the client
+   constructs and emits `Event_NetOut_BMCreateAuction`,
+   `Event_NetOut_BMPlaceBid`, `Event_NetOut_BMCancelAuction`, and
+   `Event_NetOut_BMSearch` with the full intended payload shapes (see
+   per-finding evidence). Mercury accepts the frames, the dispatcher
+   routes them, and the stub parses them. A scriptable client can land
+   bytes at the handler today; only the absence of a state-mutation body
+   prevents the exploits below. Whoever wires the handler bodies next
+   inherits a wire surface that *already accepts* every client-asserted
+   field (item instance id, starting price, buyout price, auction
+   length, sequence id, bid amount, sort id, client key, filter flags,
+   bForward, seller/bidder/item names) with no validation plumbed in
+   and no DB schema to enforce ownership / atomicity. That is the
+   exploit-chain-on-merge shape that CAT-G called out for mail; CAT-I
+   is the same shape with a much larger blast radius because auctions
+   are the primary economy surface (currency + item flow between
+   players, multi-step transactions, time-based expiry, COD-to-seller).
+2. The stub's wire decoding is **already wrong** in ways that will leak
+   into the future implementation if not fixed at the decoder layer:
+   - `BMCreateAuction` reads `auction_length` as a 4-byte LE i32, but
+     Ghidra shows the client emits it as a 1-byte field (Mercury
+     property-tree encoding picks the type from the property
+     registry; the emit at `00e59970` passes `param_4` as a `char`
+     widened into the byte slot — see CAT-I-02 evidence).
+   - `BMPlaceBid` and `BMCancelAuction` use the field name
+     `auction_id` (i32) in Rust, but Ghidra shows the client wire field
+     is `sequenceId` and the cancel path emits it as a `char` (i8 —
+     `FUN_00e59c70`, param_1 is `char`), while the place-bid path
+     emits it as a wider int (`FUN_00e59da0`, param_1 is `char` but
+     `param_2` is `uint`). The "auction id" identifier is **not a
+     32-bit row id** on the wire — the client's "sequenceId" appears
+     to be a per-listing index into a paginated result set, not a
+     stable DB key. Any future implementation that treats it as a row
+     id will dereference attacker-chosen indices.
+
+The dominant finding for this category is therefore "an entire economy
+vertical will land as an exploit chain the moment it is implemented".
+The remaining findings nail down each specific trust gap that the
+implementation must close, with evidence anchored in the client's
+Ghidra-decoded emit functions so the implementer cannot accidentally
+re-derive a wrong invariant.
+
+---
+
+### CAT-I-01 — Entire SGWBlackMarketManager interface is a stub that accepts every client field unvalidated
+
+**Severity**: High (latent — becomes Critical when handler bodies are filled in without validation)
+**Class**: Missing handler / silent client trust / latent exploit surface
+**Wire surface**: `Event_NetOut_BMSearch`, `Event_NetOut_BMCreateAuction`, `Event_NetOut_BMPlaceBid`, `Event_NetOut_BMCancelAuction` (CellMethod indices 61–64), plus indices 65–66 (`BMStartWatchingItem` / `BMStopWatchingItem` — no `Event_NetOut_*` discovered in the binary for those, may be invoked via a different path).
+**Demonstrable / Likely-theoretical**: Demonstrable (Ghidra confirms the emits; server confirms the stub).
+
+**Trust violation**
+The dispatcher at `crates/services/src/cell/cell_methods/black_market.rs`
+returns `true` (handled) from every arm but performs **no** state
+mutation, **no** validation, **no** reply, and the surface has **no**
+backing DB schema. The wire is open, the client can land bytes at the
+handler, the stub silently absorbs them. A future implementer who fills
+in the body will, by default, build a wire-trust violation unless the
+audit catches it at design time. The five subsequent CAT-I findings
+(02–06) enumerate the specific server-authority invariants that the
+implementation must enforce; they are filed pre-emptively because the
+wire surface already accepts every field a finished feature would need
+to mis-trust.
+
+**Evidence**
+- Ghidra: `019dd370` — `Event_NetOut_BMCreateAuction` string; emit
+  registration at `00e5c200` (`register_NetOut_BMCreateAuction`); the
+  actual emit constructor at `00e59970` (`FUN_00e59970`) packs
+  `itemInstanceId`, `startingPrice`, `buyoutPrice`, `auctionLength`
+  into a Mercury property tree and dispatches.
+- Ghidra: `019dd3e8` — `Event_NetOut_BMPlaceBid` string; emit
+  constructor at `00e59da0` packs `sequenceId` (auction selector) and
+  `bidAmount`.
+- Ghidra: `019dd3ac` — `Event_NetOut_BMCancelAuction` string; emit
+  constructor at `00e59c70` packs `sequenceId` only.
+- Ghidra: `019dd41c` — `Event_NetOut_BMSearch` string; emit
+  constructor at `00e59f70` packs `sortId`, `clientKey`,
+  `sequenceId`, `bForward`, `sellerName`, `bidderName`, `itemName`,
+  `minTC`, `maxTC`, `quality`, `filterFlags`.
+- Client behavioral log: n/a (BM UI has never been triggered in
+  captured logs).
+- Cross-ref to Rust handler (for the fix author, NOT as truth):
+  `crates/services/src/cell/cell_methods/black_market.rs:14-80`.
+
+**Attack scenario**
+1. The category is currently dormant — exploit requires the handler
+   bodies to be filled in.
+2. The "attack" today is the *latent* one: an implementer writes
+   `BMCreateAuction` that consumes the client's `itemInstanceId` and
+   `startingPrice` directly, ships, and ships a dupe / free-listing
+   bug in the same patch because the audit didn't pre-flag the
+   invariants.
+3. Observable effect: economic catastrophe at activation time
+   (CAT-I-02..06 each cite a different concrete exploit shape).
+
+**Suggested remediation (one line)**
+Land the per-handler authority invariants (CAT-I-02..06) as
+comments-as-acceptance-criteria on `black_market.rs` *before* anyone
+fills in a body; reject implementation PRs that mutate auction state
+without citing the specific invariant they enforce.
+
+**Would benefit from x64dbg trace?**
+No — wire shapes are already pinned by Ghidra; the gap is server-side.
+
+---
+
+### CAT-I-02 — BMCreateAuction: no item ownership / tradeable / lock validation, no listing-fee deduction, no duration cap, no per-player cap
+
+**Severity**: Critical (post-implementation) / High (latent)
+**Class**: TOCTOU-shaped dupe, missing ownership check, missing currency deduction, missing rate-limit
+**Wire surface**: `Event_NetOut_BMCreateAuction` (CellMethod index 62)
+**Demonstrable / Likely-theoretical**: Likely-theoretical (the handler is a stub; the trust violation is the *absence of any validation in the wire shape*).
+
+**Trust violation**
+The client emits four fields — `itemInstanceId` (u32, the item to
+list), `startingPrice` (i32), `buyoutPrice` (i32), `auctionLength`
+(u8) — and the server must independently verify *all four* before
+creating any persisted listing row. The required server-side checks,
+in order:
+
+1. **Item ownership**: server resolves the caller's character_id and
+   confirms `itemInstanceId` lives in *that* character's inventory at
+   the moment of the create call. The wire field is just a raw u32; a
+   modified client can supply any item id it has ever seen (a friend's
+   item, a vendor's stock id, a dropped-loot id). The handler MUST NOT
+   key off the client-supplied id without an ownership join.
+2. **Item is tradeable / unequipped / not soulbound / not container
+   non-empty**: same shape — these are item properties the server
+   must look up, not trust the client to have pre-filtered.
+3. **Atomic lock-or-remove of the item at create time**: the item row
+   must transition `owner=character_id → owner=null,
+   reserved_by=auction_id` (or be moved to an auction-escrow
+   container) inside the same transaction as the listing row insert.
+   If this is two separate statements, a disconnect / concurrent
+   `MoveItem` / `UseItem` between them is a dupe. This is the same
+   TOCTOU shape that bandolier ammo type_id-vs-item_id had — keyed
+   on the wrong row, the wrong record gets mutated.
+4. **Listing-fee deduction from naqahdah** in the same transaction —
+   client-side debit display is cosmetic.
+5. **`startingPrice`, `buyoutPrice` bounds**: both must be > 0; on
+   the wire they are signed i32 (the client packs them as
+   `undefined4` per `FUN_00e59970`), so negative values are
+   trivially injectable. `buyoutPrice >= startingPrice` (or
+   `buyoutPrice == 0` for "no buyout") must be a server check.
+   Without `i64`-cast bounds, multiplications during fee-percentage
+   calculation overflow.
+6. **`auctionLength` cap**: server-side max (e.g. 7 days). The wire
+   field is a u8 (Ghidra: `FUN_00e59970` passes `param_4` as
+   `param_2 = param_4; … FUN_00a4fb70(this,…)` — the second
+   property-tree write at offset for `auctionLength` is a byte
+   widening, not a 32-bit slot), so the maximum literal value is
+   255 — but 255 days is still well past any reasonable cap. Note
+   the current Rust stub reads this as a 4-byte i32 (bug — see
+   below).
+7. **Per-player listing cap**: a single attacker can DoS the listing
+   table with infinite create calls; this needs an `active_listings
+   < N`-per-character check at handler entry.
+
+**Evidence**
+- Ghidra: `00e59970` `FUN_00e59970` — the BMCreateAuction emit
+  constructor. Field order: `itemInstanceId` (u32, prop name
+  `"itemInstanceId"`), `startingPrice` (u32, prop name
+  `"startingPrice"`), `buyoutPrice` (i32, prop name `"buyoutPrice"`),
+  `auctionLength` (byte widened; prop name `"auctionLength"`).
+- Ghidra: `019dd370` — `Event_NetOut_BMCreateAuction` string anchor.
+- Ghidra: `019dd078` `auctionItems` / `019dd0e4` `buyoutPrice` /
+  `019dd0f0` `auctionLength` — string anchors confirming prop names.
+- Client behavioral log: n/a.
+- Cross-ref to Rust handler (for the fix author, NOT as truth):
+  `crates/services/src/cell/cell_methods/black_market.rs:27-43`. Note
+  the current stub names the field `duration_days` and decodes 16
+  bytes as four i32s; the wire shape is `u32 + u32 + i32 + u8`, so
+  the offset math will collide with the real Mercury frame when the
+  handler is wired. Fix the wire decoder first; then enforce the
+  validations above.
+
+**Attack scenario** (post-implementation, given a naive port)
+1. Attacker scripts a client that emits `BMCreateAuction` with
+   `itemInstanceId` = the id of a high-value item that lives in a
+   friend's inventory (observable via party / `Show*` GM commands /
+   linkshell sharing). `startingPrice` = `-2147483647`.
+2. Server creates a listing keyed on the borrowed item id; if it
+   then proceeds to delete-from-inventory on the wrong character's
+   row (via item_id alone, no ownership join), the friend's item is
+   consumed. Even if the delete fails, the listing row exists and a
+   colluder can bid `0` (negative-`startingPrice` allows `0` to win
+   the buyout check) and "purchase" the item from the listing,
+   netting it without ever owning it.
+3. Observable effect: dupe + cross-player item theft.
+
+**Suggested remediation (one line)**
+Implement the create path as a single transaction that joins the
+inventory row by `(character_id, item_id)`, locks-or-moves the item,
+deducts the listing fee, inserts the listing row, and runs every
+field-bound check above before the COMMIT; reject any
+`startingPrice <= 0`, `buyoutPrice < startingPrice` (when
+non-zero), `auctionLength > 7`, `active_listings >= N` at the
+handler entry.
+
+**Would benefit from x64dbg trace?**
+No — wire shape and field names confirmed by Ghidra; the gap is
+in the absent server implementation.
+
+---
+
+### CAT-I-03 — BMPlaceBid: no current-bid comparison, no naqahdah hold, no self-bid prevention, no listing-visibility check, replayable
+
+**Severity**: Critical (post-implementation) / High (latent)
+**Class**: Bid-integrity TOCTOU, replay, currency overdraft, self-bid dupe
+**Wire surface**: `Event_NetOut_BMPlaceBid` (CellMethod index 63)
+**Demonstrable / Likely-theoretical**: Likely-theoretical (handler is a stub).
+
+**Trust violation**
+The client emits `sequenceId` (auction selector — see below) and
+`bidAmount` (u32 on the wire). Required server-side checks:
+
+1. **Server-side `bidAmount > current_high_bid + min_increment`** —
+   the client's emit at `FUN_00e59da0` has a *client-side* sanity
+   check (`if ((int)param_2 <= *(int *)(*(int *)(*(int *)(iVar1 + 0x8c) + 0x24) + 0x60))` —
+   comparing the bid to what appears to be the caller's naqahdah
+   balance), but that gate lives entirely in the client and is
+   trivially bypassed by a modified emit. The server must
+   independently compare against the listing's persisted
+   `current_bid`, not against any client-asserted value.
+2. **Currency hold at bid time**, not at win time. The standard
+   auction-house pattern is: deduct `bidAmount` from the bidder
+   immediately, refund the previous high bidder. Any deferred-debit
+   model lets the bidder spend the same naqahdah elsewhere between
+   bid-place and bid-resolve, and the auction settles in the
+   server's favor (item never delivered, currency never collected).
+3. **Self-bid prevention** — the listing's seller_character_id must
+   not equal the bidder's character_id. Otherwise the seller bids
+   on their own listing, "wins", and the listing-fee + bid-fee
+   round-trip is a small naqahdah sink the seller can use to
+   launder funds across mules (or, more dangerously, the
+   collusion partner who placed a real bid is refunded but the
+   item still goes to the seller — depends on the resolution
+   logic).
+4. **Listing-visibility check**: `sequenceId` is the client's
+   *paginated index* into the search result set (see CAT-I-05 —
+   the BMSearch emit packs `clientKey` and `sequenceId` together,
+   strongly suggesting the auction selector is a per-search
+   cursor, not a stable row id). The server MUST translate
+   `sequenceId` through the caller's most recent search-result
+   cache (keyed by `clientKey`) before mutating; otherwise the
+   client can supply any integer and the server dereferences an
+   arbitrary listing the player was never authorized to see
+   (cross-faction listing, GM-only listing, removed-but-not-
+   reaped listing). A client that has never opened the BM UI can
+   place bids on any listing by enumerating `sequenceId`.
+5. **Replay**: the framing layer's per-tick authenticate token
+   and 512-entry dedup hash (spec §1.7) defends against bit-for-
+   bit packet replay, but the bid handler must *also* be
+   idempotent within an in-flight tick — two `BMPlaceBid` calls
+   with the same `(character_id, sequenceId, bidAmount)` in the
+   same tick must produce one persisted bid, not two. The stub
+   has neither.
+6. **Race condition on equal-amount concurrent bids**: two
+   clients submitting the same `bidAmount = current_bid +
+   min_increment` simultaneously must serialize through a row
+   lock on the listing; the loser's currency must be refunded
+   atomically. Without `SELECT … FOR UPDATE` (or equivalent) on
+   the listing row, both bidders' currency gets deducted and
+   only one wins, netting a free naqahdah burn.
+
+**Evidence**
+- Ghidra: `00e59da0` `FUN_00e59da0` — the BMPlaceBid emit
+  constructor. Field order: `sequenceId` (i8 widened to int
+  per the prop-tree write; prop name `"sequenceId"`),
+  `bidAmount` (u32, prop name `"bidAmount"`). The client-side
+  balance gate is `param_2 <= *(*(*(*(iVar1+0x8c)+0x24)+0x60)`.
+- Ghidra: `019dd3e8` — `Event_NetOut_BMPlaceBid` string anchor.
+- Ghidra: `019dd118` `bidAmount` — string anchor.
+- Client behavioral log: n/a.
+- Cross-ref to Rust handler (for the fix author, NOT as truth):
+  `crates/services/src/cell/cell_methods/black_market.rs:44-56`.
+  The stub names the wire field `auction_id` and decodes it as
+  i32 — the wire field is `sequenceId` and is a paginated
+  index, not a row id.
+
+**Attack scenario** (post-implementation, given a naive port)
+1. Attacker scripts a client that emits `BMPlaceBid` with
+   `sequenceId` chosen by brute-forcing 0..N until a listing
+   responds; `bidAmount = 1`. If the server treats sequenceId
+   as a row id and skips the current-bid comparison, the
+   listing is "won" for a single naqahdah.
+2. Variant: attacker scripts the same emit with `bidAmount =
+   currentBid` (read from a prior `Event_NetIn_BMAuctions`
+   payload) — if the server compares against
+   *attacker-asserted* current bid (stored client-side after
+   the search), the attacker simply lies about the current
+   bid value.
+3. Variant: attacker lists an item via mule, scripts the mule
+   to bid against itself with the buyout amount; the listing
+   settles immediately and the mule pockets the buyout
+   minus the listing fee (less than 100%), turning the BM
+   into a per-listing-fee laundering surface.
+4. Observable effect: bid-integrity collapse, free items,
+   currency laundering, listing-discovery bypass.
+
+**Suggested remediation (one line)**
+Translate `sequenceId` through a caller-scoped (`clientKey`-
+matching) search-result cache, lock the listing row, validate
+`bidAmount > current_bid + min_increment`, deduct from
+bidder naqahdah and refund prior high bidder atomically, and
+reject `seller_character_id == bidder_character_id`.
+
+**Would benefit from x64dbg trace?**
+Yes — confirming the wire type width of `sequenceId` (i8 vs i32 vs
+"the prop-tree encoder writes whatever fits") needs a live capture
+of one `BMPlaceBid` packet to lock the decoder before writing the
+handler. The Ghidra-decoded `param_1` being `char` is suggestive
+but the prop-tree write may widen it.
+
+---
+
+### CAT-I-04 — BMCancelAuction: no ownership check, no bidder refund, no item-return atomicity
+
+**Severity**: Critical (post-implementation) / High (latent)
+**Class**: Cross-player listing pull, dupe via cancel-with-active-bid
+**Wire surface**: `Event_NetOut_BMCancelAuction` (CellMethod index 64)
+**Demonstrable / Likely-theoretical**: Likely-theoretical (handler is a stub).
+
+**Trust violation**
+The client emits a single field — `sequenceId` (i8 / paginated
+index — see CAT-I-03 for the type-width caveat). Required
+server-side checks:
+
+1. **Ownership**: the listing being cancelled must have
+   `seller_character_id = caller_character_id`. Without this, a
+   modified client can cancel any visible listing, denying
+   sale to anyone in the marketplace.
+2. **Active-bid handling**: if the listing has a `current_bid`,
+   the bid currency must be returned to the prior high bidder
+   *before* the listing is closed. Otherwise a seller who sees
+   their listing about to settle for less than they'd like can
+   cancel, pocket nothing, the bidder's naqahdah is forfeit, and
+   the bidder has no recourse. (Or the seller may also need a
+   listing-fee forfeiture penalty to prevent the inverse
+   griefing — a server-side policy decision, but the
+   *currency-return-to-bidder* invariant is non-negotiable.)
+3. **Item return atomicity**: the escrowed item must be moved
+   back to the seller's inventory in the same transaction as
+   the listing-row delete. A partial commit (item already
+   removed from escrow, listing still exists) and a partial
+   commit (item never returned, listing already deleted) are
+   both dupe-shaped: the former lets a future
+   create-from-escrow re-list the same item via a sibling
+   listing if escrow keys collide; the latter is a
+   straight-up item loss recoverable via GM intervention but
+   noisy.
+4. **Disconnect-mid-cancel**: same shape as the trade
+   disconnect-timing dupe — if the cancel handler commits
+   item-return-to-seller before commit-listing-delete, a
+   well-timed client disconnect between the two writes lets
+   the seller keep the item AND the listing remains live, so a
+   colluder can bid on it and "win" the still-escrowed copy.
+
+**Evidence**
+- Ghidra: `00e59c70` `FUN_00e59c70` — the BMCancelAuction emit
+  constructor. Single field: `sequenceId` (`param_1: char`, prop
+  name `"sequenceId"`). No ownership marker on the wire — the
+  server must derive that from the caller's session.
+- Ghidra: `019dd3ac` — `Event_NetOut_BMCancelAuction` string anchor.
+- Client behavioral log: n/a.
+- Cross-ref to Rust handler (for the fix author, NOT as truth):
+  `crates/services/src/cell/cell_methods/black_market.rs:57-63`.
+
+**Attack scenario** (post-implementation, given a naive port)
+1. Attacker scripts a client that emits `BMCancelAuction` with
+   `sequenceId` from a competitor's listing observed via a
+   normal `BMSearch`. Server obeys, the competitor's listing
+   dies, the competitor's item is left in escrow forever.
+2. Variant: attacker times a disconnect between item-return
+   and listing-delete on their own listing to keep both the
+   escrowed item and an active listing pointing at it.
+3. Observable effect: market-wide denial of sale (variant 1)
+   or self-dupe (variant 2).
+
+**Suggested remediation (one line)**
+Cancel handler: `WHERE seller_character_id = :caller AND
+sequence_id = :sequenceId` on the listing fetch, single
+transaction wrapping item-return, bidder-refund (if any),
+listing-delete; rollback on disconnect-before-commit.
+
+**Would benefit from x64dbg trace?**
+No — wire shape is minimal and Ghidra-confirmed.
+
+---
+
+### CAT-I-05 — BMSearch: no result-size cap, no faction / region filter enforcement, paginated `clientKey` is a client-asserted cursor
+
+**Severity**: High (post-implementation) / Medium (latent — DoS surface today)
+**Class**: Search-result-DoS, cross-faction listing leak, client-trusted cursor
+**Wire surface**: `Event_NetOut_BMSearch` (CellMethod index 61)
+**Demonstrable / Likely-theoretical**: Likely-theoretical (handler is a stub today; the wire shape is fully exposed and the stub returns `true` immediately).
+
+**Trust violation**
+The client emits a *very* rich filter set — `sortId`, `clientKey`,
+`sequenceId`, `bForward`, `sellerName`, `bidderName`, `itemName`,
+`minTC`, `maxTC`, `quality`, `filterFlags`. The required
+server-side properties:
+
+1. **Result-size cap server-side**: the client cannot ask for
+   "all listings". A modified emit can set `filterFlags` to a
+   value that disables every filter and the server must still
+   only return e.g. the first 50 rows. Without a server-side
+   cap, a single search can pull the entire listing table —
+   classic search-DoS shape.
+2. **Faction / region / level-gate enforcement**: SGW
+   maintains faction-based content gating. If the BM is faction-
+   scoped (Lucian Alliance can't see Tau'ri listings, etc.),
+   that scope must be applied server-side by joining caller
+   faction against listing faction; client-supplied
+   `filterFlags` cannot be the only gate.
+3. **`clientKey` is a client-asserted pagination cursor** —
+   the emit packs `clientKey` (likely a per-search
+   correlation id the server hands back in
+   `Event_NetIn_BMAuctions` so subsequent paged calls can be
+   matched against the cached result set). The server must
+   not trust the `clientKey` value to point at any session's
+   cache other than the caller's own. If the cache is keyed
+   by `(clientKey)` alone (not `(character_id, clientKey)`),
+   a colluder can read another player's result page — minor
+   leak but real.
+4. **`itemName` / `sellerName` / `bidderName` are wide
+   strings**: the wire emit packs them as `wchar_t*` (per
+   `FUN_0043d380` at offsets `puVar1 + 0` (seller),
+   `puVar1 + 7` (bidder), `puVar1 + 0xe` (item)). These
+   flow into a `WHERE name LIKE :pattern` shape; without
+   server-side length caps and pattern-escape rules, the
+   query is a polynomial-time string-search amplification
+   vector.
+
+**Evidence**
+- Ghidra: `00e59f70` `FUN_00e59f70` — the BMSearch emit
+  constructor. Fields (in emit order): `sortId` (u32, prop
+  name `"sortId"`), `clientKey` (u32, prop name
+  `"clientKey"`), `sequenceId` (u32, prop name
+  `"sequenceId"`), `bForward` (bool, prop name
+  `"bForward"`), `sellerName` (wchar_t*, prop name
+  `"sellerName"`), `bidderName` (wchar_t*, prop name
+  `"bidderName"`), `itemName` (wchar_t*, prop name
+  `"itemName"`), `minTC` (u32, prop name `"minTC"`),
+  `maxTC` (u32, prop name `"maxTC"`), `quality` (u32,
+  prop name `"quality"`), `filterFlags` (u32, prop name
+  `"filterFlags"`). Eleven fields, all driven from a
+  caller-controlled struct passed in `param_1`.
+- Ghidra: `019dd41c` — `Event_NetOut_BMSearch` string anchor.
+- Client behavioral log: n/a.
+- Cross-ref to Rust handler (for the fix author, NOT as truth):
+  `crates/services/src/cell/cell_methods/black_market.rs:22-26`.
+  The stub does not even attempt to parse `args` — comment
+  `"BMSearchOptions is a complex struct, just log arrival"`.
+
+**Attack scenario** (post-implementation, given a naive port)
+1. Attacker emits `BMSearch` with all filter strings empty,
+   `filterFlags = 0xFFFFFFFF`, and a `sortId` that the
+   server doesn't recognize (so server returns
+   unfiltered). Server returns the entire listings table.
+2. Variant: attacker emits `BMSearch` with a
+   pathological `itemName` value (e.g. a long `%` -heavy
+   wildcard pattern) and observes a CPU-bound DB response.
+3. Variant: attacker emits `BMSearch` with `clientKey`
+   read from a packet capture of another player's session
+   and reads that player's paginated result cache.
+4. Observable effect: server-side DoS (1, 2) or minor
+   cross-player query-cache leak (3).
+
+**Suggested remediation (one line)**
+Cap result count server-side (e.g. 50 rows / page);
+enforce faction / region scope by joining caller session;
+key the result cache by `(character_id, clientKey)` not
+`clientKey` alone; bound all name fields to a max length
+and escape `%` / `_` before injecting into `LIKE`.
+
+**Would benefit from x64dbg trace?**
+Yes — locking the exact prop-tree decoding of the eleven
+fields requires one captured `BMSearch` packet to confirm
+type widths before writing the decoder.
+
+---
+
+### CAT-I-06 — Expiry sweep / COD-to-seller cascade is unimplemented and unscaffolded
+
+**Severity**: Critical (post-implementation) / High (latent)
+**Class**: Missing server-tick, missing atomicity boundary, item / currency loss
+**Wire surface**: None client-side — this is a server-side scheduled-task gap. Surfaces back to the client via the `Event_NetIn_BMAuctionRemove` / `Event_NetIn_BMAuctionUpdate` reply paths (Ghidra string anchors `019bd874` and `019bd858`).
+**Demonstrable / Likely-theoretical**: Likely-theoretical (the server tick is absent — there is no auction expiry task in `crates/services/src/` at all; grep returns zero hits for `auction`/`black_market` outside the stub).
+
+**Trust violation**
+Auction houses are not just request/response surfaces — they
+require a server-tick sweep that closes expired listings,
+delivers the winning bid's currency to the seller, delivers
+the item to the winner, returns the item to the seller on a
+no-bid expiry, and ages out abandoned listings. None of this
+exists. Required invariants:
+
+1. **Expiry-detection tick** — a periodic task that selects
+   listings with `expires_at <= now()` and processes them.
+   The current crate ships no scheduler for this.
+2. **Atomic resolution per listing**:
+   - With a bid: deduct nothing further from bidder (currency
+     was held at bid time per CAT-I-03), credit seller with
+     bid amount minus market fee, move escrowed item to
+     winner's inventory, emit `ON_BM_AUCTION_REMOVE` (index
+     93) to the winner and seller. All in one transaction.
+   - Without a bid: return escrowed item to seller, refund
+     any partial listing-fee policy decides to refund, emit
+     `ON_BM_AUCTION_REMOVE`.
+3. **Crash-resilient delivery** — if the server crashes mid-
+   resolution, on restart the surviving "item is in escrow,
+   listing is closed, winner has not been credited" state
+   must be detectable and replayable. This is the same
+   shape as the mail outbox pattern: an outbox row holds the
+   pending delivery until it commits to the recipient. The
+   stub lays no groundwork for this.
+4. **COD-to-seller cascade**: if the auction model includes
+   a COD shape (cash-on-delivery), the winner's bid currency
+   must flow to the seller in a way that survives a winner
+   disconnect during pickup. The cleanest pattern is "credit
+   the seller's mail with currency on auction settle" so the
+   currency-delivery surface is the existing mail vertical
+   — but CAT-G found that mail itself is unimplemented, so
+   the BM expiry cascade has no settled delivery surface
+   today.
+
+**Evidence**
+- Ghidra: `019bd874` — `Event_NetIn_BMAuctionRemove` string anchor
+  (server-to-client notification of listing closure — the trigger
+  that the expiry sweep must emit).
+- Ghidra: `019bd858` — `Event_NetIn_BMAuctionUpdate` string anchor
+  (server-to-client listing-state change — needed for the
+  "your listing just got outbid" / "your bid was beaten" UX).
+- Client behavioral log: n/a.
+- Cross-ref to Rust handler (for the fix author, NOT as truth):
+  `crates/services/src/cell/client_methods/black_market.rs:9-13`.
+  Server-side scheduler: **absent**. No `cell_methods/black_market.rs`
+  callee references a Tokio interval or a periodic-task harness.
+
+**Attack scenario** (post-implementation, given a naive port without
+the expiry sweep)
+1. Attacker creates a listing, waits past the duration, observes
+   that the server never closes it. If a colluder bids during this
+   window, the bid currency is held forever (per CAT-I-03) and the
+   listing never settles. Either the attacker or the colluder can
+   then file a GM ticket claiming the listing should have closed,
+   and the GM workaround manually delivers — at scale, this is a
+   support-cost amplifier and a route to GM-error dupes.
+2. Variant: attacker creates a listing, lets a colluder win,
+   then crashes the server (or just waits for a real crash);
+   the resolution is mid-flight, item is in escrow, winner has
+   not been credited. On restart, with no outbox / recovery
+   step, the colluder gets the item but also gets the bid
+   refund (or the seller gets the bid amount but also gets the
+   item back) — either side wins double depending on which
+   half of the resolution committed first.
+3. Observable effect: market stalls on expiry, support-cost
+   amplification, dupe windows on every server restart with
+   active auctions.
+
+**Suggested remediation (one line)**
+Land an auction-expiry tick (Tokio periodic) and an
+outbox-pattern resolution path *before* the create/bid/cancel
+handlers are wired, so the wire surface cannot accept
+listings the server has no path to close; back currency /
+item delivery via the existing mail surface (once that is
+itself implemented per CAT-G).
+
+**Would benefit from x64dbg trace?**
+No — this is a server-architecture gap, not a wire-trust one.
+
+---
+
+## Not Filed
+
+- **"BMStartWatchingItem / BMStopWatchingItem (indices 65–66)
+  trust violations"** — these stubs exist in the dispatcher and
+  decode an `auction_id: i32` from `args`, but no
+  `Event_NetOut_BMStartWatchingItem` or `Event_NetOut_BMStopWatchingItem`
+  string was found in the binary via Ghidra string search. The
+  client may invoke these via a different code path (e.g. an
+  `onBM*` UI action that routes through a generic property
+  setter), or they may be planned-but-unused indices. Without an
+  emit trace I cannot characterize the wire-trust surface, and
+  the surface is read-only (a "watching" relation is a per-player
+  bookmark with no currency or item impact). Not filed — re-
+  examine when the BM UI is exercised live and the actual emit
+  path lands in a capture.
+- **"Server-side stub args-length floor is undersized for the
+  real Mercury frame"** — the current stub does
+  `if args.len() >= 16` for `CREATE_AUCTION`, `>= 8` for
+  `PLACE_BID`, `>= 4` for `CANCEL_AUCTION`. Per Ghidra the wire
+  shape carries a Mercury property tree with name/length-tagged
+  fields (not a flat 4-byte i32 array), so the byte budget is
+  much larger. Not filed as a security finding because the
+  stub never acts on the parsed values — it is a *correctness*
+  issue that will be caught the moment a handler body is
+  written. Mentioned inside CAT-I-02 / CAT-I-03 for the
+  implementer's benefit.
+- **"`Event_NetIn_BMOpen` reply path is unimplemented (server
+  never opens the BM UI)"** — true, but the absence of a server-
+  to-client open notification is a feature-completeness gap,
+  not a server-authority gap. The wire surface still accepts
+  `Event_NetOut_BM*` calls regardless of whether the client UI
+  was opened, so a scripted client doesn't need the open
+  notification. Mentioned in the summary; not a separate
+  finding.
+- **"The BMSearch stub doesn't decode `args` at all so it
+  cannot mis-validate"** — true, but the absence of a parser
+  is *also* the absence of validation. The latent surface is
+  what CAT-I-05 captures; an additional finding here would
+  duplicate it.
+- **"GM-gate the BM dispatch entirely until implementation
+  lands"** — considered, but the BM is not a GM surface; the
+  fix is to land the handlers correctly, not to lock them
+  out. A "feature gate per-build" suggestion sits outside the
+  server-authority audit scope. Routed to the implementation
+  PR's design discussion instead.

--- a/docs/security-audit/2026-05-31-server-authority/findings/CAT-J-mission-dialog.md
+++ b/docs/security-audit/2026-05-31-server-authority/findings/CAT-J-mission-dialog.md
@@ -1,0 +1,664 @@
+# CAT-J — Mission / Dialog / Interaction
+
+**Overall trust posture**: The wire surface for this category is **broader than
+the implemented surface**. The Rust dispatch hooks up `INTERACT` (74),
+`DIALOG_BUTTON_CHOICE` (75), `INITIAL_RESPONSE` (76) on the SGWPlayer interface
+and `ABANDON_MISSION` (52), `SHARE_MISSION` (53), `SHARE_MISSION_RESPONSE` (54)
+on the Missionary interface. Every other client-emitted name in CAT-J
+(`Event_NetOut_MissionAdvance`, `MissionComplete`, `MissionAssign`,
+`MissionReset`, `MissionClear`, `MissionClearActive`, `MissionClearHistory`,
+`MissionList`, `MissionListFull`, `MissionDetails`, `MissionSetAvailable`,
+`ChosenRewards`, `DebugInteract`, `AbandonMission` as a slash-cmd variant) is
+registered in `register_NetOut_*` on the client (confirmed via Ghidra string
+search + `register_NetOut_*` decompile showing `Direction: NetOut (client ->
+server)`), and a non-trivial subset of them also has a sibling
+`Event_SlashCmd_*` registration routed through `SGWTextCommandMgr` — so they
+are emittable from console as well as from UI affordances. None of those names
+hit a dedicated cell-method handler today; they fall through to the unhandled
+`warn!` at `crates/services/src/cell/dispatch/router.rs:101` (`"Unhandled cell
+method call -- no registered handler for this index; client behaviour may
+diverge silently"`). That's good defense-in-depth for *server* state — these
+won't mutate anything — but it leaves them as latent exploit shapes that a
+future "wire it up" PR will inherit unless the validation is designed in now.
+
+The substantive trust violations live in the *implemented* paths. The
+strongest finding is **CAT-J-01**: `DIALOG_BUTTON_CHOICE` fires a chain-engine
+event keyed on a client-supplied `dialog_id` with **no server-side check that
+the dialog is or was ever open for this player**. Chain actions reachable via
+`OnDialogChoice` include `GrantXP`, `GrantItem`, `Teleport`, `AcceptMission`,
+`CompleteMission`, `AdvanceStep`, `AbandonMission` — so a single forged
+packet can drive any of those for any `dialog_id` an attacker discovers. The
+client-side `DialogPortrait` widget hides which dialog_ids exist, but they're
+not secret — they're in cooked client data (`SGWGame/CookedData/*`) and
+recoverable via Ghidra. **CAT-J-04** is the matching gap on `MissionAssign`
+prereqs (no level / faction / prior-mission gate is checked on the cell-side
+`accept_or_advance`). **CAT-J-02** is the analogous `INITIAL_RESPONSE` gap
+(dialog selection unscoped from `last_interaction_target`).
+
+Note: the trace from CAT-J chains back into CAT-D (Inventory) and CAT-C
+(Combat) on the *action* side — a finding closed in CAT-J that ends up
+delegating to `GrantItem` or `Teleport` is only safe to the extent CAT-D
+and CAT-O cover their own input validation. Mission-systems-advisor and
+movement-physics-advisor should consult-review on **CAT-J-01** and **CAT-J-04**.
+
+---
+
+### CAT-J-01 — DialogButtonChoice fires arbitrary content chain with no "is this dialog open?" check
+
+**Severity**: Critical
+**Class**: Missing server-side state precondition; chain-engine event spoofing
+**Wire surface**: `Event_NetOut_DialogButtonChoice` (cell method 75)
+**Demonstrable / Likely-theoretical**: Likely-theoretical (Ghidra confirms
+client emits `dialog_id:i32, button_id:i32` payload via
+`SGWNetworkManager::EventHandler<Event_NetOut_DialogButtonChoice>` at
+`0x00d68050`; Rust handler obeys without precondition check)
+
+**Trust violation**
+The client sends `(dialog_id: i32, button_id: i32)` and the server processes
+it by calling `fire_dialog_choice(entity_id, player_id, dialog_id, button_id,
+…)` (`cell/cell_methods/player/interaction.rs:247-250`). That helper
+unconditionally builds a `TriggerEvent { trigger_type: DialogChoice, params:
+{dialog_id, button_id, …} }` and resolves it against the chain engine. The
+engine matches any registered `OnDialogChoice { dialog_id }` chain
+(`crates/content-engine/src/triggers.rs:287`) and executes its actions via
+the executor. There is **no server-side bookkeeping of "is dialog X currently
+open for player Y?"** — `CellEntity` carries `last_interaction_target` but
+not a `current_dialog_id`, and `available_interactions` is consulted only by
+the `INTERACT` and `INITIAL_RESPONSE` *open* paths, not by the *choice*
+handler. The button_id field has no validation at all — `OnDialogChoice` only
+matches on `dialog_id`, the button_id is just stuffed into params and is
+available to chain conditions if any choose to read it.
+
+The action surface reachable via `OnDialogChoice` includes (see
+`crates/content-engine/src/actions.rs:20–`): `GrantXP`, `GrantItem`,
+`RemoveItem`, `Teleport`, `CrossWorldTeleport`, `AcceptMission`,
+`AdvanceMission`, `CompleteMission`, `AdvanceStep`, `AbandonMission`,
+`CompleteObjective`, `RollLootTable`, `SpawnEntity`, `DespawnEntity`,
+`TriggerChain`. An attacker who replays `DialogButtonChoice(dialog_id=N)` for
+a `dialog_id` bound to any of these actions gets the action's side-effect
+without ever opening the dialog, talking to the giver NPC, being in the
+giver's space, or meeting any of the gating conditions the chain author
+*expected* would be enforced by the precondition of having opened the dialog.
+
+**Evidence**
+- Ghidra: `0x019b3e30` `Event_NetOut_DialogButtonChoice` — string + class
+  registration confirms client→server direction; `0x00d68050`
+  `SGWNetworkManager::EventHandler<Event_NetOut_DialogButtonChoice>::vfunc_0`
+  is the server-side bundle deserializer. Payload from the cell handler:
+  `dialog_id: i32 LE | button_id: i32 LE` (8 bytes total, parsed at
+  `interaction.rs:239-240`).
+- Client behavioral log: n/a (no symbol-named log entries for dialog choice
+  in `SGWDebugLog.log`).
+- Cross-ref to Rust handler (for the fix author, NOT as truth):
+  `crates/services/src/cell/cell_methods/player/interaction.rs:237-253`
+  (handler) → `crates/services/src/cell/content/event_dispatch/dialog.rs:69-111`
+  (`fire_dialog_choice`).
+
+**Attack scenario**
+1. Attacker enumerates dialog_ids referenced by `OnDialogChoice` chains by
+   inspecting content seeds (the chain table is loaded from PG; for an
+   external attacker this is recoverable via Ghidra dialog-id constants
+   plus knowledge of which missions have reward dialogs).
+2. Attacker crafts a Mercury cell-method bundle for method_index = 75 (the
+   SGWPlayer `DIALOG_BUTTON_CHOICE` index — pinned by
+   `cell_methods/player/dispatch.rs` test
+   `cell_method_constants_pin_expected_values`) with `args =
+   dialog_id_LE || button_id_LE` (8 bytes).
+3. Server's `dispatch_cell_method` routes to `player::dispatch` →
+   `interaction::dispatch::DIALOG_BUTTON_CHOICE` arm → `fire_dialog_choice`.
+4. Content engine executes any chain bound to that `dialog_id`. **Observable
+   effect**: the chain's actions fire with no precondition — most directly,
+   `GrantXP` / `GrantItem` give the attacker the reward bundle of any
+   dialog-completion chain; `AcceptMission` / `CompleteMission` skip the
+   intended quest path; `Teleport` / `CrossWorldTeleport` moves the player
+   without the dialogue-context the chain author assumed.
+
+**Suggested remediation (one line)**
+Pin the currently-open dialog on the player (e.g. `player.open_dialog_id:
+Option<i32>`) at `send_dialog_display` time, clear it on choice or on a new
+dialog open, and reject `DIALOG_BUTTON_CHOICE` whose `dialog_id !=
+player.open_dialog_id` with a `warn!` (consult mission-systems-advisor on
+multi-dialog overlap rules).
+
+**Would benefit from x64dbg trace?**
+Yes — confirm the precise wire shape (8 bytes vs longer encoding for the
+button_id), and confirm `SGWNetworkManager::EventHandler<Event_NetOut_
+DialogButtonChoice>::vfunc_0` doesn't append a session token the Rust
+handler is dropping.
+
+---
+
+### CAT-J-02 — InitialResponse dialog selection is not scoped to the interacted NPC
+
+**Severity**: Medium
+**Class**: Missing scope check on per-player state lookup
+**Wire surface**: `Event_NetOut_InitialResponse` (cell method 76, name on the
+wire is `initialResponse` per `dispatch/names.rs:108`)
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+`handle_initial_response` (`crates/services/src/cell/interactions/dispatch.rs:
+207–287`) takes the client-supplied `interaction_set_map_id: i32` and searches
+**every** template-keyed entry in `player.available_interactions` for a
+matching `dsm_id` (`for entries in p.available_interactions.values() { for
+&(dsm_id, dialog_id, _) in entries { if dsm_id == interaction_set_map_id {
+return Some(dialog_id); } } }`). The pin on `last_interaction_target` is
+consulted only to populate the wire `EntityId` field of `onDialogDisplay` —
+the lookup of *which dialog* to open is **unscoped from the actor**. A
+client who has ever had `AddDialogSet`/`AddDialog` register multiple
+interaction sets across multiple templates can send any
+`interactionSetMapId` from any of them, regardless of which NPC they
+just right-clicked.
+
+This is bounded by the fact that the dsm_id must already exist in the
+player's `available_interactions` (a server-side chain must have added it),
+so it's not a full dialog-id-enumeration exploit. But the actor mismatch
+lets a player open a chain-fired dialog *bound to one NPC* while interacting
+with a *different NPC*, breaking the chain author's assumption that the
+`OnDialogOpen` follow-up runs with the correct dialog-NPC pairing — and
+specifically the `last_interaction_target` will reflect the **wrong** NPC
+(the one the player most recently clicked, not the one the dsm_id belongs
+to).
+
+**Evidence**
+- Ghidra: confirms client emits `interactionSetMapId: i32`; routing to method
+  76 is pinned by `cell_method_constants_pin_expected_values` test.
+- Cross-ref to Rust handler: `crates/services/src/cell/interactions/dispatch.rs:
+  215-224` (unscoped dsm_id lookup loop).
+
+**Attack scenario**
+1. Server fires chain Z which calls `Action::AddDialogSet` adding entry
+   `(dsm_z, dialog_z, _)` under `available_interactions[template_Z]` —
+   intended to open when the player interacts with an NPC of template Z.
+2. Server fires chain W which adds `(dsm_w, dialog_w, _)` under
+   `available_interactions[template_W]` — intended for an NPC of template W.
+3. Attacker INTERACTs with an NPC of template W (pins
+   `last_interaction_target = NPC_W`).
+4. Attacker sends `InitialResponse(dsm_z)`. Server scans
+   `available_interactions.values()`, finds dsm_z, returns `dialog_z`, and
+   sends `onDialogDisplay(EntityId=NPC_W, DialogId=dialog_z)` — the W NPC
+   speaks Z's dialog, the chain follow-up fires with mismatched
+   actor/dialog pairing.
+
+**Suggested remediation (one line)**
+Scope the dsm_id lookup to `available_interactions[template_of(last_
+interaction_target)]` only, not the full map of all templates.
+
+**Would benefit from x64dbg trace?**
+No — the wire shape is short (just `interactionSetMapId: i32`), the bug is
+purely in the server-side lookup scope.
+
+---
+
+### CAT-J-03 — Interact has no liveness check on the acting player
+
+**Severity**: Low
+**Class**: Missing actor-state precondition
+**Wire surface**: `Event_NetOut_Interact` (cell method 74)
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+The `INTERACT` arm at `crates/services/src/cell/cell_methods/player/
+interaction.rs:22-235` validates `MAX_INTERACT_DISTANCE` and the target's
+faction/aliveness for the auto-attack reroute, but **never checks whether
+the acting player itself is alive** (no `is_dead_state(e.state_field)`
+guard on `entity_id`). A dead player can right-click an NPC to open a
+dialog, open a vendor, interact with a loot corpse, or trigger
+`fire_interact_tag` / `fire_interact_template` chains, all while their own
+`BSF_DEAD` is set. The downstream handlers (`send_store_open`,
+`send_loot_display`, `fire_interact_*`) don't guard either.
+
+The exploit shape is bounded — once the player is dead they can't actually
+use most of the resulting UI (their movement and ability inputs are gated
+elsewhere) — but mission-completion dialogs, mission-accept dialogs, and
+content chains tied to `OnInteractTag` will fire and persist state changes
+(mission accepts, counter bumps, `last_interaction_target` updates) even
+while the player is in BSF_DEAD. That state then persists across respawn
+and affects the chain-evaluation context.
+
+**Evidence**
+- Ghidra: `Event_NetOut_Interact` at `0x019bf184` (string ref) and
+  `0x00d68010` (server-side handler vfunc_0) confirm client→server
+  direction.
+- Cross-ref to Rust handler: `crates/services/src/cell/cell_methods/player/
+  interaction.rs:22-235` — no `is_dead_state` guard on the acting entity.
+
+**Attack scenario**
+1. Player takes lethal damage; server marks them BSF_DEAD but the death
+   animation / respawn window is still running.
+2. Before respawning, client sends `Interact(targetEntityId=NPC_GIVER)`.
+3. Server resolves dialog via `handle_interact`, sets
+   `last_interaction_target = NPC_GIVER`, fires
+   `OnInteractTag`/`OnInteractTemplate` chains.
+4. Chain `Action::AcceptMission` or `IncrementCounter` runs against a
+   dead player, persisting state that "shouldn't" have happened until
+   after respawn.
+
+**Suggested remediation (one line)**
+Drop `INTERACT` (and `DIALOG_BUTTON_CHOICE`, `INITIAL_RESPONSE`) at the
+top of their handlers when `is_dead_state(player.state_field) == true`,
+matching the implicit assumption that a dead player can't talk.
+
+**Would benefit from x64dbg trace?**
+No — the wire shape is well-known (`targetEntityId: i32`); the bug is
+absence of a guard, not a wire-format ambiguity.
+
+---
+
+### CAT-J-04 — accept_or_advance has no mission-prerequisite validation
+
+**Severity**: High
+**Class**: Missing server-side precondition (level / faction / prior-mission gating)
+**Wire surface**: Chain-driven via `Action::AcceptMission`. Reachable from the
+client via `DIALOG_BUTTON_CHOICE` (75) when a chain is keyed on
+`OnDialogChoice` with an `AcceptMission` action, or via `INITIAL_RESPONSE`
+(76) → `fire_dialog_open` → `OnDialogOpen` chain with an `AcceptMission`
+action. **Not directly reachable** from `Event_NetOut_MissionAssign` because
+that cell method has no handler today (falls through to the unhandled
+`warn!`), but the *intent* of `MissionAssign` is what's described here.
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+`crates/services/src/cell/content/executor/mission.rs::accept_or_advance`
+(lines 27-100) accepts any `mission_id` whose `space_mgr.mission_defs`
+entry exists, with **no check on player level, archetype, faction,
+required prior missions, instance flags, or cooldown**. It directly calls
+`accept_mission` (which writes the in-memory mission tracker) and emits
+`MissionUpdate` for persistence. There is no `prereq_ok(player,
+mission_def)` predicate anywhere in the flow. The chain author is the
+*only* guard — if a content chain fires `AcceptMission { mission_id: 688 }`
+unconditionally, the player gets mission 688 regardless of any gating the
+designer might have intended to enforce in the dialog tree.
+
+Combined with **CAT-J-01** (DialogButtonChoice with no open-dialog check),
+the practical exploit is: discover a `dialog_id` whose `OnDialogChoice`
+chain calls `AcceptMission`, send `DialogButtonChoice(dialog_id, button_id)`
+without ever opening that dialog, and the server hands the player the
+mission. From there, mission completion through the legitimate objective
+path grants the rewards the mission was guarding.
+
+**Evidence**
+- Ghidra: `Event_NetOut_MissionAssign` at `0x019b33e0` confirms the client
+  emits such a message (8 references); the Rust dispatch has no handler
+  for it, but the same validation gap applies to chain-driven accepts.
+- Cross-ref to Rust handler: `crates/services/src/cell/content/executor/
+  mission.rs:27-100`. The `if let Some(def) = space_mgr.mission_defs.get(
+  &mission_id)` is the only precondition.
+
+**Attack scenario**
+1. Per **CAT-J-01**, attacker forges `DIALOG_BUTTON_CHOICE(dialog_id=X)`
+   for a dialog_id bound to an `OnDialogChoice` chain with action
+   `AcceptMission { mission_id: 999 }`.
+2. Server fires the chain unconditionally; `accept_or_advance` runs.
+3. `mission_defs[999]` exists → mission is accepted, regardless of level,
+   prior-mission completion, or faction gating that the chain author
+   *would have written into the dialog tree* if they could trust
+   `DIALOG_BUTTON_CHOICE` to only fire after the dialog was actually
+   shown.
+
+**Suggested remediation (one line)**
+Route `accept_or_advance` through a `validate_can_accept(player,
+mission_def)` predicate that checks min_level, faction, prereq_mission_ids,
+and one-instance ownership; consult mission-systems-advisor on which
+fields belong on `MissionDef`.
+
+**Would benefit from x64dbg trace?**
+No — the gap is fully visible in Rust.
+
+---
+
+### CAT-J-05 — ChosenRewards is unimplemented; reward selection is missing entirely
+
+**Severity**: High (when wired up; latent today)
+**Class**: Missing handler (latent server-authority gap)
+**Wire surface**: `Event_NetOut_ChosenRewards` (cell method 87, `chosenRewards`)
+**Demonstrable / Likely-theoretical**: Likely-theoretical (the bug is the
+absence, plus the shape a naïve implementation would take)
+
+**Trust violation**
+`CHOSEN_REWARDS` is in the SGWPlayer constant table (`cell_methods/player/
+constants.rs:25`) but the handler in `world/mod.rs:202-205` just logs
+`UNIMPLEMENTED: chosenRewards` and returns `true`. The intent of the
+message — based on the name + the slash-cmd absence (no `Event_SlashCmd_
+ChosenRewards`, so this is purely from the mission-turn-in UI) — is to
+let the client tell the server "I picked reward N from the offered list."
+
+This is the classic "client picks index, server hands out item" trust
+violation. When the handler is wired up, the *only* secure shape is:
+the server remembers what reward set was offered to this player for this
+mission turn-in (server-authoritative offered list), and the client's
+choice is validated as an index into *that* list — not as an item_id
+the client supplied. A naïve "client sends item_id, server grants
+item_id" path is a dupe + cross-mission reward pick exploit.
+
+Filing now to lock in the design constraint before the implementation
+PR ships.
+
+**Evidence**
+- Ghidra: `Event_NetOut_ChosenRewards` at `0x019baed4` (string ref) +
+  `0x00d67c10` (server-side handler vfunc_0) — client→server direction
+  confirmed by the `register_NetOut_*` convention.
+- Cross-ref to Rust handler: `crates/services/src/cell/cell_methods/
+  player/world/mod.rs:202-205` (`UNIMPLEMENTED: chosenRewards`).
+
+**Attack scenario**
+1. (Latent — requires the handler to be wired up.) Implementation PR adds
+   `CHOSEN_REWARDS` arm that takes `(item_id: i32)` or `(reward_index:
+   i32)` from the client and grants the corresponding reward.
+2. If keyed by item_id: attacker sends any item_id from the canonical
+   reward pool — bypasses single-pick scoping, gets every reward.
+3. If keyed by index but the offered-list isn't pinned per-player +
+   per-mission server-side: attacker can submit an index against a
+   different (richer) mission's reward list.
+
+**Suggested remediation (one line)**
+Pin per-(player, mission) offered-reward state server-side at
+turn-in-dialog-open time, key `ChosenRewards` by an index into THAT list,
+and clear the pin after the first successful choice (or on dialog
+cancel).
+
+**Would benefit from x64dbg trace?**
+Yes — capture an actual `ChosenRewards` packet from a stock client to
+confirm whether the field is `item_id`, `reward_index`, or a richer
+multi-pick array. Determines whether the eventual handler is single-
+or multi-pick.
+
+---
+
+### CAT-J-06 — Missionary.SHARE_MISSION / SHARE_MISSION_RESPONSE are unimplemented but accept payloads
+
+**Severity**: Medium (when wired up; latent today)
+**Class**: Missing peer / group / consent validation (latent)
+**Wire surface**: `Event_NetOut_ShareMission`,
+`Event_NetOut_ShareMissionResponse` (Missionary cell methods 53, 54)
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+`crates/services/src/cell/cell_methods/missionary.rs` parses the payload
+(`mission_id: i32` for SHARE_MISSION, `choice: i8` for SHARE_MISSION_
+RESPONSE) but only logs `UNIMPLEMENTED: shareMission` /
+`UNIMPLEMENTED: shareMissionResponse`. The wire shape — and the absence
+of a target player_id in the payload as currently parsed — is suspect:
+the client almost certainly sends a target (group member to share with);
+the Rust handler doesn't read it. When wired up the requirements are:
+(1) verify the sharer **owns** the mission (`get_mission(mission_id)` !=
+None), (2) the mission is **shareable** (mission_def flag),
+(3) the target is in the sharer's **group/squad** (server-tracked
+membership, not a client-supplied target id), (4) the recipient must
+**accept** (not auto-accept) and the recipient must independently
+**pass prereqs** before AcceptMission fires.
+
+This pre-files the design constraints so the implementation PR has a
+checklist.
+
+**Evidence**
+- Ghidra: `Event_NetOut_ShareMission` and `Event_NetOut_ShareMissionResponse`
+  present in `Event_NetOut_Mission*` enumeration at `0x019b347c` /
+  `0x019b34bc` area (8 refs each — class + emit-info + handler vfunc).
+- Cross-ref to Rust handler: `crates/services/src/cell/cell_methods/
+  missionary.rs:27-40` (UNIMPLEMENTED logs).
+
+**Attack scenario**
+1. (Latent.) Implementation PR wires up `SHARE_MISSION(mission_id,
+   target_player_id)`.
+2. If `target_player_id` is client-supplied and not validated against
+   server-side group membership: attacker can push a quest pop-up
+   onto any online player (chat spam / griefing) regardless of group
+   relationship.
+3. If recipient's `SHARE_MISSION_RESPONSE` auto-accepts on a yes-choice
+   without recipient-side prereq validation: cross-faction mission
+   assignment, level skip, etc.
+
+**Suggested remediation (one line)**
+Verify ownership server-side (sharer has the mission), validate target
+against server-side group membership (not client-supplied target id),
+require recipient explicit consent, and re-run prereq validation on the
+recipient before `accept_or_advance` fires.
+
+**Would benefit from x64dbg trace?**
+Yes — capture the actual payload to confirm whether SHARE_MISSION
+carries a target_player_id or whether the server is supposed to broadcast
+to the sharer's whole group.
+
+---
+
+### CAT-J-07 — abandon_mission has no DB cleanup; mission re-materialises on relog
+
+**Severity**: Low
+**Class**: State inconsistency between in-memory tracker and persisted row
+**Wire surface**: `Event_NetOut_MissionAbandon` (Missionary method 52)
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+`crates/services/src/cell/missions.rs::abandon_mission` removes the
+`MissionInstance` from the player's in-memory `Missions` table and emits
+an `ON_MISSION_UPDATE` wire frame with `STATUS_COMPLETED` so the client
+log clears. It does **not** send a `CellToBaseMsg::MissionUpdate` or a
+`MissionDelete` to base, so the `sgw_mission` DB row keeps its prior
+status (typically MISSION_ACTIVE = 1). On the player's next login,
+`query_saved_missions` (`crates/services/src/base/world_entry/methods/
+missions.rs:7-76`) re-reads the row and re-seeds the in-memory tracker
+— the "abandoned" mission is back.
+
+This isn't a privilege escalation, but it is a server-authority gap: the
+client thinks the mission is gone (the wire frame says so), the server's
+in-memory tracker agrees, the *DB* doesn't, and the post-relog state
+silently disagrees with both. A player could use this to effectively
+"undo" a dialog choice tree by abandoning a mission they'd progressed
+into a dead-end, then relog to get it back at the original step.
+
+**Evidence**
+- Ghidra: confirms `Event_NetOut_MissionAbandon` is a client→server
+  message; the Rust dispatch routes method 52 to `missionary::dispatch`
+  which calls `abandon_mission` with the client-supplied mission_id.
+- Cross-ref to Rust handler: `crates/services/src/cell/missions.rs:282-312`
+  (no DB-write side; only wire emit). `base/world_entry/methods/missions.rs`
+  has no `delete_mission` function.
+
+**Attack scenario**
+1. Player accepts mission X at step 1.
+2. Player progresses to step 3, finds the rewards aren't as good as
+   expected.
+3. Player abandons mission X. Server clears in-memory state; DB still
+   has `status=1, current_step_id=2`.
+4. Player relogs; server re-seeds mission X at the persisted step 2.
+   The player is back in the mission *and* has the chain-fired side
+   effects from the prior partial progression (counters, dialog sets)
+   still applied.
+
+**Suggested remediation (one line)**
+On abandon, send a `CellToBaseMsg::MissionDelete { player_id, mission_id }`
+that the base bridges to a `DELETE FROM sgw_mission WHERE player_id=$1
+AND mission_id=$2`, ensuring the persisted state matches the cleared
+in-memory state.
+
+**Would benefit from x64dbg trace?**
+No — this is a server-side persistence gap, not a wire-format question.
+
+---
+
+### CAT-J-08 — Mission*/Debug* names fall through the unhandled warn — latent server-authority hole
+
+**Severity**: Medium (latent / advisory)
+**Class**: Latent dispatch hole — future "wire it up" PRs inherit no
+validation skeleton
+**Wire surface**: `Event_NetOut_MissionAdvance`, `MissionComplete`,
+`MissionAssign`, `MissionReset`, `MissionClear`, `MissionClearActive`,
+`MissionClearHistory`, `MissionList`, `MissionListFull`, `MissionDetails`,
+`MissionSetAvailable`, `DebugInteract`, `AbandonMission` (the slash-cmd
+variant, distinct from MissionAbandon at method 52)
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+Every name above has a `register_NetOut_*` symbol in the SGW client whose
+Ghidra-decompiled comment reads `Direction: NetOut (client -> server)`.
+None of them has a cell-method dispatch arm in the Rust server today —
+they all fall through to `dispatch_cell_method`'s unhandled `warn!` at
+`crates/services/src/cell/dispatch/router.rs:101`. That is safe **today**,
+but is exactly the bug shape a future "wire up MissionAdvance" PR will
+inherit: the implementer writes a handler, parses a `mission_id: i32`
+off the wire, and calls `advance_step` or `complete` directly — no GM
+gate, no ownership check ("does this player own this mission?"), no
+step-validity check ("is the requested step actually the next legal step
+for this mission's current state?").
+
+`DebugInteract` is the clearest GM-only candidate by name — when wired up
+it MUST be GM-gated (read GM bit from server-side session state, not from
+the inbound payload — per CAT-N convention). The Mission*/Clear/Reset
+variants are mixed: some are "client requests view" (MissionList,
+MissionListFull, MissionDetails — generally safe if they only read), but
+**MissionAdvance, MissionComplete, MissionReset, MissionClear,
+MissionClearActive, MissionClearHistory, MissionSetAvailable** are all
+state-mutating shapes that require server-side validation of (1) GM bit
+for the clear/reset/setAvailable family if they're admin-only, and (2)
+ownership + step-validity for any per-player advance/complete that's
+meant to be reachable from non-GM UI.
+
+Filing as a single finding because the remediation is structural — the
+dispatch table needs a pre-implementation review row for each before the
+handler is added, not after.
+
+**Evidence**
+- Ghidra: `Event_NetOut_Mission*` enumeration at `0x019b33e0–0x019b35f4`
+  (12 strings), `Event_NetOut_DebugInteract` at `0x019b3a08`,
+  `Event_NetOut_AbandonMission` at `0x019baea4` — all decompile to
+  `Direction: NetOut (client -> server)` `register_NetOut_*` functions.
+- Cross-ref to Rust handler: no handler; falls through
+  `crates/services/src/cell/dispatch/router.rs:101` unhandled-warn arm.
+
+**Attack scenario**
+Latent. If a future PR wires up `MissionAdvance(mission_id, step_id)`
+without ownership + step-validity validation, attacker sends arbitrary
+`(mission_id, step_id)` pairs to skip directly to mission completion
+steps, claim rewards, fire `OnMissionCompleted` chains for missions
+they never started.
+
+**Suggested remediation (one line)**
+Before wiring any of these up, add a row in
+`docs/protocol/client-method-dispatch-table.md` naming the server-side
+validation each requires; for `DebugInteract` + the Mission*Clear /
+Reset / SetAvailable family, gate on
+`session.gm_flag` read from server-side session state (not from the
+inbound packet) per CAT-N convention.
+
+**Would benefit from x64dbg trace?**
+Yes — capture each payload from a known-good (GM-flag-on) client to
+pin the field layouts before the implementation PR lands; otherwise
+the implementer guesses and the wire format ends up undocumented.
+
+---
+
+### CAT-J-09 — fire_dialog_choice/fire_dialog_open populate context with chain-author-trusted player_id but no entity-vs-player linkage check
+
+**Severity**: Low
+**Class**: Trust-context shape (defensive, not directly exploitable today)
+**Wire surface**: `Event_NetOut_DialogButtonChoice` (75),
+`Event_NetOut_Interact` (74) downstream of dialog open
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+Both `fire_dialog_choice` and `fire_dialog_open` (`crates/services/src/
+cell/content/event_dispatch/dialog.rs:24-111`) take `player_id` as a
+parameter and pass it as the chain `ExecutionContext`'s source binding,
+**but the call sites read `player_id` from `space_mgr.get_entity(entity_
+id).player_id` and fall back to `0`** (`interaction.rs:243-246`,
+`interaction.rs:218-221`). Falling back to `0` would attribute chain
+side-effects (`GrantItem`, `IncrementCounter`, `AcceptMission`) to a
+non-existent player. The same `Some/None` pattern is checked in
+`handle_initial_response` (`interactions/dispatch.rs:231-242`) which
+warn-and-returns when player_id is None — but the DIALOG_BUTTON_CHOICE
+and INTERACT arms in `cell_methods/player/interaction.rs` use
+`.unwrap_or(0)` instead.
+
+This is the same bug shape PR #105 + Copilot caught for `handle_initial_
+response` (regression test at `interactions/dispatch.rs:593-632`) — the
+fix wasn't propagated to the DIALOG_BUTTON_CHOICE / INTERACT call sites.
+A future test or code path that lets a non-player CellEntity reach
+`DIALOG_BUTTON_CHOICE` (e.g. some NPC AI control path forwarded to the
+dialog choice handler in error) would attribute chain side-effects to
+player_id=0. Today that path doesn't exist, so this is a defense-in-depth
+finding.
+
+**Evidence**
+- Cross-ref to Rust handler: `crates/services/src/cell/cell_methods/
+  player/interaction.rs:243-246` (`unwrap_or(0)` for DIALOG_BUTTON_CHOICE),
+  `:218-221` (`unwrap_or(0)` for INTERACT → fire_dialog_open).
+- Companion fix already in place: `crates/services/src/cell/interactions/
+  dispatch.rs:231-242` (warn-and-return for missing player_id) — same
+  shape, applied at `handle_initial_response` only.
+
+**Attack scenario**
+Not directly exploitable today (the only entity that reaches the
+SGWPlayer cell-method range is a CellEntity with `is_player = true` and
+`player_id = Some`). Filing as a defense-in-depth alignment with the
+PR #105 fix.
+
+**Suggested remediation (one line)**
+Replace `.unwrap_or(0)` with the same `Some(id) => id, None => warn! +
+return` pattern used in `handle_initial_response`, in both the
+DIALOG_BUTTON_CHOICE and INTERACT (`fire_dialog_open`) call sites.
+
+**Would benefit from x64dbg trace?**
+No — pure code-shape alignment.
+
+---
+
+## Not Filed
+
+- **Dialog button_id is unvalidated** — folded into **CAT-J-01**. The
+  separate exploit shape would be "send a button_id that wasn't in the
+  rendered dialog," but since OnDialogChoice's only built-in matcher is
+  `dialog_id` (not button_id), the practical impact is identical to
+  CAT-J-01: any chain bound to the dialog fires. Worth noting once that
+  the button_id is just passed into chain params and any chain
+  *condition* that reads it is the only thing that can validate it.
+
+- **`MAX_INTERACT_DISTANCE = 5.0` could be tightened / spec'd from
+  Ghidra** — the value is sourced from a comment referencing python
+  `common/Constants.py: MAX_INTERACT_DISTANCE = 5`, not from Ghidra.
+  Spec verification needed but not an authority gap.
+
+- **Range check uses `distance_squared_to(&target_pos).sqrt()`** —
+  could be optimized to `< MAX_INTERACT_DISTANCE * MAX_INTERACT_DISTANCE`
+  without the sqrt; not a security issue.
+
+- **Negative target_entity_id in INTERACT is dropped with a warn** —
+  `interaction.rs:30-39`. That's already a defensive check the code does
+  right; calling it out only as a positive example for other handlers
+  that *don't* do this.
+
+- **abandon_mission doesn't validate ownership before calling
+  remove_mission** — looked at this. `remove_mission` is keyed on the
+  player's own missions HashMap, so a mission_id the player doesn't own
+  is a silent no-op. No privilege escalation; just a stale-target
+  log-noise opportunity. Not filed.
+
+- **`MissionList` / `MissionListFull` / `MissionDetails` falling through
+  unhandled** — these are read-only inquiry shapes (the client wants
+  the server to send back its mission state). Folded under **CAT-J-08**
+  as part of the dispatch-table review. The latent risk is much smaller
+  than the state-mutating variants, but they share the same
+  pre-implementation review row.
+
+- **The `MissionUpdate` channel send is best-effort (`if let Err(e) =
+  tx.send(...)`)** in `accept_or_advance` and `complete`. A channel
+  closure means the chain has run + in-memory state is mutated but
+  persistence didn't queue. That's a data-loss/consistency bug shape
+  but not an exploit — the comment at `executor/mission.rs:78-92`
+  documents the design ("in-process state is authoritative"). Not
+  filed; sits in the same category as **CAT-J-07** (state-consistency
+  gaps that aren't security findings).
+
+- **DialogButtonChoice + InitialResponse have no rate limit** — minor
+  spam vector (each event reads the chain table and may trigger a
+  GrantItem/GrantXP). Not filed because the underlying issue is
+  CAT-J-01's "no precondition" — a rate limit on a wide-open handler
+  treats the symptom not the cause.
+
+- **Chain replay (sending the same DialogButtonChoice twice quickly)** —
+  if the chain has a `mission_completed N` guard that uses
+  `transitioned_from_active` (mission/executor.rs:130-179), the second
+  call won't re-fire. But for chains with no such guard (e.g. simple
+  `IncrementCounter` actions), the second call **does** double-fire.
+  Folded under CAT-J-01: same root cause (no open-dialog tracking +
+  no idempotency on the choice).

--- a/docs/security-audit/2026-05-31-server-authority/findings/CAT-K-minigame.md
+++ b/docs/security-audit/2026-05-31-server-authority/findings/CAT-K-minigame.md
@@ -1,0 +1,545 @@
+# CAT-K — Minigame
+
+## Trust posture
+
+The minigame system has a deliberately **good** architecture for server authority — content
+chains issue 256-bit random tickets, the client connects to an in-process SmartFoxServer-
+compatible TCP server with the ticket, and the SFS server (`crates/services/src/minigame/server.rs`)
+is the **only** producer of `CellToBaseMsg::MinigameResult` that fires victory chains.
+The client never directly asserts "I won." All seventeen `Event_NetOut_Minigame*` and
+`Event_NetOut_debug*Minigame` wire messages currently land in cell-method handlers that
+log `UNIMPLEMENTED` (`crates/services/src/cell/cell_methods/minigame.rs`) — none of them
+mutate game state in the current Rust server.
+
+However, the architecture has a **load-bearing hole**: the `PlaceholderGame`
+(`crates/services/src/minigame/games/placeholder.rs`) handles every minigame except Livewire
+(Hack, Activate, Analyze, Bypass, Converse, ConverseBasicHumanoid) and instant-victories
+on receipt of the client SFS message `cmd=victory` with no challenge or validation. For
+those minigame types the SFS server simply rubber-stamps whatever the client claims, which
+is exactly the "client self-declares success" trust violation the minigame-systems-advisor
+explicitly warns against. Mission gating on Hack/Bypass/Analyze/Activate/Converse is
+trivially bypassable: any client with a valid ticket sends `<xtReq>cmd=victory</xtReq>`
+and the `on_victory_chains` fire.
+
+Beyond that core issue, ticket lifecycle has a DoS-shaped gap (no TTL, no IP binding),
+several `<Exposed/>` MinigamePlayer cell methods are designed to take a client-supplied
+target / instance / contact id with no validation (currently UNIMPLEMENTED — but the wire
+shape is on file as the next contributor's design target), and the cross-domain XML policy
+the SFS server emits is wide open.
+
+Findings below are prioritised by exploitability assuming the unimplemented handlers stay
+that way and the placeholder remains in place.
+
+---
+
+### CAT-K-01 — PlaceholderGame instant-victory on client `cmd=victory`
+
+**Severity**: Critical
+**Class**: Server-authority bypass / mission gating bypass
+**Wire surface**: SmartFoxServer XT request (`<xtReq>cmd=victory</xtReq>`) over the TCP
+minigame port — NOT a Mercury `Event_NetOut_*`, but the result of the StartMinigame URL
+the server hands the client
+**Demonstrable / Likely-theoretical**: Demonstrable (server code self-incriminates)
+
+**Trust violation**
+For every minigame type except Livewire (i.e. Hack, Activate, Analyze, Bypass, Converse,
+ConverseBasicHumanoid — all the SWF-based ones that aren't yet ported from Python), the
+SFS-side game instance is `PlaceholderGame`, whose `message()` handler responds to the
+client command `victory` with `[Send("victory"), GameOutput::Victory]` — no challenge,
+no time check, no progress tracking, no proof-of-play. The server immediately fires the
+victory chains the content engine attached to the session. The cross-disciplinary
+minigame-systems-advisor states "Client cannot self-declare success — the result the
+cell sees is whatever the minigame server decided." This placeholder violates that rule
+directly: the only thing "the minigame server decided" is to trust the client's claim.
+
+**Evidence**
+- Ghidra: `019b31c4` `Event_NetOut_MinigameComplete` — client wire type exists, but the
+  exploit doesn't need it; the SFS connection is sufficient.
+- Ghidra: `01841adc` `Event_SlashCmd_MinigameComplete` registered in
+  `CMERegistry__RegisterAllEventEmitHandlers` (`005ca670`) — confirms a client console
+  console `/MinigameComplete` slash command exists, though the active path is the SFS
+  `cmd=victory`.
+- Client behavioral log: n/a (server-side stub bypass).
+- Cross-ref to Rust handler (for the fix author):
+  `crates/services/src/minigame/games/placeholder.rs:39-47` — the `"victory"` arm.
+
+**Attack scenario**
+1. Player accepts a mission whose advance step uses content action
+   `StartMinigame { minigame_type: "Hack", on_victory_chains: [X] }`.
+2. Server registers a session with a 256-bit ticket and pushes the connect URL via
+   `onStartMinigame(URL)`.
+3. The legitimate Flash client would play the Hack puzzle. Instead, the attacker uses a
+   trivial TCP client that connects to the minigame port, sends the verChk + login (with
+   the ticket extracted from the URL), then sends
+   `<msg t='xt'><body action='xtReq'><![CDATA[<dataObj><var n='cmd' t='s'>victory</var></dataObj>]]></body></msg>`.
+4. `PlaceholderGame::message("victory")` returns `GameOutput::Victory` → SFS server emits
+   `CellToBaseMsg::MinigameResult { result_code: 1, on_victory_chains: [X] }` → cell fires
+   chain X → mission step completes.
+
+**Suggested remediation (one line)**
+Until the per-game Rust implementations land, stub these games with a server-driven timer
+(e.g. minimum 30s) and reject `victory` before the timer elapses; longer-term, port the
+Python game logic so the server decides victory from observed gameplay events.
+
+**Would benefit from x64dbg trace?**
+No — the server code is self-evidently bypassable; reproducing the exploit is a 50-line
+Python TCP client, not a debugger session.
+
+---
+
+### CAT-K-02 — MinigamePlayer "debug*" cell methods exposed on regular SGWPlayer
+
+**Severity**: High (latent — currently UNIMPLEMENTED)
+**Class**: GM-only command exposed on non-GM entity
+**Wire surface**: `Event_NetOut_debugStartMinigame`, `Event_NetOut_debugSpectateMinigame`,
+`Event_NetOut_debugJoinMinigame`, `Event_NetOut_debugMinigameInstance`
+**Demonstrable / Likely-theoretical**: Likely-theoretical (handlers exist as stubs; design
+intent if implemented as-named violates server authority)
+
+**Trust violation**
+`entities/defs/interfaces/MinigamePlayer.def` declares `debugStartMinigame`,
+`debugSpectateMinigame`, `debugJoinMinigame`, `debugMinigameInstance` as `<Exposed/>` cell
+methods (lines 352–367). Every SGWPlayer implements MinigamePlayer
+(`entities/defs/SGWPlayer.def:8`). The "debug" prefix conveys GM-only intent — and indeed
+`SGWGmPlayer.def:395` has the **parallel** `gmDebugStartMinigame` that is the real GM
+surface. The MinigamePlayer "debug*" versions are a stranded duplicate set that any
+non-GM client can dispatch through the standard cell-method router
+(`crates/services/src/cell/cell_methods/minigame.rs:31-62`, indices 20–23). Currently
+all four handlers just log `UNIMPLEMENTED: debug*Minigame` and don't mutate state, so
+this is latent. But the wire is open, the dispatch is wired, and the next contributor
+implementing "debugStartMinigame" against the def-driven flat method index will
+implement a non-GM debug surface unless they recognise the duplicate.
+
+**Evidence**
+- Ghidra: `019b3114` `Event_NetOut_debugStartMinigame`, `019b3148` `debugSpectateMinigame`,
+  `019b3188` `debugJoinMinigame`, `019acf08` `debugMinigameInstance` — all real client
+  emit points.
+- Client behavioral log: n/a (UI exposure is GM client; wire is unconditional).
+- Cross-ref to Rust handler:
+  `crates/services/src/cell/cell_methods/minigame.rs:31-62` (the four `UNIMPLEMENTED`
+  arms at indices 20–23).
+
+**Attack scenario** (presumed if implemented as named)
+1. A future PR implements `debugStartMinigame(gameId)` against the MinigamePlayer slot 20.
+2. Non-GM client sends a method-call packet with `method_idx = 20 + flatten_offset` and
+   payload `INT32 aGameId`.
+3. Cell dispatcher routes to the new handler, which (per the "debug" naming) lets the
+   client start any minigame ID without satisfying the chain prerequisite that normally
+   gates it.
+4. Mission chains gated on minigame completion become trivially skippable.
+
+**Suggested remediation (one line)**
+Either remove the four MinigamePlayer "debug*" `<Exposed/>` entries (preferred — keep
+only the SGWGmPlayer parallel methods), or hard-gate the cell-method handlers behind
+the same `access_level > 0` check the SGWGmPlayer entity selection uses
+(`crates/services/src/base/world_entry/play_character.rs:89-94`).
+
+**Would benefit from x64dbg trace?**
+No — the wire slot is unambiguously named "debug" and is unambiguously on the non-GM
+interface; the def file is the authority.
+
+---
+
+### CAT-K-03 — Minigame session has no TTL → mission stall via no-connect
+
+**Severity**: Medium
+**Class**: DoS / TOCTOU
+**Wire surface**: Any chain action that fires `Action::StartMinigame` (player has no direct
+control over the trigger, but can refuse to follow through)
+**Demonstrable / Likely-theoretical**: Demonstrable (`SessionRegistry` records `created_at`
+but never reads it)
+
+**Trust violation**
+`SessionRegistry::register` (`crates/services/src/minigame/session.rs:60-96`) rejects a
+second registration for the same `entity_id`, but **never evicts stale sessions**.
+`created_at` is captured but `register()` and `authenticate()` don't consult it. A session
+is removed only when the SFS connection lifecycle completes
+(`crates/services/src/minigame/server.rs:356`). If the player never connects to the
+minigame port — which they can choose to do by simply ignoring the `onStartMinigame(URL)`
+client method — the session lives forever, and every subsequent `StartMinigame` chain
+action for that entity logs `Failed to register minigame session (duplicate?)` and
+silently drops the `on_victory_chains` (`crates/services/src/base/world_entry/cell_dispatch/minigame.rs:79-84`).
+
+**Evidence**
+- Ghidra: n/a — server-only behaviour. The client emit that triggers the chain is e.g.
+  `Event_NetOut_Interact` (`docs/protocol/message-catalog.md` interact rows), which is
+  legitimate and out of scope.
+- Client behavioral log: n/a.
+- Cross-ref to Rust handler:
+  `crates/services/src/minigame/session.rs:60-96` (`register`, no TTL check),
+  `crates/services/src/minigame/session.rs:124-127` (`remove`, only called by SFS
+  lifecycle exit).
+
+**Attack scenario**
+1. Player interacts with a mission NPC whose chain fires `Action::StartMinigame`.
+2. Server registers session, sends `onStartMinigame(URL)` to client.
+3. Client discards the URL (modified client, dropped packet, or `/MinigameStartCancel`
+   slash command — see CAT-K-04).
+4. Player re-interacts with the same NPC (or any other minigame-triggering chain).
+5. `SessionRegistry::register` returns `None` because the entity already has a session;
+   `cell_dispatch::minigame::start_minigame` logs the warn and does not push
+   `onStartMinigame`. The player is silently stuck — no minigame UI, no progress.
+6. The mission is now uncompletable until the player relogs (and even then, only if
+   process restart wipes the in-memory registry — which it does, since the registry isn't
+   persisted, but a long-lived server holds the stale session indefinitely).
+
+This is exploitable by a **griefer** if `entity_id` collisions are possible (they're per-
+world-entity), but more practically it is a **self-DoS** that makes the player look at
+the mission and conclude "the game is broken." From a server-authority standpoint, this
+is a missing TTL: the registry trusts that the player will follow through, which they
+don't have to.
+
+**Suggested remediation (one line)**
+Add a TTL sweep (e.g. 60s without a successful SFS authenticate) inside `SessionRegistry`
+and evict stale sessions; also have `cell_dispatch::minigame::start_minigame` evict any
+existing session for the entity before registering (the chain action is the authoritative
+"please start a new minigame" signal — superseding the abandoned one is correct).
+
+**Would benefit from x64dbg trace?**
+No — no client-side knowledge required; the server data structure is the witness.
+
+---
+
+### CAT-K-04 — `minigameStartCancel` / `endCurrentMinigame` cell methods accept no authentication of the cancel actor
+
+**Severity**: Medium (latent — currently UNIMPLEMENTED)
+**Class**: Authority — actor identity vs target session
+**Wire surface**: `Event_NetOut_MinigameStartCancel`, `Event_NetOut_EndMinigame`
+(MinigamePlayer cell methods 30 and 25)
+**Demonstrable / Likely-theoretical**: Likely-theoretical (handlers are `UNIMPLEMENTED`,
+but the def shape declares them `<Exposed/>` with client-supplied IDs)
+
+**Trust violation**
+`MinigamePlayer.def` `endCurrentMinigame` takes no args (lines 406-408) but the Rust
+stub in `cell_methods/minigame.rs:76-90` unmarshals a 12-byte payload of
+`(game_id, winner_id, loser_id)` from client. **The implementing contributor will need
+to decide which side is canonical.** If they implement against the unmarshaled wire
+shape, the client supplies `winner_id` and `loser_id` directly — a clean spoof of who
+"won" a multi-player minigame. Similarly `minigameStartCancel` (index 30, no args in def)
+unmarshals `game_id` from client — currently no verification that the canceler is the
+session owner. The session is keyed by `entity_id` on the server side, so the right
+implementation is "cancel the session for `entity_id == caller`, ignoring any client-
+supplied game_id." But the stub is set up to read the client's game_id, which guides
+the next contributor toward the wrong design.
+
+**Evidence**
+- Ghidra: `019be408` `Event_NetOut_EndMinigame`, `019be4b8`
+  `Event_NetOut_MinigameStartCancel` — real client emits.
+- Client behavioral log: n/a.
+- Cross-ref to Rust handler:
+  `crates/services/src/cell/cell_methods/minigame.rs:76-90` (END_CURRENT — unmarshals 12
+  bytes vs def's 0),
+  `crates/services/src/cell/cell_methods/minigame.rs:131-136` (START_CANCEL — unmarshals
+  game_id from client).
+
+**Attack scenario** (presumed if implemented against the current arg unmarshal shape)
+1. Player A and Player B are in a 2-player minigame instance (e.g. a shared Livewire
+   instance — the def supports this via `joinMinigame`).
+2. Player A sends `endCurrentMinigame` with `winner_id = A` and `loser_id = B`.
+3. Server (in the wrong implementation) trusts the client-supplied winner/loser,
+   awards the victory chain to A even though the SFS instance hadn't completed.
+
+**Suggested remediation (one line)**
+Drop the client-supplied unmarshals; the server already knows `entity_id == caller`
+and looks up the session by that key — the per-handler design must derive winner/loser
+from server state (the SFS instance), not from client args.
+
+**Would benefit from x64dbg trace?**
+Yes — confirming the actual NetOut payload shape (does Event_NetOut_EndMinigame really
+serialize 12 bytes, or is the Rust stub wrong about the wire) needs a live debugger or
+a Ghidra trace of the EventHandler::vfunc_0 serialiser. The def says zero args.
+
+---
+
+### CAT-K-05 — `spectateMinigame(playerId)` accepts client-chosen target with no perception check
+
+**Severity**: Medium (latent — currently UNIMPLEMENTED)
+**Class**: Information disclosure / privacy
+**Wire surface**: `Event_NetOut_SpectateMinigame`, `Event_NetOut_RequestSpectateList`
+**Demonstrable / Likely-theoretical**: Likely-theoretical (UNIMPLEMENTED, but the wire
+takes a client-supplied INT32 `playerId`)
+
+**Trust violation**
+`MinigamePlayer.def` `spectateMinigame` (lines 449-452) is `<Exposed/>` and takes
+`INT32 playerId`. There is no def-level constraint that the spectator be in the same
+group/squad/world as the target, or that the target's session is set to allow
+spectators. The stub at `cell_methods/minigame.rs:99-104` unmarshals the player id but
+doesn't act. The implementing contributor needs to validate that:
+- the target player is in an active minigame session,
+- the target's session has `allow_spectators` (no such field exists yet),
+- the spectator is in the target's AoI or is otherwise authorised (group, squad, GM).
+
+Without those checks, any client can spectate any other player's minigame, which is
+both a privacy/info-disclosure issue (sees the puzzle state) and a co-op-cheat enabler
+(off-screen friend can tell the spectated player which wire is the goal).
+
+**Evidence**
+- Ghidra: `019be498` `Event_NetOut_SpectateMinigame`, `019be474`
+  `Event_NetOut_RequestSpectateList`.
+- Client behavioral log: n/a.
+- Cross-ref to Rust handler:
+  `crates/services/src/cell/cell_methods/minigame.rs:98-104` (SPECTATE, UNIMPLEMENTED).
+
+**Attack scenario** (presumed if implemented without check)
+1. Attacker queries `RequestSpectateList` for game_id covering all active sessions in
+   the world.
+2. Attacker calls `spectateMinigame(targetPlayerId)` for any returned id.
+3. Server pipes the target's SFS XT frames to the attacker via
+   `onSpectateList`/equivalent client method, leaking the puzzle state in real time.
+
+**Suggested remediation (one line)**
+Before piping spectator frames, require that the target session's `allow_spectators`
+flag is set (add the field to `MinigameSession`) and that the spectator is either in
+the target's group/squad or in the target's AoI.
+
+**Would benefit from x64dbg trace?**
+No — the design constraint is clear from the def; the wire shape is just a single INT32.
+
+---
+
+### CAT-K-06 — `minigameCallRequest` accepts client-named recipient with no contact / rate gate
+
+**Severity**: Medium (latent — currently UNIMPLEMENTED)
+**Class**: Spam / griefing / unsolicited interaction
+**Wire surface**: `Event_NetOut_MinigameCallRequest`
+**Demonstrable / Likely-theoretical**: Likely-theoretical (UNIMPLEMENTED, but def shape
+is clear)
+
+**Trust violation**
+`MinigamePlayer.def` `minigameCallRequest` is a **base method** (line 300) `<Exposed/>`
+with args `(RemotePlayerName: WSTRING, TipAmount: INT32)`. The client picks the target
+by name and supplies a "tip amount" (which translates to in-game currency the caller
+allegedly promises to pay). Recipient resolution will need to scan online players by
+name — which is fine — but the server design must also enforce:
+- the caller is on the recipient's contact list (per the `minigameRegistrationInfo`
+  protocol), OR the recipient has `wantsRequests = true`,
+- a rate limit per caller (otherwise this is a free spam channel — every accept dialog
+  the recipient sees is one the caller can fire),
+- the `TipAmount` must be debited atomically with the tip-claim flow (otherwise the
+  tip is a free promise — client can claim any value).
+
+Currently UNIMPLEMENTED. Cell-method version at index 34
+(`cell_methods/minigame.rs:159-170`) unmarshals `(target_entity_id, game_def_id)` —
+which doesn't even match the base-method def (`RemotePlayerName: WSTRING, TipAmount:
+INT32`). Whichever direction the implementing contributor takes, the validation matrix
+above needs to land before the handler is wired up.
+
+**Evidence**
+- Ghidra: `019be4dc` `Event_NetOut_MinigameCallRequest`.
+- Client behavioral log: n/a.
+- Cross-ref to Rust handler:
+  `crates/services/src/cell/cell_methods/minigame.rs:159-170` (CONTACT_REQUEST — note
+  this maps to `minigameContactRequest`, NOT `minigameCallRequest`; the cell-method
+  index for the call request itself isn't in the current dispatch table).
+
+**Attack scenario** (presumed if implemented without validation)
+1. Attacker scripts a 10-Hz loop sending `minigameCallRequest("Victim", 0)`.
+2. Victim sees a `minigameCallDisplay` popup every 100ms — full UI takeover until they
+   relog.
+
+**Suggested remediation (one line)**
+Hard rate-limit `minigameCallRequest` per caller (e.g. one outbound call per 30s), reject
+if the recipient's `minigameRegisteredWantsRequests` is false and the caller isn't a
+mutual contact, and lock the `TipAmount` against the caller's wallet at send time (debit
+on accept, refund on decline/timeout/abort).
+
+**Would benefit from x64dbg trace?**
+Yes — confirming `Event_NetOut_MinigameCallRequest` payload includes the full set of
+args the def declares (`RemotePlayerName`, `TipAmount`) and not just the `target_entity_id`
+the stub unmarshals would help the implementing contributor.
+
+---
+
+### CAT-K-07 — Minigame ticket has no IP / connection binding
+
+**Severity**: Low
+**Class**: Session hijack (defense in depth)
+**Wire surface**: SFS TCP login (`<msg t='sys'><body action='login'>`) on the minigame port
+**Demonstrable / Likely-theoretical**: Demonstrable (the auth check only validates
+`(entity_id, ticket, game_name)`)
+
+**Trust violation**
+`SessionRegistry::authenticate` (`crates/services/src/minigame/session.rs:99-121`)
+validates the ticket and the requested game name but not the client IP. The `handle_connection`
+function (`crates/services/src/minigame/server.rs:94-358`) accepts the connection's `peer`
+address only for tracing, never for binding. The `onStartMinigame(URL)` push to the player
+goes over UDP Mercury without encryption, so any path that exposes that packet (a MITM,
+shoulder-surfing, debug log, future telemetry stream) lets a third party who learns the
+ticket play the minigame on the player's behalf. Once they do, the legitimate player —
+who's also racing for the connection — finds their session has been authenticated by
+someone else and their own SFS handshake will produce the same session, since
+`authenticate()` doesn't burn the ticket (it just looks it up; the session is removed only
+at SFS connection close).
+
+Two players using the same ticket would both be allowed through `authenticate()`. Both
+spawn independent `LivewireGame` instances seeded from the same `session.seed`, both compete
+to send `cmd=victory`, and **whichever completes first wins** — the SFS server clones the
+session in authenticate and the registry's `remove(entity_id)` is called only on
+connection close.
+
+**Evidence**
+- Ghidra: n/a — server-only flaw. The wire that leaks the ticket is Mercury
+  `onStartMinigame(URL)` (`Event_NetIn_onStartMinigame` if you trace it inbound on the
+  client side).
+- Client behavioral log: n/a.
+- Cross-ref to Rust handler:
+  `crates/services/src/minigame/session.rs:99-121` (authenticate doesn't burn the ticket,
+  doesn't check IP),
+  `crates/services/src/minigame/server.rs:81-90` (peer captured for tracing only).
+
+**Attack scenario**
+1. Attacker obtains a ticket by any means (intercept the UDP packet carrying
+   `onStartMinigame(URL)`, observe a server log, shoulder-surf the client's debug overlay).
+2. Attacker connects to the minigame port with the same ticket and entity_id, completes
+   `verChk` + `login`, and authenticates successfully.
+3. Attacker plays the minigame (or sends `cmd=victory` for placeholder games, per
+   CAT-K-01); the victim's chain fires from the attacker's session.
+
+**Suggested remediation (one line)**
+Burn the ticket atomically inside `authenticate()` (drop the session from the registry on
+first successful auth, not on connection close) and optionally bind the ticket to the
+calling player's currently-recorded UDP peer in `connected` so a different IP is rejected.
+
+**Would benefit from x64dbg trace?**
+No — server-side data structure proves the gap.
+
+---
+
+### CAT-K-08 — `BaseToCellMsg::MinigameResult` handler fires chains with no idempotency / mission-context check
+
+**Severity**: Low (defense in depth — currently only one producer, but the design is
+fragile)
+**Class**: Idempotency / double-fire
+**Wire surface**: Internal — `CellToBaseMsg::MinigameResult` (originates from the SFS
+server) → `BaseToCellMsg::MinigameResult`
+**Demonstrable / Likely-theoretical**: Likely-theoretical (no current producer fires twice;
+a future contributor adding a second producer would silently break)
+
+**Trust violation**
+`base_messages/mod.rs:247-266` accepts `BaseToCellMsg::MinigameResult { entity_id,
+result_code, on_victory_chains }` and unconditionally calls `fire_chain_by_id` for every
+chain on victory. `fire_chain_by_id` (`event_dispatch/mod.rs:51-80`) "bypasses trigger
+matching" — it has no mission-state check, no "has this chain already fired for this
+entity" record. The current implementation is safe because the only producer
+(`minigame/server.rs:39-45`) sends one message per session and removes the session before
+exiting. But:
+- A future cell handler implementing client-side `endCurrentMinigame` or
+  `minigameContactRequest` may also need to fire chains, and if it routes through the
+  same `BaseToCellMsg::MinigameResult`, no de-dup is in place.
+- If the SFS server's `handle_connection` ever errors after sending the result but before
+  the session is removed, a reconnect can re-authenticate and produce a second result.
+
+**Evidence**
+- Ghidra: n/a — internal Rust message flow.
+- Cross-ref to Rust handler:
+  `crates/services/src/cell/service/base_messages/mod.rs:247-266` (no idempotency),
+  `crates/services/src/cell/content/event_dispatch/mod.rs:47-80` (fire_chain_by_id bypasses
+  every gate).
+
+**Attack scenario** (latent)
+1. (Future) The session-removed-on-close ordering is changed in `handle_connection` to
+   "send result, then send leave, then remove session" — and a runtime panic between
+   send-result and remove-session leaves the session intact.
+2. The player reconnects with the same ticket (which now isn't burned per CAT-K-07) and
+   plays again.
+3. The chain fires a second time — duplicate XP, duplicate item, duplicate mission
+   advance.
+
+**Suggested remediation (one line)**
+Inside `BaseToCellMsg::MinigameResult` handling, record `(entity_id, session_id_or_ticket_hash)`
+and refuse to re-fire chains for an entity whose previous chain firing is still
+in-progress, or atomically delete the session and use its absence as the gate.
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-K-09 — `RegisterToMinigameHelp` / `UpdateRegisterToMinigameHelp` accept self-registration with no skill check
+
+**Severity**: Low (latent — UNIMPLEMENTED; minor griefing surface if implemented blindly)
+**Class**: Authority — claimed-skill vs actual-skill
+**Wire surface**: `Event_NetOut_RegisterToMinigameHelp`, `Event_NetOut_UpdateRegisterToMinigameHelp`
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+`MinigamePlayer.def` `registerToMinigameHelp` (lines 454-458) is `<Exposed/>` and takes
+`(note: WSTRING, inRangeOnly: UINT8)`. The handler is supposed to mark the caller as
+"available to help with minigames" so other players can call them via `minigameCallRequest`.
+The implementing contributor must validate that the registrant actually meets the per-game
+prerequisite (e.g. a `Hack` helper needs a minimum tech_competency or specific ability
+unlock). Without that, any low-level character can register as a helper, accept the
+tip, and then fail every call they accept.
+
+Cell-method stub at `cell_methods/minigame.rs:105-117` parses
+`(game_def_id, help_level)` — which doesn't match the def either; the def has
+`(note: WSTRING, inRangeOnly: UINT8)`. Same arg-shape mismatch as CAT-K-04 and CAT-K-06.
+
+**Evidence**
+- Ghidra: `019be424` `Event_NetOut_RegisterToMinigameHelp`, `019be448`
+  `Event_NetOut_UpdateRegisterToMinigameHelp`.
+- Cross-ref to Rust handler:
+  `crates/services/src/cell/cell_methods/minigame.rs:105-130`.
+
+**Attack scenario** (presumed if implemented without skill check)
+1. Low-level griefer registers as a helper for `Hack` minigames with a high
+   `minigameRegistrationCost` (tip).
+2. Players in need of `Hack` help see the griefer in the helper list and call them.
+3. Griefer accepts the call (charging the tip), then deliberately fails the minigame.
+
+**Suggested remediation (one line)**
+Before persisting the registration, look up the registrant's per-game minimum prerequisite
+(probably from `Atrea.cooked_data` or a server-side resource table) and reject the
+registration if unmet.
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### Not Filed
+
+- **`processmove` rate limiting in Livewire.** A bot client could send `processmove` for
+  every wire faster than humanly possible. The server validates each cut (wire exists,
+  not already cut, correct prefix, game started) so each individual operation is sound;
+  bot detection is out of scope for the server-authority audit. Not filed.
+
+- **Cross-domain XML policy `allow-access-from domain='*' to-ports='{external_port}'`.**
+  This is required for the Flash XMLSocket protocol that the original SWFs spoke — narrowing
+  the policy breaks legitimate clients. The policy is informational only on the SFS port
+  (no cross-origin requests can authenticate without a valid 256-bit ticket). Not filed.
+
+- **`updateMinigameItemCheats(instcc, CA0..CA4)` base method.** The name suggests
+  client-asserted "cheat activations" (consumable/instrument uses), which sounds alarming.
+  But the def has it as a CELL_PRIVATE-mailbox-callable base method without `<Exposed/>` —
+  the wire path is server-driven (Atrea computes the cheat-class from the equipped
+  instrument and pushes it down). Currently UNIMPLEMENTED in Rust. Not filed; the def
+  protects it.
+
+- **`addItemToMinigame` / `remItemFromMinigame` / `consumeItemByMinigame` base methods.**
+  All non-`<Exposed/>` (lines 249-267 in `MinigamePlayer.def`). Server-to-server only.
+  Not filed.
+
+- **`onStartMinigame(URL)` URL string format.** The URL the server builds is
+  `http://unused/{ip}/{port}/{gameName}/{entityId}/{ticket}`. The client parses this to
+  extract the connect info. If an attacker can inject into the `gameName` field (e.g.
+  via a content-defined chain) they could control part of the URL. But `gameName` comes
+  from `Action::StartMinigame { minigame_type }` which is server-defined in content data,
+  not client-supplied. Not filed.
+
+- **`SGWGmPlayer` debug methods (`gmDebugStartMinigame`, `debugMinigameComplete`,
+  `gmGiveMinigameContact`, etc.).** All `<Exposed/>` but on the GM-entity, which the
+  current Rust server **never instantiates** (`play_character.rs:89-94` always picks
+  SGWPlayer 0x02). When the SGWGmPlayer entity is eventually added, GM gating on
+  `access_level > 0` must come with it — but that's a CAT-N concern, not CAT-K. Not
+  filed here; flagged in CAT-N if not already covered.
+
+- **`processStartMinigameAction` / `processForceMinigameAction` cell methods.** Not
+  `<Exposed/>` (lines 410-423 in def). Server-to-server only. Not filed.
+
+- **`<minigame>` property of type PYTHON on MinigamePlayer.** A `PYTHON` type property
+  is opaque pickled state — the original BigWorld engine deserialised it server-side and
+  pushed dict-shaped state to the client. If the Rust port ever round-trips that property
+  through the client, the client could send back arbitrary pickled bytes. Currently
+  this property is unused server-side. Not filed today; revisit if/when entity property
+  sync starts replicating PYTHON-typed values.

--- a/docs/security-audit/2026-05-31-server-authority/findings/CAT-L-chat-contact.md
+++ b/docs/security-audit/2026-05-31-server-authority/findings/CAT-L-chat-contact.md
@@ -1,0 +1,594 @@
+# CAT-L — Chat / Contact list / Communication — Findings
+
+## Overall trust posture
+
+The chat surface in Cimmeria is **partially implemented**: exactly five base methods
+are dispatched (`chatJoin`, `chatLeave`, `chatSetAFKMessage`, `chatSetDNDMessage`,
+`sendPlayerCommunication`), and three of those (`chatJoin`/`chatLeave`/`chatSetAFK`)
+are log-only stubs. `sendPlayerCommunication` is the **only path that actually
+broadcasts** — and it does so unconditionally to all AoI witnesses without any
+rate limit, length cap, mute / ignore filter, or per-channel authorization. The
+contact-list surface (6 indices), the channel-admin surface (mute / kick / ban /
+op / password / friend / ignore), `Petition`, `Who`, `SendGMShout`, and
+`BroadcastMinimapPing` are all **completely unimplemented** — the bytes are
+consumed, an `UNIMPLEMENTED:` log line fires, and the handler returns. No state
+mutates.
+
+This produces two distinct risk shapes:
+
+1. **Demonstrable today (live exploit surface):** `sendPlayerCommunication` will
+   broadcast attacker-controlled `text` to every witness in the sender's AoI with
+   no rate limit, no length cap, and no `chatIgnore` mute-list filter. The
+   `speaker_name` and `speaker_flags` are server-authoritative
+   (`crates/services/src/base/dispatch.rs:106,126-141`) — that part is correct —
+   but the message body is forwarded verbatim, and a single attacker can
+   ratchet chat-spam volume up to whatever the connection / Mercury bundle
+   sustains. The `text_len` field bypass on the spec's WSTRING parser is bounded
+   only by the WSTRING reader's overall buffer-size check, so messages up to the
+   single-bundle limit (~65 KB) per call are forwardable.
+2. **Likely-exploitable theoretical (lands the moment the stubs are filled):** the
+   chat-admin commands (`chatOp`, `chatMute`, `chatKick`, `chatBan`,
+   `chatPassword`), `SendGMShout`, `BroadcastMinimapPing`, `Petition`, `Who`, and
+   every contact-list operation will trust attacker-controlled fields (target
+   channel name, target player name, ping x/y/z, org_id, list_id) when those
+   handlers are wired up, unless the implementor knows in advance which fields
+   need server-side validation. The same systemic gap that landed on CAT-N
+   applies here: `access_level` is not in scope for cell-method dispatch
+   ([[reference-gm-auth-plumbing-gap]]), so a naive future implementation of
+   `SendGMShout` or any "op-only" channel admin command lacks the bit to gate on
+   even if the author remembers to gate.
+
+The Python reference (`deprecated/python/`) and the Ghidra `Event_NetOut_*`
+classes confirm the wire shapes — for example, `Event_NetOut_BroadcastMinimapPing`
+carries the full client-asserted `(org_id, x, y, z)` quad. Once a handler is
+wired up to actually broadcast or persist, every one of these fields needs an
+explicit server-side cross-check (org membership, channel-op bit, friend
+list size cap, self-add guard) that the current stubs do not encode.
+
+Findings below are numbered in order of demonstrability — CAT-L-01 and CAT-L-02
+are live today, the rest are "lands when the stub is implemented."
+
+---
+
+### CAT-L-01 — `sendPlayerCommunication` has no rate limit, length cap, or ignore-list filter
+
+**Severity**: Medium
+**Class**: Chat-spam / DoS / harassment vector (no anti-flood)
+**Wire surface**: `Event_NetOut_sendPlayerCommunication`
+**Demonstrable / Likely-theoretical**: Demonstrable
+
+**Trust violation**
+The base-layer handler reads `(channel, target, text)` from the wire and forwards
+`text` verbatim to every AoI witness via `chat::handle_chat_message ->
+broadcast_to_witnesses`. There is no per-sender rate limit (no "messages per
+window" counter on `ConnectedClientState`), no per-message length cap (the
+WSTRING parser only bails on truncation, not on size), and no consultation of
+any ignore list before the witness fan-out (no `ChatIgnore` machinery exists
+anywhere — `grep -ri ChatIgnore crates/` returns zero hits). A modified client
+can drive `sendPlayerCommunication` at packet rate, with each `text` payload up
+to the Mercury bundle's u16 length-field max (~65 KB), and the server will fan
+each one out to every witness in AoI. There is also no profanity filter / muted-
+account filter.
+
+**Evidence**
+- Ghidra: `019b9b14` `Event_NetOut_sendPlayerCommunication` — class name string
+  registered via `register_NetOut_sendPlayerCommunication @ 00cfda00`. The
+  client emits the typed payload `(UINT8 channel, WSTRING target, WSTRING text)`
+  through `SGWNetworkManager::EventHandler<Event_NetOut_sendPlayerCommunication>`
+  (vtable installer at `00d56350`). No client-side length cap was located in
+  Ghidra string scan for `MAX_CHAT_LEN` / `MAX_MESSAGE_LENGTH` / `MAX_TEXT_LENGTH`
+  (zero hits) — so the client UI is the only natural truncation point and a
+  modified client bypasses it.
+- Client behavioral log: n/a (no spam observable in `SGWDebugLog.log` from a
+  vanilla session — the gap is in what the server fails to enforce, not in what
+  the client routinely sends).
+- Cross-ref to Rust handler (for the fix author, NOT as truth):
+  `crates/services/src/base/dispatch.rs:77-156` (decode + forward),
+  `crates/services/src/cell/chat.rs:65-95` (channel match, no rate limit),
+  `crates/services/src/cell/chat.rs:101-157` (fan-out to every witness with no
+  filter).
+
+**Attack scenario**
+1. Attacker modifies their client (or scripts a wire-level emitter) to call
+   `sendPlayerCommunication(channel=0 /*SAY*/, target="", text="<spam body>")`
+   in a tight loop.
+2. The base handler consumes the bundle, calls `handle_chat_message`, which
+   broadcasts `onPlayerCommunication` to every witness via
+   `space_mgr.get_entity(sender_id).witnesses` (server-authoritative AoI list).
+3. Observable effect: every player in AoI of the attacker receives a flood of
+   `onPlayerCommunication` callbacks at the attacker's send rate, multiplied by
+   the witness count. The server's outbound side has no per-recipient
+   throttling on this path; each fan-out goes through one
+   `CellToBaseMsg::EntityMethodCall` send per witness, then through the per-
+   client Mercury channel. The attacker can also vary `text` to slip
+   harassment / off-color content past any client-side moderation that a future
+   chat-window UI might layer.
+
+**Suggested remediation (one line)**
+Add a per-sender token-bucket (e.g. 5 messages/3s for SAY/EMOTE/YELL, separately
+per channel) on `ConnectedClientState` plus a length cap (`text.chars().count()
+<= 256` matches the original SGW UI), and consult a server-side `ignore_list`
+(when ChatIgnore is implemented) before each per-witness `EntityMethodCall`.
+
+**Would benefit from x64dbg trace?**
+No — Rust handler shape is fully readable; no additional client behavior needed
+to confirm the absence of rate-limit code.
+
+---
+
+### CAT-L-02 — `chatSetDNDMessage` stores attacker-controlled WSTRING with no length cap
+
+**Severity**: Low
+**Class**: Memory / log-pollution
+**Wire surface**: `Event_NetOut_ChatSetDNDMessage` (base method 0xC4)
+**Demonstrable / Likely-theoretical**: Demonstrable
+
+**Trust violation**
+The base handler at `crates/services/src/base/dispatch.rs:191-233` reads a
+WSTRING from the wire and stores it directly on `ConnectedClientState.dnd_message:
+Option<String>`. The only filter is `if message.chars().count() > 1` (i.e.,
+2+ chars sets DND, ≤1 clears it). There is no upper bound — the WSTRING parser
+admits any `char_count: u32` that fits in the remaining buffer (decoded by
+`read_wstring` at `mercury/mod.rs:336`). A single packet can store up to ~65 KB
+of attacker-controlled UTF-16 in the server's per-connection state, and that
+buffer persists for the entire session. Today the `dnd_message` is only consulted
+for a boolean ("is DND active" — sets the SPEAKER_DND flag), so the body never
+reaches any other player; but if the auto-reply-tell path is ever wired up
+(the comment at `dispatch.rs:198` says "future work"), it becomes a DM-spam
+vector. Worse, the WSTRING is logged with `text_len` on the base span and the
+body itself is unbounded for in-memory storage.
+
+**Evidence**
+- Ghidra: `Event_NetOut_ChatSetDNDMessage` class name appears as a registered
+  NetOut event (alongside `ChatSetAFKMessage` at the same dispatch range). The
+  payload is a single WSTRING (no length cap field).
+- Client behavioral log: n/a (vanilla client UI truncates DND message; modified
+  client bypasses).
+- Cross-ref to Rust handler: `crates/services/src/base/dispatch.rs:207-232`.
+
+**Attack scenario**
+1. Attacker modifies client (or replays a packet) to send `chatSetDNDMessage`
+   with a 32,000-character WSTRING.
+2. Server stores the entire string on `ConnectedClientState.dnd_message`.
+3. Observable effect: per-connection memory inflates by ~64 KB per shaped
+   message; if the future auto-reply-tell path lands without retroactively
+   capping the field, every chat-tell to the attacker triggers a 64 KB
+   `onPlayerCommunication` to the sender. Also: the server log captures
+   `dnd_active=true` and otherwise discards the body, so an audit trail of
+   "what did the user actually set" is lost.
+
+**Suggested remediation (one line)**
+Validate `message.chars().count() <= 128` server-side after `read_wstring`;
+truncate or reject longer strings (matches the SGW UI input cap).
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-L-03 — `sendPlayerCommunication` channel byte not validated against allowlist
+
+**Severity**: Low
+**Class**: Channel-impersonation (theoretical)
+**Wire surface**: `Event_NetOut_sendPlayerCommunication`
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+The client-supplied `channel: u8` is decoded at
+`crates/services/src/base/dispatch.rs:82` and forwarded unchanged through
+`BaseToCellMsg::ChatMessage { channel, .. }` to `chat::handle_chat_message`. The
+cell-side match at `chat.rs:74` only acts on `CHAN_SAY | CHAN_EMOTE | CHAN_YELL`
+and otherwise debug-logs and drops — so today, only those three channels actually
+broadcast. The `channel` byte is then serialized verbatim into the witness-bound
+`onPlayerCommunication(speaker, flags, channel, text)` args
+(`chat.rs:127,187-188`). A client could *try* setting `channel = CHAN_SERVER (7)`
+or `CHAN_FEEDBACK (8)` to make the witnesses' client-side UI render the message
+as a server / system broadcast — but because `handle_chat_message` filters at
+the dispatch step, the wire never carries it. **Today this is defended by the
+filter, but the defense is brittle:** if a future change adds CHAN_TEAM or
+CHAN_SQUAD to the cell-side broadcast arm without also gating on team/squad
+membership, a non-member can post into a team channel by setting the channel
+byte. Document the invariant before that future change lands.
+
+**Evidence**
+- Ghidra: `019b9b14` `Event_NetOut_sendPlayerCommunication` — wire-format
+  preserves `channel: UINT8` as the first byte after the SGWPlayer base msg_id
+  0xC2.
+- Cross-ref: `crates/services/src/base/dispatch.rs:82,150` and
+  `crates/services/src/cell/chat.rs:74-94`.
+
+**Attack scenario** (theoretical, requires future code change)
+1. A future PR adds `CHAN_TEAM | CHAN_SQUAD` arms to `handle_chat_message` to
+   broadcast team / squad chat.
+2. Attacker sends `sendPlayerCommunication(channel=CHAN_TEAM, target="", text=...)`
+   without being in any team.
+3. Without an explicit "is sender in a team?" check before broadcast, the message
+   reaches whoever the team-broadcast scope selects.
+
+**Suggested remediation (one line)**
+Add an explicit `validate_channel_membership(entity_id, channel) -> Result<()>`
+check at the head of every new channel arm, and document at the match site that
+the client-supplied `channel` byte must be paired with a server-side membership
+check (not just a "channel id is in range" check).
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-L-04 — Contact list operations are full client-trust stubs (no self-add guard, no list-size cap, no ownership check)
+
+**Severity**: High (when implemented)
+**Class**: Friend/ignore-list integrity, harassment vector, DB-row inflation
+**Wire surface**: `Event_NetOut_contactListCreate`, `contactListRename`,
+`contactListDelete`, `contactListFlagsUpdate`, `contactListAddMembers`,
+`contactListRemoveMembers`
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+All six contact-list cell methods at
+`crates/services/src/cell/cell_methods/contact_list.rs:14-73` are
+`UNIMPLEMENTED:` log-only stubs that decode the leading `list_id` (i32) and
+`flags` (u32) and return. None of the following invariants are encoded
+anywhere in the codebase, and a future implementor working from the wire shape
+alone is likely to miss them:
+
+- **Self-add prevention:** `contactListAddMembers` decodes a member list; the
+  implementor needs an explicit guard that no member entry resolves to
+  `entity_id` (the caller's own player id). Without it, a player can add
+  themselves to their own friend list — wasteful but, more importantly, can be
+  used to enumerate side-effects of "is X my friend?" lookups in any future
+  ChatIgnore / DND path that checks self-membership.
+- **Add-without-consent:** the wire shape adds members by name / player id with
+  no proposal / accept handshake (compare `tradeRequest` → `tradeRequestCancel`
+  in CAT-H, which at least has an explicit two-step). A naive port would let a
+  client unilaterally add anyone to its "ignore" list (harmless) AND its
+  "friend" list (privacy violation — the target's "Who shows me online?" state
+  may key on someone-friended-me).
+- **List-size cap:** there is no upper bound on the number of members per list,
+  the number of lists, or the total bytes per list. A client can call
+  `contactListCreate` / `contactListAddMembers` in a loop and bloat the row
+  count for that account indefinitely.
+- **Caller-owns-list check:** `list_id` is client-supplied. `contactListRename`,
+  `contactListDelete`, `contactListFlagsUpdate`, `contactListAddMembers`, and
+  `contactListRemoveMembers` all decode `list_id` without any check that the
+  caller (`entity_id`) actually owns that list row. When persistence lands, the
+  WHERE clause MUST include `account_id = caller.account_id`, not just
+  `list_id = ?`, or one player can rename / delete another's lists.
+- **Caller-can-query-others:** the wire shape doesn't expose a "read another
+  player's contact list" message, so this isn't an immediate concern — but the
+  contact-list state is itself privacy-sensitive (who I have ignored / friended),
+  so any future debug / GM accessor must be `access_level >= GM` gated.
+
+**Evidence**
+- Ghidra: `019c2528` `contactListCreate`, `019c25ac` `contactListAddMembers`,
+  `019be13c` `Event_NetIn_onContactListAddMembers` (the server-to-client mirror,
+  confirming the message family exists). The client UI dispatcher
+  `Event_UI_ContactListAddMembers` at `01e0de90` confirms the field set comes
+  straight from the UI without an authentication / consent step.
+- Client behavioral log: n/a (vanilla client constructs these but never sends
+  them in the captured session because the QA-build UI flow is incomplete).
+- Cross-ref: `crates/services/src/cell/cell_methods/contact_list.rs:14-73` (all
+  six methods stub-only).
+
+**Attack scenario** (lands when the handler is implemented)
+1. Attacker scripts `contactListAddMembers(list_id=<victim's list_id>,
+   members=[attacker])` against a list_id discovered through observation /
+   guess.
+2. Server persists attacker into victim's list because the handler trusts
+   `list_id` without `account_id = caller` cross-check.
+3. Observable effect: victim's friend list silently gains the attacker as a
+   member; if the future Who / online-status path keys "show me to my friends"
+   on this list, the attacker also harvests presence info.
+
+**Suggested remediation (one line)**
+At each handler's head, persist `list_id`-owning lookup as
+`SELECT account_id FROM contact_lists WHERE id = ? AND account_id = caller.account_id`
+and bail on row-miss; reject add-list-members payloads where any entry equals
+the caller's own player id; cap `member_count` at e.g. 100 per list and
+`list_count` at e.g. 10 per account.
+
+**Would benefit from x64dbg trace?**
+Yes — trace `Event_UI_ContactListAddMembers` to enumerate the exact wire
+field set (member name strings vs. player ids vs. account ids), because the
+Ghidra string table names the event but the payload struct isn't fully
+labeled and the fields the server will need to validate depend on which
+identifier the client actually sends.
+
+---
+
+### CAT-L-05 — `BroadcastMinimapPing` is a stub that will trust client-supplied (org_id, x, y, z) when implemented
+
+**Severity**: High (when implemented)
+**Class**: Cross-org information leak, position-spoof, griefing-spam
+**Wire surface**: `Event_NetOut_BroadcastMinimapPing` (cell method index 10 in
+OrganizationMember interface)
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+The handler at `crates/services/src/cell/cell_methods/organization.rs:48-64`
+decodes `(org_id: i32, x: f32, y: f32, z: f32)` from the wire and logs
+`UNIMPLEMENTED:`. When the handler is wired up to broadcast a "ping" to org
+members, it must validate **three** invariants the wire encoding leaves
+attacker-controlled:
+
+1. `org_id` matches the caller's actual organization (per
+   `[[reference-gm-auth-plumbing-gap]]`, the org-membership lookup currently
+   has no DB-backed canonical source — when added, must check `caller.player_id
+   IN (SELECT player_id FROM org_members WHERE org_id = ?)`). Without this,
+   any player can broadcast a ping into any org's minimap.
+2. The `(x, y, z)` are within the caller's currently-occupied space and bounded
+   by the space's coordinate envelope. The current decoded args are raw `f32`s
+   with no spatial sanity check (no `is_finite`, no in-bounds check). A NaN or
+   `f32::INFINITY` value would propagate to client UI rendering.
+3. Per-caller rate limit — the original SGW UI throttles minimap ping at one
+   per few seconds; a wire-level attacker can spam pings at packet rate to
+   griefing-spam an org's UI.
+
+**Evidence**
+- Ghidra: `0195faf0`, `019bfa48`, `019c3fb0` — `Event_NetOut_BroadcastMinimapPing`
+  / `BroadcastMinimapPing` class name strings. Handler chain installer at
+  `00d669d0`. The class name encoding `Event_NetOut_BroadcastMinimapPing` plus
+  the SGW spec convention of `(EntityId org, Vector3 pos)` as the args list
+  matches the server handler's 16-byte (i32 + 3×f32) decode shape at
+  `organization.rs:49`.
+- Cross-ref: `crates/services/src/cell/cell_methods/organization.rs:48-64`.
+
+**Attack scenario** (lands when the handler is implemented)
+1. Attacker discovers a target org's `org_id` (via Who, gossip, or guess).
+2. Attacker calls `BroadcastMinimapPing(org_id=<target>, x=0, y=0, z=0)` from a
+   foreign org / no-org character.
+3. Server fans `onBroadcastMinimapPing` to every member of the target org with
+   the attacker-supplied coordinates — appearing in their minimap UI as a
+   legitimate ping from an org member.
+
+**Suggested remediation (one line)**
+At the handler head: `assert_org_membership(entity_id, org_id)?` (DB-backed),
+`assert_finite_position(x, y, z, current_space_bounds)?`, and apply a
+per-caller token bucket of (e.g.) 1 ping per 3s.
+
+**Would benefit from x64dbg trace?**
+No — wire shape is unambiguous from the decoded byte count.
+
+---
+
+### CAT-L-06 — `SendGMShout` is a registered NetOut event with no server handler — implicit GM check missing
+
+**Severity**: High (when implemented)
+**Class**: GM-channel impersonation
+**Wire surface**: `Event_NetOut_SendGMShout`
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+The `Event_NetOut_SendGMShout` class is registered in the client
+(`019b9b50`, `01e1d880`) and dispatched through the
+`SGWNetworkManager::EventHandler<Event_NetOut_SendGMShout>` chain
+(`01e4a328`). On the server side **no handler exists** — no msg_id arm for it
+in `dispatch.rs`, no cell-method arm in any `cell_methods/*` dispatcher. The
+unhandled message currently lands in the `Unhandled SGWPlayer base method` warn
+arm at `dispatch.rs:333-346` or the `Unhandled cell method call` warn arm at
+`crates/services/src/cell/dispatch/router.rs:101-106`, depending on whether the
+client emits it via base or cell. Either way, the server today does nothing —
+which is safe by accident.
+
+The risk is **when the handler is implemented**. `SendGMShout` should be an
+`access_level >= GameMaster` privileged path (broadcasts to all players in the
+shard / region), and the server-side gate is the canonical example of "GM bit
+lives on the session, not the inbound packet" from the agent prompt. Cimmeria's
+existing `SPEAKER_GM` derivation at `dispatch.rs:131-133` uses the right pattern
+(`if c.access_level > 0 { flags |= speaker_flags::GM; }`) — `SendGMShout` MUST
+do the same: `if c.access_level < ACCESS_LEVEL_GM { return; }` at the handler
+head, NEVER deriving GM-ness from any wire field. The
+[[reference-gm-auth-plumbing-gap]] applies if the handler is added to the cell
+layer (no access_level in scope) — pin the implementation to the base layer or
+plumb `access_level` first.
+
+**Evidence**
+- Ghidra: `019b9b50` `Event_NetOut_SendGMShout`, `0184259c`
+  `Event_SlashCmd_GMShout` (slash-command source), `01e05cc0` MemberCallback
+  binding through `SGWTextCommandMgr` (the `/gmshout` slash handler emits the
+  NetOut event).
+- Cross-ref: no Rust handler exists. Lands in the catch-all warn arm at
+  `crates/services/src/base/dispatch.rs:333` or
+  `crates/services/src/cell/dispatch/router.rs:101`.
+
+**Attack scenario** (lands when the handler is implemented)
+1. A future PR adds an `SGW_GM_SHOUT` msg_id (or cell method index) arm. If the
+   author misses the access_level gate (because the cell layer has no access to
+   it, or because they trust the "the wire shape only fires from /gmshout"
+   client-side path), every player can send a server-wide GM-styled broadcast.
+2. Attacker emits the wire bytes directly without typing `/gmshout`.
+3. Observable effect: GM-flagged broadcast reaches every player on the shard,
+   impersonating real GMs.
+
+**Suggested remediation (one line)**
+Implement `SendGMShout` in the **base** layer (so `access_level` is in scope),
+and gate with `if c.access_level < ACCESS_LEVEL_GM { return Ok(()); }` as the
+first thing the handler does — matching the chat-speaker-flag idiom at
+`dispatch.rs:131`.
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-L-07 — `Petition` / `Who` / `chatFriend` / `chatIgnore` are NetOut events with no server handler — sender-identity discipline must be set before they're wired
+
+**Severity**: Medium (when implemented)
+**Class**: Sender-identity spoof / GM-petition spam / privacy
+**Wire surface**: `Event_NetOut_Petition`, `Event_NetOut_Who`,
+`Event_NetOut_ChatFriend`, `Event_NetOut_ChatIgnore`
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+Four NetOut events are registered in the client but have no server handler:
+
+- `019b9b80` `Event_NetOut_Petition` — `/petition` to GM, no handler in Rust.
+- `019be840` `Event_NetOut_ChatIgnore` — `/ignore <player>`, no handler.
+- `019b30c0` `Event_NetOut_ChatFriend` — `/friend <player>`, no handler.
+- `Event_NetOut_Who` (cell method index 73 — `WHO` constant) — handler exists
+  at `crates/services/src/cell/cell_methods/player/interaction.rs:17-20` as a
+  bare `tracing::info!("UNIMPLEMENTED: who"); true` stub.
+
+For each, the canonical security invariants are:
+
+- **Petition:** sender identity MUST come from session (`player_name`,
+  `account_id`), NEVER from any wire-supplied name field — the GM receiving the
+  petition needs to know who actually sent it. Today's `sendPlayerCommunication`
+  pattern (server reads `player_name` from `ConnectedClientState` at
+  `dispatch.rs:106`) is the right shape; reuse it. Rate limit at e.g. 1 petition
+  / 30s per account.
+- **Who:** must respect a `/hide` flag (when implemented — currently no `hide_gm`
+  / `invisible` plumbing exists outside of GM constants), and may want to
+  faction-scope the response (i.e. an Ori-faction player shouldn't see SGC
+  players in /who by default). Today the handler is a stub, so the bug is
+  latent.
+- **ChatFriend / ChatIgnore:** server-side persistence will need the same
+  ownership / size-cap / self-add discipline as the contact-list operations
+  (see CAT-L-04). Self-ignore is harmless; self-friend wastes a row. List size
+  must cap (the original SGW limit was 50 friends / 50 ignores).
+
+**Evidence**
+- Ghidra: `019b9b80` `Event_NetOut_Petition`, `019b30c0` `Event_NetOut_ChatFriend`,
+  `019be840` `Event_NetOut_ChatIgnore`, `019c2974` `chatFriend`, `019c295c`
+  `chatIgnore`, `019c2a18` `petition`. Slash-command sources
+  `Event_SlashCmd_Petition`, `Event_SlashCmd_ChatFriend`, `Event_SlashCmd_ChatIgnore`
+  bind via `Communicator` `MemberCallback` (`01e1f508`, `01e1fb88`), so the
+  client-side emission goes Communicator → NetOut.
+- Cross-ref: WHO handler stub at
+  `crates/services/src/cell/cell_methods/player/interaction.rs:17-20`; Petition
+  / ChatFriend / ChatIgnore have no handler at all (catch-all warn arm).
+
+**Attack scenario** (lands when the handlers are implemented)
+- Petition: a sender-name-spoof attack (attacker claims to be a different
+  player in the petition body) only works if the implementor reads the sender
+  from the wire instead of from `c.player_name`. Document the requirement
+  before the handler is added.
+- Who: a faction-leak / hide-flag-bypass becomes possible if the handler returns
+  all-players-unfiltered. The mitigation is to compute the response from the
+  server's authoritative space / faction state, not from any client-supplied
+  filter.
+- ChatFriend / ChatIgnore: see CAT-L-04 for the list-size and ownership
+  failure modes.
+
+**Suggested remediation (one line)**
+Before any of these four handlers are filled in, add a `// SECURITY` block in
+the stub naming the server-authority source (`c.player_name`, `c.account_id`,
+`c.player_entity_id`) and the cap / scope rule (faction scope, list size,
+rate limit) — so the next contributor doesn't trust the wire by default.
+
+**Would benefit from x64dbg trace?**
+Yes for Petition — trace `Event_SlashCmd_Petition` → `Event_NetOut_Petition` to
+confirm whether the client embeds a target-GM-name or just a free-text body, so
+the server-side validation (or lack of need for one) can be encoded precisely.
+
+---
+
+### CAT-L-08 — `chatOp`/`chatMute`/`chatKick`/`chatBan`/`chatPassword` are NetOut events with no handler — channel-op authorization will need session-side op-bit tracking
+
+**Severity**: Medium (when implemented)
+**Class**: Channel-admin privilege escalation
+**Wire surface**: `Event_NetOut_ChatOp`, `ChatMute`, `ChatKick`, `ChatBan`,
+`ChatPassword`
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+Five channel-admin events are registered in the client (`019b9a90` ChatOp,
+`019b9a38` ChatMute, `019b9a64` ChatKick, `019b9ab8` ChatBan, `019b9ae4`
+ChatPassword) with no server handler. When implemented, each handler MUST
+verify the caller's **op-bit for the specific channel** before applying the
+admin action. The op-bit must live on a server-side per-channel state
+(`channel_ops: HashMap<ChannelName, HashSet<account_id>>` or equivalent) — NOT
+on any client-supplied flag. The agent-prompt's "central question #4" applies
+verbatim: *the client cannot claim "I'm op" without being one*.
+
+A second-order risk: the wire shape carries `channel_name` (WSTRING) and
+`target_player` (WSTRING) — both attacker-controlled. The op-bit check must
+be keyed on the channel_name AFTER normalizing (case-fold, whitespace-trim),
+or an attacker could claim op on `"FOO"` while the canonical op record is
+for `"foo"`.
+
+**Evidence**
+- Ghidra: `019b9a38..019b9ae4` block of `Event_NetOut_Chat{Mute,Kick,Op,Ban,Password}`
+  strings, plus `Event_SlashCmd_*` mirror at `01842078..01842110`. Communicator
+  `MemberCallback` bindings at `01e1f508`-range route from slash command to
+  NetOut.
+- Cross-ref: no Rust handler exists; unhandled message falls into the warn arm.
+
+**Attack scenario** (lands when the handler is implemented)
+1. Attacker joins channel "lfg" as a normal user.
+2. Attacker sends `chatKick(channel="lfg", target=<random_player>)` directly.
+3. If the handler doesn't check whether `caller` is in the
+   `channel_ops["lfg"]` set, the kick lands and the victim is removed from the
+   channel.
+
+**Suggested remediation (one line)**
+At the handler head: `if !channel_ops.get(&normalize(channel)).map_or(false,
+|ops| ops.contains(&caller.account_id)) { return; }` — and document that
+op-bit is **per-channel, server-tracked**, never derived from the inbound
+packet.
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-L-09 — `chatJoin` / `chatLeave` are stubbed as auto-acknowledged — future channel-password gate inherits no verification
+
+**Severity**: Low (when chat-password is implemented)
+**Class**: Channel-password bypass (theoretical)
+**Wire surface**: `Event_NetOut_ChatJoin` (base method 0xC0), `ChatLeave` (0xC1)
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+`chatJoin` at `dispatch.rs:158-169` reads `(channel_name, password)` and emits
+`debug!(..., "chatJoin -- acknowledged (channels auto-joined)")`. The comment
+correctly notes that today all channels are auto-joined — but when a channel-
+password gate is implemented (`Event_NetOut_ChatPassword` at `019b9ae4`), the
+join handler MUST cross-check `password` against the server-side stored
+password for the channel before recording the join.
+
+The latent risk: a future "channel password" implementation that lives on a
+per-channel struct outside `ConnectedClientState` could be missed by the
+`chatJoin` handler, because the current handler discards `password` entirely.
+The two paths (set-password and check-password-on-join) need to be wired up
+in lockstep, or a `chatJoin(channel="vip", password="")` succeeds.
+
+**Evidence**
+- Ghidra: `019b9b04` `Event_NetOut_ChatJoin` (inferred from sequence;
+  alternative addresses near the `ChatMute/Kick/Ban/Password` block at
+  `019b9a38..019b9ae4`).
+- Cross-ref: `crates/services/src/base/dispatch.rs:158-169` (the entire body is
+  a debug log; `_password` is intentionally discarded by the `let (_password,
+  _)` binding).
+
+**Attack scenario** (lands when channel-password is implemented)
+1. GM creates a password-protected channel `"raid_planning"` with password
+   `"secret"`.
+2. Attacker sends `chatJoin(channel_name="raid_planning", password="")` and the
+   handler — still tracking the "channels auto-joined" stub posture — accepts
+   the join without checking against the per-channel stored password.
+
+**Suggested remediation (one line)**
+When channel-password is implemented, replace the `_password` discard at
+`dispatch.rs:164` with a server-side lookup
+(`channel_passwords.get(channel_name)`) and a constant-time string compare;
+on mismatch, return without inserting the caller into the channel-member set.
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+## Not Filed
+
+- **Channel-byte forwarding into `onPlayerCommunication` is fine for spatial channels** — the cell-side match at `chat.rs:74` strictly gates broadcast to SAY/EMOTE/YELL, so a client setting `channel=CHAN_SERVER` results in a debug log and no fan-out. The brittleness is captured in CAT-L-03 as a future-change warning, not a live exploit.
+- **`chatSetAFKMessage` is log-only and stores nothing** — the comment at `dispatch.rs:178-189` confirms AFK is not a speaker_flags input and the auto-reply path is unimplemented. No state mutates, so the "client can set AFK without being AFK" concern is degenerate.
+- **`cancelLogOff` exposed as a base method** — present at `dispatch.rs:329-331` as a debug-only acknowledgement. Not chat surface, and CAT-A owns the logoff path.
+- **Mercury bundle size DoS via gigantic `text` WSTRING** — bounded by the WSTRING parser's buffer-tail check (`read_wstring` at `mercury/mod.rs:336-364`), so a malformed `char_count = u32::MAX` is rejected before allocation. Real risk is "many small messages" (CAT-L-01), not "one gigantic message".
+- **`Who` returning all-players-unfiltered** — handler is a single info-log stub at `interaction.rs:17-20`. No response is emitted, so the privacy / faction-scope concern is theoretical; captured in CAT-L-07 alongside Petition.
+- **`onSpaceQueuedResponse` / other space-queue mechanics potentially as chat-side** — those are CAT-O scope (World / Space), not CAT-L.
+- **GM-bit on `sendPlayerCommunication`** — server correctly computes `SPEAKER_GM` from session `access_level > 0` (`dispatch.rs:131-133`), not from any client-supplied flag. The check is byte-for-byte correct against the Python reference and is regression-pinned by tests 1–4 at `dispatch.rs:588-660`. No finding.
+- **Speaker-name spoof on `sendPlayerCommunication`** — server reads `player_name` from `ConnectedClientState.player_name`, populated server-side from the DB at `play_character.rs:133`. The client-supplied WSTRING fields are `target` and `text`; `speaker_name` is never on the wire from the client. No finding.
+- **Witness fan-out using attacker-supplied entity list** — chat broadcast uses `space_mgr.get_entity(sender_id).witnesses`, which is server-computed AoI. No client-trusted target list. No finding.
+- **`cell_methods::being::dispatch` SET_MOVEMENT_TYPE and similar** — owned by CAT-B (movement) and CAT-C (combat), respectively. Out of scope for CAT-L.

--- a/docs/security-audit/2026-05-31-server-authority/findings/CAT-M-org-squad-duel.md
+++ b/docs/security-audit/2026-05-31-server-authority/findings/CAT-M-org-squad-duel.md
@@ -1,0 +1,763 @@
+# CAT-M — Organization / Squad / Duel
+
+**Overall trust posture: pre-implementation.** None of the eighteen wire
+surfaces in this category are implemented server-side. The cell-method
+handlers in `cell/cell_methods/organization.rs` (indices 8–19) and in
+`cell/cell_methods/player/social.rs` (`ORG_CREATION`=94, `SEND_DUEL_RESPONSE`=102,
+`DUEL_FORFEIT`=103) consume the args bytes, emit `tracing::info!("UNIMPLEMENTED: ...")`,
+and return `true` (success). The base-method dispatch in `base/dispatch.rs`
+has no arm for `organizationInvite` / `organizationKick` / `organizationRankChange`
+/ `sendDuelChallenge` — all four BaseMethods marked `<Exposed/>` on
+`SGWPlayer.def` and `OrganizationMember.def` land in the catch-all `warn!`
+and silently return `Ok(())`.
+
+This means the **entire category is the same shape as CAT-G (mail) and
+CAT-I (black market): a fully-defined client wire surface with zero
+server-side validation**. The exploits below are not "the server is
+doing the wrong thing" — they are "the server is doing nothing, and on
+the day someone wires it up, the trust posture is wide open by default
+unless every one of these is on the implementer's checklist."
+
+Wire shapes are extracted from `entities/defs/interfaces/OrganizationMember.def`
+and `entities/defs/SGWPlayer.def` and cross-referenced against Ghidra
+`Event_NetOut_*` RTTI strings (which confirm the client emits these
+exact classes). The .def is authoritative for arg ordering because the
+2009 BigWorld build of the SGW client and server both consume it via
+the entity codegen.
+
+The findings ordering: organization creation/lifecycle first (CAT-M-01
+through CAT-M-04), then rank/permission destructive ops (-05 through
+-08), then guild bank (-09), then text fields (-10), then squad (-11),
+then duel (-12 through -15), then PvP (-16).
+
+---
+
+### CAT-M-01 — `organizationInvite` (base): no server-side org membership/permission check, but no base handler at all
+
+**Severity**: High
+**Class**: Trust violation by omission (caller permission, target state)
+**Wire surface**: `Event_NetOut_OrganizationInvite` → BaseMethod `organizationInvite(INT32 aOrganizationId, WSTRING aPlayerName)`
+**Demonstrable / Likely-theoretical**: Likely-theoretical (no current handler — the trust violation will land on implementation)
+
+**Trust violation**
+Client supplies `(aOrganizationId, aPlayerName)`. The handler must verify:
+(a) the calling session is actually a member of `aOrganizationId`,
+(b) the caller's rank in that org has `EORG_PERM_Invite` (value 2 in `enumerations.xml:1911`),
+(c) `aPlayerName` resolves to a real player not already in an org of the same type,
+(d) the target player isn't on an ignore/block list for this caller.
+Today the server has no `organizationInvite` base-method arm at all — it
+hits the catch-all in `base/dispatch.rs:333-347` and returns `Ok` with a
+warn log, so the client UI proceeds as if the invite went out but no
+state mutated. When the handler is wired up, the implementer must not
+trust `aOrganizationId` (the caller might not be in it) or assume the
+client's UI gated the invite-permission check.
+
+**Evidence**
+- Ghidra: `0x019be900` `Event_NetOut_OrganizationInvite` (RTTI string); registered at `register_NetOut_OrganizationInvite` callsites in the OrganizationMember NetOut bundle.
+- Wire shape from `entities/defs/interfaces/OrganizationMember.def:421-425` (BaseMethods, `<Exposed/>`).
+- Permission bit from `entities/defs/enumerations.xml:1911` (`EORG_PERM_Invite`).
+- Client behavioral log: n/a
+- Cross-ref to Rust (no handler today): `crates/services/src/base/dispatch.rs:333` (catch-all `warn!` arm).
+
+**Attack scenario**
+1. Attacker is in org A (low-rank, no invite perm) but sends `organizationInvite(orgId = B, playerName = "victim")` for org B he doesn't belong to.
+2. Server-side org-state mutation must reject: not-a-member or not-permitted.
+3. Without that check, on first implementation the attacker fills any org's roster with garbage invites.
+
+**Suggested remediation (one line)**
+Server-side validate `caller_session.org_id == aOrganizationId && caller_rank_permissions & EORG_PERM_Invite != 0` before issuing any invite-state mutation.
+
+**Would benefit from x64dbg trace?**
+No — wire shape is fully decoded from the .def + the RTTI string confirms the emit.
+
+---
+
+### CAT-M-02 — `organizationInviteByType`: client picks org type, can implicit-create
+
+**Severity**: Medium
+**Class**: Privilege escalation via implicit-create + trust on caller-supplied type
+**Wire surface**: `Event_NetOut_OrganizationInviteByType` → BaseMethod `organizationInviteByType(UINT8 aOrganizationType, WSTRING aPlayerName)`
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+This method is described in the .def comment as: *"If the member is not
+in a group of that type it will be created automatically"*
+(`OrganizationMember.def:427`). That means the implicit-create path
+runs without an `OrganizationCreation`-shaped flow — no name uniqueness
+check, no founder fee, no validation that the requesting player is
+eligible to create an org of the given type. The type field is `UINT8`
+with no range validation in the def — only `EORG_TYPE_Squad=0`,
+`EORG_TYPE_Team=1`, `EORG_TYPE_Command=2` are defined
+(`enumerations.xml:1942-1944`). A client supplying type=255 must be
+rejected, not implicit-created as type-255.
+
+**Evidence**
+- Ghidra: `0x019be920` `Event_NetOut_OrganizationInviteByType`.
+- Wire shape from `entities/defs/interfaces/OrganizationMember.def:428-432`.
+- Enum values from `entities/defs/enumerations.xml:1939-1946`.
+- Cross-ref to Rust (no handler today): catch-all in `base/dispatch.rs`.
+
+**Attack scenario**
+1. Attacker emits `organizationInviteByType(type=2 [Command], playerName=bot)` repeatedly with rotating bot names.
+2. Each invocation implicit-creates a new Command-rank organization owned by the attacker, bypassing any creation fee or cooldown.
+3. Resource exhaustion on the org table plus possible naming/role abuse.
+
+**Suggested remediation (one line)**
+Range-check `aOrganizationType ∈ {0,1,2}` and route implicit-create through the same flow as `onOrganizationCreation` (fee + name uniqueness + faction check).
+
+**Would benefit from x64dbg trace?**
+No — surface is fully described in the .def.
+
+---
+
+### CAT-M-03 — `onOrganizationCreation` (cell method 94): name-only, no founder fee/faction/uniqueness validation
+
+**Severity**: High
+**Class**: Missing economic + integrity checks on a creation flow
+**Wire surface**: `onOrganizationCreation(WSTRING aOrganizationName)` (cell method index 94)
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+Client supplies the new organization's name only. The server must
+authoritatively enforce: (1) founder fee deducted from the player's
+naqahdah balance (or refused if insufficient — pattern from CAT-G mail
+COD attachment limits); (2) name uniqueness across all orgs of that
+type; (3) name length + Unicode whitelist (the field is `WSTRING` with
+no bound on the wire); (4) faction binding (cross-faction guilds, if
+disallowed in design, must be enforced server-side, not by UI). The
+current handler at `cell_methods/player/social.rs:62` is a one-line
+log stub that does none of these.
+
+**Evidence**
+- Ghidra: `0x0195fb88` `Event_NetOut_OrganizationCreation` (RTTI string).
+- Wire shape from `entities/defs/SGWPlayer.def:877-880`.
+- Cross-ref to Rust: `crates/services/src/cell/cell_methods/player/social.rs:61-64`.
+
+**Attack scenario**
+1. Attacker sends `onOrganizationCreation("Х" * 100000)` (huge WSTRING).
+2. With no length cap, server-side org-name allocation explodes; org list serialization to other clients leaks the giant string into every roster query.
+3. With no fee, attacker enumerates thousands of orgs at zero cost to squat names or DoS the org table.
+
+**Suggested remediation (one line)**
+On implementation: deduct founder fee + length-cap WSTRING server-side (mirror `MAIL_*` rank constants for analogous content limits in `enumerations.xml:1055-1062`) + unique-constraint on `(org_type, name)` in the DB row insert.
+
+**Would benefit from x64dbg trace?**
+No — wire shape is fully defined and current handler is a stub.
+
+---
+
+### CAT-M-04 — `organizationLeave`: org_id from client, no membership check
+
+**Severity**: Low
+**Class**: Trust on client-supplied org_id
+**Wire surface**: `organizationLeave(INT32 aOrganizationId)` — cell method `LEAVE`=9 on the OrganizationMember interface
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+The org_id the player is "leaving" comes from the wire. The server's
+session-tracked org membership (`SGWPlayer.organizationMember.records`
+in the Python reference; not yet in Rust) is the authority. A handler
+that takes `org_id` at face value would let a client mass-leave any
+org_id (deleting the *server's record* that this player is in that
+org, even if they aren't, breaking invariants like the leader-elect
+flow if `aOrganizationId` happens to match an org with a recent
+leadership transfer race). The current handler at
+`cell_methods/organization.rs:41-47` logs and returns.
+
+**Evidence**
+- Ghidra: `0x019be970` `Event_NetOut_OrganizationLeave`.
+- Wire shape from `entities/defs/interfaces/OrganizationMember.def:286-289`.
+- Cross-ref to Rust: `crates/services/src/cell/cell_methods/organization.rs:41-47`.
+
+**Attack scenario**
+1. Attacker sends `organizationLeave(aOrganizationId = victim's org)`.
+2. Naïve handler dereferences and removes the row keyed by `(session.player_eid, aOrganizationId)`.
+3. If the player happens to *be* in that org for some other type slot, or if the join-pending flag races a leave, the org's roster invariant is broken.
+
+**Suggested remediation (one line)**
+Cross-check `aOrganizationId` against the session-tracked membership list before any mutation; reject silently if mismatch.
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-M-05 — `organizationKick` (base): no rank-comparison invariant
+
+**Severity**: High
+**Class**: Privilege escalation via missing rank-compare
+**Wire surface**: `Event_NetOut_OrganizationKick` → BaseMethod `organizationKick(INT32 aOrganizationId, WSTRING aPlayerName)`
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+The kick operation requires two server-side comparisons that the wire
+shape forces the server to compute itself: (a) caller has
+`EORG_PERM_Eject` (value 16, `enumerations.xml:1914`), and (b)
+target's rank is **strictly lower** than caller's rank. Without the
+strict-lower check, an Officer with Eject perm could kick the Leader.
+The error enum `EDB_ERROR_Player_rank_too_low = -20072`
+(`enumerations.xml:1954`) signals that the original Python reference
+*did* enforce this — when implementing the Rust handler, the same
+invariant must reappear or the leader can be self-evicted. No base
+handler today.
+
+**Evidence**
+- Ghidra: `0x019be990` `Event_NetOut_OrganizationKick`.
+- Wire shape from `entities/defs/interfaces/OrganizationMember.def:435-439`.
+- Permission bit `EORG_PERM_Eject` from `enumerations.xml:1914`.
+- Rank ordering from `enumerations.xml:1892-1905` (`EORG_RANK_Initiate`=1 .. `EORG_RANK_Leader`=8).
+- Cross-ref to Rust (no handler today): catch-all in `base/dispatch.rs:333`.
+
+**Attack scenario**
+1. Officer (rank 6) emits `organizationKick(orgId, "Leader's name")`.
+2. With only `EORG_PERM_Eject` checked but no rank-compare, the kick succeeds.
+3. Leader is removed from their own guild; remaining-leader-promotion logic may promote the attacker.
+
+**Suggested remediation (one line)**
+Require `caller_rank > target_rank` AND `caller_perms & EORG_PERM_Eject != 0` before any roster mutation; return the existing `EDB_ERROR_Player_rank_too_low` on mismatch.
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-M-06 — `organizationRankChange` (base): can promote above own rank if not enforced
+
+**Severity**: High
+**Class**: Privilege escalation via missing rank-cap
+**Wire surface**: `Event_NetOut_OrganizationRankChange` → BaseMethod `organizationRankChange(INT32 aOrganizationId, WSTRING aPlayerName, UINT8 aRank)`
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+Three invariants the server must enforce for rank change: (a) caller
+has `EORG_PERM_Promote` (=4) or `EORG_PERM_Demote` (=8) depending on
+delta direction; (b) the requested `aRank` is strictly less than the
+caller's own rank (else any officer could promote anyone to Leader);
+(c) the target's *current* rank is also strictly less than the
+caller's rank (you can't reshuffle equals or seniors). `aRank` is
+`UINT8` on the wire — no enum guard. Without a range check on the
+enum tokens (`EORG_RANK_None=0 .. EORG_RANK_Leader=8`,
+`enumerations.xml:1892-1905`), clients can send `aRank = 255` and
+either crash a switch-on-rank somewhere or store an out-of-band rank
+that breaks UI rendering. No base handler today.
+
+**Evidence**
+- Ghidra: `0x019be9b0` `Event_NetOut_OrganizationRankChange`.
+- Wire shape from `entities/defs/interfaces/OrganizationMember.def:442-447`.
+- Cross-ref to Rust (no handler today): catch-all in `base/dispatch.rs:333`.
+
+**Attack scenario**
+1. Senior Member (rank 3) with `EORG_PERM_Promote` emits `organizationRankChange(orgId, "alt account", aRank=8 [Leader])`.
+2. Without rank-cap, alt becomes Leader.
+3. Original Leader kicked next.
+
+**Suggested remediation (one line)**
+Require `aRank ∈ [1,8]` AND `aRank < caller_rank` AND `target_current_rank < caller_rank` before any rank mutation.
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-M-07 — `organizationSetRankPermissions`: arbitrary permissions bitfield
+
+**Severity**: High
+**Class**: Privilege escalation via mask-not-validated
+**Wire surface**: `organizationSetRankPermissions(INT32 aOrganizationId, INT32 aRank, INT32 aPermissions)` — cell method `SET_RANK_PERMISSIONS`=16
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+`aPermissions` is a raw `INT32` on the wire that becomes the rank's
+permission bitfield. The valid mask is defined in
+`EOrganizationPermission` (`enumerations.xml:1907-1937`) — top defined
+bit is `EORG_PERM_AllianceCmds = 33554432` (0x2000000). Any handler
+that stores the client value as-is would let a client set bits that
+aren't in the union (potential UB if those bits collide with future
+flags) or set high-impact bits like `EORG_PERM_AlterPerms` (=8388608)
+on a low rank, which would then let that low rank further escalate.
+The caller must (a) themselves have `EORG_PERM_AlterPerms`, (b) the
+target rank must be strictly lower than caller's rank, (c)
+`aPermissions` must be a subset of the union of defined bits, (d) the
+caller cannot grant permissions they themselves do not hold
+(otherwise an officer with AlterPerms but without WithdrawBank can
+grant WithdrawBank to a subordinate). Current handler stub:
+`cell_methods/organization.rs:112-126`.
+
+**Evidence**
+- Ghidra: `0x019bea3c` `Event_NetOut_OrganizationSetRankPermissions`.
+- Wire shape from `entities/defs/interfaces/OrganizationMember.def:390-395`.
+- Permission mask values from `enumerations.xml:1907-1937`.
+- Cross-ref to Rust: `crates/services/src/cell/cell_methods/organization.rs:112-126`.
+
+**Attack scenario**
+1. Officer with `EORG_PERM_AlterPerms` sends `organizationSetRankPermissions(orgId, rank=1 [Initiate], permissions=0xFFFFFFFF)`.
+2. Initiate rank now has every permission, including `EORG_PERM_TransferLeader = 16777216` and `EORG_PERM_WithdrawCash`.
+3. Officer's alt characters at Initiate rank now have full control.
+
+**Suggested remediation (one line)**
+Mask `aPermissions` against the union of defined `EOrganizationPermission` bits, require caller's permission set is a superset of `aPermissions`, require `caller_rank > aRank`.
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-M-08 — `organizationSetRankName`: text-length not capped, no permission check
+
+**Severity**: Medium
+**Class**: Missing input cap + missing permission check
+**Wire surface**: `organizationSetRankName(INT32 aOrganizationId, INT32 aRank, WSTRING aName)` — cell method `SET_RANK_NAME`=17
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+`aName` is unbounded WSTRING. Caller permission required: `EORG_PERM_RankNames` (=128, `enumerations.xml:1917`). Rank value must be in `[1,8]`. Without a server-side length cap, this is a roster-wide DoS vector — every member's UI will render the long string each time the org rank list updates. Current handler stub: `cell_methods/organization.rs:127-138`.
+
+**Evidence**
+- Ghidra: `0x019bea68` `Event_NetOut_OrganizationSetRankName`.
+- Wire shape from `entities/defs/interfaces/OrganizationMember.def:397-402`.
+- Permission bit `EORG_PERM_RankNames` from `enumerations.xml:1917`.
+- Cross-ref to Rust: `crates/services/src/cell/cell_methods/organization.rs:127-138`.
+
+**Attack scenario**
+1. Officer with `EORG_PERM_RankNames` (or anyone, if the perm isn't checked) sends `organizationSetRankName(orgId, rank=8, aName="X" * 65535)`.
+2. Server stores the giant string; broadcasts it via `onOrganizationRankNameUpdate` to every org member.
+3. Client UI hangs rendering 65k-char rank label on every roster open.
+
+**Suggested remediation (one line)**
+Length-cap `aName` server-side (e.g. 32 chars matching typical UI box) and require `caller_perms & EORG_PERM_RankNames != 0 && caller_rank > aRank`.
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-M-09 — `organizationTransferCash`: client picks amount + direction with no rank-bound withdraw cap
+
+**Severity**: Critical
+**Class**: Guild bank dupe / privilege escalation
+**Wire surface**: `organizationTransferCash(INT32 aOrganizationId, INT32 aCash)` — cell method `TRANSFER_CASH`=19
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+`aCash` is `INT32` — a *signed* 32-bit integer. The handler must:
+(a) reject `aCash <= 0` (signed-overflow trick: aCash=INT_MIN with a
+naïve subtraction wraps into a deposit); (b) require `caller_perms`
+contains `EORG_PERM_DepositCash` (=262144) for positive transfers and
+`EORG_PERM_WithdrawCash` (=524288) for negative ones — these are
+distinct bits in `enumerations.xml:1928-1929`; (c) atomically debit
+caller's wallet and credit org bank (or vice versa) in a single DB
+transaction with rollback on disconnect; (d) per-rank withdraw
+**cap** — most MMO guild-bank designs gate withdraw amount by rank.
+The .def has no per-rank cap field, so the implementer must derive it
+from a server config or store it in the org row. Current handler
+stub: `cell_methods/organization.rs:147-159` parses
+`org_id, cash = i32::from_le_bytes(...)` and logs.
+
+**Evidence**
+- Ghidra: `0x019bea90` `Event_NetOut_OrganizationTransferCash`.
+- Wire shape from `entities/defs/interfaces/OrganizationMember.def:409-413`.
+- Permission bits from `enumerations.xml:1928-1929`.
+- Cross-ref to Rust: `crates/services/src/cell/cell_methods/organization.rs:147-159`.
+
+**Attack scenario**
+1. Member (no `EORG_PERM_WithdrawCash`) sends `organizationTransferCash(orgId, aCash=-1000000)` interpreting the negative as a withdraw.
+2. Naïve handler: `player.cash -= aCash` → player.cash *increases* by 1M; org bank decreases by 1M (or wraps if no withdraw-perm check).
+3. Dupe of guild bank into personal naqahdah.
+
+Atomicity scenario:
+1. Member with `EORG_PERM_DepositCash` sends `organizationTransferCash(orgId, aCash=1000)`; player wallet debited; client disconnects mid-transaction.
+2. If org-bank credit hasn't committed and disconnect rolls back wrong-side, 1000 cash is destroyed (refund-amount-not-credited) or duplicated (debit not committed but credit was).
+
+**Suggested remediation (one line)**
+`aCash > 0` only (direction inferred from a separate verb if both directions needed), `caller_perms & deposit_or_withdraw_bit != 0`, single-transaction wallet↔bank mutation with `with_item_lock`-style row pinning, per-rank daily withdraw cap stored server-side.
+
+**Would benefit from x64dbg trace?**
+Yes — once implemented, a live trace through the i32 sign-extension path would confirm the wallet wraparound behavior under negative input.
+
+---
+
+### CAT-M-10 — `organizationMOTD` / `organizationNote` / `organizationOfficerNote`: unbounded WSTRING + permission unchecked
+
+**Severity**: Medium
+**Class**: Missing input cap + missing permission check
+**Wire surface**:
+- `organizationMOTD(INT32 aOrganizationId, WSTRING aMOTD)` — cell `MOTD`=13
+- `organizationNote(INT32 aOrganizationId, WSTRING aNote)` — cell `NOTE`=14
+- `organizationOfficerNote(INT32 aOrganizationId, WSTRING aName, WSTRING aNote)` — cell `OFFICER_NOTE`=15
+
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+All three text-mutation cell methods accept unbounded WSTRINGs.
+`organizationMOTD` requires `EORG_PERM_MOTD` (=1024,
+`enumerations.xml:1920`); `organizationNote` requires
+`EORG_PERM_RosterNotes` (=32); `organizationOfficerNote` requires
+`EORG_PERM_OfficerNotes` (=64). All three rebroadcast via the
+matching `on*Update` cell method to every member's client. The
+current handlers at `cell_methods/organization.rs:91-111` only log
+`org_id` from the prefix bytes — the actual WSTRING contents are not
+even parsed. The OFFICER_NOTE case is the worst — it takes a
+`WSTRING aName` field which, if used to look up which member's
+officer-note to edit, would let a non-officer edit anyone's officer
+note by spoofing the name (the actual target authority is the
+member-id resolved from the name, and that resolution must enforce
+caller's officer-note-edit permission).
+
+**Evidence**
+- Ghidra: `0x019be9d4` (`MOTD`), `0x019be9f4` (`Note`), `0x019bea14` (`OfficerNote`).
+- Wire shapes from `entities/defs/interfaces/OrganizationMember.def:371-388`.
+- Permission bits from `enumerations.xml:1915-1920`.
+- Cross-ref to Rust: `crates/services/src/cell/cell_methods/organization.rs:91-111`.
+
+**Attack scenario**
+1. Initiate with no `EORG_PERM_MOTD` sends `organizationMOTD(orgId, "X" * 65535)`.
+2. Naïve handler stores + rebroadcasts to all online members. Every member's UI hangs on render.
+3. Repeat for `organizationOfficerNote` with name = victim's name to vandalize their HR note.
+
+**Suggested remediation (one line)**
+Each handler: validate caller's permission bit, length-cap the WSTRING (e.g. 256 chars for MOTD, 128 for note), resolve target name → member_id server-side and re-check permission against that target's rank for the officer-note path.
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-M-11 — `squadSetLootMode`: no leader check, no enum range check
+
+**Severity**: Medium
+**Class**: Missing caller authority + missing enum range check
+**Wire surface**: `squadSetLootMode(INT32 aLootMode)` — cell method `SQUAD_SET_LOOT_MODE`=18
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+The .def at `OrganizationMember.def:404-407` is striking: the wire
+shape carries **no `aOrganizationId`** — only the loot mode value.
+That means the server must resolve "the squad this player is in"
+entirely from session state. The handler at
+`cell_methods/organization.rs:140-146` just parses
+`loot_mode = i32::from_le_bytes(...)` and logs. When implemented,
+the implementer must:
+(a) look up the player's squad org (type=Squad, =0 in
+`enumerations.xml:1942`) from session;
+(b) verify caller is the squad leader (`EORG_RANK_Leader = 8` in this
+context, or however squad-leader is encoded for the EORG_TYPE_Squad
+case);
+(c) range-check `aLootMode` against the valid enum (the .def comment
+says it's `aLootType` on the client side at
+`OrganizationMember.def:172-175`, broadcast via `onSquadLootType`, but
+the actual enum tokens for valid loot modes are not in
+`enumerations.xml` — they may live in a different schema file and
+must be enumerated before implementing). Without (c) the client can
+send a negative or out-of-bound value that stores in the squad row
+and breaks the loot-distribution code on the next mob kill.
+
+**Evidence**
+- Ghidra: `0x019beab8` `Event_NetOut_SquadSetLootMode`.
+- Wire shape from `entities/defs/interfaces/OrganizationMember.def:404-407`.
+- Note: no aOrganizationId on the wire — server-side session lookup mandatory.
+- Cross-ref to Rust: `crates/services/src/cell/cell_methods/organization.rs:140-146`.
+
+**Attack scenario**
+1. Squad member (not leader) sends `squadSetLootMode(aLootMode=99)`.
+2. Naïve handler stores 99 as the squad's loot mode.
+3. Next mob kill, loot-distribution code switches on a value outside its match arms → either falls through to a default (e.g. FFA, which the non-leader prefers) or panics.
+
+**Suggested remediation (one line)**
+Resolve squad from session, require caller is squad-leader, range-check `aLootMode` against the defined loot-mode enum.
+
+**Would benefit from x64dbg trace?**
+Yes — to enumerate the valid loot-mode values that the SGW client UI actually sends, since the enum isn't in `enumerations.xml`.
+
+---
+
+### CAT-M-12 — `sendDuelChallenge` (base): no online/same-space/cooldown check, target by name
+
+**Severity**: High
+**Class**: Missing precondition checks on a state-machine transition
+**Wire surface**: `Event_NetOut_DuelChallenge` → BaseMethod `sendDuelChallenge(WSTRING aPlayerName, INT8 aSquadDuel)`
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+The duel state machine transition from "no duel" → "pending challenge"
+needs server-side gating on:
+(a) target player exists and is online;
+(b) target is in the same space (cross-space duels would teleport-glitch the duel marker);
+(c) target is within a sane challenge-range (movement-physics-advisor's domain — server-side position distance check);
+(d) caller is not already in a duel or pending-challenge state;
+(e) target is not already in a duel;
+(f) caller's PvP flag and target's PvP flag are compatible per the design;
+(g) cooldown on issuing challenges (anti-spam — without it, a script can spam-challenge every nearby player every tick).
+The `aSquadDuel` flag elevates the challenge to "my entire squad vs their entire squad" — that fan-out makes the precondition checks more important, not less. No base handler today.
+
+**Evidence**
+- Ghidra: `0x019b4448` `Event_NetOut_DuelChallenge`; `register_NetOut_DuelChallenge` at `0x00cbee10`; SlashCmd entry at `Event_SlashCmd_DuelChallenge__vfunc_2 @ 0x005b3b10` (client UI emit).
+- Wire shape from `entities/defs/SGWPlayer.def:509-513`.
+- Cross-ref to Rust (no handler today): catch-all in `base/dispatch.rs:333`.
+
+**Attack scenario**
+1. Script: loop {emit `sendDuelChallenge("victim", aSquadDuel=1)`; sleep 50ms; emit `duelForfeit`}.
+2. With no anti-spam, victim's UI receives a duel-challenge prompt 20×/sec forever.
+3. Or: emit `sendDuelChallenge(...)` cross-space against a player in a safe zone, dragging them into a duel state where the PvP flag forced-on causes them to take damage from PvP-flagged players.
+
+**Suggested remediation (one line)**
+Resolve target name → entity_id server-side, validate online/same-space/range/state-machine compatibility/anti-spam cooldown; route to a dedicated duel-state-machine module rather than the catch-all.
+
+**Would benefit from x64dbg trace?**
+Yes — to confirm the challenge-acceptance UI prompt the target sees can be replayed verbatim by spoofing `onDuelChallenge` client-method indices.
+
+---
+
+### CAT-M-13 — `sendDuelResponse`: no validation that a challenge is pending for this session
+
+**Severity**: High
+**Class**: Replay / state-machine bypass
+**Wire surface**: `sendDuelResponse(INT8 aResponse)` — cell method `SEND_DUEL_RESPONSE`=102
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+This is the response side of the duel state machine. The wire shape
+carries **only `aResponse` (INT8)** — no challenger id, no challenge
+nonce. That means the server must hold the pending-challenge state
+per-session and consume it on response. If the handler dispatches
+without checking "is there a pending challenge for me right now",
+then:
+(a) a client that never received a challenge can spam
+`sendDuelResponse(1)` to force-start duels against arbitrary players;
+(b) once a duel ends, a delayed `sendDuelResponse` packet could
+re-trigger the duel-start path; (c) without a nonce, the response
+can't be cross-checked against *which* challenge is being answered if
+multiple pile up. The fan-out shape `Event_NetIn_onDuelChallenge` has
+`MAILBOX + ARRAY<MAILBOX>` (`SGWPlayer.def:1372-1375`) — the server
+holds the challenger info, but it must verify the response correlates
+to a known-pending challenge. Current handler stub:
+`cell_methods/player/social.rs:90-96`.
+
+**Evidence**
+- Ghidra: `0x0195fb58` `Event_NetOut_DuelResponse` (sic — RTTI string says DuelResponse but the cell method on the .def is `sendDuelResponse`); `register_NetOut_DuelResponse` callsites confirm.
+- Wire shape from `entities/defs/SGWPlayer.def:975-978`.
+- Cross-ref to Rust: `crates/services/src/cell/cell_methods/player/social.rs:90-96`.
+- This is the same exploit shape as the [[reference-dialog-choice-exploit-shape]] (no open-dialog tracking → replay forgeable).
+
+**Attack scenario**
+1. Without ever receiving a duel challenge, send `sendDuelResponse(aResponse=1)`.
+2. Server has no `pending_duel_challenge` map → naïve handler may default-accept or, worse, look up "current duel partner" from a stale field.
+3. If the server stores "last challenger" as a side-effect of receiving a challenge but doesn't clear it on timeout, a delayed accept reactivates a stale challenge.
+
+**Suggested remediation (one line)**
+Per-session `pending_duel_challenge: Option<{challenger_eid, expires_at, nonce}>`, populated on receipt of a challenge, consumed (cleared) on response or timeout, and required to be `Some` for the response to do anything.
+
+**Would benefit from x64dbg trace?**
+No — wire and Python reference are clear about the missing state.
+
+---
+
+### CAT-M-14 — `duelForfeit`: no caller-is-in-duel check, no participant check
+
+**Severity**: Medium
+**Class**: Missing participant check on a state-machine transition
+**Wire surface**: `duelForfeit()` — cell method `DUEL_FORFEIT`=103 (no args)
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+The wire carries zero arguments — caller identity is from
+`session.player_eid` (good — already enforced by
+[[reference-cell-method-entity-id-authority]]). The server must
+verify the caller is actually a participant of a currently-active
+duel. Without this:
+(a) any player can `duelForfeit` while not in a duel, triggering the
+"end of duel" cleanup path (clearing PvP flags, removing the duel
+marker, awarding the "winner" — depending on how the duel end is
+designed, this could grant credit to a third party);
+(b) in a squad duel (squad vs squad), a non-participant squad-member
+forfeit could end the duel for everyone on their side.
+Current handler stub: `cell_methods/player/social.rs:98-101`.
+
+**Evidence**
+- Ghidra: `0x019b4478` `Event_NetOut_DuelForfeit`; `register_NetOut_DuelForfeit` at `0x00cbefc0`; SlashCmd entry at `Event_SlashCmd_DuelForfeit__vfunc_2 @ 0x005b4010`.
+- Wire shape from `entities/defs/SGWPlayer.def:1015-1017`.
+- Cross-ref to Rust: `crates/services/src/cell/cell_methods/player/social.rs:98-101`.
+
+**Attack scenario**
+1. Player A (not in a duel) emits `duelForfeit`.
+2. Naïve handler runs end-of-duel cleanup against a default/stale duel record, possibly clearing PvP flags or awarding XP to a phantom opponent.
+3. Or: in a squad duel of A vs B, an unrelated player C (not in either squad) emits `duelForfeit` and naïvely ends A's squad's side.
+
+**Suggested remediation (one line)**
+Resolve `session.player_eid` → active duel record via the `duelEntities` array on `SGWDuelMarker.def`; reject silently if the player is not listed as a participant in any active duel.
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-M-15 — Disconnect during duel: no auto-forfeit path
+
+**Severity**: Medium
+**Class**: State-machine disconnect-race exploit
+**Wire surface**: Implicit — the lack of a disconnect handler that knows about duel state
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+This is the analogue of the [[project-trade-handlers-unimplemented]]
+disconnect-timing window for duels. The duel state lives across two
+players' sessions plus an `SGWDuelMarker` entity. When one
+participant disconnects mid-duel:
+(a) if no auto-forfeit fires, the other participant is stuck in a
+duel state forever (PvP flag forced on, can't loot or interact);
+(b) if death-penalty would otherwise apply to the disconnector, they
+escape it by force-quitting;
+(c) the `SGWDuelMarker` and its `duelEntities` array
+(`SGWDuelMarker.def:15-18`) leak — the duel record never decrements
+to zero participants.
+The current logoff path in `base/dispatch.rs:235-327` (`LOG_OFF`)
+sends `DisconnectEntity` and `DestroyEntity` messages to the cell, but
+the cell side has no duel-aware handler to convert "participant
+disconnected" into "remaining-participant wins by forfeit + clear
+duel state". This needs to land at the same time as the duel
+state-machine in CAT-M-12/-13/-14.
+
+**Evidence**
+- Wire shape (the disconnect path that needs to do this) from `base/dispatch.rs:259-275`.
+- Duel state container from `entities/defs/SGWDuelMarker.def:15-18` (`duelEntities: ARRAY<of>MAILBOX`).
+- No current Rust handler — finding is about the gap in the disconnect path.
+
+**Attack scenario**
+1. Attacker challenges victim to a duel; duel starts.
+2. Attacker is losing, force-disconnects via `LogOff(disconnect=1)`.
+3. Without an auto-forfeit: attacker avoids death penalty; victim remains stuck in duel-flagged state until manual GM cleanup.
+
+**Suggested remediation (one line)**
+On `DisconnectEntity` for a player listed in any `SGWDuelMarker.duelEntities`, fire an auto-forfeit with the remaining participant(s) as winner before destroying the entity.
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-M-16 — `pvpOrganizationLeaveResponse`: no pending-leave-request correlation
+
+**Severity**: Medium
+**Class**: Replay / state-machine bypass
+**Wire surface**: `pvpOrganizationLeaveResponse(INT32 aOrganizationId, UINT8 aResponse)` — cell method `PVP_LEAVE_RESPONSE`=12
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+This is the response leg of `onPvPOrganizationLeaveRequest`
+(`OrganizationMember.def:123-126`). The server prompts the client
+"changing your PvP flag would force you to leave org X, accept?"; the
+client responds with `aResponse`. If the server doesn't track the
+*pending* leave request per session and per org, then:
+(a) a client can spam `pvpOrganizationLeaveResponse(orgId, 1)`
+without ever having received a leave prompt — naïve handler may
+execute the "leave on PvP flip" path against any org_id the player
+happens to be in;
+(b) timing race: a delayed accept after the prompt timed out should
+not still process. The session must hold a `pending_pvp_leave: Option<{org_id, expires_at}>`
+analogous to the duel-challenge state in CAT-M-13.
+Current handler stub: `cell_methods/organization.rs:78-90`.
+
+**Evidence**
+- Ghidra: `0x019bfbec` / `0x019cb5d8` `Event_NetOut_PvPOrganizationLeaveResponse` (two RTTI string sites, NetOut typed payload + EventHandler binding).
+- Wire shape from `entities/defs/interfaces/OrganizationMember.def:336-340`.
+- Cross-ref to Rust: `crates/services/src/cell/cell_methods/organization.rs:78-90`.
+
+**Attack scenario**
+1. Player is in PvP org A (joined when PvP flag was on). They want to leave A without flipping PvP first.
+2. Spam `pvpOrganizationLeaveResponse(orgId=A, aResponse=1)` without ever toggling PvP.
+3. Naïve handler treats the response as "yes, leave A and flip PvP off" — player leaves A while never having received a server-side leave-prompt.
+
+**Suggested remediation (one line)**
+Per-session `pending_pvp_leave: Option<{org_id, expires_at}>`; populate on emitting `onPvPOrganizationLeaveRequest` to that client; consume + clear on response; require `Some` with matching `org_id` for the response to act.
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-M-17 — `strikeTeamResponse`: same shape as PvP leave response — no pending-request correlation
+
+**Severity**: Low
+**Class**: Replay / state-machine bypass
+**Wire surface**: `strikeTeamResponse(INT32 aOrganizationId, UINT8 aResponse)` — cell method `STRIKE_TEAM_RESPONSE`=11
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+The exact same shape as CAT-M-16. The server prompts via
+`onStrikeTeamUpdate` (`OrganizationMember.def:323-326`), the client
+responds with `aResponse`. Without a pending-strike-team-prompt map
+on the session, a client can force-accept or force-decline a
+strike-team transition that was never offered. Lower severity than
+the PvP leave because the side effect (strike-team toggle) is narrower
+than full-org-leave, but the missing-correlation shape is identical
+and warrants flagging now so it's not skipped when the handler is
+wired up. Current handler stub: `cell_methods/organization.rs:65-77`.
+
+**Evidence**
+- Wire shape from `entities/defs/interfaces/OrganizationMember.def:329-333`.
+- Cross-ref to Rust: `crates/services/src/cell/cell_methods/organization.rs:65-77`.
+
+**Attack scenario**
+1. Member of org A (not currently being asked about strike-team) sends `strikeTeamResponse(orgId=A, aResponse=1)`.
+2. Naïve handler toggles strike-team flag on A.
+3. Org-wide PvP state shifts without leader consent.
+
+**Suggested remediation (one line)**
+Same pattern as CAT-M-16 — per-session pending-strike-team-prompt map, populate on emit, consume on response.
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-M-18 — `organizationInviteResponse`: no per-session pending-invite correlation
+
+**Severity**: Medium
+**Class**: Replay / state-machine bypass + request-id forgery
+**Wire surface**: `organizationInviteResponse(INT32 aRequestID, UINT8 aResponse)` — cell method `INVITE_RESPONSE`=8
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+The client passes `aRequestID` (server-generated invite token from
+`onOrganizationInvite` at `OrganizationMember.def:64-70`, INT32 field
+`aRequestID`). The handler must:
+(a) look up the request_id in a per-session pending-invites map;
+(b) verify the invite hasn't expired (TTL — without one, an invite
+forwarded by mail or out-of-band can be replayed forever);
+(c) confirm the invite is destined for this session's player.
+Without (c), a client could harvest a request_id from a packet
+capture and force-accept *anyone else's* invite. Without (a)/(b), the
+client can fabricate request_id = 1, 2, 3 ... and hope to brute-force
+match a real outstanding invite ID. Request IDs are INT32 — 2^32
+space, but if they're assigned monotonically from 0 the search space
+is much smaller and brute-force becomes practical against a noisy
+server. Current handler stub: `cell_methods/organization.rs:28-40`.
+
+**Evidence**
+- Ghidra: `0x019be948` `Event_NetOut_OrganizationInviteResponse`.
+- Wire shape from `entities/defs/interfaces/OrganizationMember.def:267-271`.
+- Cross-ref to Rust: `crates/services/src/cell/cell_methods/organization.rs:28-40`.
+
+**Attack scenario**
+1. Attacker harvests a victim's `aRequestID` from a packet capture or by guessing the monotonic counter range.
+2. Sends `organizationInviteResponse(aRequestID=harvested, aResponse=1)` from attacker's session.
+3. Naïve handler that keys only on `request_id` (not on session+request_id) accepts the invite on attacker's behalf, adding attacker to the org the request was destined for.
+
+**Suggested remediation (one line)**
+Per-session `pending_invites: HashMap<i32, {org_id, inviter_eid, expires_at}>`; reject if `request_id` not in this session's map; use a CSPRNG for `request_id` so guessing is infeasible.
+
+**Would benefit from x64dbg trace?**
+Yes — to inspect how the SGW client builds `aRequestID` and whether the same value is reused across sessions.
+
+---
+
+## Not Filed
+
+- **`BroadcastMinimapPing`** — categorized as Squad in CAT-L (chat) by the surface inventory; deferred to that audit. The handler stub at `cell_methods/organization.rs:48-64` accepts an arbitrary org_id + vector3 with no membership or rate-limit check, but this overlaps `sendPlayerCommunication` and other broadcast-shape exploits already filed under CAT-L.
+- **`ReloadOrganizations`** — listed in CAT-M scope but the Ghidra surface inventory shows no `Event_NetOut_ReloadOrganizations` RTTI string today. Strings search confirms 0 hits. This is likely a GM/debug-only command that's part of CAT-N's `RequestReload` family; route any future implementation through the GM-auth plumbing gap [[reference-gm-auth-plumbing-gap]] rather than the OrganizationMember dispatch.
+- **`onOrganizationCreationResult` / `launchOrganizationCreation`** — server→client messages (NetIn / cell→client direction), not client→server NetOut. Out of scope for an audit of client-supplied trust.
+- **`awardSquadXP`** — server→client (cell method on `SGWPlayer.def:572-578`, NOT `<Exposed/>`). The Python `<Exposed/>` discriminator means the wire surface does not accept client invocation; this is a cell-internal RPC.
+- **`startSquadDuel` / `duelChallenge` / `duelResponse` / `duelEntityDefeat` / `startDuel` / `registerDuelMarker` / `onDuelDefeat` / `duelAbort` / `onDuelEntitiesSet` / `onDuelEntitiesRemove` / `onDuelEntitiesClear`** — all non-`<Exposed/>` cell methods on `SGWPlayer.def:980-1013` and `1417-1426`. These are server-side inter-entity RPCs (e.g. duel marker → player) and not client-callable. Out of scope.
+- **`onSquadMemberRingTransport*`** — server→client notifications, not client emits.
+- **OrganizationCreation founder-fee value** — out of scope to specify, since `enumerations.xml` has no token for the fee amount. Implementer must source from server config or content data; the AUDIT item is "there must BE a fee," which is captured in CAT-M-03.
+- **Strike-team / PvP-leave timer fields** (`strikeTeamTimers`, `pendingPvPTimers`, `pendingGroups`, `pendingJoins`, `pendingInvitesByType` — all `CELL_PRIVATE` properties on `OrganizationMember.def:26-57`) — these are the *correct* state for the pending-request maps recommended in CAT-M-16/-17/-18. Not a finding; surfaced here so the implementer knows the per-session state is already declared in the entity model.
+- **`PythonProperty records` on OrganizationMember** — the `records` property at `OrganizationMember.def:12-16` is `PYTHON` typed, `CELL_PRIVATE`. The Python reference stored the player's organization-membership tuples here. Server-authority-critical, but not a wire-supplied field — it's authoritative server state. Not a wire-surface finding; flagged for the implementer to confirm it lives in the DB and not in the client.

--- a/docs/security-audit/2026-05-31-server-authority/findings/CAT-N-gm-commands.md
+++ b/docs/security-audit/2026-05-31-server-authority/findings/CAT-N-gm-commands.md
@@ -1,0 +1,2044 @@
+# CAT-N — GM / Debug / Cheat commands — Findings
+
+**Overall trust posture.** CAT-N covers the largest single attack surface in the
+SGW protocol — ~125 distinct `Event_NetOut_*` messages produced by the
+`Event_SlashCmd_*` → `Event_NetOut_*` debug-command pipeline in
+`SGWTextCommandMgr`, mapped onto the `gm*` exposed CellMethods + BaseMethods
+of `entities/defs/SGWGmPlayer.def` (and a handful that also live on the
+regular `SGWPlayer.def`). The current Rust server is in a paradoxical state:
+
+- **It is NOT *currently* exploitable through CAT-N** because (a) zero `gm*`
+  cell methods are implemented (every one falls through to the
+  `warn!("Unhandled cell method call")` arm at
+  `crates/services/src/cell/dispatch/router.rs:101`) and (b) the server
+  hard-codes the entity class to SGWPlayer (`class_id` 0x02) regardless of
+  `access_level`, with the explanatory comment "Until we build a separate
+  SGWGmPlayer index table, always use SGWPlayer (0x02) regardless of
+  access_level" at `crates/services/src/base/world_entry/play_character.rs:89-93`.
+- **It is structurally unsecurable as written** because the cell-dispatch
+  layer has no access to `access_level` — the auth-level bit lives only on
+  `ConnectedClientState.access_level` (`crates/services/src/base/mod.rs:117`),
+  which is base-only state. The cell `dispatch_cell_method` signature
+  (`entity_id, method_index, args, tx, space_mgr, engine`) carries
+  no caller identity beyond the entity id; nothing in the cell layer knows
+  the caller is or isn't a GM. The moment ANY `gm*` handler is added without
+  also plumbing `access_level` through the cell-base boundary, that handler
+  is unauthenticated-by-default.
+- **Three GM-shaped methods are reachable today and are stubs**:
+  `WORLD_INSTANCE_RESET` (CM 92), `RESET_MY_ABILITIES` (CM 72), and the
+  three combat/heal debug toggles (`TOGGLE_COMBAT_DEBUG` CM 2,
+  `TOGGLE_COMBAT_VERBOSE_DEBUG` CM 3, `TOGGLE_HEAL_DEBUG` CM 6). All have
+  `Exposed/` in `SGWPlayer.def` (i.e., they're in the regular-player flat
+  index table, not just SGWGmPlayer's). All stub-log and return; no GM
+  check. If implemented to do anything real without adding gating, they
+  become privilege-escalation vectors.
+
+The findings below are filed in two tiers:
+
+1. **Implementation gaps reachable today** (the three stub methods plus the
+   missing-plumbing systemic finding). These are the only items a black-box
+   attacker can poke at today.
+2. **Wire-surface findings** for the ~120 `gm*` methods that aren't yet
+   dispatched but where the wire shape is already accepted on the
+   `dispatch_cell_method` router and would immediately escalate the moment
+   a handler is added. These are filed because (a) the SGW.exe binary
+   actively emits these messages from the local slash-command UI and
+   (b) repeated additions of gm* handlers without auth plumbing are the
+   most plausible regression path — the user said this is the largest
+   single risk surface for a reason.
+
+Severity calibration: Critical is reserved for "anyone can become GM"
+(SetHideGM into authoritative access_level), High for "anyone can mutate
+authoritative inventory/state of self or others" (SetGodMode, SetHealth,
+GiveItem, Kill, Spawn, WorldInstanceReset), Medium for info-disclosure or
+self-only state hacks, Low for log-noise / DoS-shape findings.
+
+---
+
+### CAT-N-01 — `WORLD_INSTANCE_RESET` (CM 92) exposed on regular `SGWPlayer.def`, stub handler has no GM check
+
+**Severity**: High
+**Class**: Server-authority bypass — privileged action exposed at non-privileged
+flat index
+**Wire surface**: `Event_NetOut_WorldInstanceReset` → cell method index 92
+**Demonstrable / Likely-theoretical**: Likely-theoretical (handler is a stub
+today; the finding is the un-gated wire surface + the missing gating
+infrastructure that a future implementer will likely miss)
+
+**Trust violation**
+`SGWPlayer.def:868-870` declares `<onWorldInstanceReset><Exposed/></onWorldInstanceReset>`
+with no args — i.e., the method is in the flat exposed-CellMethod table that
+*every* SGWPlayer instance, including access_level=0 accounts, can call
+directly. The 2009 design intent (per the `gm*` family of equivalent
+commands) was that this would tear down and recreate the current world
+instance, kicking every other player in the same space. Today the Rust
+handler at `crates/services/src/cell/cell_methods/player/world/mod.rs:230-233`
+is `tracing::info!(entity_id, "UNIMPLEMENTED: onWorldInstanceReset")` and
+returns, but the method-index slot is fully reachable on the wire (CM 92).
+The moment someone implements the real reset path without first checking
+`access_level`, every player in the shard can grief any space by sending a
+single packet — the index is `0xBD` + sub-byte `92 - 61 = 31` per the
+extended cell-method encoding in
+`docs/protocol/client-method-dispatch-table.md`.
+
+**Evidence**
+- Ghidra: `019b4340` `Event_NetOut_WorldInstanceReset` — RTTI string for
+  the client-side event class; `01df5b90` is the typed RTTI descriptor.
+  Confirmed as an outbound (client→server) typed event with no args.
+- entities/defs/SGWPlayer.def:868-870 — `<onWorldInstanceReset><Exposed/></onWorldInstanceReset>`
+  with no args, i.e. this CellMethod is exposed on the regular SGWPlayer
+  flat-index table, not gated by SGWGmPlayer parentage.
+- Cross-ref to Rust handler (for the fix author, NOT as truth):
+  `crates/services/src/cell/cell_methods/player/world/mod.rs:230-233` —
+  stub `UNIMPLEMENTED` arm; index pinned to 92 at
+  `crates/services/src/cell/cell_methods/player/constants.rs:30`.
+
+**Attack scenario**
+1. Modified client (or replay tool) sends a single cell-method call to
+   index 92 with empty args bytes.
+2. Server dispatch routes to the world-method handler which currently
+   logs and returns — but the dispatch *succeeds* (no rejection).
+3. When this is wired up: every player in the current `space_id` (typically
+   a 30+ population zone in the live design) is torn down and respawned,
+   wiping in-progress combat / loot / mission state across all of them.
+
+**Suggested remediation (one line)**
+Move the dispatch entry behind an access-level check; the cell-dispatch
+needs a caller `access_level` plumbed in (see CAT-N-15) OR the index
+needs to be removed from the regular SGWPlayer table and only honoured
+on the SGWGmPlayer table once the latter is implemented.
+
+**Would benefit from x64dbg trace?**
+No — the wire surface and the def file are sufficient.
+
+---
+
+### CAT-N-02 — `RESET_MY_ABILITIES` (CM 72) exposed on regular `SGWPlayer.def`, stub handler will be a free respec when implemented
+
+**Severity**: High
+**Class**: Server-authority bypass — economy-impacting privileged action
+exposed at non-privileged flat index
+**Wire surface**: `Event_NetOut_ResetAbilities` → cell method index 72
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+`SGWPlayer.def:602-604` declares `<resetMyAbilities><Exposed/></resetMyAbilities>`
+with no args. The implied design is that any player can free-reset their
+ability tree, which in the live MMO would mean refunding all training
+points spent on `trainAbility` — a feature that on most MMOs is gated by
+either a per-account cooldown, a cash cost, or an NPC interaction (the
+`gmRespec` cell method on SGWGmPlayer is the GM variant; `respecCrafting`
+on the regular SGWPlayer is the *crafting-only* variant). The Rust handler
+is a stub `UNIMPLEMENTED: resetMyAbilities` at
+`crates/services/src/cell/cell_methods/player/combat/mod.rs:120`. When
+this is implemented, if it does what its name says without cost / cooldown
+/ NPC gating, a player can spam it to unlock infinite respecs every
+millisecond.
+
+**Evidence**
+- entities/defs/SGWPlayer.def:602-604 — `<resetMyAbilities><Exposed/></resetMyAbilities>`,
+  zero args.
+- Cross-ref to Rust handler: `crates/services/src/cell/cell_methods/player/combat/mod.rs:119-122`
+  (`UNIMPLEMENTED: resetMyAbilities`); constant at
+  `crates/services/src/cell/cell_methods/player/constants.rs:10`.
+- The Ghidra-side `Event_NetOut_ResetAbilities` client event has no
+  arguments (the typed event class carries no payload beyond its RTTI),
+  matching the .def's zero-arg signature.
+
+**Attack scenario**
+1. Player levels and spends all `trainingPoints` on ability A.
+2. Player sends `resetMyAbilities()` — once implemented, all points refund.
+3. Player spends all on ability B for a different rotation.
+4. Player repeats infinitely with zero cooldown / cost.
+
+**Suggested remediation (one line)**
+Implementing handler must (a) charge cash from `sgw_player.cash` and (b)
+enforce a per-character cooldown row before refunding — wire-shape match
+to `gmRespec` (which is GM-only and uncosted) is not the right model.
+
+**Would benefit from x64dbg trace?**
+No — wire surface is fully specified by the .def.
+
+---
+
+### CAT-N-03 — Cell-method dispatch has no access to `access_level`; every future `gm*` handler is unauthenticated-by-default
+
+**Severity**: Critical
+**Class**: GM auth bypass — missing infrastructure / systemic
+**Wire surface**: Every `gm*` cell method (~85 entries on SGWGmPlayer.def +
+inheritance), reachable via `dispatch_cell_method` at
+`crates/services/src/cell/dispatch/router.rs:33`
+**Demonstrable / Likely-theoretical**: Likely-theoretical (the gap is
+real today, but no `gm*` handler is wired up yet)
+
+**Trust violation**
+The cell-method dispatch entry point takes
+`(entity_id, method_index, args, tx, space_mgr, engine)` — none of these
+carry the caller's `access_level`. That field lives on
+`ConnectedClientState.access_level` (`crates/services/src/base/mod.rs:117`),
+which is set from the `account.accesslevel` DB column at login
+(`crates/services/src/auth/handlers.rs:486-488`) and currently consumed
+only by the chat dispatch (`SEND_PLAYER_COMMUNICATION`'s `SPEAKER_GM` bit
+computation at `crates/services/src/base/dispatch.rs:131-133`). When a
+cell-method dispatch arm needs to check "is the caller a GM?", it has no
+way to do so without breaking the cell/base layer boundary. The natural
+implementation path for any future contributor adding `gmGiveItem`,
+`gmSpawnByCmd`, etc. is to drop the handler into `cell_methods/...` and
+ship — and the resulting handler has zero GM check because there's
+nothing to check against.
+
+**Evidence**
+- `crates/services/src/cell/dispatch/router.rs:33-93` — the dispatch
+  signature has no caller-identity parameter beyond `entity_id`. None of
+  the per-interface dispatchers (`cell_methods::being::dispatch`,
+  `cell_methods::ability_manager::dispatch`, ...) accept an access_level
+  either.
+- `crates/services/src/base/mod.rs:108-117` — `access_level: u32` is on
+  `ConnectedClientState`. Grep `crates/services/src/cell` for
+  `access_level`: zero hits (the field never crosses into the cell layer).
+- Account DB read: `crates/services/src/auth/handlers.rs:439-488` —
+  the field is sourced authoritatively from the `account.accesslevel`
+  column; this part is correct.
+- Comment at `crates/services/src/base/world_entry/play_character.rs:89-94`:
+  "C++ Account.py:293-296 uses SGWGmPlayer (0x03) for access_level > 0,
+  but ... always use SGWPlayer (0x02) regardless of access_level. TODO:
+  Build SGWGmPlayer method index table to enable GM entity type."
+
+**Attack scenario**
+1. Future contributor implements `gmGiveItem` (CM index unknown until
+   SGWGmPlayer table is built — likely as a new `match` arm in the
+   player dispatch).
+2. Implementation grabs the player's inventory and inserts the item.
+3. There is no `if !access_level.can_execute(GM) { return; }` because
+   no `access_level` is in scope.
+4. Any non-GM player sending the same wire shape (modified client or
+   replayed packet) triggers the same code path. Free items for everyone.
+
+**Suggested remediation (one line)**
+Plumb `access_level: u32` through `BaseToCellMsg::CellMethodCall` (the
+cell receives the auth level alongside the entity id) and through
+`dispatch_cell_method` as an additional parameter; gate `gm*`-named
+methods on `access_level >= AccessLevel::GameMaster as u32`.
+
+**Would benefit from x64dbg trace?**
+No — the gap is purely a server-side architectural omission.
+
+---
+
+### CAT-N-04 — Server forces `class_id = 0x02 (SGWPlayer)` for all logins, ignoring `access_level`; legitimate GM accounts cannot use GM commands AND there is no entity-type isolation between GM and non-GM index spaces
+
+**Severity**: Medium
+**Class**: GM auth design omission — wrong entity class flattens index spaces
+**Wire surface**: All `gm*` cell methods (currently inaccessible due to
+class hardcode, but a future fix that just flips the class will expose
+them all without gating)
+**Demonstrable / Likely-theoretical**: Demonstrable (the hardcode is
+documented in code) / Likely-theoretical (the exploit needs a future flip)
+
+**Trust violation**
+The C++ reference (per the inline comment) selects entity class
+`SGWGmPlayer (0x03)` for `access_level > 0` so the GM client gets the
+extended 80+ CellMethod index table that includes the `gm*` family. The
+Rust server hardcodes `SGWPlayer (0x02)` regardless of `access_level`
+because the SGWGmPlayer flat-index table isn't built. This has two
+consequences:
+
+1. Today: legitimate GMs cannot issue GM commands (the indices for
+   `gmGiveItem` etc. don't exist in the SGWPlayer table, so the client's
+   serializer would compute the wrong index — the index 0–108 space is
+   fully occupied by non-GM methods).
+2. Tomorrow, when someone fixes (1) by switching the class on
+   `access_level > 0`: the *same* `dispatch_cell_method` router will
+   receive the GM indices, and per CAT-N-03 has no access_level
+   parameter. The natural and incorrect fix is to add the `gm*` arms
+   inside the same dispatch fns the regular `gm*`-less methods land in
+   — at which point a non-GM client can send the GM index too (it's
+   just a method_index number on the wire; the server has no way to
+   tell whether the *sender* is on the GM class).
+
+**Evidence**
+- `crates/services/src/base/world_entry/play_character.rs:89-94` — the
+  hardcode + the TODO comment.
+- `crates/services/src/cell/cell_methods/player/constants.rs` — only 42
+  SGWPlayer-own indices (67-108). SGWGmPlayer adds 80+ more; none are
+  present.
+- entities/defs/SGWGmPlayer.def — declares the parent as `SGWPlayer` so
+  the GM class would extend, not replace, the index table. Future
+  implementers must NOT collapse the two index spaces into one
+  dispatch fn unless `access_level` is also threaded through.
+
+**Attack scenario**
+1. Future contributor fixes the entity-class hardcode and adds GM method
+   indices (109+) to the `dispatch_cell_method` chain.
+2. They implement `gm*` handlers inside the same dispatch arms,
+   because that's where dispatch lives.
+3. A non-GM client modifies its serializer to use the GM indices and
+   sends `gmGiveItem("ItemTemplateXYZ", 99999)`.
+4. Server has no `access_level` in scope; the arm runs; the inventory
+   row is inserted. Item-dupe / cash-dupe / level-dupe at will.
+
+**Suggested remediation (one line)**
+Couple the entity-class fix with the CAT-N-03 access_level plumbing in
+the same PR; do NOT ship the class switch without the auth threading.
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-N-05 — `Event_NetOut_SetHideGM` wire surface accepted on regular player; nothing prevents a client from claiming GM-visible state, which is the GM-visibility property `bHideGM` on SGWGmPlayer
+
+**Severity**: Critical (worst case — if `bHideGM` is ever read as a
+GM-effective bit)
+**Class**: GM auth bypass — privileged property mutation exposed via
+client-trusted setter
+**Wire surface**: `Event_NetOut_SetHideGM(UINT8 bTurnOn)` → `gmSetHideGM`
+cell method (and base method) on SGWGmPlayer
+**Demonstrable / Likely-theoretical**: Likely-theoretical (today
+unimplemented; the property itself is also unimplemented in Rust)
+
+**Trust violation**
+`Event_NetOut_SetHideGM` carries `UINT8 bTurnOn` — a client-supplied
+boolean for whether the GM should be invisible to non-GM players. The
+SGWGmPlayer.def declares both a CellMethod and a BaseMethod with this
+name (lines 367-370 and 722-724), AND the `bHideGM` property on
+SGWGmPlayer (lines 19-23). The danger is shape-specific: if any future
+code path reads `bHideGM` as a proxy for "is this player a GM?" (e.g.,
+for /who filtering, AoI broadcast suppression, or moderator-channel
+membership), and the property mutation accepts the client-supplied byte
+without `access_level` verification, then a non-GM client can flip
+their own `bHideGM = 1` and gain whatever effects flow from it.
+
+The wire surface is already in the binary (the Slash command, the
+NetOut emit, the registration). Today no Rust handler exists for the
+property OR the method — but the *systemic gap* (CAT-N-03) means
+when a handler is added in the obvious place (a player-methods
+arm), it'll trust the byte.
+
+**Evidence**
+- Ghidra: `019b2ec8` / `019be278` `Event_NetOut_SetHideGM` —
+  client-side RTTI strings. `01df329c` is the typed RTTI descriptor.
+- entities/defs/SGWGmPlayer.def:19-23 — `bHideGM` is a `CELL_PRIVATE`
+  property with default 0. Lines 367-370 expose `gmSetHideGM` as a
+  CellMethod (`<Exposed/>` + `UINT8 bTurnOn`). Lines 722-724 also
+  expose it as a BaseMethod with the same signature.
+- No Rust handler. Wire surface is fully unhandled today.
+
+**Attack scenario**
+1. Non-GM client constructs the `gmSetHideGM(1)` cell-method bytes.
+2. Server today: dispatch falls through to the `warn!` arm (CAT-N-03
+   prevents the index from mapping into a real arm). Today this is
+   inert.
+3. Future state: handler is added without GM gating; `bHideGM=1` is
+   written to the entity / DB.
+4. Any subsequent code that uses `bHideGM` as a privilege bit
+   (extremely plausible — Python `python/cell/SGWGmPlayer.py`
+   references it as the visibility gate) treats the regular player
+   as a GM for visibility purposes.
+
+**Suggested remediation (one line)**
+Treat `bHideGM` strictly as a presentation hint downstream of the
+access_level bit and never as a privilege gate; the setter, when
+implemented, must verify `access_level >= GameMaster` before
+writing.
+
+**Would benefit from x64dbg trace?**
+Yes — if the live Python reference reads `bHideGM` from a non-Python
+caller (e.g., a base-side authority check), x64dbg breakpoints on
+the C++ `bHideGM` accessors would confirm whether the byte ever
+gates a real authority check vs. only the visual hide.
+
+---
+
+### CAT-N-06 — Wire surface for `Event_NetOut_SetGodMode` accepts client-supplied byte; the underlying `bGodMode` is `CELL_PUBLIC` on SGWAbilityManager (every player+NPC)
+
+**Severity**: High
+**Class**: Damage-immunity flag exposed via client setter
+**Wire surface**: `Event_NetOut_SetGodMode(UINT8 bTurnOn)` → `gmSetGodMode`
+cell method
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+The `bGodMode` property is declared on the `SGWAbilityManager` interface
+(`entities/defs/interfaces/SGWAbilityManager.def:67-72`) with `CELL_PUBLIC`
+visibility. The SGWGmPlayer.def line 236-239 exposes
+`gmSetGodMode(UINT8 bTurnOn)` as the setter. Because `bGodMode` is in the
+ability-manager interface that *every* combat-capable entity implements
+(SGWPlayer, SGWMob, SGWPet), the same byte determines damage immunity for
+mobs and pets, not just players. A future handler that trusts the
+client-supplied byte either (a) makes the calling player immune (no-aggro
++ no-damage) or (b) — if `gmSetGodMode` is dispatched on a target other
+than the caller — lets the caller flip mobs / pets to god mode and grind
+them safely. Wire shape carries no target id (the SGWGmPlayer.def setter
+is single-arg: `UINT8 bTurnOn`), implying the caller is the target —
+which is the worst case (no target_id check needed).
+
+**Evidence**
+- Ghidra: `019b3848` / `019bef48` `Event_NetOut_SetGodMode`. Strings
+  `019c3498` (`gmSetGodMode`) confirm the cell method name.
+- entities/defs/interfaces/SGWAbilityManager.def:67-72 — `bGodMode`
+  property, `CELL_PUBLIC` (visible to AoI witnesses; this is wire-public).
+- entities/defs/SGWGmPlayer.def:236-239 — `<gmSetGodMode><Exposed/><Arg>UINT8 bTurnOn</Arg></gmSetGodMode>`.
+- No Rust handler; no `bGodMode` property on the Rust `CellEntity`.
+
+**Attack scenario**
+1. Player sends `gmSetGodMode(1)` cell-method call (post-CAT-N-04 fix).
+2. Server (lacking CAT-N-03 access_level gating) writes
+   `entity.b_god_mode = true`.
+3. Combat code reads the flag and skips damage application.
+4. Caller is now invulnerable for the session.
+
+**Suggested remediation (one line)**
+The damage-resolution path must read `access_level` (server-side
+session record) as the authoritative god-mode gate, not the
+client-controlled `bGodMode` property.
+
+**Would benefit from x64dbg trace?**
+No — wire is sufficient.
+
+---
+
+### CAT-N-07 — `Event_NetOut_SetHealth` / `SetHealthMax` / `SetFocus` / `SetFocusMax` wire surfaces carry a client-supplied `INT64 TargetId`; future handler can mutate any entity's vital stats
+
+**Severity**: High
+**Class**: Authority bypass — direct stat-set with client-chosen target
+**Wire surface**: `Event_NetOut_SetHealth(INT32 Amount, INT64 TargetId)` and
+3 siblings; `gmSetHealth` / `gmSetHealthMax` / `gmSetFocus` / `gmSetFocusMax`
+cell methods
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+SGWGmPlayer.def:259-281 declares all four methods with a payload that
+includes `INT64 TargetId` — i.e., the GM can set health/focus on any
+entity, including PvP opponents, raid bosses, or fellow players. The
+wire signature is `<INT32 Amount, INT64 TargetId>`. A future handler
+that (a) misses CAT-N-03 access_level gating AND (b) trusts the
+client-supplied `TargetId` lets any player one-shot any other entity
+(`gmSetHealth(0, BossEntityId)`) or top up their own health to the
+cap mid-fight. The target is not validated against the caller's
+perception list, ownership, or even space — any 64-bit entity id is
+accepted.
+
+**Evidence**
+- Ghidra string scan: `Event_NetOut_SetHealth`, `Event_NetOut_SetHealthMax`,
+  `Event_NetOut_SetFocus`, `Event_NetOut_SetFocusMax` all present as
+  outbound NetOut classes.
+- entities/defs/SGWGmPlayer.def:259-281 — full setters, all carry
+  `INT32 Amount` + `INT64 TargetId`.
+- No Rust handler.
+
+**Attack scenario**
+1. Player observes a high-priority NPC's `entity_id` via the standard
+   AoI sync (the field is wire-public).
+2. Player sends `gmSetHealth(0, <npc_id>)` cell-method call.
+3. Future handler — lacking access_level gate and target authority
+   check — applies the 0-HP write; the NPC dies, drops loot,
+   awards XP/credit to whoever currently has aggro.
+
+**Suggested remediation (one line)**
+When the handlers are implemented: enforce both access_level AND
+re-validate `TargetId` against `space_mgr.get_entity(target_id)` +
+caller's witness list / aggro authority — never accept a bare client
+entity id.
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-N-08 — `Event_NetOut_SetSpeed` accepts a `FLOAT Multiplier` with no range bound
+
+**Severity**: High
+**Class**: Speed-hack flag exposed via client setter
+**Wire surface**: `Event_NetOut_SetSpeed(FLOAT Multiplier)` → `gmSetSpeed`
+cell method
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+SGWGmPlayer.def:254-257 declares `gmSetSpeed(FLOAT Multiplier)` with no
+range. Comment says "Speed Multiplier (1.0 default)" — implying 1.0 is
+normal speed. A future handler that writes the multiplier into the
+player's movement state without clamping makes the player teleport-fast
+(values >> 1.0) or freeze (values near 0). This is the classic speed-hack
+shape. The wire byte sequence is unconstrained float — clients can send
++inf, NaN, denorm, negative — all of which would land in whatever
+movement math the future handler uses.
+
+**Evidence**
+- Ghidra: `019b3818` `Event_NetOut_SetSpeed` (strings list); typed
+  RTTI is `Event_NetOut_SetSpeed@@`.
+- entities/defs/SGWGmPlayer.def:254-257 — single-arg `FLOAT Multiplier`,
+  Exposed.
+- No Rust handler.
+
+**Attack scenario**
+1. Player sends `gmSetSpeed(99999.0)` — or `gmSetSpeed(f32::NAN)`.
+2. Future handler writes into the player's `top_speed` or movement
+   scalar without clamping.
+3. Movement physics applies the multiplier — player teleports across
+   the map per tick; navmesh / collision is bypassed at high
+   per-tick deltas. (NaN path is worse: produces NaN positions that
+   break ANYTHING that does position math, potentially crashing
+   downstream code that doesn't check for NaN inputs.)
+
+**Suggested remediation (one line)**
+Clamp the multiplier to `[0.1, 5.0]` (or similar designer-decided
+band) and reject non-finite floats before applying — even after
+access_level gating, the un-bounded float arg is hostile to
+movement physics.
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-N-09 — `Event_NetOut_SetLevel` accepts client-supplied `INT32 aLevel` with no XP-table consistency
+
+**Severity**: High
+**Class**: Power-progression bypass via client setter
+**Wire surface**: `Event_NetOut_SetLevel(INT32 aLevel)` → `gmSetLevel`
+cell method
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+SGWGmPlayer.def:288-291 — single-arg `INT32 aLevel`. The Rust server
+maintains a `level` column on `sgw_player` that gates ability unlocks,
+gear binding, and damage / health scaling. A future handler that writes
+`aLevel` directly into the level column bypasses all of:
+
+- The XP curve (`sgw_player.exp`)
+- Per-archetype ability progression (only some abilities are awarded
+  per level via `trainAbility`)
+- Faction/Mission level gates
+
+Wire surface has no `TargetId` so this is self-only; but combined with
+GiveAbility, the player gains a level-cap-equivalent character in
+seconds.
+
+**Evidence**
+- Ghidra: `Event_NetOut_SetLevel` RTTI confirmed.
+- entities/defs/SGWGmPlayer.def:288-291.
+- No Rust handler.
+
+**Attack scenario**
+1. Send `gmSetLevel(60)` (or whatever the cap is).
+2. Future handler writes `sgw_player.level = 60`.
+3. Without also updating XP, ability list, and gear flags, the player
+   ends up with a level-60 character with level-1 abilities — but
+   damage/health scaling uses `level`, so they outscale all
+   matched-level content.
+
+**Suggested remediation (one line)**
+The level-set path must recompute derived stats (HP/QR/cap, ability
+list, XP rebase) atomically, AND require access_level gating; clamp
+`aLevel` to `[1, level_cap]`.
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-N-10 — `Event_NetOut_GiveItem` carries `WSTRING DesignId, INT32 Quantity` with no template whitelist, item-binding, or quantity bound
+
+**Severity**: High
+**Class**: Authority bypass — item creation with client-chosen template
+**Wire surface**: `Event_NetOut_GiveItem(WSTRING DesignId, INT32 Quantity)`
+→ `gmGiveItem` cell method
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+SGWGmPlayer.def:185-189 — `<gmGiveItem><WSTRING DesignId><INT32 Quantity>`.
+This is the same shape as the `give` command stub in
+`crates/game/src/commands/gm_cmds.rs:83-104`, which IS access-level
+gated (`AccessLevel::GameMaster`). But that stub is for the in-process
+slash-command path (chat → registry), NOT for the wire `gmGiveItem`
+cell-method that the SGW client emits. The two paths diverge. A future
+implementer who plumbs `gmGiveItem` through the cell-dispatch lane
+without access_level gating (CAT-N-03) lets any player materialise any
+item template by name, with any quantity (positive or negative; the
+arg is `INT32` not `UINT32`).
+
+The wire surface also carries no `recipient TargetId` field — implying
+self-give — but the SGWGmPlayer base method variant might differ. Either
+way: free items, any template, any (signed) quantity.
+
+**Evidence**
+- Ghidra: `019b373c` `Event_NetOut_GiveItem`; `00cb7880`
+  `register_NetOut_GiveItem`.
+- entities/defs/SGWGmPlayer.def:185-189.
+- The slash-command path at `crates/game/src/commands/gm_cmds.rs:83-104`
+  is gated `AccessLevel::GameMaster`; the wire-method path is not yet
+  gated because it doesn't exist yet — the gating gap is the
+  *architecture*, not the code.
+
+**Attack scenario**
+1. Player sends `gmGiveItem("Item_Naqahdah_Brick", 999999999)`.
+2. Future handler resolves the template + inserts the row into
+   `sgw_inventory` without checking access_level OR the quantity sign.
+3. If quantity is negative + handler does naïve arithmetic, this also
+   becomes an item-DELETION primitive (`gmGiveItem("Item_X", -50)`
+   subtracts from someone else's stack if the template-matching is
+   misimplemented to find an existing stack to "add to").
+
+**Suggested remediation (one line)**
+Cell-method `gmGiveItem`, when implemented, must (a) check
+access_level via the CAT-N-03 plumbing, (b) clamp Quantity to a
+positive band ≤ template's max stack, and (c) validate `DesignId`
+exists in the item-template loader (not blindly trust the WSTRING).
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-N-11 — `Event_NetOut_GiveNaqahdah` (currency) and `Event_NetOut_GiveXp` accept unbounded INT32 with no overflow check
+
+**Severity**: High
+**Class**: Currency / XP inflation via client setter
+**Wire surface**: `Event_NetOut_GiveNaqahdah` / `Event_NetOut_GiveXp` →
+`gmGiveCash` / `gmGiveXp` cell methods
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+SGWGmPlayer.def:180-194 — `<gmGiveXp><INT32 XpAmount>` and
+`<gmGiveCash><INT32 Amount>`. Both are signed 32-bit integers, both with
+no clamp. Two failure modes:
+
+1. **Inflation**: positive `XpAmount` / `Amount` of `INT32::MAX`
+   instantly maxes the player's stats / currency.
+2. **Negative-take**: negative values, if the handler does
+   `cash += Amount` without a `>=0` check, become a take-from-account
+   primitive (or, with overflow, a wrap-around).
+
+The Ghidra binary already has the error string "Amount to be given (or
+taken away) cannot be 0." at `019ad958` — i.e., the C++ Python-side
+implementation explicitly allowed negative amounts (the GM CAN take
+cash away), so the wire-shape contract is "any non-zero INT32". A
+Rust handler that mirrors the Python intent will be a take-from-anyone
+primitive once a TargetId arg is added (the wire shape is self-only
+today but the BaseMethod variant may differ).
+
+**Evidence**
+- Ghidra: `019b362c` `Event_NetOut_GiveXp`, `019b370c`
+  `Event_NetOut_GiveNaqahdah`; `00cb6e60` `register_NetOut_GiveXp`.
+- Behavioral string in binary: `019ad890` "Amount of XP to give must
+  not be 0." and `019ad958` "Amount to be given (or taken away)
+  cannot be 0." — confirms the historical Python allowed negatives.
+- entities/defs/SGWGmPlayer.def:180-194.
+
+**Attack scenario**
+1. Player sends `gmGiveNaqahdah(INT32::MAX)`.
+2. Future Rust handler `sgw_player.cash += amount as i64` — i64
+   add doesn't overflow but DB column is i32; the SQL UPDATE
+   fails or wraps. Either way the player's currency now reads
+   maxed or unpredictable.
+3. Or `gmGiveNaqahdah(-100000)` against any TargetId — siphon cash
+   from victim.
+
+**Suggested remediation (one line)**
+Handlers must check `Amount > 0`, that the post-add total doesn't
+exceed the column's max, and (for the BaseMethod variant) that the
+caller has access_level + that the target is reachable.
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-N-12 — `Event_NetOut_Kill` carries `INT64 TargetId` with no target authority check
+
+**Severity**: High
+**Class**: Authority bypass — instakill any entity
+**Wire surface**: `Event_NetOut_Kill(INT64 TargetId)` → `gmKillTarget`
+cell method
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+SGWGmPlayer.def:482-485 — `<gmKillTarget><INT64 TargetId>`. Direct
+"set this entity's health to 0" with a client-chosen target. Future
+handler without (a) access_level gate and (b) target authority check
+lets any player instakill any entity they can name an id for. Since
+entity ids are wire-public via AoI broadcast, all visible NPCs are
+candidates; non-visible NPCs are candidates too if their id is
+guessable (entity ids on this server are sequential per shard).
+
+**Evidence**
+- Ghidra: `019b3820` `Event_NetOut_Kill`.
+- entities/defs/SGWGmPlayer.def:482-485.
+- No Rust handler. The `kill_handler` in
+  `crates/game/src/commands/gm_cmds.rs:74-81` is a slash-command stub
+  gated on `AccessLevel::GameMaster` — but again, that's the
+  in-process chat-command path, NOT the wire cell-method that the
+  SGW client actually emits.
+
+**Attack scenario**
+1. Player picks any visible NPC's entity id (or guesses a player id
+   in range; entity ids are sequential).
+2. Sends `gmKillTarget(<target_eid>)`.
+3. Future handler sets the target's HP to 0; the target dies. Kill
+   credit / XP / loot accrues to whichever player currently has
+   aggro on that target — or to the caller, depending on impl.
+
+**Suggested remediation (one line)**
+Handler must enforce access_level + validate the target via
+`space_mgr.get_entity(target)` + verify it's in the same space as
+the caller; even GM kills should fail closed against ghost ids.
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-N-13 — `Event_NetOut_Spawn` and `Event_NetOut_Despawn` accept client-supplied template ids / target ids
+
+**Severity**: High
+**Class**: Entity creation/destruction with client-chosen parameters
+**Wire surface**: `Event_NetOut_Spawn` → `gmSpawnByCmd(WSTRING DesignId,
+FLOAT XOffset, FLOAT ZOffset)`; `Event_NetOut_Despawn` →
+`gmDespawnByCmd(INT32 TargetID)`
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+SGWGmPlayer.def:454-464 — `gmSpawnByCmd(WSTRING DesignId, FLOAT XOffset,
+FLOAT ZOffset)` and `gmDespawnByCmd(INT32 TargetID)`. Spawn template is a
+WSTRING with no whitelist; offsets are unclamped floats; despawn target
+is a 32-bit entity id with no authority check.
+
+A future spawn handler with no access_level check lets a regular player
+spawn arbitrary NPCs at arbitrary world positions. Worst case:
+- Spawn a max-level raid boss in a low-level newbie zone → mass-grief.
+- Spawn 10,000 NPCs (loop the call) → DoS the cell.
+- Spawn template = a player-faction NPC and use it for PvP-by-proxy.
+
+A future despawn handler with no target authority lets the player remove
+any NPC visible to them — clearing camps, removing quest objectives,
+etc.
+
+**Evidence**
+- Ghidra: `019b3bd8` `Event_NetOut_Spawn`, `019b3c00`
+  `Event_NetOut_Despawn`.
+- entities/defs/SGWGmPlayer.def:454-464.
+- No Rust handler. `spawn_handler` in
+  `crates/game/src/commands/gm_cmds.rs:50-61` is a slash-command stub
+  `AccessLevel::GameMaster`-gated but doesn't share code with the
+  wire path.
+
+**Attack scenario**
+1. Player crafts a `gmSpawnByCmd("HighLevelRaidBoss_Apophis", 0.0, 0.0)`
+   cell call.
+2. Future handler resolves the template + spawns at caller's position.
+3. Boss kills every other player in AoI; OR caller solos a boss
+   designed for raid-group XP/loot.
+
+**Suggested remediation (one line)**
+Access-level gate + DesignId whitelist (e.g., only spawn templates
+flagged `gm_spawnable` in the content DB) + offset clamping (e.g.,
+within ±50m of caller); despawn must enforce same-space + access_level.
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-N-14 — `Event_NetOut_GiveAbility` / `GiveAllAbilities` / `GiveBlueprint` / `GiveGearset` accept arbitrary ability/blueprint ids
+
+**Severity**: High
+**Class**: Authority bypass — content unlock via client setter
+**Wire surface**: `gmGiveAbility(INT32 aAbilityID)`,
+`gmGiveAllAbilities()`, `gmGiveTrainingPoints(INT32)`,
+`gmGiveExpertise(INT32, INT32)`, `gmGiveAppliedSciencePoints(INT32)`,
+`gmGiveRacialParadigmLevels(INT32, INT32)`
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+SGWGmPlayer.def:202-232 — a family of GiveXxx methods, each accepting
+INT32 ids / quantities with no validation. `gmGiveAllAbilities()` has
+ZERO args — fire-and-forget all-ability-unlock. The other variants
+take an INT32 ability/expertise/discipline id with no whitelist.
+
+A future implementer that mirrors the Python's "trust the GM" semantic
+without the access_level gate exposes every player to:
+- Self-unlocking any ability id (including dev-only test abilities).
+- Maxing all crafting / R&D progression in one call.
+- Maxing racial paradigm levels (`gmGiveRacialParadigmLevels`).
+
+**Evidence**
+- Ghidra: `019b3794` `Event_NetOut_GiveAbility`, `019b36b0`
+  `Event_NetOut_GiveAllAbilities`, etc. — all RTTI strings present.
+- entities/defs/SGWGmPlayer.def:202-232.
+- No Rust handler.
+
+**Attack scenario**
+1. Player sends `gmGiveAllAbilities()` — single cell-method with no
+   args.
+2. Future handler iterates all known abilities and inserts them onto
+   the player's `known_abilities`.
+3. Player can now invoke any ability via `useAbility`.
+
+**Suggested remediation (one line)**
+Access_level gating per CAT-N-03; the AbilityID arg must be
+whitelisted against the loaded ability set; `gmGiveAllAbilities` has
+no business existing on the non-GM wire surface and should reject
+unconditionally below the access_level check.
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-N-15 — `Event_NetOut_SetMobAttribute` / `SetMobAbilitySet` / `SetMobStance` / `SetMobVariable` carry arbitrary mob id + arbitrary mutation payload
+
+**Severity**: Medium
+**Class**: Authority bypass — mob mutation via client setter
+**Wire surface**: `gmSetMobAttribute(INT32 TargetID, WSTRING Attribute,
+WSTRING AttributeType, INT32 Value)`,
+`gmSetMobAbilitySet(INT32 aAbilitySetId)`,
+`gmSetMobStance(INT32 aNewStance)`, `setMobVariable(INT32, INT32)`
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+SGWGmPlayer.def:307-321, 470-476, 561-565. These methods mutate NPC
+attributes / ability sets / stances via client-supplied identifiers.
+The `gmSetMobAttribute` shape `(TargetID, Attribute name, type name,
+value)` is the dangerous one: it's a reflection-style "set any property
+to any value" on any target. A future handler that doesn't validate
+the attribute name against a property whitelist lets a non-GM player
+write any property of any visible mob (cell-public properties carry
+no GM-only flag; an `attribute name` of `bGodMode`, `level`, `faction`
+etc. would all map onto real fields).
+
+Lower severity than instakill because the worst-case is still a
+combat-balance imbalance, not an instant-kill or item dupe.
+
+**Evidence**
+- Ghidra: `Event_NetOut_SetMobAttribute`, `SetMobAbilitySet`,
+  `SetMobStance`, `SetMobVariable` strings present.
+- entities/defs/SGWGmPlayer.def:307-321, 470-476, 561-565.
+
+**Attack scenario**
+1. Player sends `gmSetMobAttribute(<boss_id>, "level", "INT32", 1)`.
+2. Future handler reflects the WSTRING attribute name to a setter on
+   the mob; boss drops from level 60 to level 1.
+3. Solo the boss for raid-loot.
+
+**Suggested remediation (one line)**
+Access_level + an explicit per-attribute-name whitelist; treat
+the WSTRING attribute arg as untrusted input that must match an
+allow-list (no reflection without a closed set).
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-N-16 — `Event_NetOut_EmitBehaviorEventOnMob` / `AddBehaviorEventSet` / `RemoveBehaviorEventSet` fire arbitrary scripted behaviors on any mob
+
+**Severity**: Medium
+**Class**: Authority bypass — fire scripted AI events on client-chosen target
+**Wire surface**: `gmEmitBehaviorEventOnMob(INT32 aBehaviorEventId)` +
+the two `BehaviorEventSet` mutators
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+SGWGmPlayer.def:437-450. The `gmEmitBehaviorEventOnMob` takes a single
+INT32 — the behavior event id — and applies it to the caller's current
+target (no target arg in this wire shape; the Python reference resolves
+to the cell's target). A future handler that fires the event without
+access_level gating lets a regular player nudge any NPC into any AI
+state — including states normally reached only on specific
+trigger conditions (e.g., "boss enrages", "NPC drops loot", "NPC opens
+dialog").
+
+The two `*BehaviorEventSet` methods add/remove entire AI event sets
+on a target mob, a more powerful primitive (can reshape the target's
+behavior tree at runtime).
+
+**Evidence**
+- Ghidra: `Event_NetOut_EmitBehaviorEventOnMob`, `AddBehaviorEventSet`,
+  `RemoveBehaviorEventSet` strings present.
+- entities/defs/SGWGmPlayer.def:437-450.
+
+**Attack scenario**
+1. Player engages a tough boss.
+2. Sends `gmEmitBehaviorEventOnMob(<flee_event_id>)`.
+3. Future handler fires flee on the boss — combat ends without
+   boss attacking back; boss dies on respawn timer (or wanders into
+   range of a friendly NPC who finishes it for free XP/loot).
+
+**Suggested remediation (one line)**
+Access_level gating + a whitelist of "safe" behavior events
+(emit_event must verify the event is in a curated set if the caller
+isn't a GM, which should always be the case here).
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-N-17 — `Event_NetOut_LoadConstants` / `LoadAbility` / `LoadAbilitySet` / `LoadBehavior` / `LoadMOB` / `LoadInteractionSet` / `LoadItem` / `LoadMission` / `LoadNACSI` — wire surface for hot-reloading server-side content data
+
+**Severity**: High
+**Class**: Authority bypass — server-data reload via client trigger
+**Wire surface**: 9 distinct `Load*` cell methods on SGWGmPlayer
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+SGWGmPlayer.def:517-559 — a family of `load*` methods on SGWGmPlayer
+that, per the Python reference, hot-reload server-side content data
+(ability defs, mob defs, mission defs, etc.) from disk. The wire
+signature is single-arg (usually `INT32 aXxxId`) with no validation.
+
+If/when implemented in Rust, a non-GM player triggering these:
+- Causes a server-wide file read on every call → DoS shape (especially
+  `loadConstants` which has no id arg → reload everything).
+- Could trigger reload races during live combat — if `loadAbility`
+  reloads an ability def while it's being resolved on an in-flight
+  combat tick, the cell can crash or produce inconsistent damage.
+
+**Evidence**
+- Ghidra: All 9 `Event_NetOut_Load*` strings present in the binary
+  near `019b370c+` (the Give/Set NetOut block).
+- entities/defs/SGWGmPlayer.def:517-559.
+
+**Attack scenario**
+1. Player loops `loadConstants()` at maximum tick rate.
+2. Future handler does a synchronous file read on each call → cell
+   thread stalls, all other players in the cell experience
+   tick-lag / disconnects.
+
+**Suggested remediation (one line)**
+Access_level gating + an explicit dev-only build flag for the entire
+reload family — these should not be reachable in a release build at
+all without an environment variable.
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-N-18 — `Event_NetOut_Goto` / `GotoXYZ` / `GotoLocation` / `Summon` — debug teleport with no navmesh / authority check
+
+**Severity**: High
+**Class**: Position spoof via client setter
+**Wire surface**: `gmGoto(WSTRING aNameOrID)`, `gmGotoXYZ(FLOAT, FLOAT,
+FLOAT)`, `gmGotoLocation(WSTRING WorldName, FLOAT X, FLOAT Y, FLOAT Z)`,
+`gmSummon(WSTRING aNameOrID)`
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+SGWGmPlayer.def:323-353 — teleport commands. The most dangerous shape
+is `gmGotoXYZ(x, y, z)` which sets the player's position to arbitrary
+floats — no clamping, no navmesh reachability check, no space-boundary
+check. `gmSummon` and `gmGoto` resolve a player name and teleport the
+*caller* to the target — meaning a non-GM player gains a free "find
+player and teleport to them" primitive even if the target is in a
+restricted area (raid instance, GM-only zone).
+
+This is the canonical position-spoof class described in the agent
+brief's CAT-B handling. CAT-N includes it because of the dev-command
+origin; CAT-B agent owns the broader movement-physics validation.
+
+**Evidence**
+- Ghidra: `Event_NetOut_Goto`, `GotoXYZ`, `GotoLocation`, `Summon`
+  strings present.
+- entities/defs/SGWGmPlayer.def:323-353.
+- Today: no Rust handler (the `teleport_handler` in
+  `crates/game/src/commands/gm_cmds.rs:63-72` is a slash-command stub
+  with `AccessLevel::GameMaster` gating, NOT the wire path).
+
+**Attack scenario**
+1. Player sends `gmGotoXYZ(<raid_boss_room_coords>)`.
+2. Future handler writes the player's position directly.
+3. Player is now inside the raid boss room without going through
+   the dungeon — skipping all the trash, all the gates, all the
+   instance-entry checks.
+
+**Suggested remediation (one line)**
+Access_level + navmesh reachability check from caller's last
+server-confirmed position + space-boundary check; never write a
+client-supplied position unless the caller is GM AND the position
+is in-bounds.
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-N-19 — `Event_NetOut_ShowIP` / `ShowInventory` / `ShowPlayer` — info-disclosure setters with client-supplied target
+
+**Severity**: Medium
+**Class**: Info disclosure via client setter
+**Wire surface**: `gmShowIP(INT32 TargetID)`,
+`gmShowInventory(INT32 TargetID)`, `gmShowPlayer(INT32 TargetID)`
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+SGWGmPlayer.def:164-177. These methods send back the target's IP /
+inventory contents / general player info. The wire shape carries
+client-chosen `TargetID`. A future handler without access_level gating
+becomes a "look up any player's IP address" primitive (PII leak),
+"look up any player's inventory" (loot scouting), "look up any player's
+location / stats" (PvP target scouting).
+
+`gmShowIP` is the worst — explicit PII (player IP) disclosure.
+
+**Evidence**
+- Ghidra: `Event_NetOut_ShowIP`, `Event_NetOut_ShowInventory`,
+  `Event_NetOut_ShowPlayer` strings present.
+- entities/defs/SGWGmPlayer.def:164-177.
+
+**Attack scenario**
+1. Player sends `gmShowIP(<another_player_eid>)`.
+2. Future handler resolves the target → reads
+   `connected[target_addr].peer_ip` (or similar) → sends back via
+   `onShowPlayer` client callback.
+3. Caller now has the target's IP address.
+
+**Suggested remediation (one line)**
+Access_level gating; `gmShowIP` should be GM-only at minimum and
+ideally audit-logged on every invocation.
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-N-20 — `Event_NetOut_Invisible` / `XRayEyes` — visibility / vision toggles bypass legitimate stealth/visibility systems
+
+**Severity**: Medium
+**Class**: Authority bypass — visibility toggles via client setter
+**Wire surface**: `onInvisible(UINT8 bTurnOn)`, `onXRayEyes(UINT8 bTurnOn)`
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+SGWGmPlayer.def:635-643. `onXRayEyes` — see through walls / through
+stealth. `onInvisible` — render self invisible. Both single-byte
+toggles. Without access_level gating, any player can fly through
+walls visually OR vanish from other players' AoI, breaking PvP /
+positional combat fundamentals.
+
+**Evidence**
+- Ghidra: `Event_NetOut_Invisible`, `Event_NetOut_XRayEyes` strings
+  present (in the SGWGmPlayer-keyed block near `019b3848` and
+  neighbours).
+- entities/defs/SGWGmPlayer.def:635-643.
+
+**Attack scenario**
+1. Player flips `onInvisible(1)`.
+2. Future handler sets the visibility bit; AoI broadcasts to other
+   players suppress this entity.
+3. Player can attack from invisibility in PvP — opponents have no
+   sight of the attacker.
+
+**Suggested remediation (one line)**
+Access_level gating; if invisibility is meant for some non-GM
+flow (e.g., stealth ability), it must come from the ability path
+(`useAbility` → effect-grant), not a direct toggle.
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-N-21 — `Event_NetOut_SetFlag` / `SetInstanceFlag` / `ShowFlag` / `ShowInstanceFlag` — arbitrary global/instance flag mutation
+
+**Severity**: Medium
+**Class**: Authority bypass — game state mutation via client setter
+**Wire surface**: `gmSetFlag(INT32 aFlagId, UINT8 aForceVal)`,
+`gmSetInstanceFlag(INT32 aFlagNumber, INT8 aFlagValue)`,
+`gmShowFlag(INT32 aFlagId)`, `gmShowInstanceFlag(INT32 aFlagNumber)`
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+SGWGmPlayer.def:144-147, 283-287, 580-589. Flags are the game's
+shared state (mission progress, quest unlocks, world events, etc.).
+A future handler without gating lets any player set or read any
+flag — bypassing mission gates ("set the 'completed-prologue' flag
+to 1 to skip the intro chain"), or scouting the value of flags they
+shouldn't see (instance flags often hold seed values, raid lockout
+counters, etc.).
+
+`gmShowFlag` is read-only and less severe; the setters are higher
+severity but the wire shapes are siblings.
+
+**Evidence**
+- Ghidra: `Event_NetOut_SetFlag`, `SetInstanceFlag`, `ShowFlag`,
+  `ShowInstanceFlag` strings present.
+- entities/defs/SGWGmPlayer.def lines as cited.
+
+**Attack scenario**
+1. Player sends `gmSetFlag(<key_quest_completion_flag>, 1)`.
+2. Future handler writes the flag without GM check.
+3. Mission/raid/instance state advances without the player having
+   played the content.
+
+**Suggested remediation (one line)**
+Access_level gating; flag setters should be GM-only at minimum.
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-N-22 — `Event_NetOut_SetTarget` (GM variant) accepts WSTRING name-or-id with no AoI / perception check
+
+**Severity**: Medium
+**Class**: AoI bypass — target acquire via client setter
+**Wire surface**: `gmSetTarget(WSTRING aNameOrID)`
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+SGWGmPlayer.def:302-305 — `gmSetTarget(WSTRING aNameOrID)`. Differs
+from the regular `setTargetID(INT32 aTargetID)` (CM 0; CAT-C surface)
+in that it resolves names → ids server-side. Once it resolves, the
+target is set without verifying caller's perception. The regular
+`setTargetID` already has this property (no AoI check; see
+`crates/services/src/cell/cell_methods/being.rs:20-63`) — but
+that's the agent's CAT-C concern. The CAT-N variant is worse because
+the WSTRING resolution can return targets not currently in the
+caller's AoI (e.g., name-lookup across the entire shard's online
+players).
+
+**Evidence**
+- Ghidra: `Event_NetOut_SetTarget` (in addition to the regular
+  `setTargetID` wire).
+- entities/defs/SGWGmPlayer.def:302-305.
+- `crates/services/src/cell/cell_methods/being.rs:20-63` shows the
+  regular `setTargetID` already accepts any int with no perception
+  check.
+
+**Attack scenario**
+1. Player sends `gmSetTarget("BossNameInAnotherZone")`.
+2. Future handler resolves name → entity_id → writes to
+   `current_target_id`.
+3. Caller's combat / autocycle path can now target an entity
+   outside their AoI.
+
+**Suggested remediation (one line)**
+Access_level gating; after name resolution, the target_id must pass
+the same perception/AoI check as the regular setTargetID path —
+which itself needs a perception check (CAT-C).
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-N-23 — `Event_NetOut_GMRemoveItem` allows client-supplied `ItemID + INT16 quantity` deletion
+
+**Severity**: Medium
+**Class**: Authority bypass — inventory deletion via client setter
+**Wire surface**: `gmRemoveItem(ItemID itemID, INT16 quantity)`
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+SGWGmPlayer.def:196-200 — `gmRemoveItem(ItemID itemID, INT16 quantity)`.
+The `ItemID` type is the inventory row id (server-trusted in
+`crates/services/src/base/world_entry/methods/inventory/` paths).
+But because the wire surface accepts it as a client-supplied INT,
+a future handler without GM gating + ownership check lets the caller
+delete arbitrary inventory rows — including other players' items if
+the row id is guessable (it's a sequential bigint per server).
+
+The signed INT16 quantity is also a footgun: negative quantity =
+add (depending on impl), so this can become a give-item primitive
+in disguise.
+
+**Evidence**
+- Ghidra: `Event_NetOut_GMRemoveItem` (RTTI string present).
+- entities/defs/SGWGmPlayer.def:196-200.
+
+**Attack scenario**
+1. Attacker guesses or scrapes target's `sgw_inventory.item_id`.
+2. Sends `gmRemoveItem(<victim_item_id>, 1)`.
+3. Future handler executes a DB DELETE without owner check.
+4. Victim's item vanishes. Reverse: negative quantity could add.
+
+**Suggested remediation (one line)**
+Access_level gating + the row must belong to the caller's
+character_id (the standard `where character_id = $player_id`
+guard from CAT-D handlers).
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-N-24 — `Event_NetOut_TestLOS` and `ToggleCombatLOS` — info-leak / runtime-toggle of combat LOS testing
+
+**Severity**: Low
+**Class**: Info disclosure / runtime-toggle without GM gate
+**Wire surface**: `testLOS(INT32 aSourceEntityID, INT32 aTargetEntityID)`,
+`toggleCombatLOS()`
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+SGWGmPlayer.def:619-628 — `testLOS` returns whether two arbitrary
+entity ids have line-of-sight; `toggleCombatLOS` flips the cell's
+combat-LOS-enforcement flag globally. The former is a
+target-scouting primitive (which mobs / players can see each other);
+the latter is a server-side rule toggle that, if accessible to
+non-GMs, lets a regular player disable LOS for all combat in the
+cell — making cover useless.
+
+**Evidence**
+- Ghidra: `Event_NetOut_TestLOS`, `Event_NetOut_ToggleCombatLOS`
+  strings present.
+- entities/defs/SGWGmPlayer.def:619-628.
+
+**Attack scenario**
+1. Player sends `toggleCombatLOS()` — single zero-arg call.
+2. Future handler flips the cell-global flag; cover is now ignored
+   in combat resolution.
+3. Caller — and every player in the cell — can hit through cover.
+
+**Suggested remediation (one line)**
+Access_level gating; `toggleCombatLOS` is a designer-only test
+toggle and must never be reachable on a release build.
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-N-25 — `Event_NetOut_PerfStats` / `PerfStatsByChannel` accept client-supplied performance counters
+
+**Severity**: Low
+**Class**: Trust-of-client-stats / log noise
+**Wire surface**: `perfStats(FLOAT fpsAvg, FLOAT fpsMin, FLOAT fpsMax,
+FLOAT bpsIn, FLOAT bpsOut, FLOAT packetsIn, FLOAT packetsOut,
+FLOAT lagAvgMS, FLOAT lagMinMS, FLOAT lagMaxMS, FLOAT resends,
+FLOAT AppearanceJobs)` (regular SGWPlayer BaseMethod),
+`gmPerfStatsByChannel(INT8 aOnOff)` (SGWGmPlayer CellMethod)
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+`perfStats` is exposed on the *regular* SGWPlayer.def
+(`SGWPlayer.def:529-543`) and carries 12 floats of client-side
+performance telemetry. Today the Rust server doesn't handle it
+(falls through to the unhandled-base-method warn arm). The wire
+surface is wide open — any future handler that ingests these
+floats into a telemetry pipeline or anti-cheat heuristic must
+remember the values are 100% client-controlled and can be
+arbitrary (NaN, +inf, manipulated to mislead anti-cheat).
+
+`gmPerfStatsByChannel` is the SGWGmPlayer toggle for
+per-channel perf logging — same handler-doesn't-exist-yet status
+but the wire is reachable on the GM index space once SGWGmPlayer
+is enabled.
+
+**Evidence**
+- Ghidra: `Event_NetOut_PerfStats`, `Event_NetOut_PerfStatsByChannel`.
+- entities/defs/SGWPlayer.def:529-543 (perfStats), SGWGmPlayer.def
+  (perfStatsByChannel).
+
+**Attack scenario**
+1. Player sends `perfStats(fps=999, bpsIn=0, ...)` continuously to
+   inflate / poison any FPS-based anti-cheat heuristic.
+2. Future handler logs the values into observability.
+3. Anti-cheat ML/heuristic training data is poisoned.
+
+**Suggested remediation (one line)**
+Any consumer of these floats must clamp / NaN-reject them and
+weight them as "advisory only" — never as authoritative for
+anti-cheat decisions.
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-N-26 — `Event_NetOut_SetMovementType` on SGWPlayer (CM 1) accepts the full `EMobMovementType` enum (0-6), exposing NPC-AI-only states to the player
+
+**Severity**: Low
+**Class**: Authority bypass — NPC-AI-state byte exposed at player-CellMethod index
+**Wire surface**: `setMovementType(UINT8 aMovementType)` (CM 1)
+**Demonstrable / Likely-theoretical**: Demonstrable (handler IS
+implemented and accepts the bytes; effect-on-game is unclear)
+
+**Trust violation**
+`crates/services/src/cell/cell_methods/being.rs:65-105` accepts the
+client's movement-type byte and broadcasts it to AoI witnesses (also
+caches it on the entity). The byte values are the
+`EMobMovementType` enum: `Cover=0, CombatAdvance=1, Patrol=2,
+Follow=3, Wander=4, Leash=5, Avoid=6`. These are NPC AI states —
+they're not meaningful for the player. A regular player sending
+`setMovementType(5)` (`Leash`) gets the byte broadcast to all
+witnesses; what they make of it depends on the client's
+animation/AI rendering pipeline. Worst case: the byte triggers
+a client-side AI animation on the player (e.g., wander/patrol)
+that's not part of the player's normal pose set — visually
+disruptive but not exploit-class on its own.
+
+CAT-N severity is Low because: (a) the handler is implemented
+defensively (unknown bytes 7+ are dropped with a warn — already
+correctly hardened), and (b) the wire surface is intended for
+NPCs/peers per the BigWorld call-on-ghost model anyway, so this is
+mostly the client passing through AI broadcasts. But: nothing
+limits the byte to player-valid values (probably 0-1 for
+Walk/Run). A player can persistently broadcast a stale AI state
+to their AoI peers.
+
+**Evidence**
+- entities/defs/interfaces/SGWBeing.def:225-228 — `setMovementType`
+  is `Exposed`, taking `UINT8 aMovementType`.
+- `crates/services/src/cell/cell_methods/being.rs:65-105` — handler
+  accepts 0-6, rejects 7+, broadcasts to witnesses.
+
+**Attack scenario**
+1. Player sends `setMovementType(5)` (`Leash`).
+2. Server caches + broadcasts to AoI witnesses.
+3. Witnesses see the player marked as in an `EMobMovementType::Leash`
+   state, which the client may render differently.
+
+**Suggested remediation (one line)**
+Filter the accepted byte set per entity-kind: players should only be
+allowed to send walk/run movement-types; the full enum is reserved
+for NPC ghost-call paths.
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-N-27 — `Event_NetOut_Users` and `Event_NetOut_ShowMobCount` — info-disclosure surfaces with no GM check
+
+**Severity**: Low
+**Class**: Info disclosure via client setter
+**Wire surface**: `gmUsers()` (zero-arg), `gmShowMobCount(INT32 SpaceID)`
+(cell) / `gmShowMobCount(WSTRING aAreaKey)` (base)
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+SGWGmPlayer.def:363-365 (`gmUsers`), 159-162 (cell `gmShowMobCount`),
+715-717 (base `gmShowMobCount`). These leak the shard's user count and
+the current mob count by space. Modest info disclosure — useful for an
+attacker doing population mapping to find empty zones for griefing or
+overloaded zones for DoS targeting. Low severity because the data
+isn't PII and doesn't directly enable an exploit on its own.
+
+**Evidence**
+- Ghidra: `Event_NetOut_Users`, `Event_NetOut_ShowMobCount` strings
+  present.
+- entities/defs/SGWGmPlayer.def lines cited.
+
+**Attack scenario**
+1. Loop `gmShowMobCount(<every_space_id>)` → map of mob population
+   per space.
+2. Choose under-populated space to spawn-camp; over-populated to
+   DoS-target.
+
+**Suggested remediation (one line)**
+Access_level gating; info-disclosure surfaces must still respect GM
+boundary even if "merely" telemetric.
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-N-28 — `Event_NetOut_GiveStargateAddress` / `RemoveStargateAddress` — gate-network unlocks via client setter
+
+**Severity**: Medium
+**Class**: Authority bypass — fast-travel network unlock
+**Wire surface**: `gmGiveStargateAddress(WSTRING AddressId, INT64
+TargetId, UINT8 Hidden)`, `gmRemoveStargateAddress(WSTRING AddressId,
+INT64 TargetId)`
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+SGWGmPlayer.def:504-515. Stargate addresses are the SGW fast-travel
+network — gating which destinations a player can dial via the DHD.
+Adding addresses unlocks fast-travel; removing them locks the target
+out. Without access_level gating, any player can self-unlock the
+entire gate network (skipping the in-game progression that gates
+addresses), or grief another player by removing their addresses.
+
+The TargetId field also allows other-player mutation.
+
+**Evidence**
+- Ghidra: `Event_NetOut_GiveStargateAddress`, `RemoveStargateAddress`.
+- entities/defs/SGWGmPlayer.def:504-515.
+
+**Attack scenario**
+1. Player sends `gmGiveStargateAddress("Atlantis", <self_eid>, 0)`.
+2. Future handler inserts the address into the player's gate book.
+3. Player can now dial Atlantis from any gate, skipping the
+   in-game mission chain that unlocks it.
+
+**Suggested remediation (one line)**
+Access_level gating + ownership check on TargetId.
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-N-29 — `Event_NetOut_RequestReload` (CM 86) handler does not validate that the reload is initiated by the entity-owner
+
+**Severity**: Low
+**Class**: Authority bypass — but for a player-facing method, low risk
+**Wire surface**: `requestReload(UINT8 reloadType)` (CM 86, normal player method)
+**Demonstrable / Likely-theoretical**: Demonstrable
+
+**Trust violation**
+The `requestReload` handler at
+`crates/services/src/cell/cell_methods/player/world/mod.rs:193-200`
+takes the dispatched `entity_id` from the cell-method framing and
+calls `handle_reload(entity_id, ...)`. The framing layer is supposed
+to substitute `entity_id = caller's player_eid` (per the connect-loop's
+cell-method routing); a regression here means a player could trigger
+another player's reload. Today the framing path does substitute
+correctly (`crates/services/src/base/...connect_loop...`), so this is
+benign — but the handler itself trusts the supplied entity_id without
+cross-checking that it matches the caller's player_eid. Low severity
+because the worst-case effect is "another player's mag refills" which
+is friendly, not exploit-class.
+
+This is included for completeness of the CAT-N review even though the
+exploit shape is mild — RequestReload was explicitly listed in the
+CAT-N scope.
+
+**Evidence**
+- `crates/services/src/cell/cell_methods/player/world/mod.rs:193-200`
+  — calls `handle_reload(entity_id, ...)` with no caller-vs-entity
+  cross-check.
+- Framing layer substitution: `crates/services/src/base/connect_loop/`
+  (caller_eid → entity_id is the framing layer's responsibility, not
+  the handler's).
+
+**Attack scenario**
+1. Player A forges a cell-method call setting `entity_id = <player_B_eid>`.
+2. Framing layer should overwrite the entity_id with player A's
+   player_eid — but if a future refactor removes that substitution,
+   the handler trusts B's id and reloads B's bandolier.
+
+**Suggested remediation (one line)**
+Defense-in-depth: the cell-method handler should assert
+`entity_id == caller_player_eid` (which requires plumbing caller
+identity into dispatch — same plumbing as CAT-N-03).
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-N-30 — `Event_NetOut_ToggleCombatDebug` / `ToggleCombatVerboseDebug` / `ToggleHealDebug` accepted at SGWAbilityManager (CM 2/3) and SGWCombatant (CM 6) without GM check
+
+**Severity**: Low
+**Class**: Info disclosure (potential — handler is currently a stub)
+**Wire surface**: `toggleCombatDebug()` (CM 2), `toggleCombatVerboseDebug()`
+(CM 3), `toggleHealDebug()` (CM 6)
+**Demonstrable / Likely-theoretical**: Demonstrable (handlers exist and
+are stubs)
+
+**Trust violation**
+These three are declared on the SGWAbilityManager / SGWCombatant
+interfaces (which every combat entity implements, including the
+non-GM SGWPlayer), with `<Exposed/>`. Today the Rust handlers
+log-and-no-op
+(`crates/services/src/cell/cell_methods/ability_manager.rs:22-25`,
+`crates/services/src/cell/cell_methods/combatant.rs:59-62`). When
+implemented to actually surface combat/damage/heal debug info — the
+intended design per the Python reference — the data they leak (raw
+QR rolls, damage formulas, target HP, modifier breakdown) gives the
+caller information that's normally hidden from the client (e.g., a
+boss's exact remaining HP, the QR threshold that just decided the
+crit roll).
+
+Today: benign. Future: info disclosure if implemented without GM
+gating.
+
+**Evidence**
+- entities/defs/interfaces/SGWAbilityManager.def:249-256 — both
+  toggle methods Exposed.
+- entities/defs/interfaces/SGWCombatant.def — `toggleHealDebug` is
+  the third (CM 6).
+- `crates/services/src/cell/cell_methods/ability_manager.rs:22-25`
+  + `combatant.rs:59-62` — stub log-only handlers.
+
+**Attack scenario**
+1. Player flips `toggleCombatDebug()` once implemented.
+2. Server-side combat resolution starts dumping per-roll details
+   to the player's combat log.
+3. Player sees boss-HP / QR-threshold information they shouldn't
+   have, enabling optimization of damage rotations or
+   boss-aware-attack timing.
+
+**Suggested remediation (one line)**
+Access_level gating; these toggles must require GM.
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-N-31 — `Event_NetOut_DebugEvents` / `DebugInteract` carry client-supplied `TargetId` and arbitrary debug levels
+
+**Severity**: Low
+**Class**: Info disclosure / debug-trigger via client setter
+**Wire surface**: `gmDebugEvents(INT32 TargetId, INT32 InformLevel)`,
+`gmDebugInteract()`
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+SGWGmPlayer.def:421-435. The `gmDebugEvents` shape sets event-throw /
+event-receive debugging on an arbitrary `TargetId`, with a
+client-supplied `InformLevel`. Once implemented this becomes a
+"dump all behavior events on any target mob" primitive — useful for
+boss-fight scouting (understanding a boss's full event tree).
+
+**Evidence**
+- Ghidra: `Event_NetOut_DebugEvents` string present.
+- entities/defs/SGWGmPlayer.def:421-435.
+
+**Attack scenario**
+1. Player sends `gmDebugEvents(<boss_id>, 3)`.
+2. Future handler enables full event tracing on the boss; client
+   sees every behavior event the boss fires.
+3. Player reverse-engineers the boss AI from the trace.
+
+**Suggested remediation (one line)**
+Access_level gating.
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-N-32 — `Event_NetOut_RegenerateCoverLinks` / `ChangeCoverWeight` / `ChangeCoverStanceWeight` — runtime AI tuning via client setter
+
+**Severity**: Low
+**Class**: Server tuning bypass via client setter
+**Wire surface**: `regenerateCoverLinks(FLOAT NormalLimit, UINT32
+MaxLinks, FLOAT MaxDistance)`, `changeCoverWeight(...)`,
+`changeCoverStanceWeight(...)`
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+SGWGmPlayer.def:656-682. These methods retune the cell's NPC cover
+pathfinding at runtime, with client-supplied float weights. A future
+handler without gating lets any player nudge enemy AI to make
+suboptimal cover choices (sit in the open, never break cover, etc.).
+Worst case: a player tunes the NPC cover weights such that enemies
+attack from random low-effective positions and die easily.
+
+`regenerateCoverLinks` also takes a `MaxLinks: UINT32` with no
+bound — looping with a huge value could DoS the cell on cover-link
+regeneration.
+
+**Evidence**
+- Ghidra: `Event_NetOut_RegenerateCoverLinks`, `ChangeCoverWeight`,
+  `ChangeCoverStanceWeight` strings present.
+- entities/defs/SGWGmPlayer.def:656-682.
+
+**Attack scenario**
+1. Player sends `regenerateCoverLinks(0.001, INT32::MAX, 9999.0)`.
+2. Future handler runs an O(N²) cover-link regen with billions of
+   links — cell thread stalls for seconds.
+
+**Suggested remediation (one line)**
+Access_level gating + bound the `MaxLinks` to sane limits even when
+caller is GM.
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-N-33 — `Event_NetOut_PrintStats` exposes per-cell statistics for client capture
+
+**Severity**: Low
+**Class**: Info disclosure via client setter
+**Wire surface**: `gmPrintStats(WSTRING aStat)`
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+SGWGmPlayer.def:372-375 — `gmPrintStats(WSTRING aStat)`. Per Python
+reference, dumps per-cell statistics matching the named stat
+category. Without GM gating, lets any player observe cell-internal
+state (NPC count, tick rate, memory usage, event-rate per channel).
+Operational info disclosure shape only — not direct exploit.
+
+**Evidence**
+- Ghidra: `Event_NetOut_PrintStats`.
+- entities/defs/SGWGmPlayer.def:372-375.
+
+**Attack scenario**
+1. Player loops `gmPrintStats("tickrate")` → measures the cell's
+   tick lag remotely.
+2. Player uses the tick-lag signal to time-coordinate griefing
+   actions during stalls.
+
+**Suggested remediation (one line)**
+Access_level gating.
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-N-34 — `Event_NetOut_GiveRespawner` / `GiveGearset` / `GiveInventory` / `GiveBlueprint` accept arbitrary template / set ids
+
+**Severity**: Medium
+**Class**: Authority bypass — content unlock via client setter
+**Wire surface**: `gmGiveRespawner(INT32 aRespawnerMobID)`,
+`gmGiveGearset` (no .def-confirmed args), `gmGiveInventory` (no
+.def-confirmed args), `gmGiveBlueprint` (not in SGWGmPlayer.def
+proper but in the NetOut RTTI strings)
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+SGWGmPlayer.def:212-215 — `gmGiveRespawner(INT32 aRespawnerMobID)`.
+The other Give* in this group (`GiveGearset`, `GiveInventory`,
+`GiveBlueprint`) appear in the Ghidra NetOut string table but are not
+all declared in the visible SGWGmPlayer.def excerpt — likely they're
+implemented via the slash-command → server-side resolution path in
+the Python reference. Same trust violation as CAT-N-14: arbitrary
+template ids accepted from client; future handler that doesn't gate
+unlocks content for free.
+
+**Evidence**
+- Ghidra: `Event_NetOut_GiveRespawner`, `GiveGearset`,
+  `GiveInventory`, `GiveBlueprint` strings present.
+- entities/defs/SGWGmPlayer.def:212-215.
+
+**Attack scenario**
+1. Player sends `gmGiveGearset(<endgame_gearset_id>)`.
+2. Future handler grants the gear without level/quest gates.
+3. Player skips entire gearing progression.
+
+**Suggested remediation (one line)**
+Access_level gating + per-gearset prerequisite check (level, faction,
+mission completion).
+
+**Would benefit from x64dbg trace?**
+Yes — the gearset / inventory grant flow in the binary may use
+templates that aren't fully captured in the .def excerpt; x64dbg
+breakpoints would confirm the wire shape of these specific Gives.
+
+---
+
+### CAT-N-35 — `Event_NetOut_SetFaction` allows arbitrary faction reassignment
+
+**Severity**: Medium
+**Class**: Authority bypass — faction-membership setter
+**Wire surface**: `Event_NetOut_SetFaction` (declared in NetOut
+RTTI strings; per Python reference this is `gmSetFaction` which is
+not directly in the SGWGmPlayer.def excerpt but is on the SGWBeing
+or related interface based on the wire shape)
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+The `setFaction` family lets the caller change their (or a target's)
+faction. Faction affects PvP-flag, NPC hostility, mission
+availability, and access to faction-locked content. Without GM
+gating: free faction-hop, mid-fight defection, accessing the
+opposing faction's missions.
+
+**Evidence**
+- Ghidra: `Event_NetOut_SetFaction` string (in the SetGodMode /
+  SetNoXP block — same family as the other Set* gm-commands).
+- Python reference shows `gmSetFaction` as the corresponding
+  cell method.
+
+**Attack scenario**
+1. Player in PvP combat with a hostile faction member sends
+   `gmSetFaction(<their_own_faction>)`.
+2. PvP-flag drops; opponent can no longer attack.
+3. Caller can disengage at will.
+
+**Suggested remediation (one line)**
+Access_level gating; if any non-GM faction-change feature is added,
+it must route through a dedicated, designer-controlled path with
+cost/cooldown, not via the GM setter.
+
+**Would benefit from x64dbg trace?**
+Yes — confirm the wire shape of `Event_NetOut_SetFaction` to know
+if it's self-only or also takes a target id.
+
+---
+
+### CAT-N-36 — `Event_NetOut_SetNoXP` / `SetNoAggro` — combat-discipline toggles via client setter
+
+**Severity**: Medium
+**Class**: Authority bypass — combat-rule toggle via client setter
+**Wire surface**: `gmSetNoXP()` (zero-arg toggle),
+`gmSetNoAggro(UINT8 bTurnOn)`
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+SGWGmPlayer.def:241-252. `gmSetNoXP` toggles whether the player
+gains XP from kills (intended for GMs who want to gain levels via
+GiveXp without polluting the normal curve). `gmSetNoAggro` toggles
+whether NPCs aggro on the player. Both are server-side flags that,
+without GM gating, let a regular player either:
+
+- Set `noXP` to bypass anti-cheat heuristics that look for
+  unusual XP gain patterns.
+- Set `noAggro` to walk through hostile zones unmolested
+  (extreme power-leveling shortcut).
+
+**Evidence**
+- Ghidra: `Event_NetOut_SetNoXP`, `Event_NetOut_SetNoAggro`.
+- entities/defs/SGWGmPlayer.def:241-252.
+- `bNoAggro` property is declared on
+  `interfaces/SGWAbilityManager.def:96-100` as `CELL_PUBLIC` —
+  meaning the setter, if implemented, affects a wire-visible
+  property the server broadcasts.
+
+**Attack scenario**
+1. Player sends `gmSetNoAggro(1)`.
+2. Future handler sets `bNoAggro = 1`; AoI broadcasts this to
+   the cell.
+3. NPC aggro tables skip this player; player walks through hostile
+   territory un-targeted.
+
+**Suggested remediation (one line)**
+Access_level gating; even after gating, broadcasting `bNoAggro`
+publicly is questionable (advertising "I'm a GM" to everyone in
+the cell defeats `bHideGM`'s purpose).
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-N-37 — `Event_NetOut_AddBehaviorEventSet` / `RemoveBehaviorEventSet` — AI behavior-set runtime modification per target
+
+**Severity**: Medium
+**Class**: Authority bypass — AI tree modification via client setter
+**Wire surface**: `gmAddBehaviorEventSet(INT32 aBehaviorEventSetId)`,
+`gmRemoveBehaviorEventSet(INT32 aBehaviorEventSetId)`
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+SGWGmPlayer.def:442-450. These add or remove entire event sets from
+a mob's behavior tree at runtime. More powerful than the single-event
+`gmEmitBehaviorEventOnMob` (CAT-N-16): the caller can permanently
+disable or enable whole categories of behavior (combat AI, dialog
+AI, idle AI). Without gating: a player can lobotomize any boss
+("remove all combat behaviors") and kill it trivially.
+
+**Evidence**
+- Ghidra: `Event_NetOut_AddBehaviorEventSet`,
+  `Event_NetOut_RemoveBehaviorEventSet`.
+- entities/defs/SGWGmPlayer.def:442-450.
+
+**Attack scenario**
+1. Player targets a boss.
+2. Sends `gmRemoveBehaviorEventSet(<boss_combat_eventset>)`.
+3. Future handler removes the event set from the boss's behavior
+   tree; boss stops attacking; player kills it solo.
+
+**Suggested remediation (one line)**
+Access_level gating; the behavior-set id should also be whitelisted
+to a curated "safe to manipulate" set.
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-N-38 — `Event_NetOut_Respec` / `RespecAbility` / `ResetAbilities` — per-character ability tree resets via client setter
+
+**Severity**: Medium
+**Class**: Authority bypass — economy primitive via client setter
+**Wire surface**: `gmRespec()` (zero-arg full respec),
+`Event_NetOut_RespecAbility` (per-ability variant in NetOut RTTI),
+`Event_NetOut_ResetAbilities` → already covered as
+`resetMyAbilities` (CAT-N-02)
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+SGWGmPlayer.def:299-301 — `gmRespec` (zero-arg). The `RespecAbility`
+variant is per-ability. Without GM gating, lets any player wipe
+their training-points investment AND get them back free — the
+classic economy-bypass shape covered separately for the
+SGWPlayer-exposed `resetMyAbilities` in CAT-N-02. This one is the
+SGWGmPlayer-only variant; the exploit shape is identical but the
+wire surface is on a different index space.
+
+**Evidence**
+- Ghidra: `Event_NetOut_Respec`, `Event_NetOut_RespecAbility`.
+- entities/defs/SGWGmPlayer.def:299-301.
+
+**Attack scenario**
+Same as CAT-N-02 with the GM variant index instead of the regular
+player one.
+
+**Suggested remediation (one line)**
+Access_level gating; respec without cost is a GM-only operation.
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-N-39 — `Event_NetOut_SetTechSkill` and `SetAutoCycle` (regular player CM 83) — handler-implementation correctness check for SET_AUTO_CYCLE
+
+**Severity**: Low
+**Class**: Self-only state mutation, but no defense-in-depth on the
+caller-vs-entity_id assertion
+**Wire surface**: `setAutoCycle(INT8 enabled)` (CM 83 on regular
+SGWPlayer), `Event_NetOut_SetTechSkill` (likely SGWGmPlayer-only)
+**Demonstrable / Likely-theoretical**: Demonstrable for SET_AUTO_CYCLE
+(handler is implemented)
+
+**Trust violation**
+`SET_AUTO_CYCLE` (CM 83) is a regular-player command (not GM) and
+its handler at
+`crates/services/src/cell/cell_methods/player/world/mod.rs:18-118`
+reads the caller's `last_fired_ability_id` and `current_target_id`
+from the server-side entity. That part is correct (server-authority).
+The handler then routes through `handle_use_ability_with_kill_credit`
+without re-validating that the `current_target_id` is in the caller's
+perception list — but `current_target_id` is itself set via
+`SET_TARGET_ID` (CM 0) which also doesn't validate perception. So
+auto-cycle inherits the missing AoI check from `setTargetID`.
+
+The `Event_NetOut_SetTechSkill` is the GM variant of a tech-skill
+setter — same shape concerns as CAT-N-14 (arbitrary content unlock).
+
+**Evidence**
+- `crates/services/src/cell/cell_methods/player/world/mod.rs:18-118`
+  — uses server-side `current_target_id`, no perception re-check.
+- `crates/services/src/cell/cell_methods/being.rs:20-63` —
+  `setTargetID` also has no perception check.
+- Ghidra: `Event_NetOut_SetTechSkill` string present.
+
+**Attack scenario**
+1. Player sets target to an out-of-AoI entity via a crafted
+   `setTargetID` packet (no perception check).
+2. Enables auto-cycle.
+3. Auto-cycle fires ability at the out-of-AoI target every
+   cooldown — bypassing line-of-sight, range, and perception
+   discipline.
+
+**Suggested remediation (one line)**
+The auto-cycle fire path must re-validate target perception /
+range on each fire; this overlaps with CAT-C's missing
+perception check on `setTargetID`.
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+### CAT-N-40 — Wire surface for `Event_NetOut_GotoXYZ` self-emit allows malformed-but-valid float triples to teleport the caller
+
+**Severity**: High
+**Class**: Position-spoof via client setter (specific shape)
+**Wire surface**: `gmGotoXYZ(FLOAT aX, FLOAT aY, FLOAT aZ)` — also
+covered under CAT-N-18 generally, but called out specifically because
+of the float-NaN handling concern
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+Reiterating CAT-N-18 with a specific float-validation focus:
+`gmGotoXYZ` accepts three IEEE-754 floats with no constraint that
+they be finite, within world bounds, or even non-NaN. A future
+handler that copies them into the entity's position field will
+break (or exploit) any downstream code that doesn't NaN-check.
+Specifically:
+
+- NaN position → AoI broadcast → witnesses receive NaN → client
+  may crash, may render at random coordinates.
+- ±inf position → out-of-bounds, may bypass per-space culling.
+- Negative-zero distinct from positive-zero in some hash code paths.
+
+**Evidence**
+- entities/defs/SGWGmPlayer.def:348-353.
+- No Rust handler today.
+
+**Attack scenario**
+1. Player sends `gmGotoXYZ(NaN, NaN, NaN)`.
+2. Future handler writes NaN into entity position.
+3. AoI tick broadcasts NaN to witnesses; clients render the player
+   at "wherever NaN ends up" (typically origin).
+4. Distance / hit-detection code that compares against NaN may
+   short-circuit (any comparison with NaN is false), making the
+   player effectively un-targetable.
+
+**Suggested remediation (one line)**
+Float-finite check (and per-space bounds check) before writing
+client-supplied floats into authoritative position state — even
+after GM gating.
+
+**Would benefit from x64dbg trace?**
+No.
+
+---
+
+## Not Filed
+
+The following items I considered but did not file as findings. Some
+overlap with other CATs that own them; some are not exploit-class.
+
+- **`Event_NetOut_LogOff` / `LogOff`** — already CAT-A's concern;
+  the existing handler is gated on the connection identity
+  (the addr resolved by the framing layer), not client-controlled.
+  Server validates correctly.
+
+- **`Event_NetOut_Disconnect`** — same as LogOff; CAT-A surface.
+
+- **`Event_NetOut_Unstuck`** — CAT-B (movement) owns this; the
+  current Rust dispatch has no handler beyond the warn-fall-through,
+  so there's no current trust violation. Future implementation
+  needs cooldown + position check.
+
+- **`Event_NetOut_CombatDebug` / `CombatDebugVerbose` /
+  `AbilityDebug` / `HealDebug`** — CAT-C territory; the cell
+  toggles ARE CAT-N-30 already filed; the slash-command variants
+  go through SGWTextCommandMgr and route to the same server-side
+  effect. No additional finding beyond CAT-N-30.
+
+- **`Event_NetOut_Petition`** — CAT-L (chat / contact) owns this.
+  The petition is a *request* to a GM, not a GM command.
+
+- **`Event_NetOut_Who`** — exposed to all players regularly
+  (`SGWPlayer.def`); not a GM command despite the name. The
+  `gmShowPlayer` / `gmShowIP` variants are GM and ARE filed as
+  CAT-N-19.
+
+- **`Event_NetOut_CancelMovie`** — exposed in SGWPlayer regular
+  methods, not GM. Not a CAT-N concern.
+
+- **`Event_NetOut_BroadcastMinimapPing`** — CAT-L (chat) owns this.
+  Not a GM command per the .def declaration (it's on
+  OrganizationMember interface).
+
+- **`Event_NetOut_OnSpaceQueueStatus`** / `OnSpaceQueueReadyResponse`
+  / `OnSpaceQueuedResponse` / `OnStrikeTeamResponse` — these are
+  RESPONSES to server prompts (the client confirming a space queue
+  result, etc.), exposed on the regular SGWPlayer because they're
+  normal-play UI confirmations, not GM. CAT-O owns the world-queue
+  surface.
+
+- **`Event_NetOut_SetMovementType` defense beyond CAT-N-26** —
+  the broader concern (does the SET_MOVEMENT_TYPE bytes affect
+  server-side movement calc?) is CAT-B's movement-physics
+  validation. CAT-N-26 captures the GM-adjacent piece (enum-byte
+  exposed beyond walk/run).
+
+- **`Event_NetOut_SetCrouched` / `ChangeWeaponState`** — CAT-B
+  movement; not GM-flagged in the .def. The current
+  SET_CROUCHED handler trusts the byte but it's a local
+  pose-state, not a privilege bit. Not a CAT-N exploit.
+
+- **`Event_NetOut_TestLOS` and `ToggleCombatLOS`** — filed as
+  CAT-N-24.
+
+- **`Event_NetOut_SendGMShout`** — IS a GM command, but no Rust
+  handler exists today and no chat-broadcast infrastructure
+  surfaces shouts. When implemented it needs GM gating — but the
+  systemic finding (CAT-N-03) already covers it. Filing a
+  CAT-N-41 just for this would be redundant.
+
+- **`Event_NetOut_ReloadOrganizations` / `ReloadInventory`** —
+  partial overlap with CAT-N-17 (LoadX family). Same severity,
+  same fix. Not double-filed.
+
+- **`Event_NetOut_PetInvokeAbility` / `PetAbilityToggle` /
+  `PetChangeStance`** — pet ability surfaces. Not GM commands.
+  CAT-C owns these.
+
+- **`Event_NetOut_MissionAbandon` / `MissionAssign` /
+  `MissionAdvance` / `MissionReset` / `MissionComplete` /
+  `MissionSetAvailable` / `MissionList` / `MissionListFull` /
+  `MissionDetails` / `MissionClear` / `MissionClearActive` /
+  `MissionClearHistory`** — these are GM variants of mission
+  control (`gmMissionAssign` etc.), per SGWGmPlayer.def:65-123.
+  The shape is identical to other GM authority bypasses
+  (arbitrary mission state mutation) but the exploit class is
+  the same as CAT-N-21 (flag mutation). Could be filed as
+  individual findings but the systemic CAT-N-03 + CAT-N-21
+  pattern already covers them. CAT-J (mission) ALSO owns the
+  legitimate non-GM `MissionAbandon` and friends.
+
+- **`Event_NetOut_OnPhysics`** — `onPhysics(UINT8 bTurnOn)` on
+  SGWGmPlayer.def:645-648. Toggles physics on/off for the player.
+  Same shape as CAT-N-20 (visibility toggles); same severity;
+  same fix. Captured under "all SGWGmPlayer toggles need
+  access_level gating" — not double-filed.
+
+- **`Event_NetOut_SetCallback`** — `gmSetCallback` on SGWGmPlayer.def
+  takes a `PYTHON` arg. The PYTHON wire type means **pickled
+  Python data deserialized at the server** — a classic pickle-RCE
+  primitive in the original Python server. Today the Rust server
+  has no PYTHON deserializer for cell-method args (the cell
+  decoder doesn't handle the `PYTHON` type at all). When/if
+  implemented, this needs (a) GM gating, (b) NO unpickling of
+  client data — switch to a typed schema. Not filed as a numbered
+  CAT-N because (1) it's a generic CAT-A-style code-execution
+  concern about the PYTHON wire type as a whole that affects
+  several entries beyond CAT-N, and (2) the Rust server doesn't
+  even ingest PYTHON args today.
+
+- **`Event_NetOut_DialGate` / `DHD`** — gate-dialing is the normal
+  player path, but `gmDHD` is the GM variant
+  (SGWGmPlayer.def:325-328). Same shape as CAT-N-18 (free
+  fast-travel). Severity-equivalent; the systemic finding covers
+  it. CAT-O (world / gate) owns the legitimate non-GM path.
+
+- **`Event_NetOut_SetRingTransporterDestination`** — already
+  has a Rust handler at
+  `crates/services/src/cell/cell_methods/player/world/mod.rs:207-228`;
+  it's a CAT-O concern. Not GM-marked in .def.
+
+- **`Event_NetOut_DebugAbilityOnMob` / `DebugBehaviorsOnMob` /
+  `DebugPathsOnMob` / `DebugMobData`** — GM debug surfaces for
+  observation only. CAT-N-31 covers `DebugEvents`; the others
+  are sibling shapes with the same severity. Not double-filed.
+
+- **`Event_NetOut_EnterErrorAIState` / `ExitErrorAIState`** —
+  AI-state toggles. Same shape as CAT-N-16 (behavior event
+  emission). Not double-filed.
+
+- **`Event_NetOut_DespawnMob` / `SpawnEntityLoot` /
+  `ActivateSpawnSet` / `DeactivateSpawnSet`** — alternate spawn
+  primitives. Same shape as CAT-N-13. Not double-filed.
+
+- **`Event_NetOut_TrackMob`** — debug command for tracking a
+  mob's AI state. Info-disclosure shape like CAT-N-19 / N-24.
+  Not double-filed.
+
+- **`Event_NetOut_DebugMinigameComplete`** — CAT-K (minigame)
+  surface, not pure-GM. Filed elsewhere.
+
+- **`Event_NetOut_OnReady` / `OnPlayerReady` / `OnPlayerFailed`** —
+  internal lifecycle methods, not GM commands.
+
+- **`Event_NetOut_setClientVersion`** — sent at handshake, not GM.
+
+- **`Event_NetOut_SetAutoCycle` (CM 83)** — auto-cycle toggle is
+  a *regular* player command, not GM. The handler IS implemented
+  and uses server-side state correctly (`last_fired_ability_id`,
+  `current_target_id`). The remaining concern is target perception
+  on the auto-cycle fire path which inherits from `setTargetID`
+  — that's CAT-N-39 already filed (perception check).
+
+- **`Event_NetOut_ShowPointSet`** — info-disclosure shape on a
+  point-set type; same severity as CAT-N-19. Not double-filed.
+
+- **`Event_NetOut_ShowRotation`** / **`ShowVariable`** — read-only
+  observation of an entity's rotation/variable. Low-severity
+  info-disclosure same as CAT-N-19. Not double-filed.
+
+- **`Event_NetOut_ListInteractions`** — GM listing of available
+  interactions on the caller's target. Same shape as
+  `gmShowPlayer`. Not double-filed.
+
+- **`Event_NetOut_GetMobAttribute`** — GM read of a mob attribute.
+  Pure info-disclosure variant of CAT-N-15 (set side). Same fix.
+  Not double-filed.
+
+- **The remaining `Show*` family in CAT-N** — every Show* method
+  is an info-disclosure variant. All share the CAT-N-19 fix
+  shape. Not individually filed.
+
+- **`Event_NetOut_NoDamage`** — `gmSetNoDamage` was in SGWGmPlayer
+  but `Event_NetOut_NoDamage` doesn't appear in the Ghidra RTTI
+  string scan as a separate event — likely it's grouped with
+  `SetGodMode` (both toggle damage immunity). Not double-filed
+  beyond CAT-N-06.

--- a/docs/security-audit/2026-05-31-server-authority/findings/CAT-O-world-space-gate.md
+++ b/docs/security-audit/2026-05-31-server-authority/findings/CAT-O-world-space-gate.md
@@ -1,0 +1,484 @@
+# CAT-O — World / Space / Gate / Ring
+
+The CAT-O surface covers cross-world travel (stargate dial, ring transport
+FSM, gate-region triggers), space-instance lifecycle controls
+(`onWorldInstanceReset`, `onSpaceQueue*` responses, `onStrikeTeamResponse`),
+cinematic suppression (`cancelMovie`), and the client-options sync
+(`updateSystemOptions`). The bulk of the *position-spoofing* attack
+surface — DHD-without-walk, ring-without-pad, region-without-position —
+is already filed under CAT-B (see [[CAT-B-02]], [[CAT-B-03]], [[CAT-B-04]])
+because the proximate trust violation is "client position discarded".
+CAT-O's contribution to those messages is the *adjacent* trust violations
+that survive even after the position check is added: destination
+authorization (player has the unlocked address?), chain-trigger spam
+(rapid-fire `triggerClientHintedGenericRegion` over a sequence of regions),
+the dial-cancel race, and the systemic exposure of
+`onWorldInstanceReset` on the **player** entity rather than the GM entity.
+The system-options handler is well-scoped (only two booleans accepted) but
+sits on a `WSTRING` wire that will silently broaden the moment anyone adds
+a PvP-flag or similar; that future trap is captured under "Not Filed". The
+space-queue / strike-team / movie-cancel paths are currently stubs — the
+exploit surface lands at implementation time, and those gaps are listed in
+"Not Filed" with the specific invariants any implementer must satisfy.
+
+---
+
+### CAT-O-01 — `onDialGate` ignores `knownStargateAddresses` — any character dials any gate the world catalog knows
+
+**Severity**: High
+**Class**: Missing destination authorization / content-gate bypass
+**Wire surface**: Cell method 35 (`onDialGate`) — `Event_NetOut_onDialGate` / `Event_NetOut_DHD`
+**Demonstrable / Likely-theoretical**: Demonstrable
+
+**Trust violation**
+The handler at `crates/services/src/cell/gate_travel.rs:35-108` validates
+`target_address_id` only against `space_mgr.stargates` — the *global*
+catalog of every stargate that exists in the world, loaded from
+`resources.stargates` at startup. It does **not** check the player's
+`knownStargateAddresses` (the CELL_PRIVATE address-book property defined
+in `entities/defs/interfaces/GateTravel.def:4-8` and persisted in
+`sgw_player.known_stargates`). Per-player gate unlocks are tracked in
+`PlayerLoadData::known_stargates` and shipped to the client via the
+`setupStargateInfo(worldStargateIds, knownStargateIds, hiddenStargateIds)`
+method at world entry (`crates/services/src/mercury/world_data/map_loaded.rs:175-181`)
+— the server knows exactly which gates the player has unlocked but never
+consults that list when authorising a dial. Any character can therefore
+dial any stargate that exists *anywhere* in the resource catalog, including
+end-game-world gates the player has never seen in-game. This is distinct
+from [[CAT-B-02]]: that finding fixes the *source* position; this finding
+fixes *destination authorization*. Both have to be fixed independently —
+adding the source-position check alone still lets a GM-spawned-near-a-
+gate character dial to any unlocked-by-anyone gate.
+
+**Evidence**
+- Ghidra: `00d93060` `register_NetOut_onDialGate` + `019be588`/`019ca724`
+  string anchors for the `Event_NetOut_onDialGate` class. Wire shape pinned
+  by `entities/defs/interfaces/GateTravel.def:70-74` —
+  `(INT32 TargetAddressId, INT32 SourceAddressId)`. The DHD slash-command
+  emit also reaches the same cell method 35 (no separate `dhd` cell
+  method exists in the dispatch surface).
+- Client behavioral log: n/a (UI-driven dialer + slash-command path).
+- Cross-ref to Rust handler:
+  `crates/services/src/cell/gate_travel.rs:49-59` — the only check is
+  `space_mgr.stargates.get(&target_address_id)`. The DB column
+  `sgw_player.known_stargates` is read into `PlayerLoadData::known_stargates`
+  at world entry (`crates/services/src/base/world_entry/methods/player_load/core.rs:60,217`)
+  but the cell entity never carries it, so the gate handler can't consult
+  it without an additional plumb.
+
+**Attack scenario**
+1. Player creates a fresh character; the server initialises
+   `known_stargates` to `[]` (or to the starter-world gate).
+2. Through any means — Ghidra string-search, capture from another
+   character, or simple bruteforce of small i32s — discover the
+   `target_address_id` for an end-game world (e.g., the Asuras hub).
+3. Send `onDialGate(target=<asuras_id>, source=<whatever>)`.
+4. Server finds the gate in `space_mgr.stargates`, calls `handle_gate_travel`,
+   destroys the entity, persists the new world, and ships the
+   `RESET_ENTITIES + new-world entry` bundle. Attacker is now on a world
+   they never unlocked, bypassing every mission-driven gate-unlock chain.
+
+**Suggested remediation (one line)**
+Plumb `known_stargates` onto the cell entity at world entry and reject
+`onDialGate` when `target_address_id` is not in the player's
+`known_stargates` (and not flagged as a free/public address). Stack on
+top of the source-position fix from [[CAT-B-02]].
+
+**Would benefit from x64dbg trace?**
+No — the gate handler's call to `space_mgr.stargates` is the proof; the
+absence of any read of `known_stargates` in the gate path is a code-level
+gap.
+
+---
+
+### CAT-O-02 — `onDialGate` skips the 4-second dial timer — no cancellation window, no cost
+
+**Severity**: Medium
+**Class**: Missing transaction window / no-cost teleport
+**Wire surface**: Cell method 35 (`onDialGate`)
+**Demonstrable / Likely-theoretical**: Demonstrable
+
+**Trust violation**
+The Python reference (`python/cell/SGWPlayer.py:onDialGate`) ran a
+4-second dial timer before invoking the world transition — that window
+was where the dial could be cancelled (`target_address_id == -1`),
+where energy/consumable cost would be checked, and where mission
+abort/interrupt could fire. The Rust handler at
+`crates/services/src/cell/gate_travel.rs:28` explicitly documents
+"we skip the timer and travel immediately for simplicity". Aside from
+making the cancel-dial path (`target_address_id == -1` at line 43)
+effectively dead code, this collapses the gate-travel transaction into a
+single atomic mutation with no opportunity to apply any cost or
+condition (the existing 2009 game charged the player nothing per dial,
+but the surface is now permanently denied to *any* future cost
+mechanic). Combined with [[CAT-O-01]], a player can chain-dial through
+every world in the catalog in seconds with no rate-limit, no UI
+animation gating, and no client-state check.
+
+**Evidence**
+- Ghidra: `onDialGate` emit path (see CAT-O-01) — the client's 4-second
+  spin-up of the dial UI is purely visual; the Mercury packet ships
+  immediately on the user's confirm click.
+- Client behavioral log: n/a.
+- Cross-ref to Rust handler:
+  `crates/services/src/cell/gate_travel.rs:25-29` documents the
+  intentional skip, `:43-46` shows `target_address_id == -1` returning
+  a no-op (would only matter if there was actually a pending dial to
+  cancel).
+
+**Attack scenario**
+1. Send `onDialGate(target=W1, source=0)` — server immediately tears
+   the entity down and starts the world-transition bundle.
+2. Halfway through the bundle's RESET_ENTITIES round-trip, send
+   `onDialGate(target=W2, source=0)`. The first transition's mid-flight
+   state on `pending_world_entry` interleaves unpredictably with the
+   second's RESET. Even when the two complete cleanly, there's no
+   rate-limit between them — a single client can chain world transitions
+   at packet-loop speed, exercising every world-load codepath in
+   sequence.
+3. (Future-cost angle.) If the project later adds a dial-cost mechanic
+   (energy/naquadah/consumable), the only place to charge it is inside
+   `handle_dial_gate` — but the transaction is atomic, so a failed
+   charge mid-transition leaves no rollback target.
+
+**Suggested remediation (one line)**
+Reinstate the 4-second dial timer (or a shorter equivalent), store the
+pending dial on `CellEntity` so a second dial cancels-and-replaces, and
+move the destination world-write to the timer-elapsed callback so any
+future cost/condition gate has a place to run before commit. Route the
+redesign to `movement-teleport-advisor`.
+
+**Would benefit from x64dbg trace?**
+Yes — observing the 2009 server's actual dial timer (Python comment
+"4 seconds" is the only reference) would tighten the duration; not
+required for the structural fix.
+
+---
+
+### CAT-O-03 — `triggerClientHintedGenericRegion` allows unbounded chain-event injection across regions
+
+**Severity**: High
+**Class**: Content-chain-engine injection / mission-skip via region spam
+**Wire surface**: Cell method 85 (`triggerClientHintedGenericRegion`)
+**Demonstrable / Likely-theoretical**: Demonstrable
+
+**Trust violation**
+Building on [[CAT-B-04]] (which is anchored on the discarded `_x/_y/_z`):
+the handler at
+`crates/services/src/cell/cell_methods/player/world/mod.rs:128-191`
+imposes **no rate limit, no per-region debounce, and no chain-event
+ordering check** beyond "the region id resolves to a known
+`region.tag`". A malicious client can rapid-fire (region=R1,
+entering=true) → (region=R1, entering=false) → (region=R2, entering=true)
+→ ... walking the chain engine through every `enter_region::<tag>` /
+`exit_region::<tag>` arm in arbitrary order at packet rate. Content
+chains are how mission-step gating is wired
+(`fire_enter_region`/`fire_exit_region` at lines 163-171 dispatch into
+`crate::cell::content`), so this is a one-handler primitive for
+advancing *any* region-triggered mission step the chain engine knows
+about — without ever having been near the region geometrically (the
+CAT-B-04 piece) and without having walked the intervening regions in
+order (the CAT-O angle here). The ring-transport FSM forwarding at
+lines 176-181 inherits the same property: a client can drive
+`region_triggered` for every loaded ring pad in sequence to scout
+destination IDs (`onRingTransporterList` is sent on each interact) or
+to leave the ring FSM in a corrupted state across multiple pads.
+
+**Evidence**
+- Ghidra: `Event_NetOut_TriggerClientHintedGenericRegion` (standard
+  `Event_NetOut_*` shape per
+  `entities/defs/SGWPlayer.def:766-771` — `INT32 id, UINT8 bEntering,
+  VECTOR3 position`).
+- Client behavioral log: n/a (continuous as the player walks; under
+  attack, packet-rate).
+- Cross-ref to Rust handler:
+  `crates/services/src/cell/cell_methods/player/world/mod.rs:128-191`.
+  No per-entity `last_region_trigger_at` field exists. No content-chain
+  step-order check exists in `crate::cell::content`.
+
+**Attack scenario**
+1. Enumerate mission-relevant region IDs (via observing one legitimate
+   playthrough, or via the `region_tag` resolution log on a captured
+   server, or via brute-force of small i32s).
+2. Build a packet sequence:
+   `[trigger(R1,true), trigger(R1,false), trigger(R2,true),
+   trigger(R2,false), ..., trigger(Rn,true)]` — one packet per step
+   needed by a multi-region mission chain.
+3. Server fires `fire_enter_region` / `fire_exit_region` for each tag
+   in order. Content chains advance the mission as if the player had
+   physically walked the entire mission path in proper order.
+4. Mission completes; rewards granted; mission-gated zones unlocked.
+   Repeat against any region-driven chain in the content engine.
+
+**Suggested remediation (one line)**
+Add a per-entity per-region cooldown (e.g., 250ms minimum between
+`enter`/`exit` on the same region; reject `enter`/`enter` or
+`exit`/`exit` without the toggle), plus a `last_region_change_at`
+field on `CellEntity` to rate-limit cross-region transitions to a sane
+walking-pace cap (e.g., max 8 region transitions per second). Layer on
+top of the position validation from [[CAT-B-04]].
+
+**Would benefit from x64dbg trace?**
+No — the absence of any cooldown / debounce / chain-order check is a
+code-level gap; the chain engine's lack of step-order enforcement is
+visible in `crate::cell::content`.
+
+---
+
+### CAT-O-04 — `onWorldInstanceReset` is exposed on the **player** entity (not GM), currently UNIMPLEMENTED
+
+**Severity**: High (future trap — currently latent)
+**Class**: GM-command exposure / instance DoS surface
+**Wire surface**: Cell method 92 (`onWorldInstanceReset`)
+**Demonstrable / Likely-theoretical**: Likely-theoretical (latent)
+
+**Trust violation**
+The entity-def at `entities/defs/SGWPlayer.def:868-870` declares
+`<onWorldInstanceReset><Exposed/></onWorldInstanceReset>` *on the player
+entity* — not the GM player entity (`SGWGmPlayer.def` has none).
+`<Exposed/>` means the client can emit this directly. The Rust handler
+at
+`crates/services/src/cell/cell_methods/player/world/mod.rs:230-233`
+is a stub: `tracing::info!(entity_id, "UNIMPLEMENTED: onWorldInstanceReset"); true`.
+Today this is harmless (it does nothing), but the failure mode is the
+*future* trap: a future contributor implementing it naturally puts the
+implementation *here*, in the player-side handler, and unless they
+*also* add an access-level check, the resulting instance-reset is
+callable by any player (instance DoS — kick every player on the
+instance, force re-entry, lose in-flight state). The
+[[reference_gm_auth_plumbing_gap]] memory documents the systemic gap:
+the cell-method dispatch path
+(`crates/services/src/base/connect_loop/cell_arms.rs`) has no
+access-level field on the call — any GM-shaped command lacking an
+explicit `is_gm_session(player_id)` check defaults to "open to all
+players". The current `Event_NetOut_WorldInstanceReset` C++ client
+emits this from a slash-command (`Event_SlashCmd_WorldInstanceReset`
+at `00cbe5a0`), but slash-commands aren't client-side-gated either —
+the gate has to land on the server.
+
+**Evidence**
+- Ghidra: `00cbe5a0` `register_NetOut_WorldInstanceReset`; the C++
+  client wires `Event_SlashCmd_WorldInstanceReset` (`018429f4`) to
+  `Event_NetOut_WorldInstanceReset` (`019b4340`) — a slash-command
+  fires the network emit with no client-side access-level gate.
+- Client behavioral log: n/a.
+- Cross-ref to Rust handler:
+  `crates/services/src/cell/cell_methods/player/world/mod.rs:230-233`
+  (UNIMPLEMENTED stub),
+  `crates/services/src/cell/cell_methods/player/constants.rs:30`
+  (the index is in the player-method range, not a GM-method range).
+
+**Attack scenario** (post-implementation)
+1. Contributor implements `WORLD_INSTANCE_RESET` to do the obvious
+   thing: walk `space_mgr.world_spaces[current_world].entities`,
+   destroy each, send RESET_ENTITIES bundles, re-spawn at the world's
+   start position.
+2. They forget (or are unaware of) the access-level check — the dispatch
+   layer doesn't surface it as a required parameter.
+3. Any player sends `onWorldInstanceReset` (empty payload — no args
+   per the def). Every player on the instance is force-kicked back to
+   start, losing in-flight loot/state/combat. Repeat at packet rate
+   for sustained denial-of-service against an instance.
+
+**Suggested remediation (one line)**
+Mark the stub `BLOCK` until two prerequisites land: (a) plumb
+`access_level` from `ConnectedClientState` into `dispatch_cell_method`
+so handlers can server-side-validate the session's GM bit, and
+(b) the `onWorldInstanceReset` arm's first line must be
+`if !is_gm_session(player_id) { return true; }`. Route to the GM-auth
+plumbing track (see [[reference_gm_auth_plumbing_gap]]).
+
+**Would benefit from x64dbg trace?**
+No — the gap is in the def (exposed-to-player) and the dispatch surface
+(no access-level plumb).
+
+---
+
+### CAT-O-05 — `cancelMovie` flips `cinematic_spam_cancel` from any sender; no movie-id binding
+
+**Severity**: Low
+**Class**: Cross-session state poisoning (cosmetic)
+**Wire surface**: Cell method 108 (`cancelMovie`) — `Event_NetOut_CancelMovie`
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+The wire payload (per `entities/defs/SGWPlayer.def:1104-1107`) is
+`WSTRING MovieName`. The base handler at
+`crates/services/src/base/world_entry_appearance.rs:721-741` ignores
+the supplied `MovieName` entirely — it just flips
+`cinematic_spam_cancel` to `true` on the connected state and resends
+BeingAppearance + onEntityTint. Today the only cinematic in flight is
+the first-login intro, so there's no scenario where canceling movie
+"A" is supposed to leave movie "B" running. But the design plants a
+foot-gun: any future code that calls `send_cinematic` for a
+mission-critical cutscene (per the in-code comment at
+`world_entry_appearance.rs:533-536` —
+"Future cinematics (mission cutscenes, gate transitions, dialog
+overlays, etc.) should go through this function") will be cancellable
+by a client `cancelMovie` packet regardless of which movie was sent.
+The trust violation is the unread `MovieName` argument: the server
+treats *all* cancellations as global.
+
+**Evidence**
+- Ghidra: `Event_NetOut_CancelMovie` standard shape — wire is just the
+  movie name wstring (matches def line 1106).
+- Client behavioral log: `SGWDebugLog.log` shows `cancelMovie` being
+  sent on Esc / Lua-stop today.
+- Cross-ref to Rust handler:
+  `crates/services/src/base/world_entry_appearance.rs:721-741` —
+  no `MovieName` parse, no movie-id binding to the currently-active
+  cinematic's id.
+
+**Attack scenario** (future)
+1. Mission script triggers `send_cinematic("mission_X_intro", true)`,
+   armed with the spam-cancel flag.
+2. Player sends `cancelMovie("some_other_movie_name")` (or even
+   the unused intro name "DHD.DHD").
+3. Server flips `cinematic_spam_cancel = true`, the spam loop exits
+   early. The cutscene continues to play on-screen, but the
+   server's post-cutscene appearance-resend guard is now off; if the
+   client `Esc`s out of the mission cutscene, the appearance-asset
+   collection race that the spam guard exists to mitigate (issue #288)
+   re-emerges as a dev-cube bug — visible to the player but not
+   server-state-damaging.
+4. Generalises to any future cinematic-gated mission-completion path
+   (none today): the server would clear the cinematic-in-flight flag
+   regardless of which movie the client claims to have cancelled.
+
+**Suggested remediation (one line)**
+Bind the in-flight cinematic id to `ConnectedClientState` when
+`send_cinematic` arms the spam guard, and compare the `MovieName`
+argument against it; reject (or no-op silently with a `debug!`) when
+the names don't match.
+
+**Would benefit from x64dbg trace?**
+No — the `MovieName` parse simply isn't there in the Rust handler.
+
+---
+
+### CAT-O-06 — `updateSystemOptions` is structurally safe today but rides a value-WSTRING wire that accepts arbitrary option names
+
+**Severity**: Low (current) / Medium (future trap)
+**Class**: Future-trap / scope-creep risk on a server-authoritative-by-default surface
+**Wire surface**: Cell method 93 (`updateSystemOptions`)
+**Demonstrable / Likely-theoretical**: Likely-theoretical
+
+**Trust violation**
+The wire-format parse at
+`crates/services/src/cell/cell_methods/player/world/mod.rs:262-399`
+is correct as far as it goes: count-capped at 256 entries, applies
+only via the closed allowlist
+`SystemOptions::apply` at `crates/entity/src/cell_entity/system_options.rs:59-71`
+(only `autoReload` and `reloadOnActivate` are recognised), unknowns
+land in a `debug!` log. So today the player can only toggle the two
+documented booleans, both of which are advisory-display / behavior
+hints with no security impact (auto-reload at clip empty;
+reload-on-activate on weapon swap).
+The trap is the SystemOptions.xml surface: it defines ~140 options,
+many of which look advisory but a non-trivial subset are
+*server-synched* in the original game's semantic
+(per the doc comment at lines 1-13 of `system_options.rs`). The wire
+shape is `(WSTRING name, WSTRING value)`, so any name added to the
+`apply` match arm becomes a client-writable server-authoritative
+field. A future contributor adding (say) `pvpFlag` or
+`acceptDuelAuto` or `accessLevel` to the apply list without an
+access-level check turns this handler into a privilege-escalation
+vector immediately. The struct currently has `Default` returning
+`auto_reload: true` from a hardcoded constant, not from the DB
+column's default — so a fresh player who never sends
+`updateSystemOptions` will use the in-code default even if the DB
+default drifts. That's a different scope-creep risk.
+
+**Evidence**
+- Ghidra: `Event_NetOut_UpdateSystemOptions` (or whatever the wire
+  shape resolves to — the def at `SGWPlayer.def:872-875` pins the
+  `ARRAY <of> NameValuePair`).
+- Client behavioral log: n/a — UI checkbox driven.
+- Cross-ref to Rust handler:
+  `crates/services/src/cell/cell_methods/player/world/mod.rs:262-399`,
+  the allowlist at `crates/entity/src/cell_entity/system_options.rs:59-71`,
+  and the persistence path at
+  `crates/services/src/base/world_entry/cell_dispatch/system_options.rs`.
+
+**Attack scenario** (future)
+1. A contributor extends the system-options panel to expose a server-
+   authoritative toggle (PvP-flag, "I am AFK", "ignore duels", etc.).
+2. They add a match arm to `SystemOptions::apply` and a column to
+   `sgw_player`. No access-level check, no value-range validation —
+   the wire is "string", so the apply path looks like a string parse.
+3. A client sends `updateSystemOptions([("pvpFlag", "false")])` from
+   inside a PvP zone where the player is engaged in combat. Server
+   flips the bit; the player becomes untargetable mid-fight.
+
+**Suggested remediation (one line)**
+Document in the system-options doc-comment that **adding any
+server-authoritative option name to `apply` requires a server-side
+condition check inside that arm** (e.g., "PvP flag only changes when
+out of combat for 60s"); add a compile-time enforcement by typing
+the allowlist as an enum or by gating the apply path behind a
+`SystemOptions::apply_with_context(name, value, &CellEntity)`
+signature that forces the implementer to read state before writing.
+
+**Would benefit from x64dbg trace?**
+No — the gap is forward-looking design, not current behavior.
+
+---
+
+## Not Filed
+
+- **`onSpaceQueuedResponse` / `onSpaceQueueReadyResponse` / `onSpaceQueueStatus`** —
+  none of these are wired up on the server. Grep confirms there's no
+  cell-method arm or dispatch entry for any of the three (the only
+  matches are server→client emits `ON_SPACE_QUEUED` / `ON_SPACE_QUEUE_READY`
+  at `crates/services/src/cell/client_methods/player.rs:99-102`). No
+  exploit until they're implemented; the implementer must validate that
+  the inbound response came from a session that is actually in the
+  pending-queue map for the named space (and that the named space is
+  instanced). Save this for the queue-system implementation review.
+- **`onStrikeTeamResponse`** —
+  stub at `crates/services/src/cell/cell_methods/organization.rs:65-77`
+  logs `UNIMPLEMENTED` and returns. No exploit until implemented; the
+  implementer must verify the receiving player was the one offered the
+  strike-team invite (server-side invite-state lookup, not client-id
+  trust). Filed as a partial overlap with CAT-M's organisation review.
+- **`onSpaceQueueStatus`** — overlaps the above three; same disposition.
+- **`DHD` (the `Event_NetOut_DHD` class)** —
+  Ghidra confirms this is the *same* server-side wire as `onDialGate`
+  (no separate `dhd` cell method exists in the SGW.def or in the Rust
+  dispatch; `Event_NetOut_DHD` is the C++ client's slash-command-shape
+  emit that maps to cell method 35 / `onDialGate`). All exploitation
+  is already captured under [[CAT-O-01]], [[CAT-O-02]], and [[CAT-B-02]].
+- **Ring-transport destination outside registered pad set** —
+  CAT-O question 6 asked whether the destination can be set to a coord
+  NOT on a registered pad. Confirmed mitigated: `validate_destination`
+  at `crates/services/src/cell/ring_transport/transporter/mod.rs:245-256`
+  rejects any `destination_id` not in the source's `destination_ids`
+  list, and the runtime additionally requires
+  `space_mgr.ring_transporters.get(destination_region_id)` to be Some
+  (`runtime.rs:289-299`). The coords are then driven from the
+  *server's* `RingRegion::x/y/z`, not from a client field. Source-pad
+  trust is the gap, but that's [[CAT-B-03]].
+- **Gate-travel destination coords can be spoofed via target_address_id** —
+  examined and dropped: `gate.x/y/z/yaw` is read from
+  `space_mgr.stargates` (server DB / resources), not from a client
+  field. The client only supplies the i32 id; the destination position
+  is fully server-sourced.
+- **`SystemOptions` PvP flag concern** — see CAT-O-06 ("future trap"). Today
+  the apply allowlist only contains the two advisory booleans; no
+  exploit path exists in the current code, the finding is forward-
+  looking.
+- **`onSquadMemberRingTransport` (and `Finished` companion)** — these
+  are server→client only (per the def — they're under `<ClientMethods>`
+  in SGWPlayer.def at lines 855-863). Not in scope for CAT-O's
+  client→server audit.
+- **`Disconnect` race during cross-world gate travel** — the
+  cross-world transition destroys the cell entity, sends `GateTravel`
+  to base, and waits for the client's next ENABLE_ENTITIES bundle. A
+  disconnect mid-flight is structurally possible but the base-side
+  bundle is keyed on a per-session token, and `entity_to_addr` is
+  cleared on disconnect. Examined `crates/services/src/base/world_entry/gate_travel/mod.rs`
+  — no obvious dupe / stuck-entity exploit. Defer to CAT-A's
+  disconnect-race coverage if one surfaces; not specifically a CAT-O
+  problem.
+- **`callForAid` / `Respawn` / `Petition`** — out of CAT-O scope (they
+  live in combat / chat respectively).

--- a/docs/security-audit/2026-05-31-server-authority/surface.md
+++ b/docs/security-audit/2026-05-31-server-authority/surface.md
@@ -1,0 +1,154 @@
+# Client → Server outbound message surface (Event_NetOut_*)
+
+Extracted from SGW.exe via Ghidra string search for `Event_NetOut_*`.
+~250 distinct C++ class names emit through `SGWNetworkManager`.
+
+## How the client emits these
+
+Pattern (from Ghidra strings):
+- C++ class `Event_NetOut_X` is the typed payload
+- `EventSignal<Event_NetOut_X>` dispatches via `SGWNetworkManager::EventHandler<Event_NetOut_X>`
+- The handler serialises the typed payload into the Mercury bundle on the wire
+
+So every `Event_NetOut_X` is one specific client → server message type.
+
+## Inventory grouped by audit category
+
+### CAT-A — Auth / Session / Character lifecycle
+- `versionInfoRequest` / `onClientVersion`
+- `elementDataRequest`
+- `onClientChallengeResponse`
+- `ClientReady`
+- `Disconnect` / `LogOff`
+- `PlayCharacter` / `CreateCharacter` / `DeleteCharacter` / `RequestCharacterVisuals`
+
+### CAT-B — Movement / Teleport / Position
+- `GotoXYZ` (debug teleport — CHEAT class)
+- `Goto` / `GotoLocation` (debug)
+- `Summon` (debug)
+- `Unstuck`
+- `SetRingTransporterDestination`
+- `SetMovementType`
+- `SetCrouched`
+- `ChangeWeaponState`
+- `Physics` (debug?)
+
+### CAT-C — Combat / Abilities
+- `UseAbility`
+- `useAbilityOnGroundTarget`
+- `ListAbilities`
+- `TrainAbility`
+- `SetTarget` / `SetTargetID`
+- `RequestAmmoChange`
+- `RechargeItem`
+- `Respawn`
+- `CombatDebug` / `CombatDebugVerbose` / `HealDebug` / `AbilityDebug`
+- `PetInvokeAbility` / `PetAbilityToggle` / `PetChangeStance`
+- `DebugAbilityOnMob` / `DebugBehaviorsOnMob` / `DebugPathsOnMob`
+- `EnterErrorAIState` / `ExitErrorAIState`
+- `ConfirmEffect`
+- `callForAid`
+
+### CAT-D — Inventory / Items
+- `UseItem`
+- `MoveItem`
+- `RemoveItem`
+- `RepairItem`
+- `LootItem`
+- `RequestActiveSlotChange`
+- `ListItems`
+- `GetItemInfo`
+- `requestItemData`
+- `RequestAmmoChange`
+
+### CAT-E — Vendor
+- `PurchaseItems` / `SellItems` / `BuybackItems` / `RepairItems` / `RechargeItems`
+
+### CAT-F — Crafting / R&D
+- `Craft` / `Alloy` / `Research` / `ReverseEngineer`
+- `SpendAppliedSciencePoint`
+- `TrainAbility`
+
+### CAT-G — Mail
+- `RequestMailHeaders`, `SendMailMessage`, `RequestMailBody`
+- `ArchiveMailMessage`, `DeleteMailMessage`, `ReturnMailMessage`
+- `TakeCashFromMailMessage`, `TakeItemFromMailMessage`
+- `PayCODForMailMessage`
+
+### CAT-H — Trade (P2P)
+- `TradeProposal`, `TradeLockState`, `TradeRequestCancel`, `TradeRequest`
+
+### CAT-I — Black Market / Auction
+- `BMCreateAuction`, `BMCancelAuction`, `BMPlaceBid`, `BMSearch`
+
+### CAT-J — Mission / Dialog / Interaction
+- `MissionAbandon`, `AbandonMission`, `ChosenRewards`
+- `ShareMission`, `ShareMissionResponse`
+- `MissionAssign`, `MissionClear`, `MissionClearActive`, `MissionClearHistory`
+- `MissionList`, `MissionListFull`, `MissionDetails`, `MissionAdvance`,
+  `MissionReset`, `MissionComplete`, `MissionSetAvailable`
+- `InitialResponse`, `DialogButtonChoice`
+- `Interact`, `DebugInteract`
+
+### CAT-K — Minigame
+- `StartMinigame`, `EndMinigame`, `MinigameComplete`
+- `SpectateMinigame`, `RequestSpectateList`, `MinigameStartCancel`
+- `RegisterToMinigameHelp`, `UpdateRegisterToMinigameHelp`
+- `GiveMinigameContact`, `RemoveMinigameContact`, `MinigameContactRequest`
+- `MinigameCallRequest`, `MinigameCallAbort`, `MinigameCallAccept`, `MinigameCallDecline`
+- `debugStartMinigame`, `debugSpectateMinigame`, `debugJoinMinigame`, `debugMinigameInstance`
+
+### CAT-L — Chat / Contact list / Communication
+- `sendPlayerCommunication`, `Petition`, `Who`, `ChatFriend`
+- `ChatJoin`, `ChatLeave`, `ChatList`, `ChatMute`, `ChatKick`, `ChatBan`,
+  `ChatOp`, `ChatPassword`, `ChatIgnore`, `ChatSetAFKMessage`, `ChatSetDNDMessage`
+- `contactListCreate`, `contactListRename`, `contactListDelete`,
+  `contactListFlagsUpdate`, `contactListAddMembers`, `contactListRemoveMembers`
+- `SendGMShout`
+- `BroadcastMinimapPing`
+
+### CAT-M — Organization / Squad / Duel
+- `OrganizationCreation`, `OrganizationInvite`, `OrganizationInviteByType`,
+  `OrganizationInviteResponse`, `OrganizationLeave`, `OrganizationKick`,
+  `OrganizationRankChange`, `OrganizationMOTD`, `OrganizationNote`,
+  `OrganizationOfficerNote`, `OrganizationSetRankPermissions`,
+  `OrganizationSetRankName`, `OrganizationTransferCash`, `ReloadOrganizations`
+- `SquadSetLootMode`
+- `PvPOrganizationLeaveResponse`
+- `DuelChallenge`, `DuelResponse`, `DuelForfeit`
+
+### CAT-N — GM / Debug / Cheat (CRITICAL — must all be GM-gated)
+- **Give**: `GiveXp`, `GiveNaqahdah`, `GiveItem`, `GiveAmmo`, `GiveAbility`,
+  `GiveAllAbilities`, `GiveRespawner`, `GiveTrainingPoints`, `GiveExpertise`,
+  `GiveAppliedSciencePoints`, `GiveRacialParadigmLevels`, `GiveFaction`,
+  `GiveBlueprint`, `GiveGearset`, `GiveInventory`, `GiveStargateAddress`
+- **Set**: `SetGodMode`, `SetNoXP`, `SetNoAggro`, `SetSpeed`, `SetHealth`,
+  `SetHealthMax`, `SetFocus`, `SetFocusMax`, `SetFlag`, `SetTarget`, `SetLevel`,
+  `SetMobStance`, `SetMobAttribute`, `SetMobAbilitySet`, `SetMobVariable`,
+  `SetFaction`, `SetTechSkill`, `SetHideGM`, `SetInstanceFlag`, `SetAutoCycle`,
+  `SetMovementType` (could be non-GM — verify), `Invisible`, `XRayEyes`
+- **Show/Get**: `ShowIP`, `ShowInventory`, `ShowPlayer`, `ShowRotation`,
+  `ShowMobCount`, `ShowPointSet`, `ShowFlag`, `ShowTargetLocation`,
+  `ShowInstanceFlag`, `ShowNavigation`, `ShowVariable`, `ListInteractions`,
+  `GetMobAttribute`
+- **Spawn/Destroy**: `Spawn`, `Despawn`, `Kill`, `GMRemoveItem`,
+  `RemoveStargateAddress`
+- **Behavior**: `EmitBehaviorEventOnMob`, `AddBehaviorEventSet`,
+  `RemoveBehaviorEventSet`
+- **Reload/Load**: `RequestReload`, `LoadConstants`, `LoadAbility`,
+  `LoadAbilitySet`, `LoadNACSI`, `LoadBehavior`, `LoadMOB`,
+  `LoadInteractionSet`, `LoadItem`, `LoadMission`, `RegenerateCoverLinks`,
+  `ChangeCoverWeight`, `ChangeCoverStanceWeight`
+- **Respec**: `Respec`, `RespecAbility`, `RespecCraft`, `ResetAbilities`
+- **Misc**: `Users`, `WorldInstanceReset`, `PerfStats`, `PerfStatsByChannel`,
+  `TestLOS`, `ToggleCombatLOS`, `PrintStats`, `DebugEvents`
+
+### CAT-O — World / Space / Gate
+- `WorldInstanceReset`
+- `onSpaceQueuedResponse`, `onSpaceQueueReadyResponse`, `onSpaceQueueStatus`
+- `onDialGate`, `DHD`
+- `TriggerClientHintedGenericRegion`
+- `onStrikeTeamResponse`
+- `SetRingTransporterDestination`
+- `CancelMovie`
+- `SystemOptions`

--- a/docs/security-audit/README.md
+++ b/docs/security-audit/README.md
@@ -1,0 +1,10 @@
+# Security audits
+
+Time-stamped reference records of security audits run against the Cimmeria
+server. Each audit directory contains the findings as committed at audit
+completion; findings are NOT updated post-audit (the audit is a point-in-time
+snapshot — fixes are tracked via the linked GitHub issues).
+
+## Audits
+
+- [`2026-05-31-server-authority/`](2026-05-31-server-authority/) — Server-authority / anti-cheat / anti-replay audit across all 15 player-facing categories. 177 findings. See [`2026-05-31-server-authority/UMBRELLA.md`](2026-05-31-server-authority/UMBRELLA.md) for the executive summary + triage tiers. Tracking umbrella issue: [#459](https://github.com/SandboxServers/Cimmeria/issues/459). Per-category issues: [#460](https://github.com/SandboxServers/Cimmeria/issues/460)-[#474](https://github.com/SandboxServers/Cimmeria/issues/474). P0 foundational issues: [#475](https://github.com/SandboxServers/Cimmeria/issues/475)-[#479](https://github.com/SandboxServers/Cimmeria/issues/479).


### PR DESCRIPTION
## Summary

Worktree-cleanup sweep before removing 47 stale worktrees. Rescues content that lives in worktrees-to-be-removed but has not yet been merged to main. No source changes — pure docs + agent-memory salvage.

## What's included

### Agent memory (new + extended dirs under `.claude/agent-memory/`)

- **`server-authority-enforcer/`** (new agent dir, 30 files): 24 audit-anchored memories from the 2026-05-31 server-authority audit (BRIEF + UMBRELLA + 15 per-category exploit references + 9 per-system unimplemented/audit project memories). Plus 2 trade-specific memories (`advisory-lock-namespaces.md`, `trade-container-whitelist.md`) that fed into PR #438. Plus 4 navmesh/crafting memories (`pattern-checked-alloc-size.md`, `pr-426-navmesh-extractor.md`, `pr-427-crafting-phase1.md`, `open-followup-runtime-navmesh-load.md`) from the sub-agent review on PRs #426/#427.
- **`testing-validation-engineer/`** (new agent dir, 7 files): revert-verify workflow, external-junction setup, asset-self-skip coverage gap, dispatcher-layering gotcha, social-arm shadow, LogCapture helper reference.
- **`rust-gameserver-dev/db-test-revert-verification.md`** (new): testing-pattern memory — split async DB-touching fn into pure sync helper + thin async shell so revert-verification works locally even when the canonical guard is a live-DB test.

### Security audit docs (new tree)

- **`docs/security-audit/2026-05-31-server-authority/`**: 19 files (BRIEF, UMBRELLA, surface, 15 CAT-A..CAT-O finding docs, + section README). This is the doc trail behind issues #459-#479.

### Telemetry audit doc

- **`docs/audits/telemetry-audit-2026-06-01.md`** (new, 381 lines): scope audit of telemetry/logging gaps in the 13 features that landed 2026-05-31 → 2026-06-01. Names 11 missing `#[instrument]`s, 6 under-logged error paths, 11 metrics opportunities; sketches a 5-PR follow-up split.

## Test plan

- [ ] No source code changed; no test impact.
- [ ] Markdownlint check: `tools/lint-md.sh` (warn-only).

## Notes

- The 47 worktrees being cleaned up include 41 squash-merged branches, 1 trash-confirmed branch (split-signoz-compose), and 5 unmerged-branch worktrees. The 6th unmerged worktree (`worktree-server-authority-audit`) is what we're branching off here — its content moves into this PR and the worktree is removable afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive 2026-05-31 server-authority security audit and category findings.
  * Added numerous project memory/reference docs covering testing patterns, revert-to-verify workflows, audit checklists, and validation guidance.
  * Added many wire-spec and protocol reference pages (chat, trade, mail, GM commands, black market, world/gate, combat, inventory, crafting, etc.) to aid review and implementation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->