### PR TITLE
fix(bandolier): clear auto-cycle stash on weapon swap

### DIFF
--- a/crates/services/src/cell/cell_methods/inventory/bandolier.rs
+++ b/crates/services/src/cell/cell_methods/inventory/bandolier.rs
@@ -248,10 +248,11 @@ pub(crate) async fn handle_request_active_slot_change(
     // drains the active slot when reloads finish; this catches
     // mid-magazine swaps where the player swaps weapons before
     // reloading the empty one.
-    let (prev_persist, new_ammo_type, prev_slot_for_log): (
+    let (prev_persist, new_ammo_type, prev_slot_for_log, auto_cycle_clear_state): (
         Option<(i32, i32, i32, i32)>,
         Option<i32>,
         i32,
+        Option<u32>,
     ) = {
         let entity = match space_mgr.get_entity_mut(entity_id) {
             Some(e) => e,
@@ -299,18 +300,46 @@ pub(crate) async fn handle_request_active_slot_change(
         // This branch catches the no-choreography paths (one slot
         // empty) and the tick re-entry path (which clears
         // `pending_slot_swap_at` above and falls through to here).
-        if slot_id != prev_slot {
+        // Weapon swap also clears auto-cycle stash + last-fired stash.
+        // The stashed ability ids resolved against the OUTGOING weapon
+        // (via `items_event_sets`); firing them on the incoming weapon
+        // either silently rejects in `use_ability` (the new weapon
+        // doesn't grant the stashed id) or misfires the wrong ability.
+        // Live observation: lomiada1 session 2026-06-04 10:04 — auto-
+        // cycle fired stale ability 559 (SMG) after swap to a non-SMG
+        // weapon. Re-engaging auto-cycle on the new weapon's slot is
+        // the player's explicit choice.
+        let auto_cycle_clear_state = if slot_id != prev_slot {
             entity.pending_reload_at = None;
             entity.pending_attack_at = None;
             entity.pending_attack_ability_id = None;
             entity.pending_attack_target_id = None;
-        }
+
+            let had_auto_cycle = entity.abilities.auto_cycle;
+            entity.abilities.auto_cycle = false;
+            entity.abilities.auto_cycle_ability_id = None;
+            entity.abilities.last_fired_ability_id = None;
+            if had_auto_cycle {
+                let old = entity.state_field;
+                entity.state_field &= !crate::cell::combat::BSF_AUTO_CYCLING;
+                (entity.state_field != old).then_some(entity.state_field)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
         entity.active_bandolier_slot = slot_id;
         let new_ammo_type = entity
             .bandolier_items
             .get(&slot_id)
             .map(|i| i.cur_ammo_type);
-        (prev_persist, new_ammo_type, prev_slot)
+        (
+            prev_persist,
+            new_ammo_type,
+            prev_slot,
+            auto_cycle_clear_state,
+        )
     };
     // Observability: log the resolved weapon ability for the new slot so
     // SigNoz can verify Phase 1's per-weapon resolution is firing
@@ -341,6 +370,22 @@ pub(crate) async fn handle_request_active_slot_change(
             resolved_ranged_ability = ?resolved_ranged_ability,
             "Active bandolier slot changed — auto-attack ability resolved"
         );
+    }
+
+    // Broadcast BSF_AUTO_CYCLING clear if the swap killed an active
+    // auto-cycle. Self-routed (matches the wire rule for BSF transitions
+    // driven by use_ability::clear_auto_cycle). Skipped when no
+    // transition fired — `Option::is_some` was set above only on a
+    // genuine bit drop.
+    if let Some(new_state) = auto_cycle_clear_state {
+        super::super::super::abilities::send_entity_method(
+            entity_id,
+            crate::mercury::method_idx::ON_STATE_FIELD_UPDATE,
+            new_state.to_le_bytes().to_vec(),
+            tx,
+            space_mgr,
+        )
+        .await;
     }
 
     // Phase 2: send messages now that the borrow is released. Clear the

--- a/crates/services/src/cell/cell_methods/inventory/tests/active_slot_change.rs
+++ b/crates/services/src/cell/cell_methods/inventory/tests/active_slot_change.rs
@@ -590,3 +590,187 @@ async fn weapon_attack_blocked_while_slot_swap_in_progress() {
         "rejection must NOT consume ammo",
     );
 }
+
+/// Weapon swap clears auto-cycle stash + last-fired stash, and
+/// broadcasts the `BSF_AUTO_CYCLING` clear to the client.
+///
+/// Bug shape: `setAutoCycle`'s immediate-fire path uses
+/// `last_fired_ability_id` to pick what to fire, and the auto-cycle
+/// tick uses `auto_cycle_ability_id`. Both are stashed at fire time
+/// against the THEN-active weapon's `items_event_sets`. Swapping
+/// weapons without clearing makes the next auto-cycle press fire
+/// the wrong ability against the new weapon — either silently rejects
+/// in `use_ability` (the new weapon doesn't grant the stashed id) or
+/// misfires.
+#[tokio::test]
+async fn slot_change_clears_auto_cycle_stash_and_broadcasts() {
+    use crate::cell::combat::BSF_AUTO_CYCLING;
+    use crate::cell::content::build_engine;
+    use crate::mercury::method_idx::ON_STATE_FIELD_UPDATE;
+    use cimmeria_entity::cell_entity::BandolierItem;
+
+    let mut mgr = make_test_space_mgr();
+    mgr.create_entity(1, "Castle_CellBlock", [0.0; 3], [0.0; 3])
+        .unwrap();
+
+    if let Some(e) = mgr.get_entity_mut(1) {
+        e.is_player = true;
+        e.player_id = Some(100);
+        // Skip the swap choreography (covered elsewhere) — this test
+        // is about the auto-cycle state mutation on the immediate swap.
+        e.pending_slot_swap_at = Some(std::time::Instant::now());
+
+        // Seed slot 0 (current active, SMG-shaped) and slot 1 (target).
+        for slot_id in 0..2 {
+            e.bandolier_items.insert(
+                slot_id,
+                BandolierItem {
+                    item_id: 100 + slot_id,
+                    clip_size: 30,
+                    default_ammo_type: 1,
+                    current_ammo: 30,
+                    cur_ammo_type: 1,
+                },
+            );
+        }
+        e.active_bandolier_slot = 0;
+
+        // Pre-arm auto-cycle on slot 0's weapon — the exact state
+        // lomiada1's session reached before the bad swap.
+        e.abilities.auto_cycle = true;
+        e.abilities.auto_cycle_ability_id = Some(559); // SMG Auto Attack
+        e.abilities.last_fired_ability_id = Some(559);
+        e.state_field |= BSF_AUTO_CYCLING;
+    }
+    mgr.connect_entity(1);
+
+    let (tx, mut rx) = mpsc::channel(16);
+    let engine = build_engine(None).await;
+
+    // Wire-slot 2 = server slot 1.
+    let mut args = Vec::with_capacity(8);
+    args.extend_from_slice(&3i32.to_le_bytes()); // bandolier bag
+    args.extend_from_slice(&2i32.to_le_bytes());
+
+    dispatch(1, REQUEST_ACTIVE_SLOT_CHANGE, &args, &tx, &mut mgr, &engine).await;
+
+    let e = mgr.get_entity(1).unwrap();
+    assert_eq!(e.active_bandolier_slot, 1, "fixture: swap must land");
+    assert!(
+        !e.abilities.auto_cycle,
+        "weapon swap must clear auto_cycle flag",
+    );
+    assert!(
+        e.abilities.auto_cycle_ability_id.is_none(),
+        "weapon swap must clear auto_cycle_ability_id — otherwise next \
+         setAutoCycle press fires the OLD weapon's stale ability",
+    );
+    assert!(
+        e.abilities.last_fired_ability_id.is_none(),
+        "weapon swap must clear last_fired_ability_id — otherwise \
+         setAutoCycle's immediate-fire path picks the OLD weapon's \
+         ability and use_ability rejects with 'not granted by active \
+         weapon' (live observation: lomiada1 ability 559 after swap)",
+    );
+    assert_eq!(
+        e.state_field & BSF_AUTO_CYCLING,
+        0,
+        "weapon swap must clear BSF_AUTO_CYCLING — the cycling icon on \
+         the UI must reflect that the loop stopped",
+    );
+
+    // Wire-side: onStateFieldUpdate must fire so the client UI's
+    // cycling icon clears. Without the broadcast, the UI shows the
+    // loop as still armed even though the server cleared it.
+    let mut saw_state_field_update = false;
+    while let Ok(msg) = rx.try_recv() {
+        if let CellToBaseMsg::EntityMethodCall {
+            entity_id: 1,
+            method_index,
+            args,
+        } = msg
+        {
+            if method_index == ON_STATE_FIELD_UPDATE {
+                let state = u32::from_le_bytes([args[0], args[1], args[2], args[3]]);
+                assert_eq!(
+                    state & BSF_AUTO_CYCLING,
+                    0,
+                    "broadcast must carry the cleared state",
+                );
+                saw_state_field_update = true;
+            }
+        }
+    }
+    assert!(
+        saw_state_field_update,
+        "weapon swap that ended an auto-cycle must broadcast \
+         onStateFieldUpdate so the client UI clears the cycling icon",
+    );
+}
+
+/// Companion: same-slot "swap" (replayed packet / no-op) must NOT
+/// clear auto-cycle. The player hasn't expressed intent to change
+/// weapons, so the loop should continue.
+#[tokio::test]
+async fn same_slot_change_preserves_auto_cycle_stash() {
+    use crate::cell::combat::BSF_AUTO_CYCLING;
+    use crate::cell::content::build_engine;
+    use cimmeria_entity::cell_entity::BandolierItem;
+
+    let mut mgr = make_test_space_mgr();
+    mgr.create_entity(1, "Castle_CellBlock", [0.0; 3], [0.0; 3])
+        .unwrap();
+
+    if let Some(e) = mgr.get_entity_mut(1) {
+        e.is_player = true;
+        e.player_id = Some(100);
+        e.pending_slot_swap_at = Some(std::time::Instant::now());
+        e.bandolier_items.insert(
+            0,
+            BandolierItem {
+                item_id: 100,
+                clip_size: 30,
+                default_ammo_type: 1,
+                current_ammo: 30,
+                cur_ammo_type: 1,
+            },
+        );
+        e.active_bandolier_slot = 0;
+        e.abilities.auto_cycle = true;
+        e.abilities.auto_cycle_ability_id = Some(559);
+        e.abilities.last_fired_ability_id = Some(559);
+        e.state_field |= BSF_AUTO_CYCLING;
+    }
+    mgr.connect_entity(1);
+
+    let (tx, _rx) = mpsc::channel(16);
+    let engine = build_engine(None).await;
+
+    // Wire-slot 1 = server slot 0 = current slot. No-op swap.
+    let mut args = Vec::with_capacity(8);
+    args.extend_from_slice(&3i32.to_le_bytes());
+    args.extend_from_slice(&1i32.to_le_bytes());
+
+    dispatch(1, REQUEST_ACTIVE_SLOT_CHANGE, &args, &tx, &mut mgr, &engine).await;
+
+    let e = mgr.get_entity(1).unwrap();
+    assert!(
+        e.abilities.auto_cycle,
+        "same-slot must NOT clear auto_cycle"
+    );
+    assert_eq!(
+        e.abilities.auto_cycle_ability_id,
+        Some(559),
+        "same-slot must preserve auto_cycle_ability_id",
+    );
+    assert_eq!(
+        e.abilities.last_fired_ability_id,
+        Some(559),
+        "same-slot must preserve last_fired_ability_id",
+    );
+    assert_ne!(
+        e.state_field & BSF_AUTO_CYCLING,
+        0,
+        "same-slot must NOT clear BSF_AUTO_CYCLING",
+    );
+}


### PR DESCRIPTION
## Summary

`handle_request_active_slot_change` cleared `pending_*` reload/attack state on a weapon swap but left `auto_cycle_ability_id` and `last_fired_ability_id` intact. Both are stashed at fire time, resolved against the THEN-active weapon's `items_event_sets`. Swapping weapons mid-session leaves a stale id pointed at the *outgoing* weapon — the next `setAutoCycle` press fires that stale id, the `use_ability` gate rejects with *"not in known set and not granted by active weapon"*, no shots fire, the cycling icon stays lit on the client.

## Live observation

SigNoz session 2026-06-04 10:04 UTC, peer `176.3.8.17:3650` (lomiada1):

```
10:04:39.043566  setAutoCycle  enabled=true  entity_id=2
10:04:39.043580  setAutoCycle: immediate fire on enable
                 ability_id=559  target_id=100130
10:04:39.043611  useAbility: ability not in known set
                 and not granted by active weapon
                 ability_id=559  entity_id=2
```

Ability 559 = SMG/P90 Auto Attack. lomiada1's active weapon at the time wasn't an SMG, so the resolver fallback failed and the shot dropped.

## Fix

On a real slot change (`slot != prev_slot`), clear:

- `entity.abilities.auto_cycle`
- `entity.abilities.auto_cycle_ability_id`
- `entity.abilities.last_fired_ability_id`
- `BSF_AUTO_CYCLING` state-field bit

Broadcast `onStateFieldUpdate` when the bit transitioned so the cycling icon clears on the client. Same-slot calls (replayed packets / no-op swaps) preserve the stash — the loop continues as intended.

## Test plan

- [x] `cargo check -p cimmeria-services --tests` clean
- [x] `cargo fmt --all` ran
- [x] `slot_change_clears_auto_cycle_stash_and_broadcasts` — fixture matches lomiada1's state (auto_cycle on with ability 559, swap to slot 1). Asserts all four state mutations + the broadcast.
- [x] `same_slot_change_preserves_auto_cycle_stash` — companion that pins "no-op swap doesn't kill the loop." Reverting the `slot_id != prev_slot` gate fails this.

## Risks

- Conservative behavior: a player who legitimately swapped from pistol A to pistol B (both grant 579) loses their auto-cycle and has to re-engage. Mildly annoying but matches what most MMOs do on weapon swap; the alternative (validate-and-keep) adds edge cases for marginal benefit.
- `BSF_AUTO_CYCLING` broadcast is self-routed (matches the wire rule for BSF transitions driven by `use_ability::clear_auto_cycle`). No witness fanout needed — the bit drives UI state on the local player only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed weapon auto-cycling state to properly clear when swapping equipment slots
  * UI cycling indicators now correctly update when changing weapon loadouts
  * Prevented unintended state resets on redundant slot swap requests

* **Tests**
  * Added tests to verify auto-cycling state behavior during equipment slot changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->