### PR TITLE
fix(loot): re-validate looter distance on every lootItem (#446, CAT-D-02)

### DIFF
--- a/crates/services/src/cell/interactions/dispatch.rs
+++ b/crates/services/src/cell/interactions/dispatch.rs
@@ -14,7 +14,12 @@ use super::vendor::send_store_open;
 
 /// Maximum distance for NPC interaction (world units).
 /// From `python/common/Constants.py: MAX_INTERACT_DISTANCE = 5`.
-const MAX_INTERACT_DISTANCE: f32 = 5.0;
+///
+/// `pub(super)` so the sibling `loot` module can re-validate looting
+/// distance against the same bound the initial `interact` enforces
+/// (#446 — the loot handler must re-check range on every take, not just
+/// trust the interact-time `looting_entity` pin).
+pub(super) const MAX_INTERACT_DISTANCE: f32 = 5.0;
 
 /// Handle `interact(targetEntityId)` cell method call.
 ///

--- a/crates/services/src/cell/interactions/loot.rs
+++ b/crates/services/src/cell/interactions/loot.rs
@@ -129,6 +129,40 @@ pub async fn handle_loot_item(
         }
     };
 
+    // Server-authority range re-check (#446). `looting_entity` was pinned
+    // at interact time, where the distance to the corpse was checked once
+    // against `MAX_INTERACT_DISTANCE`. Nothing re-validates it afterward,
+    // so a client that spoofs its position (or simply walks away while the
+    // loot window is open) can keep calling `lootItem` from anywhere in the
+    // zone — "vacuum loot" every corpse without traversing to it. Re-check
+    // the LIVE distance on every take so the pin alone can't be replayed
+    // from out of range. The corpse-position read is cheap (no DB, no
+    // fan-out).
+    //
+    // This does NOT yet enforce kill-credit / loot ownership (a player who
+    // dealt 0 damage can still loot a corpse they walked up to) — that's
+    // the larger SGW lootability-window model, tracked as the follow-up
+    // half of #446 and routed through the combat-systems advisor.
+    {
+        let looter_pos = space_mgr.get_entity(entity_id).map(|e| e.position);
+        let corpse_pos = space_mgr.get_entity(target_eid).map(|e| e.position);
+        if let (Some(lp), Some(cp)) = (looter_pos, corpse_pos) {
+            let dist = lp.distance_to(&cp);
+            if dist > super::dispatch::MAX_INTERACT_DISTANCE {
+                tracing::warn!(
+                    entity_id,
+                    target_eid,
+                    index,
+                    dist,
+                    max = super::dispatch::MAX_INTERACT_DISTANCE,
+                    "lootItem rejected -- looter is out of range of the corpse \
+                     (position spoof or walked away); no item removed (#446)"
+                );
+                return;
+            }
+        }
+    }
+
     // Find and remove the loot item from the NPC
     let removed_item = {
         let target = match space_mgr.get_entity_mut(target_eid) {
@@ -375,5 +409,107 @@ mod tests {
                 _ => {}
             }
         }
+    }
+
+    // ── #446 loot range re-validation ─────────────────────────────────
+
+    /// Build a manager with one player (id 1, has player_id) at the origin
+    /// looting an NPC corpse (id 2) seeded with one cash drop. The corpse
+    /// position is caller-chosen so the distance gate can be exercised.
+    fn make_loot_mgr(corpse_pos: [f32; 3]) -> super::super::super::space_manager::SpaceManager {
+        use super::super::super::space_manager::SpaceManager;
+        use cimmeria_entity::cell_entity::LootItem;
+
+        let mut mgr = SpaceManager::new(1);
+        let spaces_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<Spaces><Space WorldName="Agnos" Instanced="false" MinX="-2400" MaxX="2200" MinY="-3200" MaxY="2800" /></Spaces>"#;
+        let cell_spaces_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<Spaces><Space WorldName="Agnos" /></Spaces>"#;
+        mgr.parse_spaces_xml(spaces_xml).unwrap();
+        mgr.create_startup_spaces(cell_spaces_xml).unwrap();
+
+        mgr.create_entity(1, "Agnos", [0.0, 0.0, 0.0], [0.0; 3])
+            .unwrap();
+        let npc_id = mgr.allocate_npc_id();
+        mgr.spawn_npc(npc_id, "Agnos", corpse_pos, [0.0; 3])
+            .unwrap();
+        if let Some(npc) = mgr.get_entity_mut(npc_id) {
+            npc.loot.push(LootItem {
+                design_id: None, // cash
+                quantity: 50,
+                index: 1,
+            });
+        }
+        if let Some(p) = mgr.get_entity_mut(1) {
+            p.player_id = Some(42);
+            p.looting_entity = Some(npc_id);
+        }
+        mgr
+    }
+
+    /// **#446 in-range positive guard.** A looter standing on the corpse
+    /// (distance 2 < MAX_INTERACT_DISTANCE) loots normally — the gate must
+    /// not over-block. The drop is removed and a GrantCash is queued.
+    #[tokio::test]
+    async fn loot_item_in_range_succeeds() {
+        use super::*;
+        use tokio::sync::mpsc;
+
+        let mut mgr = make_loot_mgr([2.0, 0.0, 0.0]);
+        let npc_id = mgr.get_entity(1).and_then(|e| e.looting_entity).unwrap();
+
+        let (tx, mut rx) = mpsc::channel(16);
+        handle_loot_item(1, 1, &tx, &mut mgr).await;
+
+        assert_eq!(
+            mgr.get_entity(npc_id).map(|e| e.loot.len()).unwrap_or(99),
+            0,
+            "in-range loot must remove the drop from the corpse"
+        );
+        let granted = std::iter::from_fn(|| rx.try_recv().ok())
+            .any(|m| matches!(m, CellToBaseMsg::GrantCash { .. }));
+        assert!(granted, "in-range cash loot must queue a GrantCash");
+    }
+
+    /// **#446 out-of-range negative guard.** A looter far from the corpse
+    /// (distance 100 > MAX_INTERACT_DISTANCE) — the position-spoof / vacuum
+    /// case — must be denied: the drop stays on the corpse, nothing is
+    /// granted, and the rejection is logged. Pre-fix the handler trusted
+    /// the interact-time `looting_entity` pin and looted regardless of
+    /// live distance.
+    #[tokio::test]
+    async fn loot_item_out_of_range_is_denied() {
+        use super::*;
+        use crate::test_support::LogCapture;
+        use tokio::sync::mpsc;
+
+        let mut mgr = make_loot_mgr([100.0, 0.0, 0.0]);
+        let npc_id = mgr.get_entity(1).and_then(|e| e.looting_entity).unwrap();
+
+        let capture = LogCapture::install();
+        let (tx, mut rx) = mpsc::channel(16);
+        handle_loot_item(1, 1, &tx, &mut mgr).await;
+
+        assert_eq!(
+            mgr.get_entity(npc_id).map(|e| e.loot.len()).unwrap_or(0),
+            1,
+            "out-of-range loot must NOT remove the drop — the corpse keeps it"
+        );
+        let granted = std::iter::from_fn(|| rx.try_recv().ok()).any(|m| {
+            matches!(
+                m,
+                CellToBaseMsg::GrantCash { .. } | CellToBaseMsg::GrantItem { .. }
+            )
+        });
+        assert!(!granted, "out-of-range loot must not grant anything");
+        assert!(
+            capture
+                .find_message(
+                    tracing::Level::WARN,
+                    "lootItem rejected -- looter is out of range"
+                )
+                .is_some(),
+            "out-of-range loot must emit the documented rejection warn (#446)"
+        );
     }
 }

--- a/docs/gameplay/loot-system.md
+++ b/docs/gameplay/loot-system.md
@@ -162,8 +162,21 @@ When a mob dies, it immediately generates its loot and sets the `INT_NormalLoot`
 ### 64-bit Signedness Bug (FIXME)
 A signedness issue in `interactionSetMapId()` prevents the `INTERACTION_MissionLoot` flag from being used correctly. Mission-specific loot interactions are blocked until this is resolved.
 
-### Range Checking (TODO)
-There is no automatic end-of-interaction trigger when a player walks out of range of the loot container. Players who open a loot window and then move away will retain the open window until they manually close it or the server resets it. A distance check on tick or on `onLootItem` would fix this.
+### Range Checking (server-authority gate, #446)
+`handle_loot_item` re-validates the looter's **live** distance to the corpse
+against `MAX_INTERACT_DISTANCE` (5.0) on **every** `lootItem` call, not just
+once at interact time. Out-of-range takes are denied (the drop stays on the
+corpse, nothing is granted, a `warn!` is logged). This closes the
+"vacuum loot" exploit — chained with a position spoof, the interact-time
+`looting_entity` pin could otherwise be replayed to loot every corpse in
+the zone without traversing to them (CAT-D, #446).
+
+There is still no automatic end-of-interaction trigger that *closes the loot
+window* when a player walks out of range — the window lingers client-side
+until manually closed — but a take from that stale window now fails the
+range gate. **Not yet implemented**: kill-credit / loot ownership (a player
+who dealt no damage can still loot a corpse they walk up to) — the larger
+SGW lootability-window model, the follow-up half of #446.
 
 ### Dynamic Interaction Type Update (FIXME)
 There is a known workaround in place for the lack of a proper dynamic interaction type update. When the loot list empties, the entity's interaction flags should clear `INT_NormalLoot`, but the mechanism for pushing that update to nearby clients is not cleanly implemented.

--- a/docs/security-audit/2026-05-31-server-authority/findings/CAT-D-inventory.md
+++ b/docs/security-audit/2026-05-31-server-authority/findings/CAT-D-inventory.md
@@ -113,6 +113,16 @@ wrong (they can't reproduce the racing client ordering).
 
 ### CAT-D-02 — `lootItem` does not recheck range, line-of-sight, or alive-state
 
+**Status**: ✅ PARTIALLY RESOLVED (#446) — `handle_loot_item`
+(`cell/interactions/loot.rs`) now re-validates the looter's live distance
+to the corpse against `MAX_INTERACT_DISTANCE` on **every** `lootItem`
+call, denying out-of-range takes (drop preserved, nothing granted,
+`warn!` logged). This closes the position-spoof "vacuum loot" chain — the
+highest-impact half of the finding. **Still open**: kill-credit / loot
+ownership (a 0-damage player can still loot a corpse they walk up to) and
+LOS/alive-state rechecks — the larger SGW lootability-window model, routed
+through the combat-systems advisor as the #446 follow-up.
+
 **Severity**: High
 **Class**: Missing range/state recheck on stateful action
 **Wire surface**: cell method 84 (`lootItem`) — index dispatched from


### PR DESCRIPTION
Closes the range half of #446. Resolves the highest-impact part of **CAT-D-02** from the server-authority audit (#459).

## In plain language

When you kill a monster and open its corpse to grab the loot, the game is supposed to make you stand next to the body. Right now it only checks that *once* — at the moment you open the corpse. After that, it just trusts you. A cheater can open a corpse, then teleport their character anywhere on the map (a separate hacking trick), and keep "grabbing" loot from across the zone — and do that to every corpse, vacuuming up all the loot in seconds without ever walking to any of it.

This change makes the server re-check **every single time** you take an item that you're actually standing next to the corpse. If you're too far away, the take is refused — the loot stays on the body, you get nothing, and the server logs the attempt. Normal looting (standing on the corpse) is unaffected.

What this does **not** fix yet: it doesn't stop someone who didn't help kill the monster from walking up and looting it (loot-stealing from your teammates). That's a bigger gameplay-fairness feature — "you only get loot from kills you participated in, for a while" — and it's tracked as a follow-up because it needs its own design pass.

## Technical detail

`handle_loot_item` (`crates/services/src/cell/interactions/loot.rs`) gated solely on the in-memory `looting_entity` pin, set once by the range-checked `interact()`. Nothing re-validated it, so a position spoof (or simply walking away with the loot window open) let the client replay `lootItem(index)` from anywhere — "vacuum loot."

The fix re-checks the **live** distance from looter to corpse against `MAX_INTERACT_DISTANCE` (5.0) on every `lootItem` call, before the corpse loot list is mutated:

```rust
let dist = looter.position.distance_to(&corpse.position);
if dist > MAX_INTERACT_DISTANCE {
    warn!(...); return;   // drop preserved, nothing granted
}
```

`MAX_INTERACT_DISTANCE` (already enforced by `interact()` in the sibling `dispatch` module) was promoted to `pub(super)` so loot re-validation uses the same bound — single source of truth. The read is cheap (no DB, no fan-out).

### Scope

This is the range half of #446 (and CAT-D-02), which closes the position-spoof vacuum-loot chain — the highest-impact vector. **Out of scope (documented follow-up)**: kill-credit / loot-ownership (a 0-damage player can still loot a corpse they walk up to) and LOS/alive-state rechecks — the larger SGW lootability-window model, routed through the combat-systems advisor. The finding and the loot-system doc both carry the follow-up note.

## Tests (revert-verified)

- **In-range positive**: looter on the corpse (dist 2) loots normally — drop removed, GrantCash queued (gate doesn't over-block).
- **Out-of-range negative**: looter far from corpse (dist 100) — denied: drop preserved, nothing granted, documented `warn!` logged (LogCapture).
- Revert check: neutering the distance gate trips the out-of-range guard while the in-range stays green.
- Existing edge-case tests (no `looting_entity`, no `player_id`) unaffected — they return before the new check.

## Docs

- [docs/gameplay/loot-system.md](docs/gameplay/loot-system.md) — the "Range Checking (TODO)" section is now the implemented gate, with the kill-credit follow-up noted.
- CAT-D-02 finding marked ✅ PARTIALLY RESOLVED with the scope boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed "vacuum loot" exploit that allowed looting items from out-of-range corpses. Server now enforces distance validation on every loot attempt.

* **Tests**
  * Added coverage for range-enforced looting behavior.

* **Documentation**
  * Updated loot system documentation and security audit findings to reflect distance validation changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->