### PR TITLE
feat(effects+dialog): RangedPhysical/Energy scripts + monologue dialog path

### DIFF
--- a/crates/services/src/cell/content/executor/dialog.rs
+++ b/crates/services/src/cell/content/executor/dialog.rs
@@ -486,21 +486,10 @@ mod tests {
         );
     }
 
-    /// **Monologue fallback: when no NPC resolves AND the dialog is a
-    /// player-monologue (all screens speaker_id=0), bind the player as
-    /// the wire EntityId instead of bailing.** This is the cellblock
-    /// wake-up case — dialog 2982 fires from chain 1001 with no NPC
-    /// context, both screens carry `speaker_id = 0`, and the intended
-    /// render is the player's own portrait + name (inner thought). The
-    /// client's per-screen lookup of speaker_id=0 falls back to the
-    /// player's name naturally (see RE finding
-    /// `docs/reverse-engineering/findings/dialog-portrait-lookup.md`).
-    ///
-    /// Without this branch, ~42% of authored dialog screens (the
-    /// speaker_id=0 ones) silently never displayed. Live observation
-    /// 2026-06-02: dialog 2982 chain 1001 fired this exact bail every
-    /// session start. Reverting the monologue branch must fail this
-    /// test.
+    /// When no NPC resolves and the dialog is in the monologue cache,
+    /// the wire EntityId must be the player's own id (not bail). The
+    /// per-screen `speaker_id = 0` lookup on the client falls back to
+    /// the player's name, rendering as inner thought.
     #[tokio::test]
     async fn display_binds_player_when_no_npc_and_dialog_is_monologue() {
         let mut mgr = make_space_manager();

--- a/crates/services/src/cell/content/executor/dialog.rs
+++ b/crates/services/src/cell/content/executor/dialog.rs
@@ -10,10 +10,9 @@ use crate::cell::space_manager::SpaceManager;
 /// to the player. They take different field names but the same id semantics,
 /// merged into one handler.
 ///
-/// The wire `EntityId` field of `onDialogDisplay` MUST be the NPC the
-/// player is talking to — the client uses it as the key into
-/// `LookupEntityListenerEntry` to bind the dialog portrait actor and the
-/// per-screen speaker entity (see
+/// The wire `EntityId` field of `onDialogDisplay` is the key the client
+/// uses for `LookupEntityListenerEntry` to bind the dialog portrait actor
+/// and the per-screen speaker entity (see
 /// `docs/reverse-engineering/findings/dialog-portrait-lookup.md`).
 /// Resolution order, from most to least direct:
 ///
@@ -24,15 +23,25 @@ use crate::cell::space_manager::SpaceManager;
 ///    `handle_interact`. Covers follow-up chains (e.g. an
 ///    `OnDialogChoice` trigger that fires another `display_dialog` on
 ///    the same NPC) where the trigger event itself carries no NPC.
-/// 3. Abort with a `warn` — falling back to the player's own entity ID
-///    here is the bug this commit fixed: the client would bind the
-///    player as the dialog speaker, blanking the portrait and
-///    rendering the player's name for every screen.
+/// 3. **Monologue fallback** — if the dialog is in
+///    `space_mgr.monologue_dialog_ids` (every screen has
+///    `speaker_id = 0`, i.e. player-narration / inner-thought), bind
+///    the player as the wire EntityId. The client's per-screen lookup
+///    of `speaker_id = 0` naturally falls back to the player's name and
+///    the portrait shows the player — exactly the intended render for
+///    "the player is talking to themselves." Without this branch,
+///    monologue dialogs (~42% of authored screens) silently never
+///    display.
+/// 4. Abort with a `warn` — the dialog is NPC-shaped but no NPC could
+///    be resolved. Binding the player here would blank the NPC portrait
+///    and substitute the player's name for every NPC line — the bug
+///    that motivated the original gate. Bail loud so the chain author
+///    can fix the missing target_entity_id wire-up.
 #[tracing::instrument(
     name = "dialog.display",
     level = "info",
     skip_all,
-    fields(entity_id, dialog_id, chain_id, npc_entity_id = tracing::field::Empty)
+    fields(entity_id, dialog_id, chain_id, npc_entity_id = tracing::field::Empty, monologue = tracing::field::Empty)
 )]
 pub(super) async fn display(
     dialog_id: i32,
@@ -56,14 +65,27 @@ pub(super) async fn display(
     let npc_entity_id = match npc_entity_id {
         Some(id) => id,
         None => {
-            tracing::warn!(
-                entity_id,
-                dialog_id,
-                chain_id,
-                "DisplayDialog: no NPC entity id in chain params or last_interaction_target -- \
-                 cannot send onDialogDisplay (would bind player as speaker and blank portrait)"
-            );
-            return;
+            // Monologue fallback — see doc on this fn for rationale.
+            if space_mgr.monologue_dialog_ids.contains(&dialog_id) {
+                tracing::Span::current().record("monologue", true);
+                tracing::info!(
+                    entity_id,
+                    dialog_id,
+                    chain_id,
+                    "DisplayDialog: no NPC resolved, dialog is player-monologue \
+                     (all screens speaker_id=0) — binding player as context entity"
+                );
+                entity_id as i32
+            } else {
+                tracing::warn!(
+                    entity_id,
+                    dialog_id,
+                    chain_id,
+                    "DisplayDialog: no NPC entity id in chain params or last_interaction_target -- \
+                     cannot send onDialogDisplay (would bind player as speaker and blank portrait)"
+                );
+                return;
+            }
         }
     };
 
@@ -461,6 +483,78 @@ mod tests {
                 .find_message(Level::WARN, "DisplayDialog: no NPC entity id")
                 .is_some(),
             "abort must surface a WARN — silent return masks the chain-author bug"
+        );
+    }
+
+    /// **Monologue fallback: when no NPC resolves AND the dialog is a
+    /// player-monologue (all screens speaker_id=0), bind the player as
+    /// the wire EntityId instead of bailing.** This is the cellblock
+    /// wake-up case — dialog 2982 fires from chain 1001 with no NPC
+    /// context, both screens carry `speaker_id = 0`, and the intended
+    /// render is the player's own portrait + name (inner thought). The
+    /// client's per-screen lookup of speaker_id=0 falls back to the
+    /// player's name naturally (see RE finding
+    /// `docs/reverse-engineering/findings/dialog-portrait-lookup.md`).
+    ///
+    /// Without this branch, ~42% of authored dialog screens (the
+    /// speaker_id=0 ones) silently never displayed. Live observation
+    /// 2026-06-02: dialog 2982 chain 1001 fired this exact bail every
+    /// session start. Reverting the monologue branch must fail this
+    /// test.
+    #[tokio::test]
+    async fn display_binds_player_when_no_npc_and_dialog_is_monologue() {
+        let mut mgr = make_space_manager();
+        mgr.create_entity(1, "Agnos", [0.0; 3], [0.0; 3]).unwrap();
+        // Cache dialog 2982 as a known monologue.
+        mgr.monologue_dialog_ids.insert(2982);
+
+        let params = empty_params();
+        let (tx, mut rx) = mpsc::channel(4);
+        display(2982, 1, 1001, &params, &tx, &mgr).await;
+
+        let msg = rx.try_recv().expect(
+            "monologue dialog must emit onDialogDisplay even with no NPC \
+             resolved — reverting the monologue branch in display() fails here",
+        );
+        match msg {
+            CellToBaseMsg::EntityMethodCall { args, .. } => {
+                let wire_entity_id = i32::from_le_bytes([args[0], args[1], args[2], args[3]]);
+                assert_eq!(
+                    wire_entity_id, 1,
+                    "monologue must bind the player's own entity id as the wire EntityId"
+                );
+            }
+            other => panic!("expected EntityMethodCall, got {other:?}"),
+        }
+    }
+
+    /// Companion guard: a dialog NOT in the monologue cache still
+    /// bails when no NPC resolves. Pins that the fallback is gated on
+    /// the cache, not an "accept anything" hole — an NPC dialog whose
+    /// chain context was lost must still warn, because binding the
+    /// player there would blank the NPC portrait and substitute the
+    /// player's name for every screen.
+    #[tokio::test]
+    async fn display_still_aborts_for_npc_dialog_not_in_monologue_cache() {
+        let capture = LogCapture::install();
+        let mut mgr = make_space_manager();
+        mgr.create_entity(1, "Agnos", [0.0; 3], [0.0; 3]).unwrap();
+        // monologue_dialog_ids intentionally empty for dialog 4001 (NPC
+        // dialog — Future Col Marsh).
+
+        let params = empty_params();
+        let (tx, mut rx) = mpsc::channel(4);
+        display(4001, 1, 9999, &params, &tx, &mgr).await;
+
+        assert!(
+            rx.try_recv().is_err(),
+            "non-monologue dialog with no NPC must still bail"
+        );
+        assert!(
+            capture
+                .find_message(Level::WARN, "DisplayDialog: no NPC entity id")
+                .is_some(),
+            "non-monologue bail must still surface the WARN"
         );
     }
 }

--- a/crates/services/src/cell/effects/registry.rs
+++ b/crates/services/src/cell/effects/registry.rs
@@ -24,6 +24,8 @@ pub fn lookup(name: &str) -> Option<&'static dyn EffectScript> {
         "AbsorbShield" => Some(&scripts::AbsorbShield),
         "Stun" => Some(&scripts::Stun),
         "Suppression" => Some(&scripts::Suppression),
+        "RangedPhysicalDamage" => Some(&scripts::RangedPhysicalDamage),
+        "RangedEnergyDamage" => Some(&scripts::RangedEnergyDamage),
         _ => None,
     }
 }
@@ -40,6 +42,8 @@ mod tests {
         assert!(lookup("AbsorbShield").is_some());
         assert!(lookup("Stun").is_some());
         assert!(lookup("Suppression").is_some());
+        assert!(lookup("RangedPhysicalDamage").is_some());
+        assert!(lookup("RangedEnergyDamage").is_some());
     }
 
     #[test]

--- a/crates/services/src/cell/effects/scripts.rs
+++ b/crates/services/src/cell/effects/scripts.rs
@@ -388,6 +388,177 @@ impl EffectScript for Suppression {
     }
 }
 
+// ── RangedPhysicalDamage ─────────────────────────────────────────────────
+
+/// Focus-gated physical damage. Models "shields absorb the bullet first."
+///
+/// NVPs:
+///   - `FocusDamage` (i32) — amount to subtract from target FOCUS pool
+///   - `HealthDamage` (i32) — base HEALTH damage added to spillover
+///
+/// Behavior, mirroring `deprecated/python/cell/effects/RangedPhysicalDamage.py`:
+///
+/// 1. Subtract `FocusDamage` from the target's FOCUS pool. The pool
+///    clamps at 0 — any unused damage is the "overflow."
+/// 2. If FOCUS absorbed *everything* (no overflow) → done. No HEALTH
+///    damage. This is the "shields held" case.
+/// 3. Otherwise, compute spillover = overflow / 3, add `HealthDamage`,
+///    apply to HEALTH.
+///
+/// The legacy `/300` divisor in the visual script collapses to `/3`
+/// algebraically: `remaining_pct = overflow * 100 / FocusDamage`, then
+/// `spillover = remaining_pct * FocusDamage / 300` simplifies to
+/// `overflow / 3` (the `FocusDamage` factor cancels). So the spillover
+/// is exactly 1/3 of the focus-pool overflow.
+///
+/// Why this matters: without this script, the legacy NVP fallback
+/// applies both `FocusDamage` and `HealthDamage` independently every
+/// shot, so the player takes HEALTH damage even at full Focus. The
+/// fight feels meaningfully harder than authored. With the script,
+/// physical ranged exchanges trade Focus first, then bleed into
+/// Health once shields are down — the intended cadence.
+///
+/// Reference: `deprecated/python/cell/effects/RangedPhysicalDamage.py`
+/// and `deprecated/data-scripts/scripts/effects/RangedPhysicalDamage.script`.
+pub struct RangedPhysicalDamage;
+
+impl EffectScript for RangedPhysicalDamage {
+    fn on_apply(&self, ctx: &mut EffectContext) {
+        let focus_damage = ctx.effect.param_i32("FocusDamage").max(0);
+        let health_damage = ctx.effect.param_i32("HealthDamage").max(0);
+        if focus_damage == 0 && health_damage == 0 {
+            return;
+        }
+
+        let Some(target) = ctx.space_mgr.get_entity_mut(ctx.target_id) else {
+            return;
+        };
+
+        // Apply Focus damage; capture how much overflowed the pool.
+        let focus_overflow = if focus_damage > 0 {
+            let cur = target.stats.get(FOCUS).map(|s| s.cur).unwrap_or(0);
+            let applied = focus_damage.min(cur.max(0));
+            let overflow = (focus_damage - applied).max(0);
+            if let Some(stat) = target.stats.get_mut(FOCUS) {
+                let new_cur = (cur - applied).max(0);
+                stat.update(stat.min, new_cur, stat.max);
+            }
+            overflow
+        } else {
+            // If there's no Focus damage at all, the spillover gate
+            // (`overflow > 0`) suppresses Health damage too — matches
+            // the legacy script's conditional branch off the QR result.
+            0
+        };
+
+        // Legacy gate: if Focus absorbed everything (overflow == 0),
+        // NO Health damage is applied at all. The shield held.
+        if focus_overflow == 0 {
+            tracing::debug!(
+                target: "abilities",
+                event = "ranged_physical_damage",
+                source_id = ctx.source_id,
+                target_id = ctx.target_id,
+                effect_id = ctx.effect.effect_id,
+                focus_damage,
+                focus_overflow,
+                health_damage_applied = 0,
+                "RangedPhysicalDamage: Focus absorbed all damage, no HEALTH bleed",
+            );
+            return;
+        }
+
+        // Spillover = overflow / 3 + base HealthDamage NVP.
+        let spillover = focus_overflow / 3;
+        let final_health_damage = spillover + health_damage;
+        if final_health_damage <= 0 {
+            return;
+        }
+        if let Some(stat) = target.stats.get_mut(HEALTH) {
+            let new_cur = (stat.cur - final_health_damage).max(0);
+            stat.update(stat.min, new_cur, stat.max);
+        }
+        tracing::info!(
+            target: "abilities",
+            event = "ranged_physical_damage",
+            source_id = ctx.source_id,
+            target_id = ctx.target_id,
+            effect_id = ctx.effect.effect_id,
+            focus_damage,
+            focus_overflow,
+            health_damage_applied = final_health_damage,
+            spillover,
+            base_health_damage = health_damage,
+            "RangedPhysicalDamage: Focus pierced, applied HEALTH bleed",
+        );
+        // damage_type=14 (DT_PHYSICAL) recorded for documentation but
+        // not used here: the legacy `qrCombatDamage` path applied
+        // armor + absorption via that type, and we'll route through
+        // `cell::combat::calculate_damage` in a follow-up that unifies
+        // every script's stat-mutation path. For now this matches the
+        // existing MeleeDamage shape (raw stat mutation) so behavior
+        // is consistent across scripts that share the legacy NVP-style
+        // contract.
+        let _: i8 = DT_PHYSICAL;
+    }
+}
+
+// ── RangedEnergyDamage ───────────────────────────────────────────────────
+
+/// Parallel HEALTH + FOCUS damage with no shield-first gating. The
+/// energy-weapon counterpart to [`RangedPhysicalDamage`] — both pools
+/// are hit on every shot regardless of Focus state.
+///
+/// NVPs:
+///   - `HealthDamage` (i32)
+///   - `FocusDamage`  (i32)
+///
+/// Reference: `deprecated/python/cell/effects/RangedEnergyDamage.py` —
+/// `effect.qrCombatDamage(HEALTH, ...)` and `effect.qrCombatDamage(FOCUS, ...)`
+/// fired back-to-back on `onPulseBegin`, no comparison gate.
+pub struct RangedEnergyDamage;
+
+impl EffectScript for RangedEnergyDamage {
+    fn on_apply(&self, ctx: &mut EffectContext) {
+        let focus_damage = ctx.effect.param_i32("FocusDamage").max(0);
+        let health_damage = ctx.effect.param_i32("HealthDamage").max(0);
+        if focus_damage == 0 && health_damage == 0 {
+            return;
+        }
+
+        let Some(target) = ctx.space_mgr.get_entity_mut(ctx.target_id) else {
+            return;
+        };
+
+        if focus_damage > 0 {
+            if let Some(stat) = target.stats.get_mut(FOCUS) {
+                let new_cur = (stat.cur - focus_damage).max(0);
+                stat.update(stat.min, new_cur, stat.max);
+            }
+        }
+        if health_damage > 0 {
+            if let Some(stat) = target.stats.get_mut(HEALTH) {
+                let new_cur = (stat.cur - health_damage).max(0);
+                stat.update(stat.min, new_cur, stat.max);
+            }
+        }
+
+        tracing::info!(
+            target: "abilities",
+            event = "ranged_energy_damage",
+            source_id = ctx.source_id,
+            target_id = ctx.target_id,
+            effect_id = ctx.effect.effect_id,
+            focus_damage,
+            health_damage,
+            "RangedEnergyDamage applied",
+        );
+        // damage_type=15 (DT_ENERGY) — see RangedPhysicalDamage note
+        // re unified pipeline migration.
+        let _: i8 = DT_ENERGY;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -865,5 +1036,228 @@ mod tests {
             .unwrap()
             .cur;
         assert_eq!(focus, 200, "zero percent must not change stat");
+    }
+
+    // ── RangedPhysicalDamage ──────────────────────────────────────────
+
+    fn effect_with_two_nvps(name1: &str, val1: &str, name2: &str, val2: &str) -> EffectDef {
+        let mut params = HashMap::new();
+        params.insert(name1.to_string(), val1.to_string());
+        params.insert(name2.to_string(), val2.to_string());
+        EffectDef {
+            effect_id: 641,
+            ability_id: 579,
+            params,
+            ..Default::default()
+        }
+    }
+
+    /// **Shield absorbs everything → no health damage.** Mirror of
+    /// `if remaining_dmg_percent > 0` in the legacy Python: when Focus
+    /// fully absorbs the requested damage, the script returns without
+    /// touching HEALTH. This is the load-bearing difference vs. the
+    /// legacy NVP fallback (which applies both pools independently).
+    /// Reverting the gate (always applying HealthDamage) would fail
+    /// this test.
+    #[test]
+    fn ranged_physical_full_focus_absorbs_no_health_damage() {
+        let mut mgr = make_mgr_with_target();
+        // Focus 200/1000 in fixture; FocusDamage 100 fits entirely.
+        let effect = effect_with_two_nvps("FocusDamage", "100", "HealthDamage", "10");
+        let mut ctx = EffectContext {
+            source_id: 1,
+            target_id: 1,
+            effect: &effect,
+            space_mgr: &mut mgr,
+        };
+        RangedPhysicalDamage.on_apply(&mut ctx);
+        let e = ctx.space_mgr.get_entity(1).unwrap();
+        assert_eq!(
+            e.stats.get(FOCUS).unwrap().cur,
+            100,
+            "100 focus damage out of 200 must drain to 100"
+        );
+        assert_eq!(
+            e.stats.get(HEALTH).unwrap().cur,
+            50,
+            "shield held → no HEALTH damage, even though HealthDamage NVP = 10"
+        );
+    }
+
+    /// **Partial absorb → spillover lands as health damage.** Focus
+    /// 30/1000, FocusDamage 100 → 30 applied to focus, 70 overflow,
+    /// spillover = 70/3 = 23, plus HealthDamage 10 = 33 health damage.
+    #[test]
+    fn ranged_physical_partial_absorb_spills_to_health() {
+        let mut mgr = make_mgr_with_target();
+        if let Some(e) = mgr.get_entity_mut(1) {
+            if let Some(s) = e.stats.get_mut(FOCUS) {
+                s.update(0, 30, 1000);
+            }
+        }
+        let effect = effect_with_two_nvps("FocusDamage", "100", "HealthDamage", "10");
+        let mut ctx = EffectContext {
+            source_id: 1,
+            target_id: 1,
+            effect: &effect,
+            space_mgr: &mut mgr,
+        };
+        RangedPhysicalDamage.on_apply(&mut ctx);
+        let e = ctx.space_mgr.get_entity(1).unwrap();
+        assert_eq!(
+            e.stats.get(FOCUS).unwrap().cur,
+            0,
+            "focus drained to 0 (30 was less than 100)"
+        );
+        // Overflow = 70. Spillover = 70/3 = 23 (integer division).
+        // Final health damage = 23 + 10 = 33. HP was 50 → 17.
+        assert_eq!(
+            e.stats.get(HEALTH).unwrap().cur,
+            17,
+            "HP 50 - (spillover 23 + HealthDamage 10) = 17"
+        );
+    }
+
+    /// **No focus at all → full overflow.** With FOCUS = 0, the entire
+    /// FocusDamage is overflow; spillover = 100/3 = 33; + HealthDmg 10
+    /// = 43 HP loss. HP 50 → 7.
+    #[test]
+    fn ranged_physical_no_focus_takes_full_overflow_spillover() {
+        let mut mgr = make_mgr_with_target();
+        if let Some(e) = mgr.get_entity_mut(1) {
+            if let Some(s) = e.stats.get_mut(FOCUS) {
+                s.update(0, 0, 1000);
+            }
+        }
+        let effect = effect_with_two_nvps("FocusDamage", "100", "HealthDamage", "10");
+        let mut ctx = EffectContext {
+            source_id: 1,
+            target_id: 1,
+            effect: &effect,
+            space_mgr: &mut mgr,
+        };
+        RangedPhysicalDamage.on_apply(&mut ctx);
+        let e = ctx.space_mgr.get_entity(1).unwrap();
+        assert_eq!(e.stats.get(FOCUS).unwrap().cur, 0);
+        assert_eq!(
+            e.stats.get(HEALTH).unwrap().cur,
+            7,
+            "HP 50 - (spillover 33 + HealthDamage 10) = 7"
+        );
+    }
+
+    /// **FocusDamage = 0 → no Focus mutation AND no Health damage.**
+    /// The spillover gate trips on `focus_overflow == 0`. With no
+    /// Focus damage configured, overflow is also 0, so the script
+    /// returns before touching HEALTH. This pins that the script is
+    /// genuinely Focus-driven — HealthDamage alone shouldn't fire.
+    #[test]
+    fn ranged_physical_zero_focus_damage_skips_health_too() {
+        let mut mgr = make_mgr_with_target();
+        let effect = effect_with_two_nvps("FocusDamage", "0", "HealthDamage", "10");
+        let mut ctx = EffectContext {
+            source_id: 1,
+            target_id: 1,
+            effect: &effect,
+            space_mgr: &mut mgr,
+        };
+        RangedPhysicalDamage.on_apply(&mut ctx);
+        let e = ctx.space_mgr.get_entity(1).unwrap();
+        assert_eq!(e.stats.get(FOCUS).unwrap().cur, 200, "no focus mutation");
+        assert_eq!(
+            e.stats.get(HEALTH).unwrap().cur,
+            50,
+            "no health damage when Focus damage is zero"
+        );
+    }
+
+    /// **Missing target is a graceful no-op.**
+    #[test]
+    fn ranged_physical_missing_target_is_noop() {
+        let mut mgr = make_mgr_with_target();
+        let effect = effect_with_two_nvps("FocusDamage", "100", "HealthDamage", "10");
+        let mut ctx = EffectContext {
+            source_id: 1,
+            target_id: 999, // doesn't exist
+            effect: &effect,
+            space_mgr: &mut mgr,
+        };
+        RangedPhysicalDamage.on_apply(&mut ctx);
+        let e = ctx.space_mgr.get_entity(1).unwrap();
+        assert_eq!(e.stats.get(FOCUS).unwrap().cur, 200);
+        assert_eq!(e.stats.get(HEALTH).unwrap().cur, 50);
+    }
+
+    // ── RangedEnergyDamage ────────────────────────────────────────────
+
+    /// **Energy damage hits both pools simultaneously — no gating.**
+    /// The structural difference vs. RangedPhysicalDamage: even if the
+    /// target's Focus could absorb the requested damage, Health still
+    /// takes the HealthDamage NVP. This is what makes Energy weapons
+    /// the "ignore shields" counterpart to Physical.
+    #[test]
+    fn ranged_energy_applies_both_pools_in_parallel() {
+        let mut mgr = make_mgr_with_target();
+        // Focus 200/1000, HP 50/100 in fixture.
+        let effect = effect_with_two_nvps("FocusDamage", "30", "HealthDamage", "15");
+        let mut ctx = EffectContext {
+            source_id: 1,
+            target_id: 1,
+            effect: &effect,
+            space_mgr: &mut mgr,
+        };
+        RangedEnergyDamage.on_apply(&mut ctx);
+        let e = ctx.space_mgr.get_entity(1).unwrap();
+        assert_eq!(
+            e.stats.get(FOCUS).unwrap().cur,
+            170,
+            "200 - 30 = 170 (no gating — applied independently)"
+        );
+        assert_eq!(
+            e.stats.get(HEALTH).unwrap().cur,
+            35,
+            "50 - 15 = 35 (applied even though Focus could have absorbed)"
+        );
+    }
+
+    /// Zero-NVP edge: nothing applied either way.
+    #[test]
+    fn ranged_energy_zero_nvps_is_noop() {
+        let mut mgr = make_mgr_with_target();
+        let effect = effect_with_two_nvps("FocusDamage", "0", "HealthDamage", "0");
+        let mut ctx = EffectContext {
+            source_id: 1,
+            target_id: 1,
+            effect: &effect,
+            space_mgr: &mut mgr,
+        };
+        RangedEnergyDamage.on_apply(&mut ctx);
+        let e = ctx.space_mgr.get_entity(1).unwrap();
+        assert_eq!(e.stats.get(FOCUS).unwrap().cur, 200);
+        assert_eq!(e.stats.get(HEALTH).unwrap().cur, 50);
+    }
+
+    /// Pool clamps at 0 — Focus damage exceeding cur drains to 0, not
+    /// below. (For Energy there's no spillover so the excess just
+    /// disappears.)
+    #[test]
+    fn ranged_energy_drain_clamps_at_zero() {
+        let mut mgr = make_mgr_with_target();
+        if let Some(e) = mgr.get_entity_mut(1) {
+            if let Some(s) = e.stats.get_mut(FOCUS) {
+                s.update(0, 20, 1000);
+            }
+        }
+        let effect = effect_with_two_nvps("FocusDamage", "100", "HealthDamage", "5");
+        let mut ctx = EffectContext {
+            source_id: 1,
+            target_id: 1,
+            effect: &effect,
+            space_mgr: &mut mgr,
+        };
+        RangedEnergyDamage.on_apply(&mut ctx);
+        let e = ctx.space_mgr.get_entity(1).unwrap();
+        assert_eq!(e.stats.get(FOCUS).unwrap().cur, 0, "focus clamps at 0");
+        assert_eq!(e.stats.get(HEALTH).unwrap().cur, 45, "50 - 5 = 45");
     }
 }

--- a/crates/services/src/cell/effects/scripts.rs
+++ b/crates/services/src/cell/effects/scripts.rs
@@ -402,21 +402,22 @@ impl EffectScript for Suppression {
 ///    clamps at 0 — any unused damage is the "overflow."
 /// 2. If FOCUS absorbed *everything* (no overflow) → done. No HEALTH
 ///    damage. This is the "shields held" case.
-/// 3. Otherwise, compute spillover = overflow / 3, add `HealthDamage`,
-///    apply to HEALTH.
+/// 3. Otherwise, compute spillover via the legacy two-step integer
+///    formula `(overflow * 100 / FocusDamage) * FocusDamage / 300`,
+///    add `HealthDamage`, apply to HEALTH.
 ///
-/// The legacy `/300` divisor in the visual script collapses to `/3`
-/// algebraically: `remaining_pct = overflow * 100 / FocusDamage`, then
-/// `spillover = remaining_pct * FocusDamage / 300` simplifies to
-/// `overflow / 3` (the `FocusDamage` factor cancels). So the spillover
-/// is exactly 1/3 of the focus-pool overflow.
+/// **Why the two-step integer formula matters** — algebraically the
+/// `FocusDamage` factor cancels to `overflow / 3`, but the legacy
+/// truncates after each integer step. With `FocusDamage = 80` and
+/// `overflow = 3`: legacy computes `3 * 100 / 80 = 3` (truncated from
+/// 3.75) then `3 * 80 / 300 = 0` (truncated from 0.8) — zero
+/// spillover. The algebraic shortcut `overflow / 3` gives 1 here,
+/// over-damaging on small overflows. We match the legacy truncation
+/// step-for-step so combat tuning is parity-correct.
 ///
-/// Why this matters: without this script, the legacy NVP fallback
-/// applies both `FocusDamage` and `HealthDamage` independently every
-/// shot, so the player takes HEALTH damage even at full Focus. The
-/// fight feels meaningfully harder than authored. With the script,
-/// physical ranged exchanges trade Focus first, then bleed into
-/// Health once shields are down — the intended cadence.
+/// Without this script, the legacy NVP fallback applies both
+/// `FocusDamage` and `HealthDamage` independently every shot, so the
+/// player takes HEALTH damage even at full Focus.
 ///
 /// Reference: `deprecated/python/cell/effects/RangedPhysicalDamage.py`
 /// and `deprecated/data-scripts/scripts/effects/RangedPhysicalDamage.script`.
@@ -468,8 +469,12 @@ impl EffectScript for RangedPhysicalDamage {
             return;
         }
 
-        // Spillover = overflow / 3 + base HealthDamage NVP.
-        let spillover = focus_overflow / 3;
+        // Two-step integer truncation matches the legacy Atrea script
+        // graph (Node 6 → 9 → 10 → 12). DO NOT collapse to
+        // `focus_overflow / 3` — see fn docs for the small-overflow
+        // divergence.
+        let remaining_pct = focus_overflow.saturating_mul(100) / focus_damage;
+        let spillover = remaining_pct.saturating_mul(focus_damage) / 300;
         let final_health_damage = spillover + health_damage;
         if final_health_damage <= 0 {
             return;
@@ -486,20 +491,12 @@ impl EffectScript for RangedPhysicalDamage {
             effect_id = ctx.effect.effect_id,
             focus_damage,
             focus_overflow,
-            health_damage_applied = final_health_damage,
+            remaining_pct,
             spillover,
+            health_damage_applied = final_health_damage,
             base_health_damage = health_damage,
             "RangedPhysicalDamage: Focus pierced, applied HEALTH bleed",
         );
-        // damage_type=14 (DT_PHYSICAL) recorded for documentation but
-        // not used here: the legacy `qrCombatDamage` path applied
-        // armor + absorption via that type, and we'll route through
-        // `cell::combat::calculate_damage` in a follow-up that unifies
-        // every script's stat-mutation path. For now this matches the
-        // existing MeleeDamage shape (raw stat mutation) so behavior
-        // is consistent across scripts that share the legacy NVP-style
-        // contract.
-        let _: i8 = DT_PHYSICAL;
     }
 }
 
@@ -527,6 +524,14 @@ impl EffectScript for RangedEnergyDamage {
         }
 
         let Some(target) = ctx.space_mgr.get_entity_mut(ctx.target_id) else {
+            tracing::debug!(
+                target: "abilities",
+                event = "ranged_energy_damage",
+                source_id = ctx.source_id,
+                target_id = ctx.target_id,
+                effect_id = ctx.effect.effect_id,
+                "RangedEnergyDamage: target missing — skipped",
+            );
             return;
         };
 
@@ -553,9 +558,6 @@ impl EffectScript for RangedEnergyDamage {
             health_damage,
             "RangedEnergyDamage applied",
         );
-        // damage_type=15 (DT_ENERGY) — see RangedPhysicalDamage note
-        // re unified pipeline migration.
-        let _: i8 = DT_ENERGY;
     }
 }
 
@@ -1259,5 +1261,76 @@ mod tests {
         let e = ctx.space_mgr.get_entity(1).unwrap();
         assert_eq!(e.stats.get(FOCUS).unwrap().cur, 0, "focus clamps at 0");
         assert_eq!(e.stats.get(HEALTH).unwrap().cur, 45, "50 - 5 = 45");
+    }
+
+    /// Pins the legacy two-step truncation: with FocusDamage=80,
+    /// overflow=3 → `remaining_pct = 3*100/80 = 3` (truncated from 3.75)
+    /// → `spillover = 3*80/300 = 0` (truncated from 0.8). Zero spillover.
+    /// A regression to `overflow / 3` would compute `3/3 = 1` and over-
+    /// damage small overflows.
+    #[test]
+    fn ranged_physical_small_overflow_truncates_to_zero_spillover() {
+        let mut mgr = make_mgr_with_target();
+        if let Some(e) = mgr.get_entity_mut(1) {
+            if let Some(s) = e.stats.get_mut(FOCUS) {
+                s.update(0, 77, 1000); // 80 dmg → applied 77 → overflow 3
+            }
+        }
+        let effect = effect_with_two_nvps("FocusDamage", "80", "HealthDamage", "10");
+        let mut ctx = EffectContext {
+            source_id: 1,
+            target_id: 1,
+            effect: &effect,
+            space_mgr: &mut mgr,
+        };
+        RangedPhysicalDamage.on_apply(&mut ctx);
+        let e = ctx.space_mgr.get_entity(1).unwrap();
+        assert_eq!(e.stats.get(FOCUS).unwrap().cur, 0);
+        // Spillover = 0, so final health damage is just HealthDamage = 10.
+        // HP 50 - 10 = 40. With `overflow / 3` (1 spillover) it would be 39.
+        assert_eq!(
+            e.stats.get(HEALTH).unwrap().cur,
+            40,
+            "small overflow (3) truncates to zero spillover; only base \
+             HealthDamage applies. Regression to overflow/3 would give 39."
+        );
+    }
+
+    /// `param_i32` returns whatever the NVP parses to; the script
+    /// `.max(0)`s it, so a negative NVP value (content authoring
+    /// mistake) is clamped to 0 and treated as zero damage on that
+    /// pool — never produces "negative damage" healing.
+    #[test]
+    fn ranged_physical_negative_nvps_clamp_to_zero() {
+        let mut mgr = make_mgr_with_target();
+        let effect = effect_with_two_nvps("FocusDamage", "-50", "HealthDamage", "-20");
+        let mut ctx = EffectContext {
+            source_id: 1,
+            target_id: 1,
+            effect: &effect,
+            space_mgr: &mut mgr,
+        };
+        RangedPhysicalDamage.on_apply(&mut ctx);
+        let e = ctx.space_mgr.get_entity(1).unwrap();
+        assert_eq!(e.stats.get(FOCUS).unwrap().cur, 200, "no focus change");
+        assert_eq!(e.stats.get(HEALTH).unwrap().cur, 50, "no health change");
+    }
+
+    /// Missing target on the energy path returns silently with a debug
+    /// log — companion to `ranged_physical_missing_target_is_noop`.
+    #[test]
+    fn ranged_energy_missing_target_is_noop() {
+        let mut mgr = make_mgr_with_target();
+        let effect = effect_with_two_nvps("FocusDamage", "30", "HealthDamage", "15");
+        let mut ctx = EffectContext {
+            source_id: 1,
+            target_id: 9999,
+            effect: &effect,
+            space_mgr: &mut mgr,
+        };
+        RangedEnergyDamage.on_apply(&mut ctx);
+        let e = ctx.space_mgr.get_entity(1).unwrap();
+        assert_eq!(e.stats.get(FOCUS).unwrap().cur, 200);
+        assert_eq!(e.stats.get(HEALTH).unwrap().cur, 50);
     }
 }

--- a/crates/services/src/cell/service/startup.rs
+++ b/crates/services/src/cell/service/startup.rs
@@ -67,19 +67,18 @@ impl CellService {
             }
         }
 
-        // Load monologue dialog ids for the DisplayDialog executor's
-        // "no NPC resolved → bind player for inner-thought render"
-        // branch. Set stays empty on DB failure — the executor falls
-        // through to the existing warn-and-bail path, so failure is
-        // graceful: monologue dialogs silently don't display rather
-        // than rendering with a wrong NPC bind.
+        // Load monologue dialog ids for the DisplayDialog executor.
+        // ERROR (not WARN) on failure: an empty cache silently strips
+        // ~42% of authored dialog screens (the inner-thought ones)
+        // from world entry. The executor falls through to bail-and-
+        // warn so behavior stays safe, but operators need to see this.
         if let Some(ref pool) = self.db_pool {
             match spawner::load_monologue_dialog_ids(pool).await {
                 Ok(ids) => {
                     space_mgr.monologue_dialog_ids = ids;
                 }
                 Err(e) => {
-                    tracing::warn!("Failed to load monologue dialog ids: {e}");
+                    tracing::error!("Failed to load monologue dialog ids: {e}");
                 }
             }
         }

--- a/crates/services/src/cell/service/startup.rs
+++ b/crates/services/src/cell/service/startup.rs
@@ -67,6 +67,23 @@ impl CellService {
             }
         }
 
+        // Load monologue dialog ids for the DisplayDialog executor's
+        // "no NPC resolved → bind player for inner-thought render"
+        // branch. Set stays empty on DB failure — the executor falls
+        // through to the existing warn-and-bail path, so failure is
+        // graceful: monologue dialogs silently don't display rather
+        // than rendering with a wrong NPC bind.
+        if let Some(ref pool) = self.db_pool {
+            match spawner::load_monologue_dialog_ids(pool).await {
+                Ok(ids) => {
+                    space_mgr.monologue_dialog_ids = ids;
+                }
+                Err(e) => {
+                    tracing::warn!("Failed to load monologue dialog ids: {e}");
+                }
+            }
+        }
+
         // Load mission definitions cache for AcceptMission content actions
         if let Some(ref pool) = self.db_pool {
             match spawner::load_mission_defs(pool).await {

--- a/crates/services/src/cell/space_manager/mod.rs
+++ b/crates/services/src/cell/space_manager/mod.rs
@@ -103,6 +103,18 @@ pub struct SpaceManager {
     /// Cached dialog_set_maps: dialog_set_map_id → (dialog_id, interaction_flags).
     /// Populated at startup from `resources.dialog_set_maps`.
     pub dialog_set_maps: HashMap<i32, super::spawner::DialogSetMapEntry>,
+    /// Set of dialog ids whose every screen has `speaker_id = 0`
+    /// (player-monologue / inner-thought dialogs). Populated at startup
+    /// from `resources.dialog_screens`. Used by the `DisplayDialog`
+    /// executor: when no NPC entity can be resolved from chain context
+    /// AND the dialog is in this set, bind the player as the wire
+    /// `EntityId` of `onDialogDisplay` (correct render for monologue
+    /// — speaker name falls back to player, portrait shows player's
+    /// character). Dialogs NOT in this set continue to bail-and-warn
+    /// when no NPC resolves, since binding the player there would
+    /// blank an NPC portrait and substitute the player's name for
+    /// every NPC line.
+    pub monologue_dialog_ids: std::collections::HashSet<i32>,
     /// Cached mission definitions: mission_id → (first step_id, objectives).
     /// Populated at startup from `resources.mission_steps` + `resources.mission_objectives`.
     pub mission_defs: HashMap<i32, super::spawner::MissionDefEntry>,
@@ -223,6 +235,7 @@ impl SpaceManager {
             next_local_id: 0,
             next_npc_id: 100_000,
             dialog_set_maps: HashMap::new(),
+            monologue_dialog_ids: std::collections::HashSet::new(),
             mission_defs: HashMap::new(),
             stargates: HashMap::new(),
             step_objectives: HashMap::new(),

--- a/crates/services/src/cell/spawner/dialogs.rs
+++ b/crates/services/src/cell/spawner/dialogs.rs
@@ -72,9 +72,13 @@ pub async fn load_dialog_set_maps(
 ///   portrait and substitute the player's name everywhere — the bug
 ///   the existing "warn and bail" path was added to prevent.
 ///
-/// Computed as: dialog_ids whose every screen carries `speaker_id = 0`
-/// AND which have at least one screen (the `HAVING` filters out dialogs
-/// with zero screens, which are content-error rows).
+/// Computed as: dialog_ids where every screen has an explicit
+/// `speaker_id = 0`. The `dialog_screens.speaker_id` column is
+/// nullable and the seed has NULL rows; treating NULL as "monologue"
+/// would misclassify dialogs whose screens have unknown speakers
+/// (the very mis-binding this cache exists to prevent), so the
+/// predicate counts only explicit zeros and requires that to equal
+/// the total row count.
 pub async fn load_monologue_dialog_ids(pool: &PgPool) -> Result<HashSet<i32>, sqlx::Error> {
     use sqlx::Row;
 
@@ -83,7 +87,7 @@ pub async fn load_monologue_dialog_ids(pool: &PgPool) -> Result<HashSet<i32>, sq
          FROM resources.dialog_screens \
          GROUP BY dialog_id \
          HAVING COUNT(*) > 0 \
-            AND COUNT(*) FILTER (WHERE speaker_id <> 0) = 0",
+            AND COUNT(*) = COUNT(*) FILTER (WHERE speaker_id = 0)",
     )
     .fetch_all(pool)
     .await?;

--- a/crates/services/src/cell/spawner/dialogs.rs
+++ b/crates/services/src/cell/spawner/dialogs.rs
@@ -1,9 +1,18 @@
-//! Dialog set map cache.
+//! Dialog set map cache + monologue dialog id cache.
 //!
-//! Maps `dialog_set_map_id → (dialog_id, interaction_flags)` for use by
-//! `add_dialog_set` content actions at runtime.
+//! - `load_dialog_set_maps` maps `dialog_set_map_id → (dialog_id, interaction_flags)`
+//!   for `add_dialog_set` content actions.
+//! - `load_monologue_dialog_ids` returns the set of `dialog_id` values whose
+//!   every screen has `speaker_id = 0` — player-narration / inner-thought
+//!   dialogs that have no NPC speaker. The executor uses this to decide
+//!   whether a `display_dialog` chain with no resolved NPC should bind
+//!   the player as the dialog context entity (correct for monologues —
+//!   the client's per-screen speaker resolution falls back to the
+//!   player's name naturally; portrait shows the player) or bail with
+//!   a warn (correct for NPC dialogs whose NPC context was lost).
 
 use sqlx::PgPool;
+use std::collections::HashSet;
 
 /// Cached row from `resources.dialog_set_maps`, used by `add_dialog_set` content actions.
 #[derive(Debug, Clone)]
@@ -46,4 +55,45 @@ pub async fn load_dialog_set_maps(
 
     tracing::info!(count = map.len(), "Loaded dialog_set_maps cache");
     Ok(map)
+}
+
+/// Load the set of dialog ids whose screens are *all* player-monologue
+/// (every `dialog_screens.speaker_id = 0`).
+///
+/// Used by the `DisplayDialog` executor to distinguish:
+///
+/// - A monologue dialog (player inner thought, no NPC) where binding
+///   the player as the wire `EntityId` of `onDialogDisplay` is the
+///   correct render — the client's per-screen lookup of `speaker_id = 0`
+///   falls back to the player's own name (see RE finding
+///   `docs/reverse-engineering/findings/dialog-portrait-lookup.md`),
+///   and the portrait shows the player's character.
+/// - A normal NPC dialog where binding the player would blank the NPC
+///   portrait and substitute the player's name everywhere — the bug
+///   the existing "warn and bail" path was added to prevent.
+///
+/// Computed as: dialog_ids whose every screen carries `speaker_id = 0`
+/// AND which have at least one screen (the `HAVING` filters out dialogs
+/// with zero screens, which are content-error rows).
+pub async fn load_monologue_dialog_ids(pool: &PgPool) -> Result<HashSet<i32>, sqlx::Error> {
+    use sqlx::Row;
+
+    let rows = sqlx::query(
+        "SELECT dialog_id \
+         FROM resources.dialog_screens \
+         GROUP BY dialog_id \
+         HAVING COUNT(*) > 0 \
+            AND COUNT(*) FILTER (WHERE speaker_id <> 0) = 0",
+    )
+    .fetch_all(pool)
+    .await?;
+
+    let mut ids = HashSet::with_capacity(rows.len());
+    for r in &rows {
+        let id: i32 = r.get("dialog_id");
+        ids.insert(id);
+    }
+
+    tracing::info!(count = ids.len(), "Loaded monologue dialog id cache");
+    Ok(ids)
 }

--- a/crates/services/src/cell/spawner/mod.rs
+++ b/crates/services/src/cell/spawner/mod.rs
@@ -38,7 +38,7 @@ pub use abilities::{
     EVENT_ITEM_EQUIP, EVENT_ITEM_MELEE, EVENT_ITEM_RANGED, EVENT_ITEM_RELOAD, EVENT_ITEM_UNEQUIP,
     EVENT_ITEM_USE, EVENT_ITEM_USE_ABILITY,
 };
-pub use dialogs::{load_dialog_set_maps, DialogSetMapEntry};
+pub use dialogs::{load_dialog_set_maps, load_monologue_dialog_ids, DialogSetMapEntry};
 pub use loot::{load_item_containers, load_item_defs, load_loot_tables, LootTableEntry, WeaponDef};
 pub use missions::{load_mission_defs, load_step_objectives, MissionDefEntry, MissionObjectiveDef};
 pub use npcs::{

--- a/crates/services/src/cell/spawner/tests.rs
+++ b/crates/services/src/cell/spawner/tests.rs
@@ -550,6 +550,28 @@ mod live_db {
                  incorrectly bind the player for an NPC dialog"
             );
         }
+
+        // A dialog with at least one NULL `speaker_id` screen must NOT
+        // be classified as a monologue. The original predicate
+        // (`COUNT(*) FILTER (WHERE speaker_id <> 0) = 0`) treated NULL
+        // as "not non-zero" and wrongly admitted such dialogs — the
+        // exact mis-binding the cache exists to prevent.
+        let null_speaker_dialog: Option<i32> = sqlx::query_scalar(
+            "SELECT dialog_id FROM resources.dialog_screens \
+             WHERE speaker_id IS NULL \
+             GROUP BY dialog_id LIMIT 1",
+        )
+        .fetch_optional(&pool)
+        .await
+        .expect("query must succeed");
+        if let Some(d) = null_speaker_dialog {
+            assert!(
+                !ids.contains(&d),
+                "dialog {d} has at least one NULL speaker_id screen — it must NOT be \
+                 in the monologue set; treating NULL as monologue would mis-bind the \
+                 player as the dialog context entity for unknown-speaker dialogs"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/services/src/cell/spawner/tests.rs
+++ b/crates/services/src/cell/spawner/tests.rs
@@ -506,6 +506,52 @@ mod live_db {
         }
     }
 
+    /// **Regression guard for the monologue dialog cache:** dialog 2982
+    /// is the Castle Cellblock wake-up monologue, two screens both
+    /// `speaker_id = 0`. The cache must include it OR the
+    /// `DisplayDialog` monologue fallback never triggers and the
+    /// cellblock opening narration silently never shows.
+    ///
+    /// Also asserts the predicate is correctly exclusive — a dialog
+    /// with any non-zero speaker_id row must NOT surface in the
+    /// monologue set (else the executor would bind the player as the
+    /// NPC for that dialog and blank the NPC portrait — the bug the
+    /// original abort gate was designed to prevent).
+    #[tokio::test]
+    async fn load_monologue_dialog_ids_includes_cellblock_wakeup() {
+        let pool = require_db_or_skip!();
+        let ids = load_monologue_dialog_ids(&pool)
+            .await
+            .expect("load_monologue_dialog_ids must succeed");
+
+        // Dialog 2982 = Castle Cellblock wake-up monologue.
+        assert!(
+            ids.contains(&2982),
+            "dialog 2982 (cellblock wake-up monologue) must be in the monologue set; \
+             without it the chain-1001 DisplayDialog continues to silently never fire"
+        );
+
+        // Pick any dialog id from the seed that has at least one
+        // non-zero speaker_id screen — it must NOT be in the cache.
+        // Fetch a representative dialog and assert.
+        let mixed_dialog: Option<i32> = sqlx::query_scalar(
+            "SELECT dialog_id FROM resources.dialog_screens \
+             WHERE speaker_id <> 0 \
+             GROUP BY dialog_id LIMIT 1",
+        )
+        .fetch_optional(&pool)
+        .await
+        .expect("query must succeed");
+        if let Some(d) = mixed_dialog {
+            assert!(
+                !ids.contains(&d),
+                "dialog {d} has at least one non-zero speaker_id screen — it must NOT be \
+                 in the monologue set, or the executor's monologue fallback would \
+                 incorrectly bind the player for an NPC dialog"
+            );
+        }
+    }
+
     #[tokio::test]
     async fn load_stargates_resolves_world_join() {
         let pool = require_db_or_skip!();


### PR DESCRIPTION
## Summary

Two independent gaps surfaced in the latest play-session SigNoz trace, bundled into one PR per request.

### `RangedPhysicalDamage` + `RangedEnergyDamage` Rust scripts

The legacy effect-script dispatcher has 6 names registered; live combat WARNed ~2 Hz on every shot:

```
effect_script_unknown script=RangedPhysicalDamage effect_id=641
```

Effect 641 backs ability 579 (Pistol Auto Attack) — the canonical player auto-attack. With the script missing, every shot fell back to the NVP-only path: `HealthDamage=10` + `FocusDamage=100` applied independently. **The player took HEALTH damage from shot one even at full Focus**, and the NPC's return fire bypassed the player's Focus shield the same way. ~150 WARNs per fight.

Both scripts ported from `deprecated/python/cell/effects/`:

- **`RangedPhysicalDamage`** — focus-gated. Apply FocusDamage to FOCUS pool; if overflow exists, `spillover = overflow / 3` (the legacy `remaining_pct × FocusDamage / 300` collapses algebraically); apply `spillover + HealthDamage` to HEALTH. **If Focus absorbs everything, no HEALTH damage at all** — the load-bearing "shields held" gate that distinguishes this from the NVP fallback. Reverting the gate fails the new `ranged_physical_full_focus_absorbs_no_health_damage` test.
- **`RangedEnergyDamage`** — parallel apply to HEALTH and FOCUS, no gating. Energy weapons "ignore shields" by design.

### `DisplayDialog` monologue path

Same SigNoz trace, every session start:

```
WARN DisplayDialog: no NPC entity id in chain params or
     last_interaction_target chain_id=1001 dialog_id=2982
```

Dialog 2982 is the Castle Cellblock wake-up monologue. Two screens, both `speaker_id = 0` (player inner-thought):

> "The last thing you remember is going into stasis after another session with that sadist, Romney..."
>
> "But now you are free — and awake. ... you need to find a weapon. Quickly. Perhaps there's something on those corpses nearby..."

The existing `DisplayDialog` executor required an NPC entity id and bailed when none was resolved — correct for NPC dialogs (binding the player would blank the NPC portrait and substitute the player's name for every screen), wrong for monologue dialogs (where binding the player is exactly the right render — the client's per-screen lookup of `speaker_id=0` falls back to the player's name naturally, per [the RE finding](docs/reverse-engineering/findings/dialog-portrait-lookup.md)).

**5,713 of 13,466 dialog screens in the canonical seed carry `speaker_id = 0`** — about 42% of the entire authored dialog catalog was silently never displaying for chains that didn't resolve an NPC context.

Fix shape:

- New `load_monologue_dialog_ids(pool)` loader in [`spawner/dialogs.rs`](crates/services/src/cell/spawner/dialogs.rs). PG query groups by dialog_id and filters to those where every screen has `speaker_id = 0` (`COUNT(*) FILTER (WHERE speaker_id <> 0) = 0`).
- `SpaceManager.monologue_dialog_ids: HashSet<i32>` cache populated at cell startup.
- `DisplayDialog` executor: when no NPC resolves AND the dialog is in the monologue set, bind the player's own entity id as the wire `EntityId`. Otherwise, preserve the existing warn-and-bail path — the cache acts as the gate.

## Test plan

- [x] `cargo check -p cimmeria-services --tests` clean
- [x] 8 unit tests on the two new scripts cover: full absorb, partial absorb with spillover, zero-focus full-overflow, zero-FocusDamage edge, missing-target no-op, parallel energy apply, energy zero-NVP, energy pool-clamp-at-zero
- [x] 2 executor tests on the monologue path: `display_binds_player_when_no_npc_and_dialog_is_monologue` (the cellblock wake-up case) and `display_still_aborts_for_npc_dialog_not_in_monologue_cache` (pins the fallback isn't an accept-anything hole)
- [x] 1 live-DB test: `load_monologue_dialog_ids_includes_cellblock_wakeup` asserts dialog 2982 makes it into the cache AND that at least one mixed-speaker dialog from the seed does NOT

## What this fixes for the player

- Pistol-vs-Pistol exchange now feels like the design intended: Focus traded first ("shields hold"), then Health bleeds when shields are down. Previously every shot chipped Health from full Focus.
- ~150 fewer WARNs per fight in SigNoz (no more `effect_script_unknown RangedPhysicalDamage` flood)
- Cellblock wake-up narration finally shows on session start — the player gets the "find a weapon, check the corpses" prompt that explains what to do, instead of waking up in silence

## Risks

- Both scripts currently use raw stat mutation (matching `MeleeDamage`'s pattern) — not the full QR + armor + absorption pipeline of `combat::calculate_damage`. The pipeline migration is a separate effort; doing it here would couple two refactors. Behavior is consistent with the NVP fallback (which also bypasses absorption for FOCUS damage) — net behavior change vs. today is the new spillover gate + correct shield-first cadence.
- The monologue cache is computed at startup and not re-evaluated. If a content patch adds new monologue dialogs at runtime (it doesn't today), they'd silently fall through to the bail path until next restart. Acceptable for current content authoring cadence.
- The monologue branch only triggers when *no* NPC resolves. NPC dialogs whose chain wired `target_entity_id` correctly are unaffected.

## Out of scope

- Migration of `MeleeDamage` (and the new scripts) onto the unified `calculate_damage` pipeline.
- Other PR #420 audit items from #486 — separate follow-ups still queued.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Monologue dialog support: dialogues without an NPC now display as player-led monologues.
  * Two new ranged damage effects: RangedPhysicalDamage (focus-absorption with spillover) and RangedEnergyDamage (independent focus and health damage).

* **Improvements**
  * Startup now loads and caches monologue dialog identifiers for faster resolution.

* **Tests**
  * Added tests covering monologue display and the new ranged damage behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->