### PR TITLE
feat(gm): seed accounts become GameMaster + plumb access_level to characters (KI-11, #64)

### DIFF
--- a/crates/services/src/auth/handlers.rs
+++ b/crates/services/src/auth/handlers.rs
@@ -516,6 +516,31 @@ pub(super) fn random_alphanumeric(char_count: usize) -> String {
 mod tests {
     use super::*;
 
+    /// **Seed-GM guard (#64).** The dev/seed accounts must be at least
+    /// GameMaster (accesslevel 2) so they can run GM commands and reach
+    /// protected shards (the `< 2` gate at `validate_shard_access`). A
+    /// regression that reverts the seed accounts to Moderator (1) — below
+    /// the GM threshold — trips this. Runs against the CI live DB loaded
+    /// from `db/database.sql` (which seeds the account table).
+    #[tokio::test]
+    async fn seed_dev_accounts_are_at_least_gamemaster() {
+        use crate::test_support::require_db_or_skip;
+        let pool = require_db_or_skip!();
+
+        for name in ["test", "cady", "jorsh"] {
+            let level: i32 =
+                sqlx::query_scalar("SELECT accesslevel FROM account WHERE account_name = $1")
+                    .bind(name)
+                    .fetch_one(&pool)
+                    .await
+                    .unwrap_or_else(|e| panic!("seed account '{name}' must exist: {e}"));
+            assert!(
+                level >= 2,
+                "seed account '{name}' must be >= GameMaster (2) so it can run GM commands; got {level}"
+            );
+        }
+    }
+
     #[test]
     fn random_hex_length() {
         assert_eq!(random_hex(10).len(), 20); // ticket

--- a/crates/services/src/auth/handlers.rs
+++ b/crates/services/src/auth/handlers.rs
@@ -516,18 +516,28 @@ pub(super) fn random_alphanumeric(char_count: usize) -> String {
 mod tests {
     use super::*;
 
-    /// **Seed-GM guard (#64).** The dev/seed accounts must be at least
-    /// GameMaster (accesslevel 2) so they can run GM commands and reach
-    /// protected shards (the `< 2` gate at `validate_shard_access`). A
-    /// regression that reverts the seed accounts to Moderator (1) — below
-    /// the GM threshold — trips this. Runs against the CI live DB loaded
-    /// from `db/database.sql` (which seeds the account table).
+    /// **Seed-GM guard.** The dev/seed accounts must be at least GameMaster
+    /// (accesslevel 2) so they can run GM commands and reach protected shards
+    /// (the `access_level < 2` gate in `handle_server_selection`). A
+    /// regression that reverts any seeded account to Moderator (1) — below
+    /// the GM threshold — trips this. Covers every account the seed file
+    /// promotes, so a partial regression is caught too. Runs against the CI
+    /// live DB loaded from `db/database.sql` (which seeds the account table).
     #[tokio::test]
     async fn seed_dev_accounts_are_at_least_gamemaster() {
         use crate::test_support::require_db_or_skip;
         let pool = require_db_or_skip!();
 
-        for name in ["test", "cady", "jorsh"] {
+        // Every account promoted in db/sgw/Accounts/Seed/account.sql.
+        for name in [
+            "test",
+            "cady",
+            "jorsh",
+            "cake",
+            "lomiada1",
+            "nonwo1984",
+            "ishido972",
+        ] {
             let level: i32 =
                 sqlx::query_scalar("SELECT accesslevel FROM account WHERE account_name = $1")
                     .bind(name)

--- a/crates/services/src/base/character_create.rs
+++ b/crates/services/src/base/character_create.rs
@@ -377,10 +377,13 @@ pub(crate) async fn handle_create_character(
     // Stamp the new character's `access_level` from the account's session
     // level (loaded from `account.accesslevel` at login), mirroring the C++
     // server which passed the account access level into the character INSERT.
-    // The persisted value is loaded back into `PlayerLoadData` at world entry
-    // (see player_load) and surfaces as the client's `AccessLevel` entity
-    // property; without it a GM account's characters were created at
-    // access_level 0 and lost that privilege marker on every load.
+    // The persisted column is loaded at world entry (player_load) and sent to
+    // the client as the `AccessLevel` entity property — propId 7 in the
+    // mapLoaded block (`mercury::world_data::map_loaded`) — i.e. the
+    // per-character marker the client uses for GM UI. (Server-side GM
+    // authorization gates on the session level, not this column.) Without it,
+    // a GM account's characters were created at access_level 0 and carried no
+    // GM marker on every load.
     let access_level = get_access_level(connected, addr) as i32;
 
     let result = sqlx::query_scalar::<_, i32>(

--- a/crates/services/src/base/character_create.rs
+++ b/crates/services/src/base/character_create.rs
@@ -11,7 +11,7 @@ use crate::mercury::read_wstring;
 
 use super::character::{query_character_list, send_char_create_failed};
 use super::chardef::chardef_lookup;
-use super::helpers::{drain_acks_and_seq, get_account_entity_id};
+use super::helpers::{drain_acks_and_seq, get_access_level, get_account_entity_id};
 use super::resources::{bag_min_slot, pick_first_open_bag, BAG_FILL_ORDER};
 use super::ConnectedClientState;
 
@@ -374,12 +374,20 @@ pub(crate) async fn handle_create_character(
 
     // ── INSERT into sgw_player with components, world_id, abilities ───
 
+    // KI-11 fix: stamp the new character's `access_level` from the
+    // account's session level (loaded from `account.accesslevel` at login),
+    // mirroring the C++ server which passed the account access level into
+    // the character INSERT. Without this, a GM account created normal
+    // (access_level 0) characters, so the character never carried GM
+    // authority into the cell entity or the client's AccessLevel property.
+    let access_level = get_access_level(connected, addr) as i32;
+
     let result = sqlx::query_scalar::<_, i32>(
         "INSERT INTO sgw_player \
          (account_id, player_name, extra_name, alignment, archetype, gender, \
           world_location, bodyset, level, title, pos_x, pos_y, pos_z, \
-          skin_color_id, components, world_id, abilities) \
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 1, 0, $9, $10, $11, $12, $13, $14, $15) \
+          skin_color_id, components, world_id, abilities, access_level) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 1, 0, $9, $10, $11, $12, $13, $14, $15, $16) \
          RETURNING player_id",
     )
     .bind(account_id as i32)
@@ -397,6 +405,7 @@ pub(crate) async fn handle_create_character(
     .bind(&body_components)
     .bind(world_id)
     .bind(&abilities)
+    .bind(access_level)
     .fetch_one(pool.as_ref())
     .await;
 

--- a/crates/services/src/base/character_create.rs
+++ b/crates/services/src/base/character_create.rs
@@ -374,12 +374,13 @@ pub(crate) async fn handle_create_character(
 
     // ── INSERT into sgw_player with components, world_id, abilities ───
 
-    // KI-11 fix: stamp the new character's `access_level` from the
-    // account's session level (loaded from `account.accesslevel` at login),
-    // mirroring the C++ server which passed the account access level into
-    // the character INSERT. Without this, a GM account created normal
-    // (access_level 0) characters, so the character never carried GM
-    // authority into the cell entity or the client's AccessLevel property.
+    // Stamp the new character's `access_level` from the account's session
+    // level (loaded from `account.accesslevel` at login), mirroring the C++
+    // server which passed the account access level into the character INSERT.
+    // The persisted value is loaded back into `PlayerLoadData` at world entry
+    // (see player_load) and surfaces as the client's `AccessLevel` entity
+    // property; without it a GM account's characters were created at
+    // access_level 0 and lost that privilege marker on every load.
     let access_level = get_access_level(connected, addr) as i32;
 
     let result = sqlx::query_scalar::<_, i32>(
@@ -539,6 +540,10 @@ fn validate_character_name(name: &str) -> Result<(), &'static str> {
     }
     Ok(())
 }
+
+#[cfg(test)]
+#[path = "character_create_live_db_tests.rs"]
+mod character_create_live_db_tests;
 
 #[cfg(test)]
 mod tests {

--- a/crates/services/src/base/character_create_live_db_tests.rs
+++ b/crates/services/src/base/character_create_live_db_tests.rs
@@ -1,0 +1,209 @@
+//! Live-DB guard for `handle_create_character`'s `access_level`
+//! persistence.
+//!
+//! Bug shape: the `createCharacter` INSERT stamps the new
+//! `sgw_player.access_level` from the session's account access level
+//! (`get_access_level(connected, addr)`). The column defaults to
+//! `0 NOT NULL`, so if the `access_level` column or its `$N` bind is
+//! ever dropped from the INSERT, the row silently lands at
+//! `access_level = 0` and a GM account's characters lose their
+//! privilege marker on every world-entry load. This test drives the
+//! real handler with a session at access_level 2 (GameMaster) and
+//! asserts the persisted row reads back 2 — it FAILS the moment the
+//! bind/column is reverted.
+//!
+//! The payload is built to be valid against the same `db/database.sql`
+//! the CI live-DB job loads. It uses CharDefId 9 (SGU Asgard Male),
+//! which has the fewest `VIS_Optional` visual groups in
+//! `resources.char_creation_visgroups` (only 115 Head, 118 SkinPattern,
+//! 119 Accessory). The handler requires a client choice for every
+//! optional group, so all three are supplied with real choice ids from
+//! `resources.char_creation_choices`:
+//!   - group 115 -> choice 619 (`BS_Asgard.BS_AS_Head_00`, no item)
+//!   - group 118 -> choice 631 (`BS_Asgard.BS_AS_SkinPattern_00`, no item)
+//!   - group 119 -> choice 641 (`ACC_HumanMale.ACC_HM_Accessory_00`,
+//!     item 4343 — a starter item that the handler may insert into
+//!     `sgw_inventory`; cleanup removes any such rows by character_id).
+//!
+//! The four `VIS_Forced` groups (113 Torso, 114 Legs, 116 Hands,
+//! 117 Boots) are auto-resolved by the handler and need no choice.
+
+use super::*;
+use crate::test_support::{require_db_or_skip, test_default_connected_client_state, TestTransport};
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::sync::{Arc, Mutex};
+
+/// Sentinel base for the character-create live-DB tests. The crate's
+/// `0x7000_xx00` windows are reserved contiguously up through
+/// `0x7000_1900` (cover-loader); this steps to the next free slot so
+/// concurrent live-DB runs don't collide on account/player ids. Fits
+/// in `i32`. See the neighbour map in
+/// `crates/services/src/base/character/delete_live_db_tests.rs`.
+const TEST_BASE: i32 = 0x7000_1A00;
+
+/// CharDefId with the fewest `VIS_Optional` groups in the seed data
+/// (SGU Asgard Male). Keeps the valid payload as small as possible.
+const TEST_CHAR_DEF_ID: i32 = 9;
+
+/// `(vis_group_id, choice_id)` pairs satisfying every `VIS_Optional`
+/// group of `TEST_CHAR_DEF_ID`. Derived from
+/// `db/resources/Archetypes/Seed/char_creation_choices.sql`.
+const VISUAL_CHOICES: &[(i32, i32)] = &[(115, 619), (118, 631), (119, 641)];
+
+/// Skin tint id inside the handler's accepted `0..=15` range.
+const TEST_SKIN_TINT: i32 = 0;
+
+/// The session's account access level we expect to be persisted.
+/// 2 == GameMaster — a non-default value, so a row that reads back 0
+/// means the access_level bind/column was lost.
+const SESSION_ACCESS_LEVEL: u32 = 2;
+
+async fn cleanup(pool: &PgPool, account_id: i32) {
+    // sgw_inventory FKs to sgw_player(player_id); delete starter items
+    // (if any) by joining back through the account before the player row.
+    let _ = sqlx::query(
+        "DELETE FROM sgw_inventory WHERE character_id IN \
+         (SELECT player_id FROM sgw_player WHERE account_id = $1)",
+    )
+    .bind(account_id)
+    .execute(pool)
+    .await;
+    let _ = sqlx::query("DELETE FROM sgw_player WHERE account_id = $1")
+        .bind(account_id)
+        .execute(pool)
+        .await;
+    let _ = sqlx::query("DELETE FROM account WHERE account_id = $1")
+        .bind(account_id)
+        .execute(pool)
+        .await;
+}
+
+/// Insert the test account with `accesslevel = 2` to mirror a real GM
+/// account. The handler reads the level from session state, not this
+/// row, but seeding it keeps the fixture self-consistent.
+async fn insert_account(pool: &PgPool, account_id: i32, access_level: i32) {
+    sqlx::query(
+        "INSERT INTO account (account_id, account_name, password, accesslevel) \
+         VALUES ($1, $2, '', $3)",
+    )
+    .bind(account_id)
+    .bind(format!("ccreate-{account_id}"))
+    .bind(access_level)
+    .execute(pool)
+    .await
+    .expect("insert account");
+}
+
+fn make_connected(
+    addr: SocketAddr,
+    account_id: u32,
+    access_level: u32,
+) -> Arc<Mutex<HashMap<SocketAddr, ConnectedClientState>>> {
+    let mut state = test_default_connected_client_state();
+    state.account_id = account_id;
+    state.access_level = access_level;
+    // A non-zero account entity id so the post-INSERT onCharacterList
+    // build path has something to address; value is otherwise irrelevant
+    // to the access_level assertion.
+    state.account_entity_id = 0xAAAA_0001;
+    let mut m = HashMap::new();
+    m.insert(addr, state);
+    Arc::new(Mutex::new(m))
+}
+
+/// Build a valid `createCharacter` payload, mirroring the handler's own
+/// wire parsing:
+/// `[WSTRING Name][WSTRING ExtraName][INT32 CharDefId]
+///  [u32 VisualChoiceCount][count × {INT32 VisGroupId, INT32 ChoiceId}]
+///  [INT32 SkinTintColorID]`.
+fn build_create_character_payload(
+    name: &str,
+    extra_name: &str,
+    char_def_id: i32,
+    visual_choices: &[(i32, i32)],
+    skin_tint_color_id: i32,
+) -> Vec<u8> {
+    let mut buf = Vec::new();
+    crate::mercury::write_wstring(&mut buf, name);
+    crate::mercury::write_wstring(&mut buf, extra_name);
+    buf.extend_from_slice(&char_def_id.to_le_bytes());
+    buf.extend_from_slice(&(visual_choices.len() as u32).to_le_bytes());
+    for &(vis_group_id, choice_id) in visual_choices {
+        buf.extend_from_slice(&vis_group_id.to_le_bytes());
+        buf.extend_from_slice(&choice_id.to_le_bytes());
+    }
+    buf.extend_from_slice(&skin_tint_color_id.to_le_bytes());
+    buf
+}
+
+/// The new character must persist the session's account access level,
+/// not the column default. A session at access_level 2 (GameMaster)
+/// must produce an `sgw_player` row whose `access_level` reads back 2.
+///
+/// Reverting the `access_level` column or its `$16` bind in
+/// `handle_create_character`'s INSERT makes the row default to 0 and
+/// trips the final assertion.
+#[tokio::test]
+async fn create_character_persists_session_access_level() {
+    let pool = require_db_or_skip!();
+    let account_id = TEST_BASE;
+
+    cleanup(&pool, account_id).await;
+    insert_account(&pool, account_id, SESSION_ACCESS_LEVEL as i32).await;
+
+    let transport = Arc::new(TestTransport::new());
+    let dyn_transport: Arc<dyn Transport> = transport.clone();
+    let addr: SocketAddr = "127.0.0.1:55810".parse().unwrap();
+    let connected = make_connected(addr, account_id as u32, SESSION_ACCESS_LEVEL);
+    let key = [0u8; 32];
+    let db_pool = Some(Arc::new(pool.clone()));
+
+    let payload = build_create_character_payload(
+        "Asgard Test",
+        "",
+        TEST_CHAR_DEF_ID,
+        VISUAL_CHOICES,
+        TEST_SKIN_TINT,
+    );
+
+    let result = handle_create_character(
+        &dyn_transport,
+        addr,
+        key,
+        account_id as u32,
+        &payload,
+        &connected,
+        &db_pool,
+    )
+    .await;
+    assert!(
+        result.is_ok(),
+        "createCharacter handler must return Ok for a valid payload \
+         (CharDefId {TEST_CHAR_DEF_ID} with all optional visual groups \
+         satisfied); got {result:?}",
+    );
+
+    // The handler succeeds by sending the updated character list back;
+    // a failure path would have sent onCharacterCreateFailed instead.
+    // The authoritative check is the persisted row below — read it back
+    // by the account we created.
+    let persisted: Option<i32> =
+        sqlx::query_scalar("SELECT access_level FROM sgw_player WHERE account_id = $1")
+            .bind(account_id)
+            .fetch_optional(&pool)
+            .await
+            .expect("query persisted access_level");
+
+    assert_eq!(
+        persisted,
+        Some(SESSION_ACCESS_LEVEL as i32),
+        "createCharacter must persist sgw_player.access_level from the \
+         session's account access level ({SESSION_ACCESS_LEVEL}). A value \
+         of Some(0) means the access_level column/bind was dropped from \
+         the INSERT — a GM account's characters would silently load at \
+         access_level 0. None means the character row was never inserted.",
+    );
+
+    cleanup(&pool, account_id).await;
+}

--- a/crates/services/src/base/helpers/mod.rs
+++ b/crates/services/src/base/helpers/mod.rs
@@ -210,9 +210,8 @@ pub(crate) fn get_account_entity_id(
 /// Read the session's account access level (from `account.accesslevel`,
 /// loaded at login). Returns 0 (Player) when the addr isn't connected or
 /// the lock is poisoned — a missing session must never be treated as
-/// privileged. Used by `createCharacter` to stamp the character's
-/// `access_level` from the account (KI-11) and by the GM chat-command
-/// path to authorize commands.
+/// privileged. Used by `createCharacter` to stamp the new character's
+/// `access_level` from the account so it persists into world entry.
 pub(crate) fn get_access_level(
     connected: &Arc<Mutex<HashMap<SocketAddr, ConnectedClientState>>>,
     addr: SocketAddr,

--- a/crates/services/src/base/helpers/mod.rs
+++ b/crates/services/src/base/helpers/mod.rs
@@ -207,6 +207,23 @@ pub(crate) fn get_account_entity_id(
     Ok(c.account_entity_id)
 }
 
+/// Read the session's account access level (from `account.accesslevel`,
+/// loaded at login). Returns 0 (Player) when the addr isn't connected or
+/// the lock is poisoned — a missing session must never be treated as
+/// privileged. Used by `createCharacter` to stamp the character's
+/// `access_level` from the account (KI-11) and by the GM chat-command
+/// path to authorize commands.
+pub(crate) fn get_access_level(
+    connected: &Arc<Mutex<HashMap<SocketAddr, ConnectedClientState>>>,
+    addr: SocketAddr,
+) -> u32 {
+    connected
+        .lock()
+        .ok()
+        .and_then(|clients| clients.get(&addr).map(|c| c.access_level))
+        .unwrap_or(0)
+}
+
 /// Read the currently active entity ID for a connected client.
 ///
 /// After world entry, the Account entity is destroyed and replaced by the

--- a/crates/services/src/base/helpers/tests.rs
+++ b/crates/services/src/base/helpers/tests.rs
@@ -548,13 +548,12 @@ fn destroy_client_entities_logs_reason_on_already_cleaned_short_circuit() {
     );
 }
 
-// ── get_access_level (#64 / KI-11) ────────────────────────────────────
+// ── get_access_level ──────────────────────────────────────────────────
 
 /// `get_access_level` returns the connected session's account access
-/// level — the value `createCharacter` stamps onto the new character row
-/// (KI-11) and the GM chat-command path authorizes against. A regression
-/// that read the wrong field (or hardcoded a level) would let GM accounts
-/// create non-GM characters again.
+/// level — the value `createCharacter` stamps onto the new character row.
+/// A regression that read the wrong field (or hardcoded a level) would let
+/// GM accounts create non-GM characters again.
 #[test]
 fn get_access_level_returns_session_level() {
     use std::collections::HashMap;

--- a/crates/services/src/base/helpers/tests.rs
+++ b/crates/services/src/base/helpers/tests.rs
@@ -588,3 +588,33 @@ fn get_access_level_fails_closed_for_unknown_addr() {
         "unknown session must fail closed to Player (0), never privileged"
     );
 }
+
+/// **Fail-closed guard (poisoned lock).** `get_access_level` reads the
+/// session under `.lock().ok()`, so a poisoned mutex (a thread panicked
+/// while holding it) yields `None` and must fall through to 0 (Player) —
+/// a poisoned lock must never be treated as a GM. Reverting the `.ok()`
+/// to an `.unwrap()` would panic here instead of returning 0.
+#[test]
+fn get_access_level_fails_closed_for_poisoned_lock() {
+    use std::collections::HashMap;
+    use std::net::SocketAddr;
+    use std::sync::{Arc, Mutex};
+
+    let connected: Arc<Mutex<HashMap<SocketAddr, crate::base::ConnectedClientState>>> =
+        Arc::new(Mutex::new(HashMap::new()));
+    let poison_target = Arc::clone(&connected);
+
+    // Poison the mutex by panicking while holding the guard.
+    let _ = std::thread::spawn(move || {
+        let _guard = poison_target.lock().unwrap();
+        panic!("poison connected mutex");
+    })
+    .join();
+
+    let addr: SocketAddr = "127.0.0.1:5002".parse().unwrap();
+    assert_eq!(
+        get_access_level(&connected, addr),
+        0,
+        "poisoned lock must fail closed to Player (0), never privileged"
+    );
+}

--- a/crates/services/src/base/helpers/tests.rs
+++ b/crates/services/src/base/helpers/tests.rs
@@ -547,3 +547,45 @@ fn destroy_client_entities_logs_reason_on_already_cleaned_short_circuit() {
         event.fields,
     );
 }
+
+// ── get_access_level (#64 / KI-11) ────────────────────────────────────
+
+/// `get_access_level` returns the connected session's account access
+/// level — the value `createCharacter` stamps onto the new character row
+/// (KI-11) and the GM chat-command path authorizes against. A regression
+/// that read the wrong field (or hardcoded a level) would let GM accounts
+/// create non-GM characters again.
+#[test]
+fn get_access_level_returns_session_level() {
+    use std::collections::HashMap;
+    use std::net::SocketAddr;
+    use std::sync::{Arc, Mutex};
+
+    let addr: SocketAddr = "127.0.0.1:5000".parse().unwrap();
+    let mut state = crate::test_support::test_default_connected_client_state();
+    state.access_level = 2; // GameMaster
+    let mut m = HashMap::new();
+    m.insert(addr, state);
+    let connected = Arc::new(Mutex::new(m));
+
+    assert_eq!(get_access_level(&connected, addr), 2);
+}
+
+/// **Fail-closed guard.** A request from an address that isn't in the
+/// connected map must return 0 (Player), never a privileged default — a
+/// missing session must not be treated as a GM. Reverting the
+/// `unwrap_or(0)` to a non-zero default trips this.
+#[test]
+fn get_access_level_fails_closed_for_unknown_addr() {
+    use std::collections::HashMap;
+    use std::net::SocketAddr;
+    use std::sync::{Arc, Mutex};
+
+    let connected = Arc::new(Mutex::new(HashMap::new()));
+    let addr: SocketAddr = "127.0.0.1:5001".parse().unwrap();
+    assert_eq!(
+        get_access_level(&connected, addr),
+        0,
+        "unknown session must fail closed to Player (0), never privileged"
+    );
+}

--- a/db/sgw/Accounts/Seed/account.sql
+++ b/db/sgw/Accounts/Seed/account.sql
@@ -4,13 +4,20 @@
 -- Data for Name: account; Type: TABLE DATA; Schema: public; Owner: -
 --
 
-INSERT INTO account (account_id, account_name, password, accesslevel, enabled) VALUES (2, 'test',     'a94a8fe5ccb19ba61c4c0873d391e987982fbbd3', 1, true);
-INSERT INTO account (account_id, account_name, password, accesslevel, enabled) VALUES (3, 'cady',     'a94a8fe5ccb19ba61c4c0873d391e987982fbbd3', 1, true);
-INSERT INTO account (account_id, account_name, password, accesslevel, enabled) VALUES (4, 'jorsh',    'a94a8fe5ccb19ba61c4c0873d391e987982fbbd3', 1, true);
-INSERT INTO account (account_id, account_name, password, accesslevel, enabled) VALUES (5, 'cake',     'a94a8fe5ccb19ba61c4c0873d391e987982fbbd3', 1, true);
-INSERT INTO account (account_id, account_name, password, accesslevel, enabled) VALUES (6, 'lomiada1', 'a94a8fe5ccb19ba61c4c0873d391e987982fbbd3', 1, true);
-INSERT INTO account (account_id, account_name, password, accesslevel, enabled) VALUES (7, 'nonwo1984','a94a8fe5ccb19ba61c4c0873d391e987982fbbd3', 1, true);
-INSERT INTO account (account_id, account_name, password, accesslevel, enabled) VALUES (8, 'ishido972','a94a8fe5ccb19ba61c4c0873d391e987982fbbd3', 1, true);
+-- Seed/dev accounts are GameMaster (accesslevel 2) so they can use GM
+-- commands on a dev shard. AccessLevel: 0=Player, 1=Moderator,
+-- 2=GameMaster, 3=Admin, 4=Developer (cimmeria_commands::permissions).
+-- 2 clears the GM threshold (the cell gm_gate requires >= GameMaster and
+-- the chat-command path gates GM commands at GameMaster) without granting
+-- Admin-only commands (e.g. /shutdown). Bump an individual account to 3/4
+-- locally if you need Admin/Developer-tier commands. (#64)
+INSERT INTO account (account_id, account_name, password, accesslevel, enabled) VALUES (2, 'test',     'a94a8fe5ccb19ba61c4c0873d391e987982fbbd3', 2, true);
+INSERT INTO account (account_id, account_name, password, accesslevel, enabled) VALUES (3, 'cady',     'a94a8fe5ccb19ba61c4c0873d391e987982fbbd3', 2, true);
+INSERT INTO account (account_id, account_name, password, accesslevel, enabled) VALUES (4, 'jorsh',    'a94a8fe5ccb19ba61c4c0873d391e987982fbbd3', 2, true);
+INSERT INTO account (account_id, account_name, password, accesslevel, enabled) VALUES (5, 'cake',     'a94a8fe5ccb19ba61c4c0873d391e987982fbbd3', 2, true);
+INSERT INTO account (account_id, account_name, password, accesslevel, enabled) VALUES (6, 'lomiada1', 'a94a8fe5ccb19ba61c4c0873d391e987982fbbd3', 2, true);
+INSERT INTO account (account_id, account_name, password, accesslevel, enabled) VALUES (7, 'nonwo1984','a94a8fe5ccb19ba61c4c0873d391e987982fbbd3', 2, true);
+INSERT INTO account (account_id, account_name, password, accesslevel, enabled) VALUES (8, 'ishido972','a94a8fe5ccb19ba61c4c0873d391e987982fbbd3', 2, true);
 
 --
 -- TOC entry 2709 (class 0 OID 0)

--- a/db/sgw/Accounts/Seed/account.sql
+++ b/db/sgw/Accounts/Seed/account.sql
@@ -7,10 +7,9 @@
 -- Seed/dev accounts are GameMaster (accesslevel 2) so they can use GM
 -- commands on a dev shard. AccessLevel: 0=Player, 1=Moderator,
 -- 2=GameMaster, 3=Admin, 4=Developer (cimmeria_commands::permissions).
--- 2 clears the GM threshold (the cell gm_gate requires >= GameMaster and
--- the chat-command path gates GM commands at GameMaster) without granting
--- Admin-only commands (e.g. /shutdown). Bump an individual account to 3/4
--- locally if you need Admin/Developer-tier commands. (#64)
+-- 2 clears the GameMaster threshold the GM command paths gate on, without
+-- granting Admin-only commands (e.g. /shutdown). Bump an individual account
+-- to 3/4 locally if you need Admin/Developer-tier commands.
 INSERT INTO account (account_id, account_name, password, accesslevel, enabled) VALUES (2, 'test',     'a94a8fe5ccb19ba61c4c0873d391e987982fbbd3', 2, true);
 INSERT INTO account (account_id, account_name, password, accesslevel, enabled) VALUES (3, 'cady',     'a94a8fe5ccb19ba61c4c0873d391e987982fbbd3', 2, true);
 INSERT INTO account (account_id, account_name, password, accesslevel, enabled) VALUES (4, 'jorsh',    'a94a8fe5ccb19ba61c4c0873d391e987982fbbd3', 2, true);

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -67,10 +67,13 @@ Features from the C++ reference that are stubbed or missing in the Rust rewrite.
 
 **Status**: Fixed by character creation visual pipeline. `createCharacter` now stores starting abilities from archetype definitions.
 
-### KI-11: createCharacter does not store access_level
+### ~~KI-11: createCharacter does not store access_level~~ — RESOLVED
 
-**Severity**: Low
-**Description**: GM accounts create normal characters instead of GM-flagged characters. C++ passes account access_level into the character INSERT.
+**Status**: Fixed (#64 precondition). `createCharacter` now stamps the new
+character's `sgw_player.access_level` from the account's session access
+level (`get_access_level`, sourced from `account.accesslevel` at login),
+mirroring the C++ server. GM accounts now create GM-flagged characters, so
+GM authority reaches the cell entity and the client `AccessLevel` property.
 
 ### ~~KI-12: createCharacter does not validate visual choices~~ — RESOLVED
 

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -2,7 +2,7 @@
 title: "Known Issues"
 type: reference
 audience: engineers, operators
-last_updated: 2026-05-27
+last_updated: 2026-06-16
 ---
 
 # Known Issues
@@ -69,11 +69,12 @@ Features from the C++ reference that are stubbed or missing in the Rust rewrite.
 
 ### ~~KI-11: createCharacter does not store access_level~~ — RESOLVED
 
-**Status**: Fixed (#64 precondition). `createCharacter` now stamps the new
-character's `sgw_player.access_level` from the account's session access
-level (`get_access_level`, sourced from `account.accesslevel` at login),
-mirroring the C++ server. GM accounts now create GM-flagged characters, so
-GM authority reaches the cell entity and the client `AccessLevel` property.
+**Status**: Fixed. `createCharacter` now stamps the new character's
+`sgw_player.access_level` from the account's session access level
+(`get_access_level`, sourced from `account.accesslevel` at login), mirroring
+the C++ server. The persisted value is loaded back into `PlayerLoadData` at
+world entry and surfaces as the client's `AccessLevel` property, so GM
+accounts no longer lose their privilege marker on every character load.
 
 ### ~~KI-12: createCharacter does not validate visual choices~~ — RESOLVED
 

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -72,9 +72,11 @@ Features from the C++ reference that are stubbed or missing in the Rust rewrite.
 **Status**: Fixed. `createCharacter` now stamps the new character's
 `sgw_player.access_level` from the account's session access level
 (`get_access_level`, sourced from `account.accesslevel` at login), mirroring
-the C++ server. The persisted value is loaded back into `PlayerLoadData` at
-world entry and surfaces as the client's `AccessLevel` property, so GM
-accounts no longer lose their privilege marker on every character load.
+the C++ server. The persisted column is loaded at world entry and sent to the
+client as the `AccessLevel` entity property (propId 7 in the mapLoaded block),
+so a GM account's characters carry the correct marker instead of loading at
+access_level 0. (Server-side GM authority is gated on the session level, not
+this per-character column.)
 
 ### ~~KI-12: createCharacter does not validate visual choices~~ — RESOLVED
 


### PR DESCRIPTION
Precondition for #64 (GM commands). Fixes KI-11.

## In plain language

For a Game Master to actually *be* a Game Master, two things have to be true: their account has to be flagged as a GM, and that flag has to follow them onto the character they play. Right now neither is fully true on a dev server — the seed accounts are only "Moderator" (one notch below GM), and even a GM account creates plain non-GM characters because the character-creation code forgets to copy the flag across. This PR makes the dev/seed accounts real GMs and makes new characters inherit their account's level, so GM authority actually reaches the character you log in as. It doesn't add any GM commands yet — it's the groundwork that makes the GM work (the next PRs) usable.

## Technical detail

Two small, independent changes:

**1. Seed accounts → GameMaster.** The 7 seed accounts in `db/sgw/Accounts/Seed/account.sql` were `accesslevel = 1` (Moderator), which is *below* the GM threshold — they couldn't run GM commands or reach protected shards (`validate_credentials` gates protected shards on `access_level < 2`). Bumped to `2` (GameMaster). That's the minimal level that grants real GM authority without unlocking Admin-only commands (e.g. `/shutdown`); bump an individual account to 3/4 locally for Admin/Developer tiers.

**2. KI-11 — `createCharacter` now stamps `access_level`.** The `sgw_player` INSERT omitted `access_level`, so every new character defaulted to 0 regardless of account level — a GM account created non-GM characters (the C++ server passed the account level into the character INSERT). Added a `get_access_level(connected, addr)` helper that reads the session's level (from `account.accesslevel`, loaded at login into `ConnectedClientState.access_level`), and bound it into the character INSERT. The helper **fails closed** to 0 (Player) for any unknown session — a missing session is never treated as privileged.

## How GM authority flows after this

`account.accesslevel` → login → `ConnectedClientState.access_level` → `createCharacter` → `sgw_player.access_level` → cell entity / client `AccessLevel` property. PR1 closes the account→character break (KI-11); the seed bump makes the dev accounts GMs at the source.

## Tests

- **Unit** (`get_access_level`): returns the session's level; **fails closed to 0** for an unknown address (a missing session must never be privileged). Reverting the fail-closed default trips the second test.
- **Live-DB** (CI): the dev seed accounts (`test`, `cady`, `jorsh`) are `>= GameMaster (2)`. Reverting the seed bump to Moderator (1) trips it.
- KI-11 marked RESOLVED in `docs/known-issues.md`.

## Scope / what's next

This is PR1 of the GM-commands work (issues #64, #473). It's deliberately small and independent of the open PR #512. Next: **PR2** wires the `/`-prefix chat command path and implements the GM commands (#64); **PR3** (after #512 merges) adds the SGWGmPlayer entity class for the native client console (#473 / CAT-N-04).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure character creation now persists the connected account’s access level into the saved character data, so GM permission markers remain correct after loading.
  * Updated dev/test seed accounts so their access level is set to GameMaster (without changing passwords or enabled status).

* **Tests**
  * Added unit tests covering access-level lookup behavior (including safe fail-closed for unknown sessions).
  * Added live DB integration coverage to verify `access_level` is correctly written during character creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->