### PR TITLE
fix(combat): faction gate on player single-target useAbility (#444, CAT-C-03)

### DIFF
--- a/crates/services/src/cell/abilities/damage_apply/tests.rs
+++ b/crates/services/src/cell/abilities/damage_apply/tests.rs
@@ -32,6 +32,13 @@ fn make_mgr_player_vs_npc() -> SpaceManager {
         p.is_player = true;
         p.player_id = Some(100);
     }
+    if let Some(npc) = mgr.get_entity_mut(2) {
+        // The NPC target is the enemy under attack — hostile so the #444
+        // single-target target-validity gate in `handle_use_ability` lets
+        // the damage path run. Tests that call `apply_damage_to_target`
+        // directly are unaffected (they bypass the gate).
+        npc.faction = crate::cell::combat::HOSTILE_FACTION;
+    }
     mgr.connect_entity(1);
     let _ = mgr.compute_aoi_changes();
     mgr

--- a/crates/services/src/cell/abilities/use_ability/mod.rs
+++ b/crates/services/src/cell/abilities/use_ability/mod.rs
@@ -286,6 +286,49 @@ pub async fn handle_use_ability(
                     );
                     return false;
                 }
+                // Server-authority target-validity gate (#444), scoped to
+                // PLAYER attackers — that's the forgery vector. The
+                // single-target path resolves as damage unconditionally
+                // (see `apply_damage_to_target` — there is no offensive vs
+                // supportive branch), so a player may only target a hostile
+                // NPC. A non-hostile NPC (vendor / quest giver / neutral)
+                // must never take player damage, and another player is
+                // never a legitimate single-target target in today's
+                // PvE-only design. Mirrors the AoE (`abilities/dispatch.rs`)
+                // and cone (`abilities/cone_aoe.rs`) faction filters;
+                // without it a forged `useAbility` packet griefs vendors,
+                // quest NPCs, party members, or other players (the client
+                // UI restricts target selection, but the server must
+                // enforce it).
+                //
+                // NPC attackers are deliberately NOT gated here: NPC AI
+                // fight (`npc_ai`) calls this same entry point to attack a
+                // PLAYER, which is legitimate — the AI already picks valid
+                // targets server-side.
+                //
+                // TODO: supportive single-target abilities (heal/buff an
+                // ally) will need the inverse gate (require friendly/self
+                // target) once an offensive/supportive ability flag exists
+                // — `AbilityDef` has no such field today, and
+                // `target_type_id` only encodes self/target/ground. Same
+                // seam where a per-pair hostility check replaces the flat
+                // `HOSTILE_FACTION` sentinel when PvP lands (see the cone
+                // module doc).
+                if entity.is_player
+                    && (target.is_player || target.faction != combat::HOSTILE_FACTION)
+                {
+                    tracing::warn!(
+                        entity_id,
+                        ability_id,
+                        target_id,
+                        target_is_player = target.is_player,
+                        target_faction = target.faction,
+                        "useAbility rejected -- player single-target ability against a \
+                         non-hostile target (friendly-fire / forged target); \
+                         damage pipeline not entered (#444)"
+                    );
+                    return false;
+                }
                 // Range check
                 let max_range = ability_def.as_ref().map_or(30.0, |d| {
                     if d.max_range > 0 {

--- a/crates/services/src/cell/abilities/use_ability/tests.rs
+++ b/crates/services/src/cell/abilities/use_ability/tests.rs
@@ -95,9 +95,14 @@ async fn cooldown_blocks_fire_and_emits_no_packets() {
 async fn out_of_range_emits_on_error_code_with_condition_42() {
     let mut mgr = make_mgr();
     make_player(&mut mgr, 1, [0.0; 3]);
-    // Target far away beyond max_range=10.
+    // Target far away beyond max_range=10. Hostile so it passes the
+    // #444 target-validity gate and reaches the range check this test
+    // is about.
     mgr.create_entity(2, "Castle_CellBlock", [100.0, 0.0, 0.0], [0.0; 3])
         .unwrap();
+    if let Some(t) = mgr.get_entity_mut(2) {
+        t.faction = crate::cell::combat::HOSTILE_FACTION;
+    }
     if let Some(p) = mgr.get_entity_mut(1) {
         p.abilities.add_ability(7);
     }
@@ -214,6 +219,91 @@ async fn dead_target_blocks_fire_without_consuming_resources() {
     assert!(
         !mgr.get_entity(1).unwrap().abilities.is_on_cooldown(7),
         "rejecting against a dead target must not start the cooldown"
+    );
+}
+
+// ── #444 single-target faction / target-validity gate ─────────────────
+
+/// **#444 friendly-fire guard.** A single-target ability against a
+/// non-hostile NPC (vendor / quest giver / neutral, faction != 10) must
+/// be rejected before the damage pipeline — no commit, no cooldown.
+/// Pre-fix the path only checked alive + range, so a forged
+/// `useAbility(weapon_id, vendor_eid)` killed vendors and quest NPCs.
+#[tokio::test]
+async fn non_hostile_npc_target_blocks_fire() {
+    let mut mgr = make_mgr();
+    make_player(&mut mgr, 1, [0.0; 3]);
+    // Neutral NPC (default faction 0) within range — a vendor / quest giver.
+    mgr.create_entity(2, "Castle_CellBlock", [3.0, 0.0, 0.0], [0.0; 3])
+        .unwrap();
+    if let Some(p) = mgr.get_entity_mut(1) {
+        p.abilities.add_ability(7);
+    }
+    mgr.ability_defs.insert(7, make_ability(7, 0, 30));
+    let (tx, _rx) = mpsc::channel(8);
+
+    let committed = handle_use_ability(1, 7, 2, &tx, &mut mgr).await;
+    assert!(
+        !committed,
+        "a single-target ability must not commit against a non-hostile NPC"
+    );
+    assert!(
+        !mgr.get_entity(1).unwrap().abilities.is_on_cooldown(7),
+        "rejecting a non-hostile target must not start the cooldown"
+    );
+}
+
+/// **#444 PvP-forgery guard.** A forged single-target ability against
+/// another PLAYER must be rejected — players are never legitimate
+/// single-target ability targets in today's PvE-only design, and the
+/// wire path doesn't otherwise stop `target_id = other_player_eid`.
+#[tokio::test]
+async fn player_target_blocks_fire() {
+    let mut mgr = make_mgr();
+    make_player(&mut mgr, 1, [0.0; 3]);
+    make_player(&mut mgr, 2, [3.0, 0.0, 0.0]); // another player in range
+    if let Some(p) = mgr.get_entity_mut(1) {
+        p.abilities.add_ability(7);
+    }
+    mgr.ability_defs.insert(7, make_ability(7, 0, 30));
+    let (tx, _rx) = mpsc::channel(8);
+
+    let committed = handle_use_ability(1, 7, 2, &tx, &mut mgr).await;
+    assert!(
+        !committed,
+        "a single-target ability must not commit against another player"
+    );
+    assert!(!mgr.get_entity(1).unwrap().abilities.is_on_cooldown(7));
+}
+
+/// **#444 regression guard (positive).** A hostile NPC target still
+/// passes the gate and the ability commits — proves the new check
+/// doesn't over-block legitimate combat. A revert that drops the gate
+/// keeps this green, but the two negative tests above flip to failing,
+/// which is the intended fail-shape.
+#[tokio::test]
+async fn hostile_npc_target_commits() {
+    let mut mgr = make_mgr();
+    make_player(&mut mgr, 1, [0.0; 3]);
+    mgr.create_entity(2, "Castle_CellBlock", [3.0, 0.0, 0.0], [0.0; 3])
+        .unwrap();
+    if let Some(t) = mgr.get_entity_mut(2) {
+        t.faction = crate::cell::combat::HOSTILE_FACTION;
+    }
+    if let Some(p) = mgr.get_entity_mut(1) {
+        p.abilities.add_ability(7);
+    }
+    mgr.ability_defs.insert(7, make_ability(7, 0, 30));
+    let (tx, _rx) = mpsc::channel(8);
+
+    let committed = handle_use_ability(1, 7, 2, &tx, &mut mgr).await;
+    assert!(
+        committed,
+        "a hostile NPC target must still commit — the gate must not over-block combat"
+    );
+    assert!(
+        mgr.get_entity(1).unwrap().abilities.is_on_cooldown(7),
+        "a committed fire against a hostile target starts the cooldown"
     );
 }
 
@@ -738,9 +828,13 @@ async fn weapon_granted_ability_commits_even_when_not_in_known_set() {
     use cimmeria_entity::cell_entity::BandolierItem;
     let mut mgr = make_mgr();
     make_player(&mut mgr, 1, [0.0; 3]);
-    // Target NPC within range.
+    // Target NPC within range. Hostile so it passes the #444
+    // target-validity gate.
     mgr.create_entity(2, "Castle_CellBlock", [3.0, 0.0, 0.0], [0.0; 3])
         .unwrap();
+    if let Some(t) = mgr.get_entity_mut(2) {
+        t.faction = crate::cell::combat::HOSTILE_FACTION;
+    }
 
     if let Some(p) = mgr.get_entity_mut(1) {
         // Pistol (item 55) in active bandolier slot 0. Weapon drawn so
@@ -855,6 +949,9 @@ async fn use_ability_redirects_pistol_shot_to_smg_when_p90_equipped() {
     // NPC target so the post-redirect range check has something to find.
     mgr.spawn_npc(50, "Castle_CellBlock", [3.0, 0.0, 0.0], [0.0; 3])
         .unwrap();
+    if let Some(t) = mgr.get_entity_mut(50) {
+        t.faction = crate::cell::combat::HOSTILE_FACTION;
+    }
 
     if let Some(p) = mgr.get_entity_mut(1) {
         // Pistol Shot (592) — archetype starter. The player only
@@ -913,6 +1010,9 @@ async fn use_ability_does_not_redirect_pistol_shot_when_no_weapon_equipped() {
     make_player(&mut mgr, 1, [0.0; 3]);
     mgr.spawn_npc(50, "Castle_CellBlock", [3.0, 0.0, 0.0], [0.0; 3])
         .unwrap();
+    if let Some(t) = mgr.get_entity_mut(50) {
+        t.faction = crate::cell::combat::HOSTILE_FACTION;
+    }
 
     if let Some(p) = mgr.get_entity_mut(1) {
         p.abilities.add_ability(592);
@@ -953,6 +1053,9 @@ async fn use_ability_does_not_redirect_when_called_ability_is_already_weapon_bin
     make_player(&mut mgr, 1, [0.0; 3]);
     mgr.spawn_npc(50, "Castle_CellBlock", [3.0, 0.0, 0.0], [0.0; 3])
         .unwrap();
+    if let Some(t) = mgr.get_entity_mut(50) {
+        t.faction = crate::cell::combat::HOSTILE_FACTION;
+    }
 
     if let Some(p) = mgr.get_entity_mut(1) {
         p.abilities.add_ability(559);

--- a/crates/services/src/cell/cell_methods/player/world/tests.rs
+++ b/crates/services/src/cell/cell_methods/player/world/tests.rs
@@ -212,6 +212,9 @@ async fn set_auto_cycle_enable_fires_immediately_when_target_and_last_ability_se
     let mut mgr = make_mgr_with_player();
     mgr.spawn_npc(50, "Castle_CellBlock", [3.0, 0.0, 0.0], [0.0; 3])
         .unwrap();
+    if let Some(npc) = mgr.get_entity_mut(50) {
+        npc.faction = crate::cell::combat::HOSTILE_FACTION;
+    }
     if let Some(p) = mgr.get_entity_mut(1) {
         p.abilities.add_ability(7);
         p.abilities.last_fired_ability_id = Some(7);
@@ -356,6 +359,9 @@ async fn set_auto_cycle_enable_skips_immediate_fire_when_on_cooldown() {
     let mut mgr = make_mgr_with_player();
     mgr.spawn_npc(50, "Castle_CellBlock", [3.0, 0.0, 0.0], [0.0; 3])
         .unwrap();
+    if let Some(npc) = mgr.get_entity_mut(50) {
+        npc.faction = crate::cell::combat::HOSTILE_FACTION;
+    }
     if let Some(p) = mgr.get_entity_mut(1) {
         p.abilities.add_ability(7);
         p.abilities.last_fired_ability_id = Some(7);
@@ -1160,6 +1166,9 @@ async fn set_auto_cycle_immediate_fire_credits_quest_kill_on_tagged_npc_death() 
     let mut mgr = make_mgr_with_player();
     mgr.spawn_npc(50, "Castle_CellBlock", [3.0, 0.0, 0.0], [0.0; 3])
         .unwrap();
+    if let Some(npc) = mgr.get_entity_mut(50) {
+        npc.faction = crate::cell::combat::HOSTILE_FACTION;
+    }
     // Pre-conditions for SET_AUTO_CYCLE's immediate-fire branch:
     // current_target_id + last_fired_ability_id both Some. Mirror
     // the existing `set_auto_cycle_enable_fires_immediately_*` test

--- a/crates/services/src/cell/service/ticks/auto_cycle.rs
+++ b/crates/services/src/cell/service/ticks/auto_cycle.rs
@@ -220,6 +220,11 @@ mod tests {
         mgr.create_entity(1, "Castle", [0.0; 3], [0.0; 3]).unwrap();
         mgr.spawn_npc(50, "Castle", [5.0, 0.0, 0.0], [0.0; 3])
             .unwrap();
+        // Hostile so the #444 player-attacker target-validity gate lets
+        // the auto-cycle re-fire reach this NPC.
+        if let Some(npc) = mgr.get_entity_mut(50) {
+            npc.faction = crate::cell::combat::HOSTILE_FACTION;
+        }
         if let Some(p) = mgr.get_entity_mut(1) {
             p.is_player = true;
             p.player_id = Some(100);
@@ -426,6 +431,11 @@ mod tests {
         let mut mgr = make_auto_cycle_mgr();
         mgr.spawn_npc(75, "Castle", [3.0, 0.0, 0.0], [0.0; 3])
             .unwrap();
+        // Hostile so the #444 player-attacker gate lets the re-fire reach
+        // the switched-to live target.
+        if let Some(npc) = mgr.get_entity_mut(75) {
+            npc.faction = crate::cell::combat::HOSTILE_FACTION;
+        }
         if let Some(p) = mgr.get_entity_mut(1) {
             p.current_target_id = Some(75);
             p.position = Vector3::new(0.0, 0.0, 0.0);

--- a/crates/services/src/cell/service/ticks/mod.rs
+++ b/crates/services/src/cell/service/ticks/mod.rs
@@ -689,6 +689,11 @@ mod tests {
         mgr.create_entity(1, "Castle", [0.0; 3], [0.0; 3]).unwrap();
         mgr.spawn_npc(50, "Castle", [3.0, 0.0, 0.0], [0.0; 3])
             .unwrap();
+        // Hostile so the #444 single-target target-validity gate allows
+        // the deferred attack through to the kill path this test drives.
+        if let Some(npc) = mgr.get_entity_mut(50) {
+            npc.faction = crate::cell::combat::HOSTILE_FACTION;
+        }
         // Phase-B queue pre-conditions: stamp is in the past so the
         // tick promotes it, and the queue carries the target+ability
         // the deferred fire should pick up.

--- a/crates/services/src/cell/service/ticks/npc_respawn.rs
+++ b/crates/services/src/cell/service/ticks/npc_respawn.rs
@@ -791,6 +791,9 @@ mod tests {
         mgr.spawn_npc(50, "Castle", [3.0, 0.0, 0.0], [0.0, 1.57, 0.0])
             .unwrap();
         if let Some(npc) = mgr.get_entity_mut(50) {
+            // Hostile so the #444 single-target target-validity gate
+            // allows the attack through to the kill path this test drives.
+            npc.faction = crate::cell::combat::HOSTILE_FACTION;
             npc.respawn_secs = Some(3);
             npc.original_interaction_type_flags = 1 << 5;
             npc.interaction_type_flags = 1 << 5;

--- a/docs/gameplay/combat-system.md
+++ b/docs/gameplay/combat-system.md
@@ -175,6 +175,19 @@ distinction is load-bearing for mission progression.
 | Player-driven, single target | `handle_use_ability_with_kill_credit` | Every player-initiated single-target attack |
 | NPC AI, tests, AoE caller layer | `handle_use_ability` (bare) | NPC attacks; ability-mechanic tests; AoE primary cast (the AoE caller fires `fire_entity_death` per-death itself) |
 
+Both entry points share `handle_use_ability`'s single-target validation,
+which gates on target validity: the target must be alive and in range, and
+— **for player attackers** — a hostile NPC (`entity.is_player &&
+(target.is_player || target.faction != HOSTILE_FACTION)` → rejected with a
+`warn!`). This mirrors the AoE/cone faction filters and is the
+server-authority guard against forged `useAbility` packets that would
+otherwise grief vendors, quest NPCs, party members, or other players
+(#444 / CAT-C-03). The check is scoped to player attackers because NPC AI
+fight calls the same entry point to attack a *player*, which is
+legitimate. Single-target abilities resolve as damage unconditionally
+today; supportive single-target abilities (heal/buff an ally) will need
+the inverse gate once an offensive/supportive ability field exists.
+
 `handle_use_ability_with_kill_credit` wraps `handle_use_ability` with
 an alive→dead transition detector that fires the content-engine
 `EntityDeath` event. KillCount-style mission chains (e.g., "kill 5

--- a/docs/security-audit/2026-05-31-server-authority/findings/CAT-C-combat-abilities.md
+++ b/docs/security-audit/2026-05-31-server-authority/findings/CAT-C-combat-abilities.md
@@ -151,6 +151,23 @@ No.
 
 ### CAT-C-03 — `useAbility` allows player→player damage (no friendly-fire / faction check)
 
+**Status**: ✅ RESOLVED (#444) — the single-target validation block in
+`handle_use_ability` (`cell/abilities/use_ability/mod.rs`) now rejects,
+**for player attackers**, any target that is a player or a non-hostile NPC
+(`entity.is_player && (target.is_player || target.faction !=
+HOSTILE_FACTION)`) before the damage pipeline, mirroring the AoE
+(`abilities/dispatch.rs`) and cone (`abilities/cone_aoe.rs`) faction
+filters, with a `warn!` for the attempted friendly-fire. Closes the
+vendor/quest-NPC/party-member and forged-player-target vectors. The gate
+is scoped to player attackers because NPC AI fight calls the same entry
+point to attack a *player* (legitimate combat).
+Single-target abilities resolve as damage unconditionally today (no
+offensive/supportive field exists on `AbilityDef`), so supportive
+single-target abilities (heal/buff an ally) will need the inverse gate
+when that field is added — documented as a TODO at the guard. The flat
+`HOSTILE_FACTION` sentinel is the same PvP seam the cone module already
+flags for a future per-pair hostility model.
+
 **Severity**: High
 **Class**: Missing faction/hostility gate
 **Wire surface**: `Event_NetOut_UseAbility` (cell method 68)


### PR DESCRIPTION
Closes #444. Resolves **CAT-C-03** from the server-authority audit (#459).

> Branched from `main` — independent of the open PR stack (touches only the combat ability path).

## What

`handle_use_ability`'s single-target validation checked target *alive* and *in range* but **not target validity**. A forged `useAbility(weapon_ability_id, vendor_entity_id)` ran the damage pipeline against a vendor, quest NPC, party member, or another player — the AoE (`abilities/dispatch.rs`) and cone (`abilities/cone_aoe.rs`) paths gate on `faction != HOSTILE_FACTION`, but single-target bypassed it.

The fix adds the missing gate, mirroring AoE/cone, **scoped to player attackers**:

```rust
if entity.is_player && (target.is_player || target.faction != combat::HOSTILE_FACTION) {
    warn!(...); return false;
}
```

placed in the validation block right after the dead-target check, before the damage pipeline. The `entity.is_player` scope is load-bearing: NPC AI fight calls the same `handle_use_ability` entry point to attack a *player*, which is legitimate — gating all attackers would break every NPC→player attack. Rejection logs at `warn!` (a legit client never sends a player-vs-non-hostile single-target — the UI restricts target selection — so it's a forged/buggy packet worth surfacing for the security audit), with `target_is_player` / `target_faction` fields.

## Design (verified with the combat-systems advisor)

The issue's naive `faction != HOSTILE → reject` would break heal/buff abilities that target allies — so I checked the model first:

- **Single-target useAbility resolves as damage unconditionally** — there is no offensive-vs-supportive branch in `apply_damage_to_target`, and **no supportive single-target ability is wired today**. So gating on hostile is correct for the current code; it doesn't over-block anything that exists.
- **There is no offensive/supportive field** on `AbilityDef` — `target_type_id` only encodes self/target/ground. So category-based gating isn't possible yet; a documented TODO marks where the inverse gate (require friendly/self) goes when heal-an-ally lands.
- **Players are never legitimate single-target ability targets for a player attacker** in today's PvE-only design (the kill-credit wrapper already excludes them), so `target.is_player` rejection also closes the forged-player-target (PvP) variant of the same forgery. The flat `HOSTILE_FACTION` sentinel is the exact seam where a per-pair hostility check replaces it when PvP lands — the same TODO the cone module already carries.
- **NPC attackers are not gated** — NPC AI fight uses the same entry point to attack players (legitimate). Found via the full-suite run: scoping to player attackers was required to keep the 3 `npc_ai_fight` tests green.

## Tests (all revert-verified)

- **Negative — non-hostile NPC**: ability against a neutral NPC (vendor/quest giver) → rejected, no commit, no cooldown.
- **Negative — player target**: forged ability against another player → rejected.
- **Positive — hostile NPC**: still commits and starts cooldown (proves the gate doesn't over-block combat).
- Updated pre-existing fixtures (use_ability, damage_apply `make_mgr_player_vs_npc`, auto-cycle/pending-attack/respawn ticks) that fire at live NPC targets to make those targets hostile — they represent enemies being attacked; the fixtures predated the gate.
- Revert check: neutering the gate trips both negative guards while the positive stays green — the intended fail-shape.

## Docs

- [docs/gameplay/combat-system.md](docs/gameplay/combat-system.md) — single-target validation now documents the faction gate.
- CAT-C-03 finding marked ✅ RESOLVED with the scope note (supportive-ability TODO, PvP seam).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security / Anti-Griefing**
  * Added server-side validation preventing players from casting single-target abilities on other players or non-hostile NPCs. Invalid casts are rejected before damage processing and do not consume cooldowns.

* **Documentation**
  * Updated combat system documentation detailing ability validation requirements. Previously identified security findings related to combat abilities now marked as resolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->