### PR TITLE
fix(use_ability): redirect Pistol Shot (592) → active weapon's RANGED binding

### DIFF
--- a/crates/services/src/cell/abilities/use_ability/mod.rs
+++ b/crates/services/src/cell/abilities/use_ability/mod.rs
@@ -22,6 +22,25 @@ use super::super::space_manager::SpaceManager;
 
 use super::messaging::{flush_attacker_ammo_stat, send_entity_method};
 
+/// The universal archetype-starter default ranged auto-attack ability.
+///
+/// Granted to every char_def (1-14) at character creation per
+/// `db/resources/Archetypes/Seed/char_creation_abilities.sql`. The
+/// action-bar slot the player drags Pistol Shot into stays bound to
+/// `592` across weapon swaps; the fire-time redirect in
+/// `handle_use_ability` resolves it to the active weapon's RANGED
+/// binding so a player firing this with a P90 equipped fires SMG
+/// Auto Attack (559), with a pistol fires Pistol Auto Attack (579),
+/// etc. See the redirect comment in `handle_use_ability` for the
+/// full rationale + scope limits.
+///
+/// Single-id constant rather than a slice because every archetype
+/// shares this one — Soldier, Commando, Scientist, Archaeologist all
+/// get 592. If a future archetype defines a different default ranged
+/// starter, add it as a second constant + extend the redirect check
+/// to walk a small `&[i32]` slice.
+const ARCHETYPE_DEFAULT_RANGED_AUTO_ATTACK: i32 = 592;
+
 /// Broadcast `onStateFieldUpdate` after a `BSF_AUTO_CYCLING` transition.
 /// Self-only routing (like BSF_InCombat changes) — kept in one place so
 /// arm/clear sites don't drift apart on the wire rule.
@@ -69,13 +88,80 @@ async fn send_state_field(
 )]
 pub async fn handle_use_ability(
     entity_id: u32,
-    ability_id: i32,
+    mut ability_id: i32,
     target_id: i32,
     tx: &mpsc::Sender<CellToBaseMsg>,
     space_mgr: &mut SpaceManager,
 ) -> bool {
     // ── Look up ability definition from DB (before mutable borrow) ──
-    let ability_def = space_mgr.ability_defs.get(&ability_id).cloned();
+    let mut ability_def = space_mgr.ability_defs.get(&ability_id).cloned();
+
+    // ── Archetype-default weapon redirect ──
+    //
+    // Ability 592 (Pistol Shot) is granted to every char_def at
+    // character creation as the universal "default ranged auto-attack"
+    // (see `db/resources/Archetypes/Seed/char_creation_abilities.sql`:
+    // every char_def 1-14 gets 592). The action-bar slot the player
+    // drags it into stays bound to 592 across weapon swaps — the
+    // client has no wire path for single-slot rebind (confirmed by
+    // Ghidra scan, `client.def` audit, and the deprecated python
+    // SGWPlayer reference). So when the player equips a P90 (which
+    // binds 559 SMG Auto Attack to its RANGED event) and presses the
+    // action-bar slot, the wire arrives as `useAbility(592)` and the
+    // server fires Pistol Shot — wrong animation, wrong damage
+    // profile, wrong ammo pool. Reported as "P90 fires using the
+    // pistol shot ability and not the SMG shot ability."
+    //
+    // Redirect rule: if the called ability is the archetype default
+    // ranged auto-attack AND the player has a weapon active whose
+    // RANGED binding differs, swap `ability_id` to the weapon's
+    // binding before validation runs. The rest of the handler uses
+    // the post-redirect id naturally — known-set check, cooldown,
+    // range, effect dispatch, on-wire packets all key on the weapon's
+    // ability. The player drags Pistol Shot to slot 1 once; equipping
+    // a P90 makes that slot fire SMG; equipping a pistol fires Pistol
+    // Auto Attack; the slot follows the weapon without ever needing a
+    // rebind from the server.
+    //
+    // **What's NOT in scope here:**
+    // - Melee equivalent (Strike, 594). Strike's animation/identity is
+    //   more distinct than Pistol Shot's, and weapons each bind a
+    //   different MELEE id (P90: 595, pistol: 708). Could redirect
+    //   symmetrically but the user only reported the ranged break;
+    //   handle melee in a follow-up if it turns out to need the same
+    //   treatment.
+    // - Heal Focus (597) and other non-attack archetype starters —
+    //   these have no weapon binding, the lookup returns None,
+    //   redirect is a no-op.
+    // - Weapon-bound abilities already in the known set (e.g. player
+    //   firing 559 directly with P90 equipped). The redirect only
+    //   fires for the archetype-default starter id; firing the weapon
+    //   binding directly skips this entire block.
+    if ability_id == ARCHETYPE_DEFAULT_RANGED_AUTO_ATTACK {
+        if let Some(item_id) = space_mgr
+            .get_entity(entity_id)
+            .and_then(|e| e.bandolier_items.get(&e.active_bandolier_slot))
+            .map(|b| b.item_id)
+        {
+            if let Some(&weapon_ranged_ability) = space_mgr
+                .item_event_set_abilities
+                .get(&(item_id, super::super::spawner::EVENT_ITEM_RANGED))
+            {
+                if weapon_ranged_ability != ability_id {
+                    tracing::info!(
+                        entity_id,
+                        original_ability_id = ability_id,
+                        weapon_ability_id = weapon_ranged_ability,
+                        item_id,
+                        "useAbility: redirecting archetype-default ranged \
+                         auto-attack to active weapon's RANGED binding"
+                    );
+                    ability_id = weapon_ranged_ability;
+                    ability_def = space_mgr.ability_defs.get(&ability_id).cloned();
+                }
+            }
+        }
+    }
 
     // ── Auto-cycle manual-override gate ──
     //

--- a/crates/services/src/cell/abilities/use_ability/mod.rs
+++ b/crates/services/src/cell/abilities/use_ability/mod.rs
@@ -147,8 +147,20 @@ pub async fn handle_use_ability(
                 .item_event_set_abilities
                 .get(&(item_id, super::super::spawner::EVENT_ITEM_RANGED))
             {
+                // Same-id guard: if a weapon ever bound the same id the
+                // player already presses (hypothetical content where a
+                // pistol-class item binds 592 directly), the redirect is
+                // a no-op — skip the rewrite and the re-lookup so the
+                // DEBUG log only fires when something actually changed.
                 if weapon_ranged_ability != ability_id {
-                    tracing::info!(
+                    // DEBUG, not INFO — fires on every player shot
+                    // during sustained fire (auto-cycle 1.5–2 Hz). INFO
+                    // would balloon the log volume for what is, after
+                    // the first redirect, expected steady-state
+                    // behavior. The `combat.use_ability` span (INFO)
+                    // already records every commit; this DEBUG just
+                    // discriminates the redirect path inside it.
+                    tracing::debug!(
                         entity_id,
                         original_ability_id = ability_id,
                         weapon_ability_id = weapon_ranged_ability,
@@ -158,6 +170,12 @@ pub async fn handle_use_ability(
                     );
                     ability_id = weapon_ranged_ability;
                     ability_def = space_mgr.ability_defs.get(&ability_id).cloned();
+                    // Depends on PR #494 adding the weapon's RANGED
+                    // binding to `known_abilities` at equip time. The
+                    // `is_ability_granted_by_active_weapon` fallback in
+                    // the validation block below catches the gap if PR
+                    // #494 hasn't landed yet, but the explicit grant is
+                    // the cleaner path so this comment doesn't drift.
                 }
             }
         }

--- a/crates/services/src/cell/abilities/use_ability/tests.rs
+++ b/crates/services/src/cell/abilities/use_ability/tests.rs
@@ -831,3 +831,149 @@ async fn ungranted_ability_still_rejected_when_active_weapon_does_not_grant_it()
         "ability not in known set and not bound to active weapon must reject"
     );
 }
+
+// ── Archetype-default weapon redirect (592 → weapon's RANGED binding) ──
+
+/// **The P90 case.** Player has Pistol Shot (592) bound to an
+/// action-bar slot from when their archetype was Soldier; that slot
+/// stays bound to 592 forever client-side. Player equips a P90,
+/// presses the slot → wire arrives as `useAbility(592)`. The redirect
+/// must rewrite this to 559 (P90's items_event_sets RANGED binding)
+/// before validation runs, so the SMG actually fires.
+///
+/// Bug shape pre-fix: 592 was in the known set (archetype starter),
+/// validation passed, server fired Pistol Shot — wrong animation,
+/// wrong damage profile, wrong ammo pool, with a P90 visibly equipped.
+/// Reverting the redirect block trips this test on the cooldown
+/// assertion (Pistol Shot's cooldown gets stamped instead of SMG's).
+#[tokio::test]
+async fn use_ability_redirects_pistol_shot_to_smg_when_p90_equipped() {
+    use cimmeria_entity::cell_entity::BandolierItem;
+
+    let mut mgr = make_mgr();
+    make_player(&mut mgr, 1, [0.0; 3]);
+    // NPC target so the post-redirect range check has something to find.
+    mgr.spawn_npc(50, "Castle_CellBlock", [3.0, 0.0, 0.0], [0.0; 3])
+        .unwrap();
+
+    if let Some(p) = mgr.get_entity_mut(1) {
+        // Pistol Shot (592) — archetype starter. The player only
+        // knows this id; SMG Auto Attack (559) is NOT in the known
+        // set (it's not auto-granted by PR #494 in this fixture).
+        // The redirect must let the call land on 559 anyway.
+        p.abilities.add_ability(592);
+        // P90 in slot 0 — item id 21 per items_event_sets seed.
+        p.bandolier_items.insert(
+            0,
+            BandolierItem {
+                item_id: 21,
+                clip_size: 30,
+                default_ammo_type: 2,
+                current_ammo: 30,
+                cur_ammo_type: 2,
+            },
+        );
+        p.active_bandolier_slot = 0;
+    }
+    // P90 (21) binds 559 to RANGED (event 7).
+    mgr.item_event_set_abilities.insert((21, 7), 559);
+    // ability_defs entries for both — the redirect re-looks-up the
+    // def after rewriting ability_id, so 559's def must be in the
+    // map for the post-redirect validation to find a max_range and
+    // cooldown.
+    mgr.ability_defs.insert(592, make_ability(592, 0, 30));
+    mgr.ability_defs.insert(559, make_ability(559, 0, 30));
+
+    let (tx, _rx) = mpsc::channel(64);
+    let committed = handle_use_ability(1, 592, 50, &tx, &mut mgr).await;
+
+    assert!(
+        committed,
+        "redirect must succeed end-to-end — the SMG fire commits via 559's path"
+    );
+    let entity = mgr.get_entity(1).unwrap();
+    assert!(
+        entity.abilities.is_on_cooldown(559),
+        "the WEAPON ability (559 SMG Auto Attack) must be the one that started \
+         cooldown — proves the redirect ran and the fire took place against 559",
+    );
+    assert!(
+        !entity.abilities.is_on_cooldown(592),
+        "Pistol Shot (592) must NOT have entered cooldown — the redirect \
+         rewrites ability_id BEFORE the cooldown is stamped, so 592 stays \
+         untouched even though the client sent it on the wire",
+    );
+}
+
+/// Companion: when the player has NO weapon active (empty slot 0), the
+/// redirect must NOT fire — 592 fires as itself. Pins the off-switch.
+#[tokio::test]
+async fn use_ability_does_not_redirect_pistol_shot_when_no_weapon_equipped() {
+    let mut mgr = make_mgr();
+    make_player(&mut mgr, 1, [0.0; 3]);
+    mgr.spawn_npc(50, "Castle_CellBlock", [3.0, 0.0, 0.0], [0.0; 3])
+        .unwrap();
+
+    if let Some(p) = mgr.get_entity_mut(1) {
+        p.abilities.add_ability(592);
+        // Slot 0 left empty — no bandolier_items insert.
+        p.active_bandolier_slot = 0;
+    }
+    // items_event_sets unchanged — would never be consulted in the
+    // empty-slot case, but pin the negative-space assertion below
+    // regardless.
+    mgr.item_event_set_abilities.insert((21, 7), 559);
+    mgr.ability_defs.insert(592, make_ability(592, 0, 30));
+    mgr.ability_defs.insert(559, make_ability(559, 0, 30));
+
+    let (tx, _rx) = mpsc::channel(64);
+    let committed = handle_use_ability(1, 592, 50, &tx, &mut mgr).await;
+
+    assert!(committed, "Pistol Shot must still fire bare-handed");
+    let entity = mgr.get_entity(1).unwrap();
+    assert!(
+        entity.abilities.is_on_cooldown(592),
+        "no weapon active → no redirect → 592 stamps its own cooldown"
+    );
+    assert!(
+        !entity.abilities.is_on_cooldown(559),
+        "redirect target (559) must not have been touched"
+    );
+}
+
+/// Companion: when the player fires the weapon's binding (559)
+/// DIRECTLY — e.g. they manually bound 559 to a slot — the redirect
+/// must be a no-op. Pins that the redirect only triggers on the
+/// archetype-default id, not on any in-bound weapon ability.
+#[tokio::test]
+async fn use_ability_does_not_redirect_when_called_ability_is_already_weapon_binding() {
+    use cimmeria_entity::cell_entity::BandolierItem;
+
+    let mut mgr = make_mgr();
+    make_player(&mut mgr, 1, [0.0; 3]);
+    mgr.spawn_npc(50, "Castle_CellBlock", [3.0, 0.0, 0.0], [0.0; 3])
+        .unwrap();
+
+    if let Some(p) = mgr.get_entity_mut(1) {
+        p.abilities.add_ability(559);
+        p.bandolier_items.insert(
+            0,
+            BandolierItem {
+                item_id: 21,
+                clip_size: 30,
+                default_ammo_type: 2,
+                current_ammo: 30,
+                cur_ammo_type: 2,
+            },
+        );
+        p.active_bandolier_slot = 0;
+    }
+    mgr.item_event_set_abilities.insert((21, 7), 559);
+    mgr.ability_defs.insert(559, make_ability(559, 0, 30));
+
+    let (tx, _rx) = mpsc::channel(64);
+    let committed = handle_use_ability(1, 559, 50, &tx, &mut mgr).await;
+    assert!(committed);
+    // Single cooldown — no double-fire, no redirect loop.
+    assert!(mgr.get_entity(1).unwrap().abilities.is_on_cooldown(559));
+}


### PR DESCRIPTION
## Summary

**User-visible problem.** Equip a P90 → action-bar slot still bound to Pistol Shot (592) fires Pistol Shot, not SMG Auto Attack (559). Reported as *"the P90 seems to work with pistol shot ability and not the smg shot ability."*

## Root cause

Ability 592 (Pistol Shot) is granted to **every char_def** at character creation per `db/resources/Archetypes/Seed/char_creation_abilities.sql` — Soldier, Commando, Scientist, Archaeologist (char_defs 1-14) all get 592. The player drags Pistol Shot into an action-bar slot once; that slot stays bound to 592 forever client-side because the wire protocol has NO single-slot rebind method (confirmed by the prior Ghidra audit + client.def scan).

When the player equips a P90, pressing that slot wires `useAbility(592)`. The known-set check passes (592 is archetype-granted), validation passes, server fires Pistol Shot — wrong animation, wrong damage profile, wrong ammo pool.

## Fix

Fire-time redirect at the top of `handle_use_ability`: if the called ability is the archetype-default ranged auto-attack (592) AND the player has a weapon active whose RANGED binding via `items_event_sets` differs, rewrite `ability_id` to the weapon's binding **before validation runs**.

The rest of the handler keys on the post-redirect id naturally:
- cooldown stamps on 559
- range checks against 559's def
- effect dispatch fires 559's effects
- on-wire packets carry 559

Player drags Pistol Shot to slot 1 once; equipping a P90 makes that slot fire SMG (559); equipping a pistol fires Pistol Auto Attack (579); the slot follows the weapon **without ever needing a rebind from the server**.

## Scope limits (intentional)

- **Melee (594 Strike) is NOT redirected.** Strike's animation and identity are more distinct than Pistol Shot's, and weapons each bind a different MELEE id (P90: 595, pistol: 708). Could redirect symmetrically but the user only reported the ranged break.
- **Heal Focus (597) and other non-attack archetype starters** — no weapon binding → lookup returns None → no-op.
- **Weapon-bound abilities bound directly** (e.g. 559 in slot 2) skip this block entirely — the redirect gate (`ability_id == 592`) doesn't trip.
- **No weapon equipped** (empty slot) → no items_event_sets row → no redirect → 592 fires as itself.

## Test plan

- [x] `cargo check -p cimmeria-services --tests` clean
- [x] `cargo clippy -p cimmeria-services --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` clean
- [x] `use_ability_redirects_pistol_shot_to_smg_when_p90_equipped` — canonical fix case
- [x] `use_ability_does_not_redirect_pistol_shot_when_no_weapon_equipped` — empty-slot off-switch
- [x] `use_ability_does_not_redirect_when_called_ability_is_already_weapon_binding` — direct-binding short-circuit

Reverting the redirect block trips the first test on the cooldown assertion (592's cooldown gets stamped instead of 559's).

## Relationship to PR #494

PR #494 adds 559 to the known set on P90 equip (via `onKnownAbilitiesUpdate`). This PR is the **other half** of the same UX: even with 559 known, the *client* still sends 592 because the action-bar slot is bound to it, so the *server* has to redirect. With both PRs landed, the slot binding and the firing both end up on the right ability — without the client needing any RE-discovered wire surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic ability redirection for starter ranged attacks. When players use the default ranged ability with an equipped weapon, the action now properly redirects to the weapon's configured ranged ability.

* **Tests**
  * Added comprehensive regression tests covering weapon ability redirect behavior, including equipped weapon scenarios, empty slot handling, and direct weapon binding invocations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->