### PR TITLE
fix(combat): persist BSF_AUTO_CYCLING across relog via sgw_player.state_field (#412)

### DIFF
--- a/.github/instructions/content-chains.instructions.md
+++ b/.github/instructions/content-chains.instructions.md
@@ -31,6 +31,17 @@ Every `op: "|"` (set) needs a matching `op: "~"` (clear) on the chain that compl
 
 For mission progression, also add a `player_loaded`-triggered chain that re-applies the bit for active steps. Interaction flags don't persist on the entity across server restart, so without restoration a relog mid-mission breaks interactivity. Worked example: chains 1045/1046 in `castle_cellblock_chains.sql` restore HackTheRings_Switch's bit based on which step is active.
 
+## Mission grants must gate on `not_active`
+
+Every chain whose actions include `accept_mission` must carry a
+`mission_status <id> eq not_active` condition (see chain 1001 for the
+canonical shape). Since #411 the server also refuses re-accepts
+authoritatively (`accept_mission`'s offer guard: already-active,
+failed-without-`can_repeat_on_fail`, or completed past `num_repeats`),
+so a missing gate no longer corrupts saved mission rows — but it still
+fires the chain's *other* actions (dialogs, highlights) spuriously, so
+the condition remains a review requirement.
+
 ## Inventory consumption
 
 `UseInventoryItem` fires `OnItemUse` as a pure event — the base no longer auto-consumes the stack. Chains that need to consume (consumable vials, mission objects) must include an explicit `remove_item` action. This is the correct pattern for `item_use`-triggered chains:

--- a/crates/services/src/base/world_entry/cell_dispatch/mod.rs
+++ b/crates/services/src/base/world_entry/cell_dispatch/mod.rs
@@ -37,6 +37,7 @@ use super::teleport::handle_teleport_player;
 mod aoi;
 mod bandolier;
 mod minigame;
+mod state_field;
 mod system_options;
 
 pub(crate) use aoi::flush_deferred_aoi;
@@ -783,6 +784,12 @@ pub(crate) async fn handle_cell_message(
                 db_pool,
             )
             .await;
+        }
+        CellToBaseMsg::StateFieldUpdate {
+            player_id,
+            state_field,
+        } => {
+            state_field::persist_state_field(player_id, state_field, db_pool).await;
         }
         CellToBaseMsg::RefreshAppearance {
             entity_id,

--- a/crates/services/src/base/world_entry/cell_dispatch/state_field.rs
+++ b/crates/services/src/base/world_entry/cell_dispatch/state_field.rs
@@ -1,0 +1,245 @@
+//! `CellToBaseMsg::StateFieldUpdate` — persist the user-preference bits
+//! of the player's `state_field` bitmask.
+//!
+//! The cell side owns the in-memory `state_field` on every `CellEntity`;
+//! the base side owns DB writes. When the player presses the auto-cycle
+//! button (`setAutoCycle`, player method 83) and `BSF_AutoCycling`
+//! transitions, the cell handler broadcasts `onStateFieldUpdate` to the
+//! client, then sends this message so base persists the row. On next
+//! login, the hydrate path in
+//! `crates/services/src/base/world_entry_appearance.rs` reads the column
+//! back into `InitPlayerState` and the preference survives the relog. (#412)
+//!
+//! Schema column:
+//!
+//! - `sgw_player.state_field INTEGER NOT NULL DEFAULT 0`
+//!
+//! Only bits in [`crate::cell::combat::PERSISTED_STATE_FIELD_MASK`] are
+//! ever stored. The cell send site already masks; this handler masks
+//! again defensively so a future send site that forgets can't leak a
+//! transient combat bit (BSF_Dead, BSF_InCombat, BSF_MovementLock) into
+//! durable state — a relog must always be a clean combat slate.
+//!
+//! No appearance refresh needed (unlike `ActiveSlotUpdate`) — the bit
+//! affects the player's own UI highlight + the server loop driver, not
+//! the visual model.
+
+use std::sync::Arc;
+
+use sqlx::PgPool;
+
+use crate::cell::combat::PERSISTED_STATE_FIELD_MASK;
+
+/// Persist a player's preference `state_field` bits to `sgw_player`.
+/// Returns silently after a `warn` if the row is missing or the write
+/// fails — the in-memory cell-side value still applies for the rest of
+/// the session, so the toggle isn't completely lost even when
+/// persistence breaks. Loud enough that ops will notice.
+pub(super) async fn persist_state_field(
+    player_id: i32,
+    state_field: u32,
+    db_pool: &Option<Arc<PgPool>>,
+) {
+    let Some(pool) = db_pool else {
+        // No pool means the server is running without persistence (test
+        // / repl / smoke mode). Mirror the system-options handler:
+        // silent no-op.
+        return;
+    };
+
+    let masked = state_field & PERSISTED_STATE_FIELD_MASK;
+
+    match sqlx::query("UPDATE sgw_player SET state_field = $1 WHERE player_id = $2")
+        .bind(masked as i32)
+        .bind(player_id)
+        .execute(pool.as_ref())
+        .await
+    {
+        Ok(res) if res.rows_affected() == 0 => {
+            // No row updated — typically a test fixture or a deleted
+            // character. Loud because losing this silently means the
+            // next relog hydrates to 0 and the user thinks the toggle
+            // didn't save.
+            tracing::warn!(
+                player_id,
+                state_field = masked,
+                "StateFieldUpdate: no rows updated (player row missing?)"
+            );
+        }
+        Ok(_) => {
+            tracing::info!(
+                player_id,
+                state_field = masked,
+                "StateFieldUpdate: persisted"
+            );
+        }
+        Err(e) => {
+            tracing::warn!(
+                player_id,
+                state_field = masked,
+                error = %e,
+                "StateFieldUpdate: DB write failed (in-memory value still applies for this session)"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Live-DB regression guards for the state_field persistence path
+    //! (#412). Sentinel id range `0x7000_1700` — sibling slot reserved
+    //! past `system_options::tests` at `0x7000_1600`.
+
+    use super::*;
+    use crate::cell::combat::{BSF_AUTO_CYCLING, BSF_DEAD, BSF_IN_COMBAT, BSF_MOVEMENT_LOCK};
+    use crate::test_support::require_db_or_skip;
+
+    const TEST_BASE: i32 = 0x7000_1700;
+
+    async fn cleanup(pool: &PgPool, account_id: i32) {
+        let _ = sqlx::query("DELETE FROM sgw_player WHERE account_id = $1")
+            .bind(account_id)
+            .execute(pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM account WHERE account_id = $1")
+            .bind(account_id)
+            .execute(pool)
+            .await;
+    }
+
+    async fn insert_player(pool: &PgPool, account_id: i32, player_id: i32) {
+        sqlx::query(
+            "INSERT INTO account (account_id, account_name, password) \
+             VALUES ($1, $2, '')",
+        )
+        .bind(account_id)
+        .bind(format!("statefield-{account_id}"))
+        .execute(pool)
+        .await
+        .expect("insert account");
+        sqlx::query(
+            "INSERT INTO sgw_player (\
+                account_id, player_id, level, alignment, archetype, gender, \
+                player_name, extra_name, world_location, bodyset, \
+                pos_x, pos_y, pos_z, skin_color_id, naquadah, bandolier_slot\
+             ) VALUES ($1, $2, 1, 1, 1, 1, $3, '', 'CombatSim', \
+                       'BS_HumanMale.BS_HumanMale', 0.0, 0.0, 0.0, 0, 0, 0)",
+        )
+        .bind(account_id)
+        .bind(player_id)
+        .bind(format!("stfd-{player_id}"))
+        .execute(pool)
+        .await
+        .expect("insert player");
+    }
+
+    async fn read_state_field(pool: &PgPool, player_id: i32) -> i32 {
+        sqlx::query_scalar("SELECT state_field FROM sgw_player WHERE player_id = $1")
+            .bind(player_id)
+            .fetch_one(pool)
+            .await
+            .expect("read state_field")
+    }
+
+    /// **#412 round-trip.** A fresh row defaults to 0; persisting the
+    /// auto-cycle bit stores it; persisting 0 (explicit disable) clears
+    /// it. Reverting the persist implementation to a no-op fails the
+    /// middle assertion.
+    #[tokio::test]
+    async fn auto_cycle_bit_round_trips() {
+        let pool = require_db_or_skip!();
+        let account_id = TEST_BASE;
+        let player_id = TEST_BASE + 1;
+        cleanup(&pool, account_id).await;
+        insert_player(&pool, account_id, player_id).await;
+        let pool_opt = Some(Arc::new(pool.clone()));
+
+        assert_eq!(
+            read_state_field(&pool, player_id).await,
+            0,
+            "fresh player row must default state_field to 0"
+        );
+
+        persist_state_field(player_id, BSF_AUTO_CYCLING, &pool_opt).await;
+        assert_eq!(
+            read_state_field(&pool, player_id).await,
+            BSF_AUTO_CYCLING as i32,
+            "enable toggle must store the auto-cycle bit"
+        );
+
+        persist_state_field(player_id, 0, &pool_opt).await;
+        assert_eq!(
+            read_state_field(&pool, player_id).await,
+            0,
+            "disable toggle must clear the stored bit"
+        );
+
+        cleanup(&pool, account_id).await;
+    }
+
+    /// **#412 mask guard.** Transient combat bits must never reach the
+    /// DB even when a caller passes an unmasked `state_field` (e.g. the
+    /// raw broadcast value while the player is mid-fight: dead +
+    /// in-combat + movement-locked + auto-cycling). Only the
+    /// auto-cycle bit may survive the write. Reverting the
+    /// `& PERSISTED_STATE_FIELD_MASK` in `persist_state_field` fails
+    /// this.
+    #[tokio::test]
+    async fn transient_combat_bits_are_masked_out() {
+        let pool = require_db_or_skip!();
+        let account_id = TEST_BASE + 0x10;
+        let player_id = TEST_BASE + 0x11;
+        cleanup(&pool, account_id).await;
+        insert_player(&pool, account_id, player_id).await;
+        let pool_opt = Some(Arc::new(pool.clone()));
+
+        let mid_fight = BSF_DEAD | BSF_AUTO_CYCLING | BSF_IN_COMBAT | BSF_MOVEMENT_LOCK;
+        persist_state_field(player_id, mid_fight, &pool_opt).await;
+        assert_eq!(
+            read_state_field(&pool, player_id).await,
+            BSF_AUTO_CYCLING as i32,
+            "only PERSISTED_STATE_FIELD_MASK bits may be stored — a dead, \
+             movement-locked relog would otherwise spawn the player frozen"
+        );
+
+        // Pure-transient value (no preference bit at all) must store 0.
+        persist_state_field(player_id, BSF_DEAD | BSF_IN_COMBAT, &pool_opt).await;
+        assert_eq!(
+            read_state_field(&pool, player_id).await,
+            0,
+            "an all-transient state_field must persist as 0"
+        );
+
+        cleanup(&pool, account_id).await;
+    }
+
+    /// Missing-row contract: persisting against a non-existent player_id
+    /// must warn (not error / not silently succeed), mirroring the
+    /// system-options handler per the negative-logging convention.
+    #[tokio::test]
+    async fn persist_no_row_is_silent_warn() {
+        use crate::test_support::LogCapture;
+        let pool = require_db_or_skip!();
+        let pool_opt = Some(Arc::new(pool.clone()));
+        let phantom_id = TEST_BASE + 0x20;
+        let _ = sqlx::query("DELETE FROM sgw_player WHERE player_id = $1")
+            .bind(phantom_id)
+            .execute(&pool)
+            .await;
+
+        let capture = LogCapture::install();
+        persist_state_field(phantom_id, BSF_AUTO_CYCLING, &pool_opt).await;
+
+        let event = capture
+            .find_message(tracing::Level::WARN, "StateFieldUpdate: no rows updated")
+            .expect(
+                "missing-row persist must emit the documented warn — \
+                 reverting the rows_affected==0 arm fails this guard",
+            );
+        assert!(
+            event.has_field("player_id", &phantom_id.to_string()),
+            "warn must carry player_id field; got {:?}",
+            event
+        );
+    }
+}

--- a/crates/services/src/base/world_entry/methods/missions.rs
+++ b/crates/services/src/base/world_entry/methods/missions.rs
@@ -514,6 +514,19 @@ mod tests {
         mgr.create_startup_spaces(cxml).unwrap();
         mgr.create_entity(ENTITY_ID, "Agnos", [0.0; 3], [0.0; 3])
             .unwrap();
+        // Repeatable def (num_repeats=2 → two completions stay under the
+        // `repeats > num_repeats` cap) so the post-relog re-accept passes
+        // the offer guard. Without a def the guard fails closed.
+        mgr.mission_defs.insert(
+            MISSION_ID,
+            crate::cell::spawner::MissionDefEntry {
+                step_id: STEP_ID,
+                objectives: vec![],
+                is_hidden: false,
+                num_repeats: 2,
+                can_repeat_on_fail: true,
+            },
+        );
 
         let (tx, _rx) = mpsc::channel::<crate::cell::messages::CellToBaseMsg>(64);
         let objectives = || {

--- a/crates/services/src/base/world_entry_appearance.rs
+++ b/crates/services/src/base/world_entry_appearance.rs
@@ -276,55 +276,62 @@ pub(crate) async fn handle_on_client_ready(
     // silently default a real player to empty bandolier state. The
     // two booleans come from the same SELECT so we make one
     // round-trip not three.
-    let (active_bandolier_slot, bandolier_items, system_options) = if let Some(pool) = db_pool {
-        #[derive(sqlx::FromRow)]
-        struct PlayerInitRow {
-            bandolier_slot: i32,
-            auto_reload: bool,
-            reload_on_activate: bool,
-        }
-        let row: Option<PlayerInitRow> = match sqlx::query_as::<_, PlayerInitRow>(
-            "SELECT bandolier_slot, auto_reload, reload_on_activate \
-             FROM sgw_player WHERE player_id = $1",
-        )
-        .bind(pending.player_id)
-        .fetch_optional(pool.as_ref())
-        .await
-        {
-            Ok(r) => r,
-            Err(e) => {
-                tracing::error!(
-                    player_id = pending.player_id,
-                    "Player init read failed; defaulting to XML defaults but logging error: {e}"
-                );
-                None
+    let (active_bandolier_slot, bandolier_items, system_options, state_field) =
+        if let Some(pool) = db_pool {
+            #[derive(sqlx::FromRow)]
+            struct PlayerInitRow {
+                bandolier_slot: i32,
+                auto_reload: bool,
+                reload_on_activate: bool,
+                state_field: i32,
             }
-        };
-        let (slot, opts) = match row {
-            Some(r) => (
-                r.bandolier_slot,
-                cimmeria_entity::cell_entity::SystemOptions {
-                    auto_reload: r.auto_reload,
-                    reload_on_activate: r.reload_on_activate,
-                },
-            ),
-            None => (0, cimmeria_entity::cell_entity::SystemOptions::default()),
-        };
+            let row: Option<PlayerInitRow> = match sqlx::query_as::<_, PlayerInitRow>(
+                "SELECT bandolier_slot, auto_reload, reload_on_activate, state_field \
+                 FROM sgw_player WHERE player_id = $1",
+            )
+            .bind(pending.player_id)
+            .fetch_optional(pool.as_ref())
+            .await
+            {
+                Ok(r) => r,
+                Err(e) => {
+                    tracing::error!(
+                        player_id = pending.player_id,
+                        "Player init read failed; defaulting to XML defaults but logging error: {e}"
+                    );
+                    None
+                }
+            };
+            let (slot, opts, state_field) = match row {
+                Some(r) => (
+                    r.bandolier_slot,
+                    cimmeria_entity::cell_entity::SystemOptions {
+                        auto_reload: r.auto_reload,
+                        reload_on_activate: r.reload_on_activate,
+                    },
+                    // Stored masked (PERSISTED_STATE_FIELD_MASK + the
+                    // schema's non-negative CHECK), so the lossless cast
+                    // back to the in-memory u32 bitmask is safe.
+                    r.state_field as u32,
+                ),
+                None => (0, cimmeria_entity::cell_entity::SystemOptions::default(), 0),
+            };
 
-        let items = super::world_entry::methods::player_load::meta::query_bandolier_items(
-            db_pool,
-            pending.player_id,
-        )
-        .await;
+            let items = super::world_entry::methods::player_load::meta::query_bandolier_items(
+                db_pool,
+                pending.player_id,
+            )
+            .await;
 
-        (slot, items, opts)
-    } else {
-        (
-            0,
-            Vec::new(),
-            cimmeria_entity::cell_entity::SystemOptions::default(),
-        )
-    };
+            (slot, items, opts, state_field)
+        } else {
+            (
+                0,
+                Vec::new(),
+                cimmeria_entity::cell_entity::SystemOptions::default(),
+                0,
+            )
+        };
 
     // Cross-world ring transport carry-through: take the pending ring id
     // BEFORE we drop the connected lock so a concurrent disconnect can't
@@ -361,6 +368,7 @@ pub(crate) async fn handle_on_client_ready(
                 active_bandolier_slot,
                 bandolier_items,
                 system_options,
+                state_field,
             })
             .await
         {

--- a/crates/services/src/cell/cell_methods/player/world/mod.rs
+++ b/crates/services/src/cell/cell_methods/player/world/mod.rs
@@ -69,6 +69,7 @@ pub async fn dispatch(
                             space_mgr,
                         )
                         .await;
+                        persist_state_field_bits(entity_id, new_state, tx, space_mgr).await;
                     }
                     // Gated on bit transition. CEGUI fires the Lua
                     // binding 3-4× per physical click (~150µs apart);
@@ -130,6 +131,7 @@ pub async fn dispatch(
                             space_mgr,
                         )
                         .await;
+                        persist_state_field_bits(entity_id, new_state, tx, space_mgr).await;
                     }
                 }
             }
@@ -257,6 +259,51 @@ pub async fn dispatch(
         }
 
         _ => false,
+    }
+}
+
+/// Fire-and-forget persist of the user-preference `state_field` bits
+/// after an explicit `setAutoCycle` toggle flipped `BSF_AutoCycling`.
+///
+/// Masks to [`crate::cell::combat::PERSISTED_STATE_FIELD_MASK`] so
+/// transient combat bits riding the same broadcast value (BSF_Dead,
+/// BSF_InCombat, BSF_MovementLock) never reach the DB — a relog must
+/// always be a clean combat slate (#412).
+///
+/// Deliberately called from the explicit toggle site only, NOT from the
+/// in-combat auto-clear paths (target death, manual fire of a different
+/// ability, AF_DEACTIVATE_AUTO_CYCLE): those are session mechanics, and
+/// mirroring them to the DB would make the post-relog state depend on
+/// whether the player's last target happened to die — the persisted
+/// value tracks the player's deliberate button choice.
+///
+/// Silent no-op for entities without a `player_id` (NPCs / test
+/// fixtures shouldn't persist).
+async fn persist_state_field_bits(
+    entity_id: u32,
+    state_field: u32,
+    tx: &mpsc::Sender<CellToBaseMsg>,
+    space_mgr: &SpaceManager,
+) {
+    let Some(player_id) = space_mgr.get_entity(entity_id).and_then(|e| e.player_id) else {
+        return;
+    };
+    if let Err(e) = tx
+        .send(CellToBaseMsg::StateFieldUpdate {
+            player_id,
+            state_field: state_field & crate::cell::combat::PERSISTED_STATE_FIELD_MASK,
+        })
+        .await
+    {
+        // Channel closed — the toggle still applies in-memory for this
+        // session but won't survive the relog. Same level rationale as
+        // the SystemOptionsUpdate persist failure path.
+        tracing::warn!(
+            entity_id,
+            player_id,
+            error = %e,
+            "StateFieldUpdate send to base failed -- auto-cycle preference not persisted"
+        );
     }
 }
 

--- a/crates/services/src/cell/cell_methods/player/world/tests.rs
+++ b/crates/services/src/cell/cell_methods/player/world/tests.rs
@@ -84,6 +84,76 @@ async fn set_auto_cycle_disable_clears_stash_and_bsf() {
     );
 }
 
+/// Collect every `StateFieldUpdate` persist message out of the channel.
+fn drain_state_field_updates(rx: &mut mpsc::Receiver<CellToBaseMsg>) -> Vec<(i32, u32)> {
+    let mut out = Vec::new();
+    while let Ok(msg) = rx.try_recv() {
+        if let CellToBaseMsg::StateFieldUpdate {
+            player_id,
+            state_field,
+        } = msg
+        {
+            out.push((player_id, state_field));
+        }
+    }
+    out
+}
+
+/// **#412 persist-on-enable.** The explicit `setAutoCycle(1)` toggle must
+/// send a `StateFieldUpdate` carrying the masked preference bits so the
+/// base persists the choice and the next relog restores it. Pre-fix,
+/// nothing persisted `state_field` and the auto-cycle loop never armed
+/// post-relog until the player pressed the button again.
+#[tokio::test]
+async fn set_auto_cycle_enable_persists_masked_state_field() {
+    use crate::cell::combat::{BSF_AUTO_CYCLING, BSF_IN_COMBAT};
+    let mut mgr = make_mgr_with_player();
+    // Pre-set a transient bit so the mask discipline is observable: the
+    // persisted value must carry ONLY the preference bit even though the
+    // live state_field has BSF_InCombat riding along.
+    if let Some(e) = mgr.get_entity_mut(1) {
+        e.state_field |= BSF_IN_COMBAT;
+    }
+    let engine = ChainEngine::new();
+    let (tx, mut rx) = mpsc::channel(8);
+
+    let handled = dispatch(1, SET_AUTO_CYCLE, &[1], &tx, &mut mgr, &engine).await;
+    assert!(handled);
+
+    let updates = drain_state_field_updates(&mut rx);
+    assert_eq!(
+        updates,
+        vec![(100, BSF_AUTO_CYCLING)],
+        "enable must persist exactly one StateFieldUpdate with the masked \
+         preference bits (BSF_InCombat must be stripped)"
+    );
+}
+
+/// **#412 persist-on-disable.** The explicit `setAutoCycle(0)` toggle must
+/// persist the cleared preference (state_field = 0) so a relog doesn't
+/// resurrect a deliberately disabled auto-cycle.
+#[tokio::test]
+async fn set_auto_cycle_disable_persists_cleared_state_field() {
+    use crate::cell::combat::BSF_AUTO_CYCLING;
+    let mut mgr = make_mgr_with_player();
+    if let Some(e) = mgr.get_entity_mut(1) {
+        e.abilities.auto_cycle = true;
+        e.state_field |= BSF_AUTO_CYCLING;
+    }
+    let engine = ChainEngine::new();
+    let (tx, mut rx) = mpsc::channel(8);
+
+    let handled = dispatch(1, SET_AUTO_CYCLE, &[0], &tx, &mut mgr, &engine).await;
+    assert!(handled);
+
+    let updates = drain_state_field_updates(&mut rx);
+    assert_eq!(
+        updates,
+        vec![(100, 0)],
+        "disable must persist exactly one StateFieldUpdate with the bit cleared"
+    );
+}
+
 /// SET_AUTO_CYCLE disable when BSF was already clear must NOT
 /// emit a redundant `onStateFieldUpdate`. The transition gate
 /// inside `clear_auto_cycle` returns `None` and the handler

--- a/crates/services/src/cell/combat/mod.rs
+++ b/crates/services/src/cell/combat/mod.rs
@@ -22,7 +22,7 @@ pub const HOSTILE_FACTION: u8 = 10;
 
 pub use state::{
     is_dead_state, mark_npc_dead, BSF_AUTO_CYCLING, BSF_DEAD, BSF_IN_COMBAT, BSF_MOVEMENT_LOCK,
-    PLAYER_STATE_DEAD,
+    PERSISTED_STATE_FIELD_MASK, PLAYER_STATE_DEAD,
 };
 pub use threat::{
     clear_dead_npc_from_all_player_threat, enter_player_combat, exit_player_combat,

--- a/crates/services/src/cell/combat/state.rs
+++ b/crates/services/src/cell/combat/state.rs
@@ -35,6 +35,22 @@ pub const BSF_DEAD: u32 = 1 << BSF_DEAD_BIT;
 /// From python `Atrea.enums.BSF_AutoCycling = 1`.
 pub const BSF_AUTO_CYCLING: u32 = 1 << 1;
 
+/// The subset of `state_field` bits that persist across logins.
+///
+/// `state_field` is mostly transient combat state — `BSF_Dead`,
+/// `BSF_InCombat`, `BSF_MovementLock` all describe the current fight and
+/// must reset on world entry (relog is a fresh combat slate; see the
+/// cooldown-wipe rationale in PR #410). `BSF_AutoCycling` is the
+/// exception: it's a player preference toggle the original game kept
+/// across sessions, so the `setAutoCycle` handler persists it through
+/// `CellToBaseMsg::StateFieldUpdate` and `InitPlayerState` restores it.
+///
+/// Both the cell-side send site and the base-side DB write mask with
+/// this constant, so growing the persisted set is a one-line change
+/// here — and a transient bit can never leak into `sgw_player.state_field`
+/// even if a send site passes an unmasked value. (#412)
+pub const PERSISTED_STATE_FIELD_MASK: u32 = BSF_AUTO_CYCLING;
+
 /// `BSF_InCombat` mask. The client uses this bit to route right-click on
 /// selected entities to `useAbility` (auto-attack) instead of `interact`.
 /// From python `Atrea.enums.BSF_InCombat = 3`.

--- a/crates/services/src/cell/content/executor/mission.rs
+++ b/crates/services/src/cell/content/executor/mission.rs
@@ -51,10 +51,25 @@ pub(super) async fn accept_or_advance(
                 optional: o.is_optional,
             })
             .collect();
-        crate::cell::missions::accept_mission(
+        let accepted = crate::cell::missions::accept_mission(
             entity_id, mission_id, step_id, objectives, tx, space_mgr,
         )
         .await;
+        // Offer refused (already active / completed at repeat cap /
+        // failed non-repeatable) or entity missing. Persisting the
+        // MissionUpdate anyway would UPSERT status=1 over the saved
+        // row — exactly the "completed missions reappear as active
+        // after relog" corruption (#411). Skip the follow-up
+        // `mission_accepted` event too: no acceptance happened.
+        if !accepted {
+            tracing::info!(
+                entity_id,
+                mission_id,
+                chain_id,
+                "Content: accept_mission refused by offer guard — skipping persist + follow-up event"
+            );
+            return;
+        }
         // Read repeats AFTER the helper runs — for a re-accept of
         // a previously-completed repeatable mission, the count
         // restored from DB is what should round-trip back, not 0.
@@ -255,4 +270,128 @@ pub(super) async fn complete_objective(
     );
     crate::cell::missions::complete_objective(entity_id, mission_id, objective_id, tx, space_mgr)
         .await;
+}
+
+#[cfg(test)]
+mod offer_guard_tests {
+    //! #411 regression guards at the executor boundary: a refused (or
+    //! entity-less) `accept_or_advance` must NOT persist a `MissionUpdate`
+    //! — pre-fix, the handler sent `status=1` to the base unconditionally,
+    //! so any re-fired grant chain UPSERTed "active" over a saved
+    //! completed row and the mission resurrected in the quest log on the
+    //! next relog.
+
+    use super::*;
+    use crate::cell::spawner::MissionDefEntry;
+    use cimmeria_entity::missions::{MissionInstance, MISSION_COMPLETED};
+    use tokio::sync::mpsc;
+
+    fn make_mgr_with_def() -> SpaceManager {
+        let mut mgr = SpaceManager::new(1);
+        let xml = r#"<?xml version="1.0"?><Spaces><Space WorldName="Agnos" Instanced="false" MinX="0" MaxX="100" MinY="0" MaxY="100" /></Spaces>"#;
+        let cxml = r#"<?xml version="1.0"?><Spaces><Space WorldName="Agnos" /></Spaces>"#;
+        mgr.parse_spaces_xml(xml).unwrap();
+        mgr.create_startup_spaces(cxml).unwrap();
+        mgr.mission_defs.insert(
+            622,
+            MissionDefEntry {
+                step_id: 2113,
+                objectives: vec![],
+                is_hidden: false,
+                num_repeats: 1,
+                can_repeat_on_fail: true,
+            },
+        );
+        mgr
+    }
+
+    fn drain(rx: &mut mpsc::Receiver<CellToBaseMsg>) -> Vec<CellToBaseMsg> {
+        let mut msgs = Vec::new();
+        while let Ok(m) = rx.try_recv() {
+            msgs.push(m);
+        }
+        msgs
+    }
+
+    fn mission_updates(msgs: &[CellToBaseMsg]) -> Vec<i8> {
+        msgs.iter()
+            .filter_map(|m| match m {
+                CellToBaseMsg::MissionUpdate { status, .. } => Some(*status),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Refused offer (completed mission at the repeat cap) → no
+    /// `MissionUpdate` reaches the base, entity state untouched.
+    #[tokio::test]
+    async fn refused_accept_does_not_persist_mission_update() {
+        let mut mgr = make_mgr_with_def();
+        mgr.create_entity(1, "Agnos", [0.0; 3], [0.0; 3]).unwrap();
+        {
+            let entity = mgr.get_entity_mut(1).unwrap();
+            let mut prior = MissionInstance::new(622, 2113, vec![]);
+            prior.complete();
+            prior.repeats = 2; // past num_repeats = 1
+            entity.missions.add_mission(prior);
+        }
+        let engine = ChainEngine::new();
+        let (tx, mut rx) = mpsc::channel(32);
+
+        accept_or_advance(622, 1, 100, 9999, &tx, &mut mgr, &engine).await;
+
+        let msgs = drain(&mut rx);
+        assert!(
+            mission_updates(&msgs).is_empty(),
+            "refused accept must not send MissionUpdate (would UPSERT \
+             status=1 over the saved completed row); got {msgs:?}"
+        );
+        let m = mgr
+            .get_entity(1)
+            .unwrap()
+            .missions
+            .get_mission(622)
+            .unwrap();
+        assert_eq!(m.status, MISSION_COMPLETED, "completed status preserved");
+    }
+
+    /// Entity missing entirely (e.g. an event fired against a player whose
+    /// cell entity is gone) → nothing to verify against, so nothing may be
+    /// persisted. Pre-fix this path still sent `MissionUpdate status=1
+    /// repeats=0`, silently corrupting the saved row.
+    #[tokio::test]
+    async fn missing_entity_does_not_persist_mission_update() {
+        let mut mgr = make_mgr_with_def();
+        // No entity created.
+        let engine = ChainEngine::new();
+        let (tx, mut rx) = mpsc::channel(32);
+
+        accept_or_advance(622, 1, 100, 9999, &tx, &mut mgr, &engine).await;
+
+        let msgs = drain(&mut rx);
+        assert!(
+            mission_updates(&msgs).is_empty(),
+            "entity-less accept must not persist anything; got {msgs:?}"
+        );
+    }
+
+    /// Happy-path companion pinning the success contract: a fresh accept
+    /// still persists exactly one `MissionUpdate` with status=1. Guards
+    /// against the refusal gate accidentally swallowing legitimate accepts.
+    #[tokio::test]
+    async fn fresh_accept_still_persists_mission_update() {
+        let mut mgr = make_mgr_with_def();
+        mgr.create_entity(1, "Agnos", [0.0; 3], [0.0; 3]).unwrap();
+        let engine = ChainEngine::new();
+        let (tx, mut rx) = mpsc::channel(32);
+
+        accept_or_advance(622, 1, 100, 9999, &tx, &mut mgr, &engine).await;
+
+        let msgs = drain(&mut rx);
+        assert_eq!(
+            mission_updates(&msgs),
+            vec![1],
+            "fresh accept must persist exactly one MissionUpdate(status=1)"
+        );
+    }
 }

--- a/crates/services/src/cell/messages/base_to_cell.rs
+++ b/crates/services/src/cell/messages/base_to_cell.rs
@@ -86,6 +86,13 @@ pub enum BaseToCellMsg {
         /// so the auto-reload and reload-on-activate triggers honour the
         /// player's saved preferences instead of falling back to defaults.
         system_options: cimmeria_entity::cell_entity::SystemOptions,
+        /// Persisted user-preference state bits from `sgw_player.state_field`
+        /// (today: `BSF_AutoCycling` only — see `PERSISTED_STATE_FIELD_MASK`).
+        /// The handler masks again on restore, ORs the bits onto
+        /// `CellEntity::state_field`, re-arms `abilities.auto_cycle`, and
+        /// re-broadcasts `onStateFieldUpdate` so the client's button
+        /// highlight survives the relog. (#412)
+        state_field: u32,
     },
 
     /// Update one bandolier slot after a runtime item grant.

--- a/crates/services/src/cell/messages/cell_to_base.rs
+++ b/crates/services/src/cell/messages/cell_to_base.rs
@@ -297,6 +297,18 @@ pub enum CellToBaseMsg {
         reload_on_activate: bool,
     },
 
+    /// Persist the user-preference bits of the player's `state_field`
+    /// after a toggle (today: `setAutoCycle`, player method 83, flipping
+    /// `BSF_AutoCycling`). Same cell-mutates / base-persists split as
+    /// `SystemOptionsUpdate`. The cell side sends the value already
+    /// masked to `PERSISTED_STATE_FIELD_MASK`; the base-side handler
+    /// masks again defensively so transient combat bits (BSF_Dead,
+    /// BSF_InCombat, BSF_MovementLock) can never reach the DB even if a
+    /// future send site forgets. Restored onto the entity (and
+    /// re-broadcast to the client) by `InitPlayerState` on the next
+    /// world entry. (#412)
+    StateFieldUpdate { player_id: i32, state_field: u32 },
+
     /// Re-broadcast `BeingAppearance` to the player's AoI with a fresh
     /// holster state. Used by the combat enter/exit path (and any other
     /// runtime holster toggle, e.g. the `requestHolsterWeapon` button)

--- a/crates/services/src/cell/missions.rs
+++ b/crates/services/src/cell/missions.rs
@@ -8,7 +8,8 @@
 use tokio::sync::mpsc;
 
 use cimmeria_entity::missions::{
-    MissionInstance, MissionObjective, MISSION_ACTIVE, STATUS_ACTIVE, STATUS_COMPLETED,
+    MissionInstance, MissionObjective, MISSION_ACTIVE, MISSION_COMPLETED, MISSION_FAILED,
+    STATUS_ACTIVE, STATUS_COMPLETED,
 };
 
 use super::messages::CellToBaseMsg;
@@ -168,6 +169,23 @@ pub async fn advance_step(
 }
 
 /// Accept a mission: create a MissionInstance and send initial state to client.
+///
+/// Returns `true` when the mission was actually (re-)accepted. Returns
+/// `false` when the offer guard refused — the caller must NOT persist a
+/// `MissionUpdate` or fire `mission_accepted` in that case, otherwise a
+/// refused accept still flips the DB row back to active (#411).
+///
+/// Offer guard (port of Python `MissionManager.canOffer`,
+/// `deprecated/python/cell/MissionManager.py:119-136`):
+/// - already ACTIVE → refuse (re-accept would reset progress to step 1 —
+///   the chain-1051/1053 "briefing loop" bug class)
+/// - FAILED and `!can_repeat_on_fail` → refuse
+/// - COMPLETED and `repeats > num_repeats` → refuse
+///
+/// Chains are expected to gate their `accept_mission` actions on
+/// `mission_status eq not_active`; this guard is the server-authoritative
+/// backstop so a mis-gated chain (or an event fired before mission state
+/// is hydrated) can't resurrect a completed mission as active on relog.
 #[tracing::instrument(
     name = "mission.accept",
     level = "info",
@@ -181,14 +199,57 @@ pub async fn accept_mission(
     objectives: Vec<MissionObjective>,
     tx: &mpsc::Sender<CellToBaseMsg>,
     space_mgr: &mut SpaceManager,
-) {
-    let entity = match space_mgr.get_entity_mut(entity_id) {
-        Some(e) => e,
-        None => return,
+) -> bool {
+    // Prior-instance snapshot + def lookup happen against the immutable
+    // borrow so the guard can run before any mutation.
+    let prior = match space_mgr.get_entity(entity_id) {
+        Some(e) => {
+            // Backfill the DB player_id for session correlation in SigNoz.
+            if let Some(pid) = e.player_id {
+                tracing::Span::current().record("player_id", pid);
+            }
+            e.missions
+                .get_mission(mission_id)
+                .map(|m| (m.status, m.repeats))
+        }
+        None => {
+            tracing::warn!(
+                entity_id,
+                mission_id,
+                "accept_mission: entity not found — refusing (nothing to mutate, \
+                 and persisting an accept for an unknown entity would corrupt \
+                 the saved row)"
+            );
+            return false;
+        }
     };
-    // Backfill the DB player_id for session correlation in SigNoz.
-    if let Some(pid) = entity.player_id {
-        tracing::Span::current().record("player_id", pid);
+    let def = space_mgr.mission_defs.get(&mission_id);
+
+    // Offer guard — see doc comment. Def-missing falls back fail-closed
+    // (treat as non-repeatable) so an unseeded mission can't loop.
+    if let Some((status, repeats)) = prior {
+        let refusal = match status {
+            MISSION_ACTIVE => Some("already active"),
+            MISSION_FAILED if !def.is_some_and(|d| d.can_repeat_on_fail) => {
+                Some("failed and not repeatable-on-fail")
+            }
+            MISSION_COMPLETED if repeats > def.map_or(0, |d| d.num_repeats) => {
+                Some("completed at repeat cap")
+            }
+            _ => None,
+        };
+        if let Some(reason) = refusal {
+            tracing::warn!(
+                entity_id,
+                mission_id,
+                status,
+                repeats,
+                num_repeats = def.map_or(0, |d| d.num_repeats),
+                reason,
+                "accept_mission: offer refused — mission state preserved"
+            );
+            return false;
+        }
     }
 
     // Carry forward `repeats` from any prior instance of this mission --
@@ -197,10 +258,7 @@ pub async fn accept_mission(
     // previously-completed repeatable mission would silently reset the counter
     // (which then UPSERTs through `MissionUpdate`), defeating `numRepeats`
     // gating. Spotted by Copilot on PR #125.
-    let prior_repeats = entity
-        .missions
-        .get_mission(mission_id)
-        .map_or(0, |m| m.repeats);
+    let prior_repeats = prior.map_or(0, |(_, repeats)| repeats);
     // Propagate the mission def's `is_hidden` into the instance. Without
     // this, hidden sub-missions (e.g. mission 682-686 Hallway0N Controllers,
     // is_hidden=true in the seed) appear in the player's mission log because
@@ -208,14 +266,10 @@ pub async fn accept_mission(
     // filters on the per-instance flag. Cellblock-only missions affected;
     // visible-by-design missions (681 Mess Hall, 687 Aftermath, etc.) are
     // is_hidden=false in the seed so this is a no-op for them.
-    let is_hidden = space_mgr
-        .mission_defs
-        .get(&mission_id)
-        .is_some_and(|m| m.is_hidden);
-    // get_entity_mut again because mission_defs lookup borrowed &space_mgr.
+    let is_hidden = def.is_some_and(|m| m.is_hidden);
     let entity = match space_mgr.get_entity_mut(entity_id) {
         Some(e) => e,
-        None => return,
+        None => return false,
     };
     let mut mission = MissionInstance::new(mission_id, step_id, objectives.clone());
     mission.repeats = prior_repeats;
@@ -270,6 +324,8 @@ pub async fn accept_mission(
             })
             .await;
     }
+
+    true
 }
 
 /// Abandon a mission: remove it and send removal to client.
@@ -547,6 +603,20 @@ mod tests {
         mgr.parse_spaces_xml(xml).unwrap();
         mgr.create_startup_spaces(cxml).unwrap();
         mgr.create_entity(1, "Agnos", [0.0; 3], [0.0; 3]).unwrap();
+        // Declare the mission repeatable (num_repeats=1 → one completion
+        // leaves it re-offerable, python parity `repeats > numRepeats`).
+        // Without a def the offer guard fails closed and this re-accept
+        // would be refused.
+        mgr.mission_defs.insert(
+            100,
+            crate::cell::spawner::MissionDefEntry {
+                step_id: 200,
+                objectives: vec![],
+                is_hidden: false,
+                num_repeats: 1,
+                can_repeat_on_fail: true,
+            },
+        );
 
         // Seed prior state: completed once, repeats == 1.
         {
@@ -569,6 +639,196 @@ mod tests {
             m.repeats, 1,
             "re-accept must carry forward prior repeats count"
         );
+    }
+
+    fn make_test_mgr() -> super::super::space_manager::SpaceManager {
+        let mut mgr = super::super::space_manager::SpaceManager::new(1);
+        let xml = r#"<?xml version="1.0"?><Spaces><Space WorldName="Agnos" Instanced="false" MinX="0" MaxX="100" MinY="0" MaxY="100" /></Spaces>"#;
+        let cxml = r#"<?xml version="1.0"?><Spaces><Space WorldName="Agnos" /></Spaces>"#;
+        mgr.parse_spaces_xml(xml).unwrap();
+        mgr.create_startup_spaces(cxml).unwrap();
+        mgr.create_entity(1, "Agnos", [0.0; 3], [0.0; 3]).unwrap();
+        mgr
+    }
+
+    fn insert_def(
+        mgr: &mut super::super::space_manager::SpaceManager,
+        mission_id: i32,
+        num_repeats: i32,
+        can_repeat_on_fail: bool,
+    ) {
+        mgr.mission_defs.insert(
+            mission_id,
+            crate::cell::spawner::MissionDefEntry {
+                step_id: 200,
+                objectives: vec![],
+                is_hidden: false,
+                num_repeats,
+                can_repeat_on_fail,
+            },
+        );
+    }
+
+    /// **#411 regression guard.** Re-accepting a COMPLETED mission whose
+    /// repeat counter is past the def's `num_repeats` cap must be a
+    /// complete no-op: returns false, mutates nothing, sends nothing.
+    /// Pre-fix, the accept overwrote the completed instance with a fresh
+    /// ACTIVE one and the executor persisted status=1 over the saved row —
+    /// the "completed missions reappear as active after relog" bug.
+    #[tokio::test]
+    async fn re_accept_of_completed_mission_at_repeat_cap_is_refused() {
+        use cimmeria_entity::missions::MISSION_COMPLETED;
+
+        let mut mgr = make_test_mgr();
+        insert_def(&mut mgr, 100, 1, true);
+        // Completed twice → repeats == 2 > num_repeats == 1 (python parity:
+        // canOffer refuses when `repeats > numRepeats`).
+        {
+            let entity = mgr.get_entity_mut(1).unwrap();
+            let mut prior = MissionInstance::new(100, 200, vec![]);
+            prior.complete();
+            prior.repeats = 2;
+            entity.missions.add_mission(prior);
+        }
+
+        let (tx, mut rx) = mpsc::channel(16);
+        let accepted = accept_mission(1, 100, 200, make_objectives(), &tx, &mut mgr).await;
+
+        assert!(
+            !accepted,
+            "offer guard must refuse a capped completed mission"
+        );
+        assert!(
+            rx.try_recv().is_err(),
+            "a refused accept must not emit any client messages"
+        );
+        let m = mgr
+            .get_entity(1)
+            .unwrap()
+            .missions
+            .get_mission(100)
+            .unwrap();
+        assert_eq!(m.status, MISSION_COMPLETED, "status must be preserved");
+        assert_eq!(m.repeats, 2, "repeat counter must be preserved");
+    }
+
+    /// Python-parity companion: a completed mission still UNDER the cap
+    /// (`repeats <= num_repeats`) stays re-offerable. Keeps the guard from
+    /// over-blocking legitimately repeatable missions.
+    #[tokio::test]
+    async fn re_accept_of_completed_mission_below_repeat_cap_is_allowed() {
+        let mut mgr = make_test_mgr();
+        insert_def(&mut mgr, 100, 1, true);
+        {
+            let entity = mgr.get_entity_mut(1).unwrap();
+            let mut prior = MissionInstance::new(100, 200, vec![]);
+            prior.complete(); // repeats = 1, not > num_repeats = 1
+            entity.missions.add_mission(prior);
+        }
+
+        let (tx, _rx) = mpsc::channel(16);
+        let accepted = accept_mission(1, 100, 200, make_objectives(), &tx, &mut mgr).await;
+
+        assert!(accepted, "below the cap the mission must be re-offerable");
+        let m = mgr
+            .get_entity(1)
+            .unwrap()
+            .missions
+            .get_mission(100)
+            .unwrap();
+        assert_eq!(m.status, MISSION_ACTIVE);
+        assert_eq!(m.repeats, 1, "repeat counter carries forward on re-accept");
+    }
+
+    /// Re-accepting a mission that is already ACTIVE must be refused —
+    /// otherwise a re-fired grant chain resets in-flight progress back to
+    /// the def's first step (the chain-1051/1053 "briefing loop" bug class,
+    /// previously only guarded by chain-side conditions).
+    #[tokio::test]
+    async fn re_accept_of_active_mission_is_refused_and_preserves_progress() {
+        let mut mgr = make_test_mgr();
+        insert_def(&mut mgr, 100, 1, true);
+
+        let (tx, mut rx) = mpsc::channel(16);
+        let accepted = accept_mission(1, 100, 200, make_objectives(), &tx, &mut mgr).await;
+        assert!(accepted, "fresh accept must succeed");
+        while rx.try_recv().is_ok() {}
+
+        // Simulate progress past the first step.
+        {
+            let entity = mgr.get_entity_mut(1).unwrap();
+            let m = entity.missions.get_mission_mut(100).unwrap();
+            m.current_step_id = Some(999);
+        }
+
+        let accepted = accept_mission(1, 100, 200, make_objectives(), &tx, &mut mgr).await;
+        assert!(!accepted, "an active mission must not be re-offered");
+        assert!(rx.try_recv().is_err(), "refusal must not emit messages");
+        let m = mgr
+            .get_entity(1)
+            .unwrap()
+            .missions
+            .get_mission(100)
+            .unwrap();
+        assert_eq!(
+            m.current_step_id,
+            Some(999),
+            "in-flight progress must survive the refused re-accept"
+        );
+    }
+
+    /// FAILED missions follow `can_repeat_on_fail` (python parity): false →
+    /// permanently refused; true → re-offerable.
+    #[tokio::test]
+    async fn re_accept_of_failed_mission_respects_can_repeat_on_fail() {
+        use cimmeria_entity::missions::MISSION_FAILED;
+
+        let mut mgr = make_test_mgr();
+        insert_def(&mut mgr, 100, 5, false);
+        {
+            let entity = mgr.get_entity_mut(1).unwrap();
+            let mut prior = MissionInstance::new(100, 200, vec![]);
+            prior.fail();
+            entity.missions.add_mission(prior);
+        }
+
+        let (tx, _rx) = mpsc::channel(16);
+        let accepted = accept_mission(1, 100, 200, make_objectives(), &tx, &mut mgr).await;
+        assert!(
+            !accepted,
+            "failed + can_repeat_on_fail=false must refuse the re-offer"
+        );
+        let m = mgr
+            .get_entity(1)
+            .unwrap()
+            .missions
+            .get_mission(100)
+            .unwrap();
+        assert_eq!(m.status, MISSION_FAILED);
+
+        // Same state with a repeat-on-fail def → allowed.
+        insert_def(&mut mgr, 100, 5, true);
+        let accepted = accept_mission(1, 100, 200, make_objectives(), &tx, &mut mgr).await;
+        assert!(
+            accepted,
+            "failed + can_repeat_on_fail=true must allow the re-offer"
+        );
+    }
+
+    /// Entity-missing accepts must return false so callers don't persist a
+    /// `MissionUpdate` for a player whose mission state was never loaded —
+    /// pre-fix, that persisted status=1 over the saved row and resurrected
+    /// completed missions on the next relog (#411).
+    #[tokio::test]
+    async fn accept_with_missing_entity_is_refused() {
+        let mut mgr = make_test_mgr();
+        insert_def(&mut mgr, 100, 1, true);
+
+        let (tx, mut rx) = mpsc::channel(16);
+        let accepted = accept_mission(999, 100, 200, make_objectives(), &tx, &mut mgr).await;
+
+        assert!(!accepted, "unknown entity must refuse the accept");
+        assert!(rx.try_recv().is_err());
     }
 
     #[tokio::test]

--- a/crates/services/src/cell/service/base_messages/mod.rs
+++ b/crates/services/src/cell/service/base_messages/mod.rs
@@ -313,6 +313,7 @@ pub(super) async fn handle_base_message(
             active_bandolier_slot,
             bandolier_items,
             system_options,
+            state_field,
         } => {
             player_init::handle_init_player_state(
                 entity_id,
@@ -324,6 +325,7 @@ pub(super) async fn handle_base_message(
                 active_bandolier_slot,
                 bandolier_items,
                 system_options,
+                state_field,
                 tx,
                 space_mgr,
                 engine,

--- a/crates/services/src/cell/service/base_messages/player_init.rs
+++ b/crates/services/src/cell/service/base_messages/player_init.rs
@@ -424,6 +424,118 @@ pub(super) async fn send_known_abilities_update(
 }
 
 #[cfg(test)]
+mod relog_mission_resurrection_tests {
+    //! **#411 end-to-end guard.** A mis-gated `player_loaded` chain (one
+    //! whose author forgot the `mission_status eq not_active` condition)
+    //! fires `accept_mission` on every world entry. Pre-fix, that
+    //! overwrote a relog-restored COMPLETED mission with a fresh ACTIVE
+    //! instance and persisted `MissionUpdate status=1` over the saved
+    //! row — completed missions reappeared as active in the quest log
+    //! after relog. The server-side offer guard must hold even when the
+    //! chain data is wrong.
+
+    use super::*;
+    use crate::cell::messages::SavedMission;
+    use cimmeria_content_engine::actions::Action;
+    use cimmeria_content_engine::chain::Chain;
+    use cimmeria_content_engine::triggers::Trigger;
+    use cimmeria_entity::missions::MISSION_COMPLETED;
+
+    #[tokio::test]
+    async fn mis_gated_player_loaded_chain_cannot_resurrect_completed_mission() {
+        let mut mgr = SpaceManager::new(1);
+        let xml = r#"<?xml version="1.0"?><Spaces><Space WorldName="Castle_CellBlock" Instanced="true" MinX="-800" MaxX="800" MinY="-800" MaxY="800" /></Spaces>"#;
+        mgr.parse_spaces_xml(xml).unwrap();
+        mgr.create_startup_spaces(r#"<?xml version="1.0"?><Spaces></Spaces>"#)
+            .unwrap();
+        mgr.create_entity(1, "Castle_CellBlock", [0.0; 3], [0.0; 3])
+            .unwrap();
+        mgr.connect_entity(1);
+        mgr.mission_defs.insert(
+            622,
+            crate::cell::spawner::MissionDefEntry {
+                step_id: 2113,
+                objectives: vec![],
+                is_hidden: false,
+                num_repeats: 1,
+                can_repeat_on_fail: true,
+            },
+        );
+
+        // The mis-gated chain: player_loaded, NO conditions, accepts 622.
+        let mut engine = ChainEngine::new();
+        engine.register_chain(Chain {
+            id: 9999,
+            name: "mis-gated 622 grant (no not_active condition)".into(),
+            enabled: true,
+            trigger: Trigger::OnPlayerLoaded { world_name: None },
+            conditions: vec![],
+            actions: vec![Action::AcceptMission { mission_id: 622 }],
+            priority: 0,
+        });
+
+        // Relog payload: 622 completed, repeat counter at the cap.
+        let saved = vec![SavedMission {
+            mission_id: 622,
+            status: MISSION_COMPLETED,
+            current_step_id: None,
+            completed_step_ids: vec![2113],
+            completed_objective_ids: vec![],
+            active_objective_ids: vec![],
+            failed_objective_ids: vec![],
+            repeats: 2, // > num_repeats = 1 → not re-offerable
+        }];
+
+        let (tx, mut rx) = mpsc::channel(64);
+        handle_init_player_state(
+            1,
+            100,
+            "Castle_CellBlock".into(),
+            1,
+            saved,
+            vec![],
+            0,
+            vec![],
+            cimmeria_entity::cell_entity::SystemOptions::default(),
+            &tx,
+            &mut mgr,
+            &engine,
+        )
+        .await;
+
+        // Cell-side state: still completed, repeat counter intact.
+        let m = mgr
+            .get_entity(1)
+            .unwrap()
+            .missions
+            .get_mission(622)
+            .expect("restored mission must still be tracked");
+        assert_eq!(
+            m.status, MISSION_COMPLETED,
+            "the offer guard must keep the restored mission COMPLETED even \
+             when a mis-gated player_loaded chain re-fires accept_mission"
+        );
+        assert_eq!(m.repeats, 2, "repeat counter must survive the relog");
+
+        // Wire/persist side: no MissionUpdate(status=1) may have been sent —
+        // that's the message that UPSERTs "active" over the saved row.
+        while let Ok(msg) = rx.try_recv() {
+            if let CellToBaseMsg::MissionUpdate {
+                mission_id, status, ..
+            } = msg
+            {
+                assert!(
+                    !(mission_id == 622 && status == 1),
+                    "relog must not persist MissionUpdate(622, status=1) — \
+                     this is the exact write that resurrected completed \
+                     missions as active (#411)"
+                );
+            }
+        }
+    }
+}
+
+#[cfg(test)]
 mod system_options_assignment_tests {
     //! The InitPlayerState handler is the hydrate-on-login site for
     //! `CellEntity::system_options`. These guards pin that the

--- a/crates/services/src/cell/service/base_messages/player_init.rs
+++ b/crates/services/src/cell/service/base_messages/player_init.rs
@@ -44,6 +44,7 @@ pub(in crate::cell::service) async fn handle_init_player_state(
     active_bandolier_slot: i32,
     bandolier_items: Vec<(i32, cimmeria_entity::cell_entity::BandolierItem)>,
     system_options: cimmeria_entity::cell_entity::SystemOptions,
+    state_field: u32,
     tx: &mpsc::Sender<CellToBaseMsg>,
     space_mgr: &mut SpaceManager,
     engine: &ChainEngine,
@@ -211,6 +212,65 @@ pub(in crate::cell::service) async fn handle_init_player_state(
         // cooldown state during the initial-load burst — one less thing
         // the client has to chew on. (PR #410)
         entity.abilities.clear_all_cooldowns();
+
+        // Restore the persisted user-preference state bits (#412). The
+        // mask strips anything a corrupt / hand-edited row might carry —
+        // restoring a saved BSF_Dead or BSF_MovementLock would spawn the
+        // player frozen, the exact "relog is a fresh combat slate"
+        // violation the cooldown wipe above exists to prevent. Raw `|=`
+        // because BSF_AutoCycling is a single-source flag that bypasses
+        // the ref-counted helpers (see cell::combat::auto_cycle's module
+        // doc). When the bit is set we also re-arm `abilities.auto_cycle`
+        // so the player's first attack of the new session enters
+        // `arm_auto_cycle` and the server-driven re-fire loop starts —
+        // the loop's ability stash (`auto_cycle_ability_id`) stays None
+        // until that first commit, by design.
+        let restored_state = state_field & crate::cell::combat::PERSISTED_STATE_FIELD_MASK;
+        if restored_state != 0 {
+            entity.state_field |= restored_state;
+            if restored_state & crate::cell::combat::BSF_AUTO_CYCLING != 0 {
+                entity.abilities.auto_cycle = true;
+            }
+            tracing::info!(
+                entity_id,
+                state_field = restored_state,
+                "Restored persisted state_field preference bits"
+            );
+        }
+    }
+
+    // Re-broadcast the restored state field so the client's UI reflects
+    // the preference immediately (the auto-cycle gun-icon button
+    // highlight listens on the BSF_AutoCycling transition — see the
+    // Ghidra note on `BSF_AUTO_CYCLING`). The client initialises its
+    // cached state_field to 0, so without this send the bit is armed
+    // server-side but the button looks off until the first in-session
+    // toggle. Sent post-onClientReady for the same ordering reason as
+    // the onActiveSlotUpdate resync below.
+    {
+        // Broadcast the FULL current state_field (the client's XOR-delta
+        // dispatcher diffs against its cached value), but gate the send
+        // on a preference bit actually having been restored — a fresh
+        // character with state_field 0 needs no packet.
+        let (full_state, restored) = space_mgr
+            .get_entity(entity_id)
+            .map(|e| {
+                (
+                    e.state_field,
+                    e.state_field & crate::cell::combat::PERSISTED_STATE_FIELD_MASK,
+                )
+            })
+            .unwrap_or((0, 0));
+        if restored != 0 {
+            crate::cell::abilities::send_entity_method(
+                entity_id,
+                crate::mercury::method_idx::ON_STATE_FIELD_UPDATE,
+                full_state.to_le_bytes().to_vec(),
+                tx,
+                space_mgr,
+            )
+            .await;
+        }
     }
 
     // Resend active mission state to the client so the journal UI is
@@ -424,6 +484,181 @@ pub(super) async fn send_known_abilities_update(
 }
 
 #[cfg(test)]
+mod state_field_restore_tests {
+    //! **#412 restore guards.** `InitPlayerState` must restore the
+    //! persisted preference bits of `state_field` (today:
+    //! `BSF_AutoCycling`), re-arm `abilities.auto_cycle`, and
+    //! re-broadcast `onStateFieldUpdate` so the client's button
+    //! highlight survives the relog — while a corrupt row carrying
+    //! transient combat bits must be masked out so the player never
+    //! spawns dead / frozen / in-combat.
+
+    use super::*;
+    use crate::cell::combat::{BSF_AUTO_CYCLING, BSF_DEAD, BSF_IN_COMBAT, BSF_MOVEMENT_LOCK};
+    use cimmeria_entity::cell_entity::SystemOptions;
+
+    fn make_mgr() -> SpaceManager {
+        let mut mgr = SpaceManager::new(1);
+        let xml = r#"<?xml version="1.0"?><Spaces><Space WorldName="Castle_CellBlock" Instanced="true" MinX="-800" MaxX="800" MinY="-800" MaxY="800" /></Spaces>"#;
+        mgr.parse_spaces_xml(xml).unwrap();
+        mgr.create_startup_spaces(r#"<?xml version="1.0"?><Spaces></Spaces>"#)
+            .unwrap();
+        mgr.create_entity(1, "Castle_CellBlock", [0.0; 3], [0.0; 3])
+            .unwrap();
+        if let Some(p) = mgr.get_entity_mut(1) {
+            p.is_player = true;
+        }
+        mgr.connect_entity(1);
+        mgr
+    }
+
+    fn drain_state_field_broadcasts(rx: &mut mpsc::Receiver<CellToBaseMsg>) -> Vec<u32> {
+        let mut out = Vec::new();
+        while let Ok(msg) = rx.try_recv() {
+            if let CellToBaseMsg::EntityMethodCall {
+                entity_id: 1,
+                method_index,
+                args,
+            } = msg
+            {
+                if method_index == crate::mercury::method_idx::ON_STATE_FIELD_UPDATE
+                    && args.len() == 4
+                {
+                    out.push(u32::from_le_bytes([args[0], args[1], args[2], args[3]]));
+                }
+            }
+        }
+        out
+    }
+
+    /// Happy path: persisted BSF_AutoCycling restores onto the entity,
+    /// re-arms the loop flag, and re-broadcasts the bit to the client.
+    /// This is the acceptance shape from #412 — after relog, the first
+    /// attack enters `arm_auto_cycle` (gated on `abilities.auto_cycle`)
+    /// and the loop drives itself without a second button press.
+    #[tokio::test]
+    async fn restores_auto_cycle_bit_and_rearms_loop_flag() {
+        let mut mgr = make_mgr();
+        let engine = ChainEngine::new();
+        let (tx, mut rx) = mpsc::channel(64);
+
+        handle_init_player_state(
+            1,
+            100,
+            "Castle_CellBlock".into(),
+            1,
+            vec![],
+            vec![],
+            0,
+            vec![],
+            SystemOptions::default(),
+            BSF_AUTO_CYCLING,
+            &tx,
+            &mut mgr,
+            &engine,
+        )
+        .await;
+
+        let e = mgr.get_entity(1).unwrap();
+        assert_ne!(
+            e.state_field & BSF_AUTO_CYCLING,
+            0,
+            "persisted BSF_AutoCycling must restore onto the entity"
+        );
+        assert!(
+            e.abilities.auto_cycle,
+            "auto_cycle must re-arm so the first attack of the session \
+             enters arm_auto_cycle and the loop starts (the #412 symptom \
+             was exactly this flag staying false)"
+        );
+        assert!(
+            e.abilities.auto_cycle_ability_id.is_none(),
+            "the ability stash stays empty until first commit, by design"
+        );
+
+        let broadcasts = drain_state_field_broadcasts(&mut rx);
+        assert_eq!(
+            broadcasts,
+            vec![BSF_AUTO_CYCLING],
+            "restore must re-broadcast onStateFieldUpdate so the client's \
+             gun-icon button highlights without an in-session toggle"
+        );
+    }
+
+    /// Mask guard: a corrupt / hand-edited row carrying transient combat
+    /// bits must NOT restore them — spawning dead + movement-locked is
+    /// the failure shape the mask exists to prevent. No broadcast either
+    /// (nothing legitimate was restored).
+    #[tokio::test]
+    async fn transient_bits_in_saved_row_are_not_restored() {
+        let mut mgr = make_mgr();
+        let engine = ChainEngine::new();
+        let (tx, mut rx) = mpsc::channel(64);
+
+        handle_init_player_state(
+            1,
+            100,
+            "Castle_CellBlock".into(),
+            1,
+            vec![],
+            vec![],
+            0,
+            vec![],
+            SystemOptions::default(),
+            BSF_DEAD | BSF_IN_COMBAT | BSF_MOVEMENT_LOCK,
+            &tx,
+            &mut mgr,
+            &engine,
+        )
+        .await;
+
+        let e = mgr.get_entity(1).unwrap();
+        assert_eq!(
+            e.state_field, 0,
+            "transient combat bits must be masked out on restore — a \
+             relog is always a clean combat slate"
+        );
+        assert!(!e.abilities.auto_cycle, "loop flag must stay disarmed");
+        assert!(
+            drain_state_field_broadcasts(&mut rx).is_empty(),
+            "nothing restored → no onStateFieldUpdate"
+        );
+    }
+
+    /// Zero-state companion: the common case (player never touched the
+    /// button) must not emit a spurious state-field packet during the
+    /// already-busy world-entry burst.
+    #[tokio::test]
+    async fn zero_state_field_emits_no_broadcast() {
+        let mut mgr = make_mgr();
+        let engine = ChainEngine::new();
+        let (tx, mut rx) = mpsc::channel(64);
+
+        handle_init_player_state(
+            1,
+            100,
+            "Castle_CellBlock".into(),
+            1,
+            vec![],
+            vec![],
+            0,
+            vec![],
+            SystemOptions::default(),
+            0,
+            &tx,
+            &mut mgr,
+            &engine,
+        )
+        .await;
+
+        assert!(
+            drain_state_field_broadcasts(&mut rx).is_empty(),
+            "state_field 0 must not add a packet to the login burst"
+        );
+    }
+}
+
+#[cfg(test)]
 mod relog_mission_resurrection_tests {
     //! **#411 end-to-end guard.** A mis-gated `player_loaded` chain (one
     //! whose author forgot the `mission_status eq not_active` condition)
@@ -497,6 +732,7 @@ mod relog_mission_resurrection_tests {
             0,
             vec![],
             cimmeria_entity::cell_entity::SystemOptions::default(),
+            0, // state_field
             &tx,
             &mut mgr,
             &engine,
@@ -587,6 +823,7 @@ mod system_options_assignment_tests {
             0,
             vec![],
             hydrated.clone(),
+            0, // state_field
             &tx,
             &mut mgr,
             &engine,
@@ -633,6 +870,7 @@ mod system_options_assignment_tests {
             0,
             vec![],
             SystemOptions::default(),
+            0, // state_field
             &tx,
             &mut mgr,
             &engine,
@@ -712,6 +950,7 @@ mod system_options_assignment_tests {
             SERVER_SLOT,
             vec![], // no bandolier items (slot can still be active over an empty slot)
             SystemOptions::default(),
+            0, // state_field
             &tx,
             &mut mgr,
             &engine,
@@ -854,6 +1093,7 @@ mod system_options_assignment_tests {
             slot,
             items,
             sys_opts,
+            0, // state_field
             &tx,
             &mut mgr,
             &engine,
@@ -935,6 +1175,7 @@ mod system_options_assignment_tests {
             slot,
             items,
             sys_opts,
+            0, // state_field
             &tx,
             &mut mgr,
             &engine,
@@ -984,6 +1225,7 @@ mod system_options_assignment_tests {
             slot,
             items,
             sys_opts,
+            0, // state_field
             &tx,
             &mut mgr,
             &engine,
@@ -1026,6 +1268,7 @@ mod system_options_assignment_tests {
             slot,
             items,
             sys_opts,
+            0, // state_field
             &tx,
             &mut mgr,
             &engine,
@@ -1065,6 +1308,7 @@ mod system_options_assignment_tests {
             0,
             vec![],
             SystemOptions::default(),
+            0, // state_field
             &tx,
             &mut mgr,
             &engine,

--- a/crates/services/src/cell/spawner/missions.rs
+++ b/crates/services/src/cell/spawner/missions.rs
@@ -22,6 +22,13 @@ pub struct MissionDefEntry {
     /// honors it. Without this, hidden sub-missions like the
     /// Hallway0N Controllers (mission 682-686) leak into the player's UI.
     pub is_hidden: bool,
+    /// `resources.missions.num_repeats` — re-acceptance cap. Python parity:
+    /// `MissionManager.py canOffer()` refuses a COMPLETED mission when
+    /// `repeats > numRepeats`. Read by the `accept_mission` offer guard.
+    pub num_repeats: i32,
+    /// `resources.missions.can_repeat_on_fail` — when false, a FAILED
+    /// mission can never be re-offered (Python parity: `canOffer()`).
+    pub can_repeat_on_fail: bool,
 }
 
 /// A single objective within a mission step.
@@ -45,7 +52,8 @@ pub async fn load_mission_defs(
     // Get the first step per mission (lowest index) plus the mission-level
     // `is_hidden` flag, joined in one query.
     let step_rows = sqlx::query(
-        "SELECT DISTINCT ON (s.mission_id) s.mission_id, s.step_id, m.is_hidden \
+        "SELECT DISTINCT ON (s.mission_id) s.mission_id, s.step_id, m.is_hidden, \
+                m.num_repeats, m.can_repeat_on_fail \
          FROM resources.mission_steps s \
          JOIN resources.missions m ON m.mission_id = s.mission_id \
          ORDER BY s.mission_id, s.index ASC",
@@ -58,12 +66,16 @@ pub async fn load_mission_defs(
         let mission_id: i32 = r.get("mission_id");
         let step_id: i32 = r.get("step_id");
         let is_hidden: bool = r.get("is_hidden");
+        let num_repeats: i32 = r.get("num_repeats");
+        let can_repeat_on_fail: bool = r.get("can_repeat_on_fail");
         map.insert(
             mission_id,
             MissionDefEntry {
                 step_id,
                 objectives: Vec::new(),
                 is_hidden,
+                num_repeats,
+                can_repeat_on_fail,
             },
         );
     }

--- a/db/scripts/add_player_state_field.sql
+++ b/db/scripts/add_player_state_field.sql
@@ -1,0 +1,35 @@
+-- Migration: add state_field column to sgw_player for persisted
+-- user-preference state bits. (#412)
+--
+-- `BSF_AutoCycling` (bit 1 of the cell entity's `state_field`) is a player
+-- preference toggle — the original game persisted it across logins, but the
+-- emulator initialised `state_field` to 0 on every world entry, so the
+-- auto-cycle loop never armed after a relog until the player pressed the
+-- button again.
+--
+-- Only bits in PERSISTED_STATE_FIELD_MASK
+-- (crates/services/src/cell/combat/state.rs) are ever written here — today
+-- that's BSF_AutoCycling (1 << 1) alone. Transient combat bits (BSF_Dead,
+-- BSF_InCombat, BSF_MovementLock) are masked out at the persist site so a
+-- relog is always a clean combat slate. Safe to run on existing databases
+-- (uses IF NOT EXISTS).
+
+ALTER TABLE sgw_player
+    ADD COLUMN IF NOT EXISTS state_field integer NOT NULL DEFAULT 0;
+
+-- Guard against malformed payloads landing as durable corruption: the
+-- persisted value is a masked bitfield, always non-negative. PostgreSQL has
+-- no IF NOT EXISTS for CHECK constraints, so use a DO block for idempotency.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'sgw_player_state_field_nonnegative_chk'
+          AND conrelid = 'sgw_player'::regclass
+    ) THEN
+        ALTER TABLE sgw_player
+            ADD CONSTRAINT sgw_player_state_field_nonnegative_chk
+            CHECK (state_field >= 0);
+    END IF;
+END $$;

--- a/db/sgw/Players/Tables/sgw_player.sql
+++ b/db/sgw/Players/Tables/sgw_player.sql
@@ -45,6 +45,13 @@ CREATE TABLE sgw_player (
     -- crates/entity/src/cell_entity/system_options.rs.
     auto_reload boolean DEFAULT true NOT NULL,
     reload_on_activate boolean DEFAULT false NOT NULL,
+    -- Persisted user-preference bits of the cell entity's `state_field`
+    -- bitmask. Only bits in PERSISTED_STATE_FIELD_MASK
+    -- (crates/services/src/cell/combat/state.rs) are ever written —
+    -- today that's BSF_AutoCycling (1 << 1) alone. Transient combat
+    -- bits (BSF_Dead, BSF_InCombat, BSF_MovementLock) are masked out
+    -- on write so a relog is always a clean combat slate. (#412)
+    state_field integer DEFAULT 0 NOT NULL,
     CONSTRAINT alignment_sanity CHECK (((alignment >= 0) AND (alignment <= 5))),
     CONSTRAINT archetype_sanity CHECK (((archetype >= 0) AND (archetype <= 8))),
     CONSTRAINT bandolier_slot_sanity CHECK (((bandolier_slot >= 0) AND (bandolier_slot <= 3))),

--- a/docs/architecture/state-field-bits.md
+++ b/docs/architecture/state-field-bits.md
@@ -2,7 +2,7 @@
 title: "`bStateField` bit map — what the SGW client actually reads"
 type: reference
 audience: engineers
-last_updated: 2026-05-27
+last_updated: 2026-06-10
 ---
 
 # `bStateField` bit map — what the SGW client actually reads
@@ -29,6 +29,29 @@ Status: verified against the live `SGW.exe` binary (image base `0x00400000`, ASL
 | 9–31 | `0x200`–`0x80000000` | Reserved | Nothing. |
 
 The `0xC4` group mask (bits 2 + 6 + 7) is the movement-speed recompute — any of crouch / movement-lock / walking changes triggers the same code path.
+
+## Persistence across relogs
+
+`state_field` is transient combat state with one exception: `BSF_AutoCycling`
+is a player preference toggle the original game kept across sessions. The
+persisted subset is defined by `PERSISTED_STATE_FIELD_MASK` in
+[crates/services/src/cell/combat/state.rs](../../crates/services/src/cell/combat/state.rs)
+(today: `BSF_AutoCycling` alone) and stored in `sgw_player.state_field`:
+
+- **Write**: the explicit `setAutoCycle` toggle (player method 83) sends
+  `CellToBaseMsg::StateFieldUpdate` with the masked value; the base-side
+  handler masks again defensively before the `UPDATE`. In-combat
+  auto-clears (target death, manual fire of a different ability,
+  `AF_DEACTIVATE_AUTO_CYCLE`) deliberately do **not** persist — the stored
+  value tracks the player's deliberate button choice, not loop mechanics.
+- **Read**: `InitPlayerState` masks the loaded value, ORs it onto
+  `CellEntity::state_field`, re-arms `abilities.auto_cycle`, and
+  re-broadcasts `onStateFieldUpdate` so the client's gun-icon highlight
+  survives the relog. Transient bits in a corrupt row (`BSF_Dead`,
+  `BSF_MovementLock`, …) are stripped — a relog is always a clean combat
+  slate, matching the cooldown wipe from PR #410.
+
+History: #412 (auto-cycle bit lost on relog).
 
 ## Bit 8 retirement (`BSF_Holster`)
 

--- a/docs/gameplay/combat-system.md
+++ b/docs/gameplay/combat-system.md
@@ -24,7 +24,7 @@ The server handles all combat resolution; the client sends ability requests and 
 | QR hit/miss/crit calculation | DONE | Beta distribution model in `DamageCalc` |
 | Damage pipeline (base -> resist -> QR -> AF -> absorb) | DONE | `calculateDamage()` |
 | Warmup / cooldown timers | DONE | Timer-based with client sync |
-| Auto-cycle (auto-attack) | DONE | Loops ability on cooldown expiry |
+| Auto-cycle (auto-attack) | DONE | Loops ability on cooldown expiry; toggle persists across relog via `sgw_player.state_field` (#412 — see [state-field-bits.md](../architecture/state-field-bits.md)) |
 | Effect application / removal | DONE | `EffectInstance` class |
 | Death / revive | DONE | `PLAYER_STATE_Dead` flag, `onDead()` / `onRevived()` |
 | Crouch / cover stance | PARTIAL | State flag set, affects QR, cover sets tracked |

--- a/docs/gameplay/mission-system.md
+++ b/docs/gameplay/mission-system.md
@@ -109,6 +109,30 @@ MissionManager.complete(missionId)
        |-> client.onMissionUpdate(id, 1, 0)
 ```
 
+## Offer Guard (server-authoritative re-accept gate)
+
+`accept_mission` ([crates/services/src/cell/missions.rs](../../crates/services/src/cell/missions.rs))
+ports Python `MissionManager.canOffer()` and refuses the accept when:
+
+- the mission is already **ACTIVE** (a re-accept would reset progress to
+  the first step — the "briefing loop" bug class), or
+- the mission is **FAILED** and `resources.missions.can_repeat_on_fail`
+  is false, or
+- the mission is **COMPLETED** and `repeats > num_repeats` (both sides
+  from the DB: instance counter vs. `resources.missions.num_repeats`).
+
+A refused accept returns `false`; the content-engine executor then skips
+both the `MissionUpdate` persist and the `mission_accepted` follow-up
+event, so a mis-gated chain (e.g. a `player_loaded` grant missing its
+`mission_status eq not_active` condition) can no longer UPSERT
+`status=active` over a saved completed row — the root corruption behind
+"completed missions reappear in the quest log after relog" (#411).
+Chain-side `not_active` gates remain the first line of defense; the
+guard is the server-authoritative backstop. Repeatability fields ride
+the `MissionDefEntry` cache loaded at startup
+([crates/services/src/cell/spawner/missions.rs](../../crates/services/src/cell/spawner/missions.rs));
+a mission without a def entry fails closed (treated as non-repeatable).
+
 ## Mission Status Codes
 
 | Code | Constant | Description |


### PR DESCRIPTION
Closes #412.

> **Stacked on #510** (`fix/411-mission-offer-guard`) — the two changes share edits in `player_init.rs`. Merge #510 first; this PR's diff against its base branch is pure #412.

## What

`BSF_AUTO_CYCLING` (bit 1 of `state_field`) is a player preference toggle, but nothing persisted `state_field` — so after a relog the auto-cycle loop never armed until the player pressed the button again. This implements the fix shape from the issue:

1. **Schema**: `sgw_player.state_field INTEGER NOT NULL DEFAULT 0` (+ non-negative CHECK), with an idempotent migration in [db/scripts/add_player_state_field.sql](db/scripts/add_player_state_field.sql).
2. **Preference mask**: `PERSISTED_STATE_FIELD_MASK` in `cell/combat/state.rs` — `BSF_AUTO_CYCLING` alone today; growing the persisted set is a one-line change. Both the cell-side send and the base-side DB write mask with it, so transient combat bits (`BSF_Dead`, `BSF_InCombat`, `BSF_MovementLock`) can never reach durable state.
3. **Write path**: the explicit `setAutoCycle` toggle sends a new `CellToBaseMsg::StateFieldUpdate`; a new `cell_dispatch/state_field.rs` handler persists the masked value (same split as `SystemOptionsUpdate`). In-combat auto-clears (target death, manual fire of a different ability, `AF_DEACTIVATE_AUTO_CYCLE`) deliberately do **not** persist — the stored value tracks the player's deliberate button choice, not loop mechanics.
4. **Read path**: `InitPlayerState` carries `state_field` from the hydrate query; the handler masks again, ORs the bits onto `CellEntity::state_field` (raw `|=` per the single-source-flag rule in `auto_cycle.rs`), re-arms `abilities.auto_cycle`, and re-broadcasts `onStateFieldUpdate` so the client's gun-icon highlight survives the relog.

## Acceptance (issue #412)

Enable auto-cycle → relog → the restored `abilities.auto_cycle = true` means the first attack enters `arm_auto_cycle` and the server-driven re-fire loop starts — no second button press. The loop's ability stash stays empty until that first commit, by design (the wire payload carries no ability id).

## Tests

All revert-verified (each guard fails with its fix line neutered — 3 revert directions checked):

- **Toggle persist** (`world/tests.rs`): enable sends exactly one `StateFieldUpdate` with masked bits (a live `BSF_InCombat` riding the same value must be stripped); disable persists the cleared bit.
- **Login restore** (`player_init.rs`): persisted bit restores onto the entity + re-arms the loop flag + re-broadcasts `onStateFieldUpdate`; a corrupt row carrying `BSF_Dead | BSF_InCombat | BSF_MovementLock` restores **nothing** (a dead, movement-locked spawn is the failure shape the mask prevents); `state_field = 0` adds no packet to the login burst.
- **Live-DB** (`cell_dispatch/state_field.rs`, sentinel range `0x7000_1700`): fresh-row default 0 → enable → disable round-trip; unmasked mid-fight value stores only the auto-cycle bit; missing-row persist emits the documented `warn!` (LogCapture, per the negative-logging convention). These run in CI's live-DB job (no local Postgres on this dev machine).

## Docs

- [docs/architecture/state-field-bits.md](docs/architecture/state-field-bits.md) — new "Persistence across relogs" section (which bits persist, write/read contracts, why auto-clears don't persist).
- [docs/gameplay/combat-system.md](docs/gameplay/combat-system.md) — auto-cycle row notes the persistence.
- Schema comment on the new column + migration header explain the mask discipline in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
