### PR TITLE
fix(cell): gate DialogButtonChoice on an open-dialog precondition (#479, CAT-J-01)

### DIFF
--- a/crates/entity/src/cell_entity/mod.rs
+++ b/crates/entity/src/cell_entity/mod.rs
@@ -656,6 +656,24 @@ pub struct CellEntity {
     /// `docs/reverse-engineering/findings/dialog-portrait-lookup.md`).
     pub last_interaction_target: Option<u32>,
 
+    /// The `dialog_id` of the dialog currently displayed to this player, or
+    /// `None` when no dialog is open. Set when `onDialogDisplay` is sent
+    /// (`cell::interactions::send_dialog_display`, the single choke point all
+    /// display paths route through), validated and cleared on
+    /// `DIALOG_BUTTON_CHOICE`.
+    ///
+    /// This is the server-side "is dialog X open for player Y?" precondition
+    /// the `DialogButtonChoice` handler checks before firing an
+    /// `OnDialogChoice` content chain. Without it, a forged choice packet for
+    /// any discovered `dialog_id` drives the chain's actions (GrantXP,
+    /// GrantItem, AcceptMission, Teleport, …) with no precondition
+    /// (CAT-J-01 / #479). Mirrors python `SGWPlayer.displayedDialogs`
+    /// (`deprecated/python/cell/SGWPlayer.py`): set on `displayDialog`,
+    /// `del`'d on `dialogButtonChoice`. A single slot suffices — SGW content
+    /// is strictly sequential (display → choice → display), never
+    /// overlapping dialogs.
+    pub open_dialog_id: Option<i32>,
+
     /// Entity ID of the currently-open vendor (only for player entities).
     pub vendor_entity: Option<u32>,
 
@@ -951,6 +969,7 @@ impl CellEntity {
             next_loot_index: 1,
             looting_entity: None,
             last_interaction_target: None,
+            open_dialog_id: None,
             vendor_entity: None,
             trade_partner_entity_id: None,
             trade_proposal: None,

--- a/crates/services/src/cell/cell_methods/player/interaction.rs
+++ b/crates/services/src/cell/cell_methods/player/interaction.rs
@@ -240,6 +240,38 @@ pub async fn dispatch(
                 let button_id = i32::from_le_bytes([args[4], args[5], args[6], args[7]]);
                 tracing::info!(entity_id, dialog_id, button_id, "dialogButtonChoice");
 
+                // Server-authority precondition (CAT-J-01 / #479): the dialog
+                // must actually be open for this player. `open_dialog_id` is
+                // pinned by `send_dialog_display` on every display path and
+                // matched here on strict equality. Without this gate, a forged
+                // `DialogButtonChoice` for any discovered `dialog_id` drives the
+                // bound `OnDialogChoice` chain's actions (GrantXP / GrantItem /
+                // AcceptMission / Teleport / …) with no precondition. Mirrors
+                // python `SGWPlayer.dialogButtonChoice` rejecting a choice whose
+                // id isn't in `displayedDialogs`. The pin is cleared on a valid
+                // choice (one-shot — SGW sends exactly one choice per displayed
+                // dialog_id), which also makes a replayed choice idempotent.
+                let open_dialog_id = space_mgr
+                    .get_entity(entity_id)
+                    .and_then(|e| e.open_dialog_id);
+                if open_dialog_id != Some(dialog_id) {
+                    tracing::warn!(
+                        entity_id,
+                        dialog_id,
+                        button_id,
+                        open_dialog_id = ?open_dialog_id,
+                        "dialogButtonChoice rejected -- no matching open dialog for this player \
+                         (forged/replayed choice or stale client state); chain not fired (#479)"
+                    );
+                    return true;
+                }
+                // Clear the pin BEFORE firing the chain: a chain action may
+                // open a follow-up dialog (`display_dialog`), whose
+                // `send_dialog_display` re-arms the pin for the next choice.
+                if let Some(player) = space_mgr.get_entity_mut(entity_id) {
+                    player.open_dialog_id = None;
+                }
+
                 let player_id = space_mgr
                     .get_entity(entity_id)
                     .and_then(|e| e.player_id)
@@ -579,6 +611,186 @@ mod tests {
              consolidation both the template-driven path AND the dead \
              NpcInteractionType::Trainer arm would fire, double-emitting \
              with two divergent ability lists"
+        );
+    }
+
+    // ── DialogButtonChoice open-dialog gate (CAT-J-01 / #479) ──────────
+
+    /// Register an `OnDialogChoice { dialog_id }` chain that bumps a counter
+    /// when it fires, so a test can observe whether the choice handler
+    /// actually ran the chain. Counter delta = proof of chain execution.
+    fn engine_with_dialog_choice_chain(dialog_id: i32, counter: &str) -> ChainEngine {
+        use cimmeria_content_engine::actions::Action;
+        use cimmeria_content_engine::chain::Chain;
+        use cimmeria_content_engine::triggers::Trigger;
+
+        let mut engine = ChainEngine::new();
+        engine.register_chain(Chain {
+            id: 70479,
+            name: "test OnDialogChoice → increment counter".into(),
+            enabled: true,
+            trigger: Trigger::OnDialogChoice { dialog_id },
+            conditions: vec![],
+            actions: vec![Action::IncrementCounter {
+                counter_name: counter.into(),
+                amount: 1,
+            }],
+            priority: 0,
+        });
+        engine
+    }
+
+    fn dialog_choice_args(dialog_id: i32, button_id: i32) -> Vec<u8> {
+        let mut a = Vec::with_capacity(8);
+        a.extend_from_slice(&dialog_id.to_le_bytes());
+        a.extend_from_slice(&button_id.to_le_bytes());
+        a
+    }
+
+    fn counter(mgr: &SpaceManager, entity_id: u32, name: &str) -> i32 {
+        mgr.get_entity(entity_id)
+            .and_then(|e| e.counters.get(name).copied())
+            .unwrap_or(0)
+    }
+
+    /// **#479 negative case.** A `DialogButtonChoice` for a `dialog_id` the
+    /// server never displayed (forged packet) must be rejected: the bound
+    /// `OnDialogChoice` chain does NOT fire, and a `warn!` is logged. Pre-fix
+    /// the handler fired the chain unconditionally, so an attacker could
+    /// drive GrantItem/AcceptMission/Teleport for any discovered dialog_id.
+    #[tokio::test]
+    async fn dialog_choice_for_unopened_dialog_is_rejected() {
+        use crate::test_support::LogCapture;
+        let mut mgr = make_space_manager();
+        mgr.create_entity(1, "Agnos", [0.0; 3], [0.0; 3]).unwrap();
+        if let Some(p) = mgr.get_entity_mut(1) {
+            p.player_id = Some(42);
+            // No dialog open — open_dialog_id stays None (the default).
+        }
+        let engine = engine_with_dialog_choice_chain(5354, "j01");
+        let (tx, _rx) = mpsc::channel(16);
+        let capture = LogCapture::install();
+
+        let handled = dispatch(
+            1,
+            DIALOG_BUTTON_CHOICE,
+            &dialog_choice_args(5354, 0),
+            &tx,
+            &mut mgr,
+            &engine,
+        )
+        .await;
+        assert!(handled, "handler still consumes the method");
+
+        assert_eq!(
+            counter(&mgr, 1, "j01"),
+            0,
+            "a forged choice for an un-opened dialog must NOT fire the chain"
+        );
+        assert!(
+            capture
+                .find_message(tracing::Level::WARN, "dialogButtonChoice rejected")
+                .is_some(),
+            "rejection must emit the documented warn for ops/audit"
+        );
+    }
+
+    /// **#479 positive case.** When the dialog IS open (pinned by
+    /// `send_dialog_display`), the matching choice fires the chain and the
+    /// pin is cleared one-shot (mirrors python `del displayedDialogs[id]`).
+    #[tokio::test]
+    async fn dialog_choice_for_open_dialog_fires_chain_and_clears_pin() {
+        let mut mgr = make_space_manager();
+        mgr.create_entity(1, "Agnos", [0.0; 3], [0.0; 3]).unwrap();
+        if let Some(p) = mgr.get_entity_mut(1) {
+            p.player_id = Some(42);
+            p.open_dialog_id = Some(5354); // dialog is open
+        }
+        let engine = engine_with_dialog_choice_chain(5354, "j01");
+        let (tx, _rx) = mpsc::channel(16);
+
+        let handled = dispatch(
+            1,
+            DIALOG_BUTTON_CHOICE,
+            &dialog_choice_args(5354, 0),
+            &tx,
+            &mut mgr,
+            &engine,
+        )
+        .await;
+        assert!(handled);
+
+        assert_eq!(
+            counter(&mgr, 1, "j01"),
+            1,
+            "an open dialog's choice must fire the bound OnDialogChoice chain"
+        );
+        assert_eq!(
+            mgr.get_entity(1).and_then(|e| e.open_dialog_id),
+            None,
+            "a valid choice must clear the pin (one-shot) so a replay is rejected"
+        );
+    }
+
+    /// **#479 mismatch case.** A choice for dialog B while dialog A is open
+    /// must be rejected — the attacker can't ride an unrelated open dialog
+    /// to fire a different dialog_id's chain.
+    #[tokio::test]
+    async fn dialog_choice_for_different_open_dialog_is_rejected() {
+        let mut mgr = make_space_manager();
+        mgr.create_entity(1, "Agnos", [0.0; 3], [0.0; 3]).unwrap();
+        if let Some(p) = mgr.get_entity_mut(1) {
+            p.player_id = Some(42);
+            p.open_dialog_id = Some(1111); // a DIFFERENT dialog is open
+        }
+        let engine = engine_with_dialog_choice_chain(5354, "j01");
+        let (tx, _rx) = mpsc::channel(16);
+
+        dispatch(
+            1,
+            DIALOG_BUTTON_CHOICE,
+            &dialog_choice_args(5354, 0),
+            &tx,
+            &mut mgr,
+            &engine,
+        )
+        .await;
+
+        assert_eq!(
+            counter(&mgr, 1, "j01"),
+            0,
+            "choice for dialog 5354 must not fire while only dialog 1111 is open"
+        );
+        assert_eq!(
+            mgr.get_entity(1).and_then(|e| e.open_dialog_id),
+            Some(1111),
+            "a rejected mismatched choice must leave the real open dialog pinned"
+        );
+    }
+
+    /// **#479 replay idempotency.** Two identical valid choices in a row:
+    /// the first fires + clears the pin; the second hits `open == None` and
+    /// is rejected. Closes the replay sub-finding for free.
+    #[tokio::test]
+    async fn replayed_dialog_choice_is_rejected_after_first() {
+        let mut mgr = make_space_manager();
+        mgr.create_entity(1, "Agnos", [0.0; 3], [0.0; 3]).unwrap();
+        if let Some(p) = mgr.get_entity_mut(1) {
+            p.player_id = Some(42);
+            p.open_dialog_id = Some(5354);
+        }
+        let engine = engine_with_dialog_choice_chain(5354, "j01");
+        let (tx, _rx) = mpsc::channel(16);
+        let args = dialog_choice_args(5354, 0);
+
+        dispatch(1, DIALOG_BUTTON_CHOICE, &args, &tx, &mut mgr, &engine).await;
+        dispatch(1, DIALOG_BUTTON_CHOICE, &args, &tx, &mut mgr, &engine).await;
+
+        assert_eq!(
+            counter(&mgr, 1, "j01"),
+            1,
+            "the chain must fire exactly once — the replayed second choice is \
+             rejected because the pin was cleared by the first"
         );
     }
 }

--- a/crates/services/src/cell/content/executor/dialog.rs
+++ b/crates/services/src/cell/content/executor/dialog.rs
@@ -49,7 +49,7 @@ pub(super) async fn display(
     chain_id: i64,
     params: &std::collections::HashMap<String, serde_json::Value>,
     tx: &mpsc::Sender<CellToBaseMsg>,
-    space_mgr: &SpaceManager,
+    space_mgr: &mut SpaceManager,
 ) {
     let npc_entity_id = params
         .get("target_entity_id")
@@ -97,7 +97,14 @@ pub(super) async fn display(
         chain_id,
         "Content: displaying dialog"
     );
-    crate::cell::interactions::send_dialog_display(entity_id, npc_entity_id, dialog_id, tx).await;
+    crate::cell::interactions::send_dialog_display(
+        entity_id,
+        npc_entity_id,
+        dialog_id,
+        tx,
+        space_mgr,
+    )
+    .await;
 }
 
 /// `Action::AddDialogSet` — register a dialog set on the player's
@@ -414,7 +421,7 @@ mod tests {
         let (tx, mut rx) = mpsc::channel(4);
         display(
             /* dialog_id */ 4001, /* entity_id */ 1, /* chain_id */ 99, &params,
-            &tx, &mgr,
+            &tx, &mut mgr,
         )
         .await;
 
@@ -445,7 +452,7 @@ mod tests {
 
         let params = empty_params();
         let (tx, mut rx) = mpsc::channel(4);
-        display(2299, 1, 1021, &params, &tx, &mgr).await;
+        display(2299, 1, 1021, &params, &tx, &mut mgr).await;
 
         let msg = rx.try_recv().expect("must emit onDialogDisplay");
         match msg {
@@ -472,7 +479,7 @@ mod tests {
 
         let params = empty_params();
         let (tx, mut rx) = mpsc::channel(4);
-        display(4001, 1, 9999, &params, &tx, &mgr).await;
+        display(4001, 1, 9999, &params, &tx, &mut mgr).await;
 
         assert!(
             rx.try_recv().is_err(),
@@ -499,7 +506,7 @@ mod tests {
 
         let params = empty_params();
         let (tx, mut rx) = mpsc::channel(4);
-        display(2982, 1, 1001, &params, &tx, &mgr).await;
+        display(2982, 1, 1001, &params, &tx, &mut mgr).await;
 
         let msg = rx.try_recv().expect(
             "monologue dialog must emit onDialogDisplay even with no NPC \
@@ -533,7 +540,7 @@ mod tests {
 
         let params = empty_params();
         let (tx, mut rx) = mpsc::channel(4);
-        display(4001, 1, 9999, &params, &tx, &mgr).await;
+        display(4001, 1, 9999, &params, &tx, &mut mgr).await;
 
         assert!(
             rx.try_recv().is_err(),

--- a/crates/services/src/cell/interactions/dialog.rs
+++ b/crates/services/src/cell/interactions/dialog.rs
@@ -3,6 +3,7 @@
 use tokio::sync::mpsc;
 
 use crate::cell::messages::CellToBaseMsg;
+use crate::cell::space_manager::SpaceManager;
 
 /// Send `onDialogDisplay` (flat index 105) to the player.
 ///
@@ -14,6 +15,17 @@ use crate::cell::messages::CellToBaseMsg;
 /// `dialog-portrait-lookup.md`). Recording it as a span field on
 /// every send lets operators verify "did the right NPC id reach
 /// the wire?" without a packet capture.
+///
+/// This is the single choke point all dialog-display paths route through
+/// (interact-open, monologue, chain `display_dialog`/`start_dialog`,
+/// offer-mission), so it's where the server pins
+/// [`CellEntity::open_dialog_id`](cimmeria_entity::cell_entity::CellEntity::open_dialog_id) —
+/// the "is this dialog open?" precondition the `DialogButtonChoice`
+/// handler validates against (CAT-J-01 / #479). The pin is set
+/// unconditionally (before the best-effort channel send) because the
+/// client treats the dialog as open the moment this method is dispatched;
+/// the existing send-failure `warn!` below covers the rare case where the
+/// packet never reaches the client.
 #[tracing::instrument(
     name = "dialog.send_display",
     level = "info",
@@ -25,7 +37,17 @@ pub async fn send_dialog_display(
     npc_entity_id: i32,
     dialog_id: i32,
     tx: &mpsc::Sender<CellToBaseMsg>,
+    space_mgr: &mut SpaceManager,
 ) {
+    // Pin the open dialog on the player so DialogButtonChoice can verify
+    // the dialog was actually shown before firing its content chain.
+    // Overwrites any prior pin — SGW dialogs are strictly sequential, so
+    // a new display always supersedes the last (mirrors python
+    // `SGWPlayer.displayDialog` setting `self.displayedDialogs[dialogId]`).
+    if let Some(player) = space_mgr.get_entity_mut(player_id) {
+        player.open_dialog_id = Some(dialog_id);
+    }
+
     let mut args = Vec::with_capacity(17);
     args.extend_from_slice(&npc_entity_id.to_le_bytes()); // EntityId
     args.extend_from_slice(&dialog_id.to_le_bytes()); // DialogID
@@ -75,9 +97,11 @@ mod tests {
         let capture = LogCapture::install();
         let (tx, rx) = mpsc::channel(1);
         drop(rx);
+        let mut mgr = crate::test_support::make_space_manager();
 
         send_dialog_display(
             /* player_id */ 1, /* npc_entity_id */ 100, /* dialog_id */ 42, &tx,
+            &mut mgr,
         )
         .await;
 
@@ -87,6 +111,29 @@ mod tests {
                 .is_some(),
             "negative-logging convention: send_dialog_display must WARN when cell→base channel is closed; \
              reverting to `let _` breaks player-stuck-on-NPC diagnosability"
+        );
+    }
+
+    /// **#479 set-side guard.** `send_dialog_display` must pin
+    /// `open_dialog_id` on the player so the `DialogButtonChoice` handler
+    /// has a precondition to validate against. Without this, the gate in
+    /// the choice handler can never pass and every dialog choice would be
+    /// rejected (the inverse failure mode).
+    #[tokio::test]
+    async fn send_dialog_display_pins_open_dialog_id() {
+        let mut mgr = crate::test_support::make_space_manager();
+        mgr.create_entity(7, "Agnos", [0.0; 3], [0.0; 3]).unwrap();
+        let (tx, _rx) = mpsc::channel(4);
+
+        send_dialog_display(
+            7, /* npc */ 100, /* dialog_id */ 5354, &tx, &mut mgr,
+        )
+        .await;
+
+        assert_eq!(
+            mgr.get_entity(7).and_then(|e| e.open_dialog_id),
+            Some(5354),
+            "send_dialog_display must pin the dialog so DialogButtonChoice can verify it"
         );
     }
 

--- a/crates/services/src/cell/interactions/dispatch.rs
+++ b/crates/services/src/cell/interactions/dispatch.rs
@@ -109,7 +109,7 @@ pub async fn handle_interact(
                 dialog_id,
                 "interact: per-player dialog set → onDialogDisplay"
             );
-            send_dialog_display(entity_id, target_entity_id as i32, dialog_id, tx).await;
+            send_dialog_display(entity_id, target_entity_id as i32, dialog_id, tx, space_mgr).await;
             return Some(dialog_id);
         } else {
             tracing::info!(
@@ -129,7 +129,7 @@ pub async fn handle_interact(
                 dialog_id,
                 "interact: static dialog → onDialogDisplay"
             );
-            send_dialog_display(entity_id, target_entity_id as i32, dialog_id, tx).await;
+            send_dialog_display(entity_id, target_entity_id as i32, dialog_id, tx, space_mgr).await;
             Some(dialog_id)
         }
         Some(NpcInteractionType::Vendor) => {
@@ -272,7 +272,7 @@ pub async fn handle_initial_response(
             npc_entity_id,
             "handle_initial_response: found dialog, sending onDialogDisplay"
         );
-        send_dialog_display(entity_id, npc_entity_id, dialog_id, tx).await;
+        send_dialog_display(entity_id, npc_entity_id, dialog_id, tx, space_mgr).await;
         crate::cell::content::fire_dialog_open(
             entity_id, player_id, dialog_id, engine, tx, space_mgr,
         )

--- a/docs/content/content-engine.md
+++ b/docs/content/content-engine.md
@@ -106,7 +106,7 @@ Defined at [triggers.rs:20-98](../../crates/content-engine/src/triggers.rs#L20-L
 | `OnCustomEvent { event_name }` | Generic invoke escape hatch / synthetic for triggerless chains |
 | `OnPlayerLoaded { world_name? }` | Player completes mapLoaded |
 | `OnDialogOpen { dialog_id }` | Server sent `onDialogDisplay` |
-| `OnDialogChoice { dialog_id }` | Player clicked a dialog button |
+| `OnDialogChoice { dialog_id }` | Player clicked a dialog button. **Server-gated**: the `DialogButtonChoice` handler rejects the event unless `CellEntity::open_dialog_id == dialog_id` (the dialog was actually displayed to this player via `send_dialog_display`); a forged/replayed choice for an un-opened `dialog_id` is dropped with a `warn!` and never fires the chain (CAT-J-01 / #479). |
 | `OnInteractTag { entity_tag }` | Right-click on tagged NPC/object |
 | `OnInteractTemplate { template_name }` | Right-click on entity from named template |
 | `OnItemUse { item_id }` | Player double-clicked inventory item |

--- a/docs/security-audit/2026-05-31-server-authority/findings/CAT-J-mission-dialog.md
+++ b/docs/security-audit/2026-05-31-server-authority/findings/CAT-J-mission-dialog.md
@@ -45,6 +45,18 @@ movement-physics-advisor should consult-review on **CAT-J-01** and **CAT-J-04**.
 
 ### CAT-J-01 — DialogButtonChoice fires arbitrary content chain with no "is this dialog open?" check
 
+**Status**: ✅ RESOLVED (#479) — `CellEntity::open_dialog_id` is pinned by
+`send_dialog_display` (the single choke point all display paths route
+through) and matched on strict equality in the `DIALOG_BUTTON_CHOICE`
+handler; a forged/replayed choice for an un-opened `dialog_id` is dropped
+with a `warn!` and never fires the chain. The pin is cleared one-shot on a
+valid choice (mirrors python `SGWPlayer.displayedDialogs`), which also
+makes a replayed choice idempotent (closes the replay sub-finding). The
+`button_id` stays unvalidated by design — `OnDialogChoice` matches
+`dialog_id` only. **Does not** address CAT-J-04 (no level/faction/prereq
+gate on `accept_or_advance`); a legitimately-opened reward dialog still
+accepts without prereq checks — that's the separate follow-up finding.
+
 **Severity**: Critical
 **Class**: Missing server-side state precondition; chain-engine event spoofing
 **Wire surface**: `Event_NetOut_DialogButtonChoice` (cell method 75)


### PR DESCRIPTION
Closes #479. Resolves **CAT-J-01** (P0-5) from the server-authority audit (#459).

> Branched from `main` — independent of the #510/#511/#512 stack (touches the dialog/content path, not `player_init.rs`).

## What

`DIALOG_BUTTON_CHOICE` (cell method 75) fired an `OnDialogChoice` content chain keyed on a client-supplied `dialog_id` with **no server-side check that the dialog was ever open for that player**. A single forged packet for any discovered `dialog_id` drove the bound chain's actions — `GrantItem`, `AcceptMission`, `CompleteMission`, `Teleport`, `RollLootTable`, … — without opening the dialog, talking to the NPC, being in its space, or meeting any gating the chain author assumed the dialog precondition enforced.

The fix mirrors the canonical Python model (`SGWPlayer.displayedDialogs`): pin the open dialog on the player, validate on choice, clear one-shot.

- **`CellEntity::open_dialog_id: Option<i32>`** — the server-side "is dialog X open for player Y?" precondition.
- **Set** in `send_dialog_display` (the single choke point every display path routes through — interact-open, monologue, chain `display_dialog`, offer-mission), so a future display site pins automatically.
- **Validate + clear** in the `DIALOG_BUTTON_CHOICE` handler: reject (warn + no chain fire) unless `open_dialog_id == dialog_id`; on a valid choice, clear the pin to `None` **before** firing the chain (so a chain action that opens a follow-up dialog re-arms the pin via its own `send_dialog_display`).

Strict equality is the tightest gate that false-rejects nothing: SGW dialogs are strictly sequential (display → choice → display), and the client sends exactly one choice per displayed `dialog_id` (multi-screen narration auto-advances client-side under the same id). Verified against the seed data and the Python reference with the mission-systems advisor.

`button_id` stays unvalidated by design — `OnDialogChoice` matches `dialog_id` only; there's no server-side button table in the choice path, so gating it would be net-new surface for no security gain.

## Acceptance (issue #479 "closes when")

1. ✅ A forged `DialogButtonChoice` for an un-opened `dialog_id` is rejected at the handler (warn-log, chain not fired).
2. ✅ A legitimately-opened dialog's choice fires its chain normally.
3. ✅ Regression tests cover the negative case.

## Tests (all revert-verified)

- **Negative**: forged choice for an un-opened dialog → chain does NOT fire (counter stays 0) + documented `warn!`.
- **Positive**: open dialog → choice fires the bound chain + pin cleared one-shot.
- **Mismatch**: choice for dialog B while dialog A is open → rejected, A stays pinned.
- **Replay idempotency**: two identical valid choices → chain fires exactly once (second hits the cleared pin). Closes the replay sub-finding for free.
- **Set-side**: `send_dialog_display` pins `open_dialog_id` (guards the inverse failure — without the pin, every choice would be wrongly rejected).
- Revert check: neutering the gate trips all three rejection tests.

## Docs

- [docs/content/content-engine.md](docs/content/content-engine.md) — `OnDialogChoice` row notes the server-side open-dialog gate.
- CAT-J-01 finding marked ✅ RESOLVED, with the explicit scope boundary: this closes the *un-opened-dialog* vector; **CAT-J-04** (no level/faction/prereq gate on `accept_or_advance`) is a separate follow-up — a legitimately-opened reward dialog still accepts without prereq checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dialog button choices now undergo server-side validation to prevent forged or replayed interactions.

* **Documentation**
  * Updated content engine and security audit documentation to describe dialog choice validation and server-authority behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->