### PR TITLE
feat(observability): log onSequence broadcasts at DEBUG

### DIFF
--- a/crates/services/src/cell/abilities/damage_apply/mod.rs
+++ b/crates/services/src/cell/abilities/damage_apply/mod.rs
@@ -352,6 +352,15 @@ pub(super) async fn apply_damage_to_target(
                         space_mgr,
                     )
                     .await;
+                    tracing::debug!(
+                        target: "abilities.sequence",
+                        event = "entity_death",
+                        source_id = target_eid,
+                        target_id = target_eid,
+                        sequence_id = death_seq_id,
+                        event_set_id = esid,
+                        "onSequence broadcast: Entity_Death (death animation)"
+                    );
                 }
             }
         }

--- a/crates/services/src/cell/abilities/use_ability/mod.rs
+++ b/crates/services/src/cell/abilities/use_ability/mod.rs
@@ -593,6 +593,16 @@ pub async fn handle_use_ability(
                 seq_args.extend_from_slice(&effect_seq.to_le_bytes()); // InstanceId
                 send_entity_method(entity_id, 1, seq_args, tx, space_mgr).await;
                 // 1 = onSequence
+                tracing::debug!(
+                    target: "abilities.sequence",
+                    event = "ability_begin",
+                    source_id = entity_id,
+                    target_id,
+                    ability_id,
+                    sequence_id = begin_seq_id,
+                    event_set_id,
+                    "onSequence broadcast: Ability_Begin (warmup animation)"
+                );
             }
         }
 
@@ -611,6 +621,16 @@ pub async fn handle_use_ability(
             seq_args.push(0); // ViewType = KISMET_VIEW_Witness
             seq_args.extend_from_slice(&effect_seq.to_le_bytes()); // InstanceId
             send_entity_method(entity_id, 1, seq_args, tx, space_mgr).await; // 1 = onSequence
+            tracing::debug!(
+                target: "abilities.sequence",
+                event = "ability_end",
+                source_id = entity_id,
+                target_id,
+                ability_id,
+                sequence_id = end_seq_id,
+                event_set_id,
+                "onSequence broadcast: Ability_End (main fire animation)"
+            );
         } else {
             tracing::debug!(
                 entity_id,


### PR DESCRIPTION
## Summary

Close the *\"no observability on attack/death animation broadcasts\"* gap identified in the lomiada 2026-06-04 18:09 audit. When she reported \"no animation on guard,\" the server-side \`attack_in_place\` decisions + \`useAbility: launched\` commits both fired correctly, but we had no log proving the \`onSequence\` packet that drives the animation actually made it onto the wire.

## Three DEBUG additions

1. **\`use_ability.rs\`** — \`Ability_Begin\` (warmup animation). Fires per warmup ability.
2. **\`use_ability.rs\`** — \`Ability_End\` (main fire animation). Fires per shot during sustained combat (~1.5-2 Hz under auto-cycle).
3. **\`damage_apply.rs\`** — \`Entity_Death\` (death animation). Fires once per kill.

All three log to \`target: \"abilities.sequence\"\` so SigNoz can filter the animation stream independently.

## What this PR does NOT do

- **No respawn lifecycle log added** — \`npc_respawn_tick\` already emits an INFO log with \`npc_id\`, \`spawn_pos\`, \`respawn_secs\`, \`world_name\`, \`state_field\`, \`interaction_flags\`. The audit's \"no respawn log\" was a search-string miss, not a real gap.
- **No FOCUS init log added** — already covered by PR #499.

## Test plan

Pure observability — no behavior change, no new tests. Reverting the logs adds zero risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)