### PR TITLE
fix(missions): server-side canOffer guard blocks re-accept of completed/active missions (#411)

### DIFF
--- a/.github/instructions/content-chains.instructions.md
+++ b/.github/instructions/content-chains.instructions.md
@@ -31,6 +31,17 @@ Every `op: "|"` (set) needs a matching `op: "~"` (clear) on the chain that compl
 
 For mission progression, also add a `player_loaded`-triggered chain that re-applies the bit for active steps. Interaction flags don't persist on the entity across server restart, so without restoration a relog mid-mission breaks interactivity. Worked example: chains 1045/1046 in `castle_cellblock_chains.sql` restore HackTheRings_Switch's bit based on which step is active.
 
+## Mission grants must gate on `not_active`
+
+Every chain whose actions include `accept_mission` must carry a
+`mission_status <id> eq not_active` condition (see chain 1001 for the
+canonical shape). Since #411 the server also refuses re-accepts
+authoritatively (`accept_mission`'s offer guard: already-active,
+failed-without-`can_repeat_on_fail`, or completed past `num_repeats`),
+so a missing gate no longer corrupts saved mission rows — but it still
+fires the chain's *other* actions (dialogs, highlights) spuriously, so
+the condition remains a review requirement.
+
 ## Inventory consumption
 
 `UseInventoryItem` fires `OnItemUse` as a pure event — the base no longer auto-consumes the stack. Chains that need to consume (consumable vials, mission objects) must include an explicit `remove_item` action. This is the correct pattern for `item_use`-triggered chains:

--- a/crates/services/src/base/world_entry/methods/missions.rs
+++ b/crates/services/src/base/world_entry/methods/missions.rs
@@ -514,6 +514,19 @@ mod tests {
         mgr.create_startup_spaces(cxml).unwrap();
         mgr.create_entity(ENTITY_ID, "Agnos", [0.0; 3], [0.0; 3])
             .unwrap();
+        // Repeatable def (num_repeats=2 → two completions stay under the
+        // `repeats > num_repeats` cap) so the post-relog re-accept passes
+        // the offer guard. Without a def the guard fails closed.
+        mgr.mission_defs.insert(
+            MISSION_ID,
+            crate::cell::spawner::MissionDefEntry {
+                step_id: STEP_ID,
+                objectives: vec![],
+                is_hidden: false,
+                num_repeats: 2,
+                can_repeat_on_fail: true,
+            },
+        );
 
         let (tx, _rx) = mpsc::channel::<crate::cell::messages::CellToBaseMsg>(64);
         let objectives = || {

--- a/crates/services/src/cell/content/executor/mission.rs
+++ b/crates/services/src/cell/content/executor/mission.rs
@@ -51,10 +51,25 @@ pub(super) async fn accept_or_advance(
                 optional: o.is_optional,
             })
             .collect();
-        crate::cell::missions::accept_mission(
+        let accepted = crate::cell::missions::accept_mission(
             entity_id, mission_id, step_id, objectives, tx, space_mgr,
         )
         .await;
+        // Offer refused (already active / completed at repeat cap /
+        // failed non-repeatable) or entity missing. Persisting the
+        // MissionUpdate anyway would UPSERT status=1 over the saved
+        // row — exactly the "completed missions reappear as active
+        // after relog" corruption (#411). Skip the follow-up
+        // `mission_accepted` event too: no acceptance happened.
+        if !accepted {
+            tracing::info!(
+                entity_id,
+                mission_id,
+                chain_id,
+                "Content: accept_mission refused by offer guard — skipping persist + follow-up event"
+            );
+            return;
+        }
         // Read repeats AFTER the helper runs — for a re-accept of
         // a previously-completed repeatable mission, the count
         // restored from DB is what should round-trip back, not 0.
@@ -255,4 +270,128 @@ pub(super) async fn complete_objective(
     );
     crate::cell::missions::complete_objective(entity_id, mission_id, objective_id, tx, space_mgr)
         .await;
+}
+
+#[cfg(test)]
+mod offer_guard_tests {
+    //! #411 regression guards at the executor boundary: a refused (or
+    //! entity-less) `accept_or_advance` must NOT persist a `MissionUpdate`
+    //! — pre-fix, the handler sent `status=1` to the base unconditionally,
+    //! so any re-fired grant chain UPSERTed "active" over a saved
+    //! completed row and the mission resurrected in the quest log on the
+    //! next relog.
+
+    use super::*;
+    use crate::cell::spawner::MissionDefEntry;
+    use cimmeria_entity::missions::{MissionInstance, MISSION_COMPLETED};
+    use tokio::sync::mpsc;
+
+    fn make_mgr_with_def() -> SpaceManager {
+        let mut mgr = SpaceManager::new(1);
+        let xml = r#"<?xml version="1.0"?><Spaces><Space WorldName="Agnos" Instanced="false" MinX="0" MaxX="100" MinY="0" MaxY="100" /></Spaces>"#;
+        let cxml = r#"<?xml version="1.0"?><Spaces><Space WorldName="Agnos" /></Spaces>"#;
+        mgr.parse_spaces_xml(xml).unwrap();
+        mgr.create_startup_spaces(cxml).unwrap();
+        mgr.mission_defs.insert(
+            622,
+            MissionDefEntry {
+                step_id: 2113,
+                objectives: vec![],
+                is_hidden: false,
+                num_repeats: 1,
+                can_repeat_on_fail: true,
+            },
+        );
+        mgr
+    }
+
+    fn drain(rx: &mut mpsc::Receiver<CellToBaseMsg>) -> Vec<CellToBaseMsg> {
+        let mut msgs = Vec::new();
+        while let Ok(m) = rx.try_recv() {
+            msgs.push(m);
+        }
+        msgs
+    }
+
+    fn mission_updates(msgs: &[CellToBaseMsg]) -> Vec<i8> {
+        msgs.iter()
+            .filter_map(|m| match m {
+                CellToBaseMsg::MissionUpdate { status, .. } => Some(*status),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Refused offer (completed mission at the repeat cap) → no
+    /// `MissionUpdate` reaches the base, entity state untouched.
+    #[tokio::test]
+    async fn refused_accept_does_not_persist_mission_update() {
+        let mut mgr = make_mgr_with_def();
+        mgr.create_entity(1, "Agnos", [0.0; 3], [0.0; 3]).unwrap();
+        {
+            let entity = mgr.get_entity_mut(1).unwrap();
+            let mut prior = MissionInstance::new(622, 2113, vec![]);
+            prior.complete();
+            prior.repeats = 2; // past num_repeats = 1
+            entity.missions.add_mission(prior);
+        }
+        let engine = ChainEngine::new();
+        let (tx, mut rx) = mpsc::channel(32);
+
+        accept_or_advance(622, 1, 100, 9999, &tx, &mut mgr, &engine).await;
+
+        let msgs = drain(&mut rx);
+        assert!(
+            mission_updates(&msgs).is_empty(),
+            "refused accept must not send MissionUpdate (would UPSERT \
+             status=1 over the saved completed row); got {msgs:?}"
+        );
+        let m = mgr
+            .get_entity(1)
+            .unwrap()
+            .missions
+            .get_mission(622)
+            .unwrap();
+        assert_eq!(m.status, MISSION_COMPLETED, "completed status preserved");
+    }
+
+    /// Entity missing entirely (e.g. an event fired against a player whose
+    /// cell entity is gone) → nothing to verify against, so nothing may be
+    /// persisted. Pre-fix this path still sent `MissionUpdate status=1
+    /// repeats=0`, silently corrupting the saved row.
+    #[tokio::test]
+    async fn missing_entity_does_not_persist_mission_update() {
+        let mut mgr = make_mgr_with_def();
+        // No entity created.
+        let engine = ChainEngine::new();
+        let (tx, mut rx) = mpsc::channel(32);
+
+        accept_or_advance(622, 1, 100, 9999, &tx, &mut mgr, &engine).await;
+
+        let msgs = drain(&mut rx);
+        assert!(
+            mission_updates(&msgs).is_empty(),
+            "entity-less accept must not persist anything; got {msgs:?}"
+        );
+    }
+
+    /// Happy-path companion pinning the success contract: a fresh accept
+    /// still persists exactly one `MissionUpdate` with status=1. Guards
+    /// against the refusal gate accidentally swallowing legitimate accepts.
+    #[tokio::test]
+    async fn fresh_accept_still_persists_mission_update() {
+        let mut mgr = make_mgr_with_def();
+        mgr.create_entity(1, "Agnos", [0.0; 3], [0.0; 3]).unwrap();
+        let engine = ChainEngine::new();
+        let (tx, mut rx) = mpsc::channel(32);
+
+        accept_or_advance(622, 1, 100, 9999, &tx, &mut mgr, &engine).await;
+
+        let msgs = drain(&mut rx);
+        assert_eq!(
+            mission_updates(&msgs),
+            vec![1],
+            "fresh accept must persist exactly one MissionUpdate(status=1)"
+        );
+    }
 }

--- a/crates/services/src/cell/missions.rs
+++ b/crates/services/src/cell/missions.rs
@@ -8,7 +8,8 @@
 use tokio::sync::mpsc;
 
 use cimmeria_entity::missions::{
-    MissionInstance, MissionObjective, MISSION_ACTIVE, STATUS_ACTIVE, STATUS_COMPLETED,
+    MissionInstance, MissionObjective, MISSION_ACTIVE, MISSION_COMPLETED, MISSION_FAILED,
+    STATUS_ACTIVE, STATUS_COMPLETED,
 };
 
 use super::messages::CellToBaseMsg;
@@ -168,6 +169,23 @@ pub async fn advance_step(
 }
 
 /// Accept a mission: create a MissionInstance and send initial state to client.
+///
+/// Returns `true` when the mission was actually (re-)accepted. Returns
+/// `false` when the offer guard refused — the caller must NOT persist a
+/// `MissionUpdate` or fire `mission_accepted` in that case, otherwise a
+/// refused accept still flips the DB row back to active (#411).
+///
+/// Offer guard (port of Python `MissionManager.canOffer`,
+/// `deprecated/python/cell/MissionManager.py:119-136`):
+/// - already ACTIVE → refuse (re-accept would reset progress to step 1 —
+///   the chain-1051/1053 "briefing loop" bug class)
+/// - FAILED and `!can_repeat_on_fail` → refuse
+/// - COMPLETED and `repeats > num_repeats` → refuse
+///
+/// Chains are expected to gate their `accept_mission` actions on
+/// `mission_status eq not_active`; this guard is the server-authoritative
+/// backstop so a mis-gated chain (or an event fired before mission state
+/// is hydrated) can't resurrect a completed mission as active on relog.
 #[tracing::instrument(
     name = "mission.accept",
     level = "info",
@@ -181,14 +199,57 @@ pub async fn accept_mission(
     objectives: Vec<MissionObjective>,
     tx: &mpsc::Sender<CellToBaseMsg>,
     space_mgr: &mut SpaceManager,
-) {
-    let entity = match space_mgr.get_entity_mut(entity_id) {
-        Some(e) => e,
-        None => return,
+) -> bool {
+    // Prior-instance snapshot + def lookup happen against the immutable
+    // borrow so the guard can run before any mutation.
+    let prior = match space_mgr.get_entity(entity_id) {
+        Some(e) => {
+            // Backfill the DB player_id for session correlation in SigNoz.
+            if let Some(pid) = e.player_id {
+                tracing::Span::current().record("player_id", pid);
+            }
+            e.missions
+                .get_mission(mission_id)
+                .map(|m| (m.status, m.repeats))
+        }
+        None => {
+            tracing::warn!(
+                entity_id,
+                mission_id,
+                "accept_mission: entity not found — refusing (nothing to mutate, \
+                 and persisting an accept for an unknown entity would corrupt \
+                 the saved row)"
+            );
+            return false;
+        }
     };
-    // Backfill the DB player_id for session correlation in SigNoz.
-    if let Some(pid) = entity.player_id {
-        tracing::Span::current().record("player_id", pid);
+    let def = space_mgr.mission_defs.get(&mission_id);
+
+    // Offer guard — see doc comment. Def-missing falls back fail-closed
+    // (treat as non-repeatable) so an unseeded mission can't loop.
+    if let Some((status, repeats)) = prior {
+        let refusal = match status {
+            MISSION_ACTIVE => Some("already active"),
+            MISSION_FAILED if !def.is_some_and(|d| d.can_repeat_on_fail) => {
+                Some("failed and not repeatable-on-fail")
+            }
+            MISSION_COMPLETED if repeats > def.map_or(0, |d| d.num_repeats) => {
+                Some("completed at repeat cap")
+            }
+            _ => None,
+        };
+        if let Some(reason) = refusal {
+            tracing::warn!(
+                entity_id,
+                mission_id,
+                status,
+                repeats,
+                num_repeats = def.map_or(0, |d| d.num_repeats),
+                reason,
+                "accept_mission: offer refused — mission state preserved"
+            );
+            return false;
+        }
     }
 
     // Carry forward `repeats` from any prior instance of this mission --
@@ -197,10 +258,7 @@ pub async fn accept_mission(
     // previously-completed repeatable mission would silently reset the counter
     // (which then UPSERTs through `MissionUpdate`), defeating `numRepeats`
     // gating. Spotted by Copilot on PR #125.
-    let prior_repeats = entity
-        .missions
-        .get_mission(mission_id)
-        .map_or(0, |m| m.repeats);
+    let prior_repeats = prior.map_or(0, |(_, repeats)| repeats);
     // Propagate the mission def's `is_hidden` into the instance. Without
     // this, hidden sub-missions (e.g. mission 682-686 Hallway0N Controllers,
     // is_hidden=true in the seed) appear in the player's mission log because
@@ -208,14 +266,10 @@ pub async fn accept_mission(
     // filters on the per-instance flag. Cellblock-only missions affected;
     // visible-by-design missions (681 Mess Hall, 687 Aftermath, etc.) are
     // is_hidden=false in the seed so this is a no-op for them.
-    let is_hidden = space_mgr
-        .mission_defs
-        .get(&mission_id)
-        .is_some_and(|m| m.is_hidden);
-    // get_entity_mut again because mission_defs lookup borrowed &space_mgr.
+    let is_hidden = def.is_some_and(|m| m.is_hidden);
     let entity = match space_mgr.get_entity_mut(entity_id) {
         Some(e) => e,
-        None => return,
+        None => return false,
     };
     let mut mission = MissionInstance::new(mission_id, step_id, objectives.clone());
     mission.repeats = prior_repeats;
@@ -270,6 +324,8 @@ pub async fn accept_mission(
             })
             .await;
     }
+
+    true
 }
 
 /// Abandon a mission: remove it and send removal to client.
@@ -547,6 +603,20 @@ mod tests {
         mgr.parse_spaces_xml(xml).unwrap();
         mgr.create_startup_spaces(cxml).unwrap();
         mgr.create_entity(1, "Agnos", [0.0; 3], [0.0; 3]).unwrap();
+        // Declare the mission repeatable (num_repeats=1 → one completion
+        // leaves it re-offerable, python parity `repeats > numRepeats`).
+        // Without a def the offer guard fails closed and this re-accept
+        // would be refused.
+        mgr.mission_defs.insert(
+            100,
+            crate::cell::spawner::MissionDefEntry {
+                step_id: 200,
+                objectives: vec![],
+                is_hidden: false,
+                num_repeats: 1,
+                can_repeat_on_fail: true,
+            },
+        );
 
         // Seed prior state: completed once, repeats == 1.
         {
@@ -569,6 +639,196 @@ mod tests {
             m.repeats, 1,
             "re-accept must carry forward prior repeats count"
         );
+    }
+
+    fn make_test_mgr() -> super::super::space_manager::SpaceManager {
+        let mut mgr = super::super::space_manager::SpaceManager::new(1);
+        let xml = r#"<?xml version="1.0"?><Spaces><Space WorldName="Agnos" Instanced="false" MinX="0" MaxX="100" MinY="0" MaxY="100" /></Spaces>"#;
+        let cxml = r#"<?xml version="1.0"?><Spaces><Space WorldName="Agnos" /></Spaces>"#;
+        mgr.parse_spaces_xml(xml).unwrap();
+        mgr.create_startup_spaces(cxml).unwrap();
+        mgr.create_entity(1, "Agnos", [0.0; 3], [0.0; 3]).unwrap();
+        mgr
+    }
+
+    fn insert_def(
+        mgr: &mut super::super::space_manager::SpaceManager,
+        mission_id: i32,
+        num_repeats: i32,
+        can_repeat_on_fail: bool,
+    ) {
+        mgr.mission_defs.insert(
+            mission_id,
+            crate::cell::spawner::MissionDefEntry {
+                step_id: 200,
+                objectives: vec![],
+                is_hidden: false,
+                num_repeats,
+                can_repeat_on_fail,
+            },
+        );
+    }
+
+    /// **#411 regression guard.** Re-accepting a COMPLETED mission whose
+    /// repeat counter is past the def's `num_repeats` cap must be a
+    /// complete no-op: returns false, mutates nothing, sends nothing.
+    /// Pre-fix, the accept overwrote the completed instance with a fresh
+    /// ACTIVE one and the executor persisted status=1 over the saved row —
+    /// the "completed missions reappear as active after relog" bug.
+    #[tokio::test]
+    async fn re_accept_of_completed_mission_at_repeat_cap_is_refused() {
+        use cimmeria_entity::missions::MISSION_COMPLETED;
+
+        let mut mgr = make_test_mgr();
+        insert_def(&mut mgr, 100, 1, true);
+        // Completed twice → repeats == 2 > num_repeats == 1 (python parity:
+        // canOffer refuses when `repeats > numRepeats`).
+        {
+            let entity = mgr.get_entity_mut(1).unwrap();
+            let mut prior = MissionInstance::new(100, 200, vec![]);
+            prior.complete();
+            prior.repeats = 2;
+            entity.missions.add_mission(prior);
+        }
+
+        let (tx, mut rx) = mpsc::channel(16);
+        let accepted = accept_mission(1, 100, 200, make_objectives(), &tx, &mut mgr).await;
+
+        assert!(
+            !accepted,
+            "offer guard must refuse a capped completed mission"
+        );
+        assert!(
+            rx.try_recv().is_err(),
+            "a refused accept must not emit any client messages"
+        );
+        let m = mgr
+            .get_entity(1)
+            .unwrap()
+            .missions
+            .get_mission(100)
+            .unwrap();
+        assert_eq!(m.status, MISSION_COMPLETED, "status must be preserved");
+        assert_eq!(m.repeats, 2, "repeat counter must be preserved");
+    }
+
+    /// Python-parity companion: a completed mission still UNDER the cap
+    /// (`repeats <= num_repeats`) stays re-offerable. Keeps the guard from
+    /// over-blocking legitimately repeatable missions.
+    #[tokio::test]
+    async fn re_accept_of_completed_mission_below_repeat_cap_is_allowed() {
+        let mut mgr = make_test_mgr();
+        insert_def(&mut mgr, 100, 1, true);
+        {
+            let entity = mgr.get_entity_mut(1).unwrap();
+            let mut prior = MissionInstance::new(100, 200, vec![]);
+            prior.complete(); // repeats = 1, not > num_repeats = 1
+            entity.missions.add_mission(prior);
+        }
+
+        let (tx, _rx) = mpsc::channel(16);
+        let accepted = accept_mission(1, 100, 200, make_objectives(), &tx, &mut mgr).await;
+
+        assert!(accepted, "below the cap the mission must be re-offerable");
+        let m = mgr
+            .get_entity(1)
+            .unwrap()
+            .missions
+            .get_mission(100)
+            .unwrap();
+        assert_eq!(m.status, MISSION_ACTIVE);
+        assert_eq!(m.repeats, 1, "repeat counter carries forward on re-accept");
+    }
+
+    /// Re-accepting a mission that is already ACTIVE must be refused —
+    /// otherwise a re-fired grant chain resets in-flight progress back to
+    /// the def's first step (the chain-1051/1053 "briefing loop" bug class,
+    /// previously only guarded by chain-side conditions).
+    #[tokio::test]
+    async fn re_accept_of_active_mission_is_refused_and_preserves_progress() {
+        let mut mgr = make_test_mgr();
+        insert_def(&mut mgr, 100, 1, true);
+
+        let (tx, mut rx) = mpsc::channel(16);
+        let accepted = accept_mission(1, 100, 200, make_objectives(), &tx, &mut mgr).await;
+        assert!(accepted, "fresh accept must succeed");
+        while rx.try_recv().is_ok() {}
+
+        // Simulate progress past the first step.
+        {
+            let entity = mgr.get_entity_mut(1).unwrap();
+            let m = entity.missions.get_mission_mut(100).unwrap();
+            m.current_step_id = Some(999);
+        }
+
+        let accepted = accept_mission(1, 100, 200, make_objectives(), &tx, &mut mgr).await;
+        assert!(!accepted, "an active mission must not be re-offered");
+        assert!(rx.try_recv().is_err(), "refusal must not emit messages");
+        let m = mgr
+            .get_entity(1)
+            .unwrap()
+            .missions
+            .get_mission(100)
+            .unwrap();
+        assert_eq!(
+            m.current_step_id,
+            Some(999),
+            "in-flight progress must survive the refused re-accept"
+        );
+    }
+
+    /// FAILED missions follow `can_repeat_on_fail` (python parity): false →
+    /// permanently refused; true → re-offerable.
+    #[tokio::test]
+    async fn re_accept_of_failed_mission_respects_can_repeat_on_fail() {
+        use cimmeria_entity::missions::MISSION_FAILED;
+
+        let mut mgr = make_test_mgr();
+        insert_def(&mut mgr, 100, 5, false);
+        {
+            let entity = mgr.get_entity_mut(1).unwrap();
+            let mut prior = MissionInstance::new(100, 200, vec![]);
+            prior.fail();
+            entity.missions.add_mission(prior);
+        }
+
+        let (tx, _rx) = mpsc::channel(16);
+        let accepted = accept_mission(1, 100, 200, make_objectives(), &tx, &mut mgr).await;
+        assert!(
+            !accepted,
+            "failed + can_repeat_on_fail=false must refuse the re-offer"
+        );
+        let m = mgr
+            .get_entity(1)
+            .unwrap()
+            .missions
+            .get_mission(100)
+            .unwrap();
+        assert_eq!(m.status, MISSION_FAILED);
+
+        // Same state with a repeat-on-fail def → allowed.
+        insert_def(&mut mgr, 100, 5, true);
+        let accepted = accept_mission(1, 100, 200, make_objectives(), &tx, &mut mgr).await;
+        assert!(
+            accepted,
+            "failed + can_repeat_on_fail=true must allow the re-offer"
+        );
+    }
+
+    /// Entity-missing accepts must return false so callers don't persist a
+    /// `MissionUpdate` for a player whose mission state was never loaded —
+    /// pre-fix, that persisted status=1 over the saved row and resurrected
+    /// completed missions on the next relog (#411).
+    #[tokio::test]
+    async fn accept_with_missing_entity_is_refused() {
+        let mut mgr = make_test_mgr();
+        insert_def(&mut mgr, 100, 1, true);
+
+        let (tx, mut rx) = mpsc::channel(16);
+        let accepted = accept_mission(999, 100, 200, make_objectives(), &tx, &mut mgr).await;
+
+        assert!(!accepted, "unknown entity must refuse the accept");
+        assert!(rx.try_recv().is_err());
     }
 
     #[tokio::test]

--- a/crates/services/src/cell/service/base_messages/player_init.rs
+++ b/crates/services/src/cell/service/base_messages/player_init.rs
@@ -424,6 +424,118 @@ pub(super) async fn send_known_abilities_update(
 }
 
 #[cfg(test)]
+mod relog_mission_resurrection_tests {
+    //! **#411 end-to-end guard.** A mis-gated `player_loaded` chain (one
+    //! whose author forgot the `mission_status eq not_active` condition)
+    //! fires `accept_mission` on every world entry. Pre-fix, that
+    //! overwrote a relog-restored COMPLETED mission with a fresh ACTIVE
+    //! instance and persisted `MissionUpdate status=1` over the saved
+    //! row — completed missions reappeared as active in the quest log
+    //! after relog. The server-side offer guard must hold even when the
+    //! chain data is wrong.
+
+    use super::*;
+    use crate::cell::messages::SavedMission;
+    use cimmeria_content_engine::actions::Action;
+    use cimmeria_content_engine::chain::Chain;
+    use cimmeria_content_engine::triggers::Trigger;
+    use cimmeria_entity::missions::MISSION_COMPLETED;
+
+    #[tokio::test]
+    async fn mis_gated_player_loaded_chain_cannot_resurrect_completed_mission() {
+        let mut mgr = SpaceManager::new(1);
+        let xml = r#"<?xml version="1.0"?><Spaces><Space WorldName="Castle_CellBlock" Instanced="true" MinX="-800" MaxX="800" MinY="-800" MaxY="800" /></Spaces>"#;
+        mgr.parse_spaces_xml(xml).unwrap();
+        mgr.create_startup_spaces(r#"<?xml version="1.0"?><Spaces></Spaces>"#)
+            .unwrap();
+        mgr.create_entity(1, "Castle_CellBlock", [0.0; 3], [0.0; 3])
+            .unwrap();
+        mgr.connect_entity(1);
+        mgr.mission_defs.insert(
+            622,
+            crate::cell::spawner::MissionDefEntry {
+                step_id: 2113,
+                objectives: vec![],
+                is_hidden: false,
+                num_repeats: 1,
+                can_repeat_on_fail: true,
+            },
+        );
+
+        // The mis-gated chain: player_loaded, NO conditions, accepts 622.
+        let mut engine = ChainEngine::new();
+        engine.register_chain(Chain {
+            id: 9999,
+            name: "mis-gated 622 grant (no not_active condition)".into(),
+            enabled: true,
+            trigger: Trigger::OnPlayerLoaded { world_name: None },
+            conditions: vec![],
+            actions: vec![Action::AcceptMission { mission_id: 622 }],
+            priority: 0,
+        });
+
+        // Relog payload: 622 completed, repeat counter at the cap.
+        let saved = vec![SavedMission {
+            mission_id: 622,
+            status: MISSION_COMPLETED,
+            current_step_id: None,
+            completed_step_ids: vec![2113],
+            completed_objective_ids: vec![],
+            active_objective_ids: vec![],
+            failed_objective_ids: vec![],
+            repeats: 2, // > num_repeats = 1 → not re-offerable
+        }];
+
+        let (tx, mut rx) = mpsc::channel(64);
+        handle_init_player_state(
+            1,
+            100,
+            "Castle_CellBlock".into(),
+            1,
+            saved,
+            vec![],
+            0,
+            vec![],
+            cimmeria_entity::cell_entity::SystemOptions::default(),
+            &tx,
+            &mut mgr,
+            &engine,
+        )
+        .await;
+
+        // Cell-side state: still completed, repeat counter intact.
+        let m = mgr
+            .get_entity(1)
+            .unwrap()
+            .missions
+            .get_mission(622)
+            .expect("restored mission must still be tracked");
+        assert_eq!(
+            m.status, MISSION_COMPLETED,
+            "the offer guard must keep the restored mission COMPLETED even \
+             when a mis-gated player_loaded chain re-fires accept_mission"
+        );
+        assert_eq!(m.repeats, 2, "repeat counter must survive the relog");
+
+        // Wire/persist side: no MissionUpdate(status=1) may have been sent —
+        // that's the message that UPSERTs "active" over the saved row.
+        while let Ok(msg) = rx.try_recv() {
+            if let CellToBaseMsg::MissionUpdate {
+                mission_id, status, ..
+            } = msg
+            {
+                assert!(
+                    !(mission_id == 622 && status == 1),
+                    "relog must not persist MissionUpdate(622, status=1) — \
+                     this is the exact write that resurrected completed \
+                     missions as active (#411)"
+                );
+            }
+        }
+    }
+}
+
+#[cfg(test)]
 mod system_options_assignment_tests {
     //! The InitPlayerState handler is the hydrate-on-login site for
     //! `CellEntity::system_options`. These guards pin that the

--- a/crates/services/src/cell/spawner/missions.rs
+++ b/crates/services/src/cell/spawner/missions.rs
@@ -22,6 +22,13 @@ pub struct MissionDefEntry {
     /// honors it. Without this, hidden sub-missions like the
     /// Hallway0N Controllers (mission 682-686) leak into the player's UI.
     pub is_hidden: bool,
+    /// `resources.missions.num_repeats` — re-acceptance cap. Python parity:
+    /// `MissionManager.py canOffer()` refuses a COMPLETED mission when
+    /// `repeats > numRepeats`. Read by the `accept_mission` offer guard.
+    pub num_repeats: i32,
+    /// `resources.missions.can_repeat_on_fail` — when false, a FAILED
+    /// mission can never be re-offered (Python parity: `canOffer()`).
+    pub can_repeat_on_fail: bool,
 }
 
 /// A single objective within a mission step.
@@ -45,7 +52,8 @@ pub async fn load_mission_defs(
     // Get the first step per mission (lowest index) plus the mission-level
     // `is_hidden` flag, joined in one query.
     let step_rows = sqlx::query(
-        "SELECT DISTINCT ON (s.mission_id) s.mission_id, s.step_id, m.is_hidden \
+        "SELECT DISTINCT ON (s.mission_id) s.mission_id, s.step_id, m.is_hidden, \
+                m.num_repeats, m.can_repeat_on_fail \
          FROM resources.mission_steps s \
          JOIN resources.missions m ON m.mission_id = s.mission_id \
          ORDER BY s.mission_id, s.index ASC",
@@ -58,12 +66,16 @@ pub async fn load_mission_defs(
         let mission_id: i32 = r.get("mission_id");
         let step_id: i32 = r.get("step_id");
         let is_hidden: bool = r.get("is_hidden");
+        let num_repeats: i32 = r.get("num_repeats");
+        let can_repeat_on_fail: bool = r.get("can_repeat_on_fail");
         map.insert(
             mission_id,
             MissionDefEntry {
                 step_id,
                 objectives: Vec::new(),
                 is_hidden,
+                num_repeats,
+                can_repeat_on_fail,
             },
         );
     }

--- a/docs/gameplay/mission-system.md
+++ b/docs/gameplay/mission-system.md
@@ -109,6 +109,30 @@ MissionManager.complete(missionId)
        |-> client.onMissionUpdate(id, 1, 0)
 ```
 
+## Offer Guard (server-authoritative re-accept gate)
+
+`accept_mission` ([crates/services/src/cell/missions.rs](../../crates/services/src/cell/missions.rs))
+ports Python `MissionManager.canOffer()` and refuses the accept when:
+
+- the mission is already **ACTIVE** (a re-accept would reset progress to
+  the first step — the "briefing loop" bug class), or
+- the mission is **FAILED** and `resources.missions.can_repeat_on_fail`
+  is false, or
+- the mission is **COMPLETED** and `repeats > num_repeats` (both sides
+  from the DB: instance counter vs. `resources.missions.num_repeats`).
+
+A refused accept returns `false`; the content-engine executor then skips
+both the `MissionUpdate` persist and the `mission_accepted` follow-up
+event, so a mis-gated chain (e.g. a `player_loaded` grant missing its
+`mission_status eq not_active` condition) can no longer UPSERT
+`status=active` over a saved completed row — the root corruption behind
+"completed missions reappear in the quest log after relog" (#411).
+Chain-side `not_active` gates remain the first line of defense; the
+guard is the server-authoritative backstop. Repeatability fields ride
+the `MissionDefEntry` cache loaded at startup
+([crates/services/src/cell/spawner/missions.rs](../../crates/services/src/cell/spawner/missions.rs));
+a mission without a def entry fails closed (treated as non-repeatable).
+
 ## Mission Status Codes
 
 | Code | Constant | Description |


### PR DESCRIPTION
Closes #411.

## What

Completed missions could reappear as **active** in the quest log after a relog. The root corruption path: any re-fired `accept_mission` content action (a chain missing its `mission_status eq not_active` gate, an event evaluated before mission state was hydrated, or even an entity-missing race) overwrote the relog-restored `MISSION_COMPLETED` instance with a fresh ACTIVE one **and unconditionally persisted `MissionUpdate status=1`**, UPSERTing "active" over the saved completed row. The executor sent that persist even when the underlying accept silently no-op'd because the cell entity didn't exist.

This PR adds the server-authoritative offer guard the issue asked for — a direct port of Python `MissionManager.canOffer()` (`deprecated/python/cell/MissionManager.py:119-136`):

- **already ACTIVE** → refuse (re-accept would reset in-flight progress to step 1 — the chain-1051/1053 "briefing loop" bug class)
- **FAILED && !can_repeat_on_fail** → refuse
- **COMPLETED && repeats > num_repeats** → refuse (both sides from the DB: the instance counter restored on relog vs. `resources.missions.num_repeats`)

`accept_mission` now returns `bool`; the content-engine executor skips both the `MissionUpdate` persist and the `mission_accepted` follow-up event on refusal, and the entity-missing path now refuses instead of persisting a phantom accept.

## Changes

- `crates/services/src/cell/spawner/missions.rs` — `MissionDefEntry` gains `num_repeats` + `can_repeat_on_fail`, loaded in the existing `load_mission_defs` JOIN against `resources.missions`.
- `crates/services/src/cell/missions.rs` — `accept_mission` ports `canOffer()` and returns `bool`. Missing def fails closed (treated as non-repeatable). Missing entity refuses.
- `crates/services/src/cell/content/executor/mission.rs` — `accept_or_advance` only persists + fires `mission_accepted` when the accept actually succeeded.
- Docs: `docs/gameplay/mission-system.md` (new "Offer Guard" section), `.github/instructions/content-chains.instructions.md` (chains must still gate on `not_active`; the guard is the backstop, not a license).

Chain-side `not_active` conditions remain the first line of defense — the guard means a content-data mistake can no longer corrupt saved mission rows.

## Tests

All regression guards verified to **fail with the guard reverted** (5/5 trip):

- `cell::missions` unit tests: completed-at-cap refused (state + wire silence), below-cap allowed (Python parity — `num_repeats=1` missions stay re-offerable after one completion), active-mission refusal preserves in-flight step, `can_repeat_on_fail` both branches, entity-missing refusal.
- `executor::mission::offer_guard_tests`: refused accept sends **no** `MissionUpdate`; entity-missing accept sends no `MissionUpdate` (the phantom-persist regression); fresh accept still persists exactly one `status=1` (happy-path pin).
- `player_init::relog_mission_resurrection_tests`: end-to-end relog — `handle_init_player_state` restores a completed-at-cap mission, a deliberately mis-gated `player_loaded` chain (no conditions) fires `accept_mission`, and the mission stays `MISSION_COMPLETED` with no `MissionUpdate(status=1)` on the wire.
- Updated two existing tests that re-accept completed missions to declare repeatable defs (the guard now fails closed without one).

## Notes

- The original hypothesis in #411 (chains missing completion gates) checks out as the *class* of bug, but the audited seed chains (1001, 3001, 1011/1012, 1051-1054…) are all correctly gated today and restore-before-fire ordering in `handle_init_player_state` predates the report — so the live corruption most likely entered through the unconditional-persist hole (entity-missing or pre-hydration event), which this PR closes regardless of which path re-fires the accept.
- Python parity detail: tutorial missions (622, 638-641, 1559-1562) ship `num_repeats=1`, so a single completion leaves them re-offerable under the original `repeats > numRepeats` rule. The guard intentionally preserves that — it blocks the *second* re-offer, and chain conditions block the first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where completed missions could be incorrectly resurrected to active status after reload.

* **New Features**
  * Implemented server-side validation for mission re-acceptance with repeat count limits and mission-specific repeatability controls.

* **Documentation**
  * Updated mission system documentation to explain server-authoritative re-acceptance validation and offer guard behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->