### PR TITLE
fix(inventory): key bandolier ammo persistence on instance id, not design id (#445)

### DIFF
--- a/crates/entity/src/cell_entity/mod.rs
+++ b/crates/entity/src/cell_entity/mod.rs
@@ -798,7 +798,21 @@ pub struct LootItem {
 /// An item slot in the player's bandolier (quick-access equipment bar).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BandolierItem {
-    /// Item design ID.
+    /// The `sgw_inventory.item_id` value — the per-row *instance* id of the
+    /// physical item row backing this slot. It's a server-allocated surrogate
+    /// (sequence default, never reused), unique per slot via the
+    /// `sgw_inventory_unique_slot` index — unique by construction rather than
+    /// by a declared PK/UNIQUE constraint. This is the TOCTOU guard for
+    /// ammo persistence: it flows into `BandolierAmmoUpdate.expected_instance_id`
+    /// and the WHERE clause of `update_bandolier_ammo`. Two physical items of
+    /// the same weapon *design* share `item_id` (the design id below) but have
+    /// distinct `instance_id`, so keying the persist guard on this — not the
+    /// design id — is what closes the same-type-swap dupe window.
+    pub instance_id: i32,
+    /// Item *design* ID (`resources.items.item_id` / `sgw_inventory.type_id`).
+    /// Used for design lookups (clip size, abilities, holster animation, ammo
+    /// type). NOT unique per physical item — do NOT use as the ammo-persist
+    /// TOCTOU guard; use `instance_id` for that.
     pub item_id: i32,
     /// Magazine/clip size for weapons.
     pub clip_size: i32,

--- a/crates/entity/src/cell_entity/tests.rs
+++ b/crates/entity/src/cell_entity/tests.rs
@@ -154,6 +154,7 @@ fn spawn_position_stores_and_retrieves() {
 
 fn make_bandolier_item(item_id: i32, clip: i32) -> BandolierItem {
     BandolierItem {
+        instance_id: 0,
         item_id,
         clip_size: clip,
         default_ammo_type: 1,
@@ -180,6 +181,7 @@ fn active_ammo_helpers_read_from_active_slot() {
     entity.bandolier_items.insert(
         1,
         BandolierItem {
+            instance_id: 0,
             item_id: 200,
             clip_size: 12,
             default_ammo_type: 2,
@@ -240,6 +242,7 @@ fn refill_active_slot_fills_to_clip_size() {
     entity.bandolier_items.insert(
         0,
         BandolierItem {
+            instance_id: 0,
             item_id: 100,
             clip_size: 30,
             default_ammo_type: 1,

--- a/crates/services/src/base/world_entry/cell_dispatch/bandolier.rs
+++ b/crates/services/src/base/world_entry/cell_dispatch/bandolier.rs
@@ -166,18 +166,18 @@ pub(super) async fn refresh_appearance(
 
 /// `CellToBaseMsg::BandolierAmmoUpdate` — persist a per-shot ammo writeback
 /// from the cell. Validates bounds (slot in 0..5, ammo / type non-negative,
-/// expected_item_id positive) at the service boundary so out-of-range
+/// expected_instance_id positive) at the service boundary so out-of-range
 /// values can't become durable corruption.
 #[tracing::instrument(
     name = "bandolier.ammo_update",
     level = "debug",
     skip_all,
-    fields(player_id, slot_id, expected_item_id, current_ammo, cur_ammo_type)
+    fields(player_id, slot_id, expected_instance_id, current_ammo, cur_ammo_type)
 )]
 pub(super) async fn bandolier_ammo_update(
     player_id: i32,
     slot_id: i32,
-    expected_item_id: i32,
+    expected_instance_id: i32,
     current_ammo: i32,
     cur_ammo_type: i32,
     db_pool: &Option<Arc<PgPool>>,
@@ -188,13 +188,17 @@ pub(super) async fn bandolier_ammo_update(
     // Validate bounds before persisting — these payloads cross a
     // service boundary, and any out-of-range value would become
     // durable corruption. Bandolier holds 5 slots (0-4); ammo and
-    // ammo_type IDs are non-negative.
-    if !(0..5).contains(&slot_id) || current_ammo < 0 || cur_ammo_type < 0 || expected_item_id <= 0
+    // ammo_type IDs are non-negative. `expected_instance_id` is the
+    // `sgw_inventory.item_id` PK and is always positive for a real row.
+    if !(0..5).contains(&slot_id)
+        || current_ammo < 0
+        || cur_ammo_type < 0
+        || expected_instance_id <= 0
     {
         tracing::warn!(
             player_id,
             slot_id,
-            expected_item_id,
+            expected_instance_id,
             current_ammo,
             cur_ammo_type,
             "BandolierAmmoUpdate: dropping out-of-range payload"
@@ -206,14 +210,14 @@ pub(super) async fn bandolier_ammo_update(
             pool.as_ref(),
             player_id,
             slot_id,
-            expected_item_id,
+            expected_instance_id,
             current_ammo,
             cur_ammo_type,
         )
         .await
         {
             tracing::warn!(
-                player_id, slot_id, expected_item_id, current_ammo, cur_ammo_type, error = %e,
+                player_id, slot_id, expected_instance_id, current_ammo, cur_ammo_type, error = %e,
                 "BandolierAmmoUpdate: DB write failed"
             );
         }

--- a/crates/services/src/base/world_entry/cell_dispatch/mod.rs
+++ b/crates/services/src/base/world_entry/cell_dispatch/mod.rs
@@ -810,14 +810,14 @@ pub(crate) async fn handle_cell_message(
         CellToBaseMsg::BandolierAmmoUpdate {
             player_id,
             slot_id,
-            expected_item_id,
+            expected_instance_id,
             current_ammo,
             cur_ammo_type,
         } => {
             bandolier::bandolier_ammo_update(
                 player_id,
                 slot_id,
-                expected_item_id,
+                expected_instance_id,
                 current_ammo,
                 cur_ammo_type,
                 db_pool,

--- a/crates/services/src/base/world_entry/cell_dispatch/tests.rs
+++ b/crates/services/src/base/world_entry/cell_dispatch/tests.rs
@@ -183,7 +183,7 @@ async fn invalid_bandolier_ammo_update_drops_before_side_effects() {
         CellToBaseMsg::BandolierAmmoUpdate {
             player_id: 10,
             slot_id: -1,
-            expected_item_id: 42,
+            expected_instance_id: 42,
             current_ammo: 17,
             cur_ammo_type: 1,
         },

--- a/crates/services/src/base/world_entry/methods/inventory/ammo.rs
+++ b/crates/services/src/base/world_entry/methods/inventory/ammo.rs
@@ -8,30 +8,36 @@ use sqlx::PgPool;
 /// container_id, slot_id) triple is unique under
 /// `sgw_inventory_unique_slot`, so this UPDATE touches at most one row.
 ///
-/// `expected_item_id` is added to the WHERE clause as a TOCTOU guard. Between
-/// the cell sending `BandolierAmmoUpdate` and this UPDATE running, the player
-/// could have swapped the slot's weapon. Without the `type_id` predicate the
-/// UPDATE would silently scribble the old weapon's ammo onto the new one.
-/// A zero-row result here means either the slot is unequipped *or* the item
-/// changed — in both cases dropping the write is correct.
+/// `expected_instance_id` is added to the WHERE clause as a TOCTOU guard.
+/// Between the cell sending `BandolierAmmoUpdate` and this UPDATE running, the
+/// player could have swapped the slot's weapon. The predicate keys on the
+/// `sgw_inventory.item_id` per-row instance id (a server-allocated surrogate,
+/// unique per slot via `sgw_inventory_unique_slot`), so it fires even
+/// when the swapped-in weapon shares the same *design* (`type_id`) as the one
+/// the ammo writeback was computed for. Keying on `type_id` instead — as an
+/// earlier version did — left a same-type-swap window: two physical instances
+/// of the same weapon design passed the predicate and could scribble each
+/// other's ammo (a dupe vector). A zero-row result here means the slot is
+/// unequipped *or* the instance changed — in both cases dropping the write is
+/// correct.
 pub async fn update_bandolier_ammo(
     pool: &PgPool,
     character_id: i32,
     slot_id: i32,
-    expected_item_id: i32,
+    expected_instance_id: i32,
     current_ammo: i32,
     cur_ammo_type: i32,
 ) -> Result<(), sqlx::Error> {
     let res = sqlx::query(
         "UPDATE sgw_inventory \
          SET ammo = $1, cur_ammo_type = $2 \
-         WHERE character_id = $3 AND container_id = 3 AND slot_id = $4 AND type_id = $5",
+         WHERE character_id = $3 AND container_id = 3 AND slot_id = $4 AND item_id = $5",
     )
     .bind(current_ammo)
     .bind(cur_ammo_type)
     .bind(character_id)
     .bind(slot_id)
-    .bind(expected_item_id)
+    .bind(expected_instance_id)
     .execute(pool)
     .await?;
 
@@ -39,10 +45,10 @@ pub async fn update_bandolier_ammo(
         tracing::debug!(
             character_id,
             slot_id,
-            expected_item_id,
+            expected_instance_id,
             current_ammo,
             cur_ammo_type,
-            "update_bandolier_ammo: no rows updated (slot empty or item swapped)"
+            "update_bandolier_ammo: no rows updated (slot empty or item instance swapped)"
         );
     }
     Ok(())
@@ -54,7 +60,9 @@ mod tests {
     //!
     //! Skip cleanly when DATABASE_URL is unset; against the bundled local
     //! Postgres they exercise the happy-path UPDATE, the TOCTOU guard
-    //! fired by an unexpected `type_id`, and the empty-slot no-op path.
+    //! fired by a stale instance PK (both a different-design swap and the
+    //! same-design-different-instance swap this fix closes), and the
+    //! empty-slot no-op path.
 
     use super::*;
     use crate::test_support::require_db_or_skip;
@@ -168,8 +176,9 @@ mod tests {
         .expect("ammo_state query")
     }
 
-    /// Happy path: the slot exists with the expected `type_id`, so the
-    /// UPDATE writes the new ammo + cur_ammo_type and rows_affected==1.
+    /// Happy path: the slot exists and the call passes its real instance
+    /// PK (`sgw_inventory.item_id`), so the UPDATE writes the new ammo +
+    /// cur_ammo_type and rows_affected==1.
     #[tokio::test]
     async fn update_writes_ammo_and_cur_ammo_type_when_type_matches() {
         let pool = require_db_or_skip!();
@@ -180,32 +189,28 @@ mod tests {
         insert_account_and_player(&pool, account_id, player_id).await;
         // Start with ammo=10, cur_ammo_type=0 so the post-call asserts
         // can pin the exact written values rather than just "non-zero".
-        insert_bandolier_item(&pool, player_id, primary_type, 1, 10, 0).await;
+        // Capture the RETURNING instance PK — that's the TOCTOU guard now.
+        let instance_id = insert_bandolier_item(&pool, player_id, primary_type, 1, 10, 0).await;
 
-        update_bandolier_ammo(&pool, player_id, 1, primary_type, 42, 7)
+        update_bandolier_ammo(&pool, player_id, 1, instance_id, 42, 7)
             .await
             .expect("update_bandolier_ammo must succeed on matching slot");
 
         assert_eq!(
             ammo_state_of(&pool, player_id, 1).await,
             Some((primary_type, 42, 7)),
-            "ammo and cur_ammo_type must be written when expected_item_id matches",
+            "ammo and cur_ammo_type must be written when expected_instance_id matches",
         );
 
         cleanup(&pool, account_id, player_id).await;
     }
 
-    /// TOCTOU guard: the slot exists but holds a DIFFERENT type_id (the
-    /// player swapped the bandolier slot's weapon between the cell event
-    /// and the persistence call). The `AND type_id = $5` predicate must
-    /// reject the write so the new weapon's ammo stays untouched.
-    ///
-    /// Coverage gap, intentional: this only pins the *different-type*
-    /// swap. A same-type swap (a different physical row of the same
-    /// design replacing the original at the same slot) still passes
-    /// the predicate and would silently scribble. Whether that's a
-    /// production bug or acceptable behavior is tracked separately —
-    /// see the issue linked from this branch's PR description.
+    /// TOCTOU guard, different-type swap: the slot exists but holds a row
+    /// whose instance PK differs from the one the call expects (the player
+    /// swapped the bandolier slot's weapon between the cell event and the
+    /// persistence call, to a DIFFERENT design). The `AND item_id = $5`
+    /// predicate must reject the write so the new weapon's ammo stays
+    /// untouched.
     #[tokio::test]
     async fn update_no_op_when_slot_holds_different_type() {
         let pool = require_db_or_skip!();
@@ -214,18 +219,78 @@ mod tests {
         let player_id = TEST_BASE + 101;
         cleanup(&pool, account_id, player_id).await;
         insert_account_and_player(&pool, account_id, player_id).await;
-        // Slot has the swapped (secondary) type, but the call passes
-        // the primary type as expected — TOCTOU guard must fire.
+        // Insert the ORIGINAL row, capture its instance PK, then delete it
+        // and re-insert a DIFFERENT design at the same slot. The call passes
+        // the now-stale original instance id, which no longer matches any
+        // row — TOCTOU guard must fire.
+        let stale_instance = insert_bandolier_item(&pool, player_id, primary_type, 2, 10, 0).await;
+        let _ = sqlx::query("DELETE FROM sgw_inventory WHERE item_id = $1")
+            .bind(stale_instance)
+            .execute(&pool)
+            .await;
         insert_bandolier_item(&pool, player_id, swapped_type, 2, 5, 1).await;
 
-        update_bandolier_ammo(&pool, player_id, 2, primary_type, 999, 99)
+        update_bandolier_ammo(&pool, player_id, 2, stale_instance, 999, 99)
             .await
-            .expect("must NOT error when type_id mismatches; just no-op");
+            .expect("must NOT error when instance_id mismatches; just no-op");
 
         assert_eq!(
             ammo_state_of(&pool, player_id, 2).await,
             Some((swapped_type, 5, 1)),
             "TOCTOU mismatch must leave ammo and cur_ammo_type untouched",
+        );
+
+        cleanup(&pool, account_id, player_id).await;
+    }
+
+    /// TOCTOU guard, SAME-type swap (the issue this fix closes): the slot
+    /// holds a row of the SAME weapon *design* as the one the writeback was
+    /// computed for, but it is a DIFFERENT physical instance (the original
+    /// was removed and a fresh copy of the same design re-equipped at the
+    /// same slot between the cell event and the persist). Keying the guard
+    /// on `type_id` would let the stale writeback scribble the new
+    /// instance's ammo — a dupe vector. Keying on the `item_id` PK rejects
+    /// it.
+    ///
+    /// Revert-verifier: changing the WHERE back to `type_id = $5` makes
+    /// this test FAIL — both rows share design `T`, so the predicate
+    /// matches the new instance and 999/99 gets written.
+    #[tokio::test]
+    async fn update_no_op_for_same_type_swap_different_instance() {
+        let pool = require_db_or_skip!();
+        // Only need ONE design — both physical instances share it.
+        let (design_t, _) = pick_two_bandolier_types(&pool).await;
+        let account_id = TEST_BASE + 300;
+        let player_id = TEST_BASE + 301;
+        cleanup(&pool, account_id, player_id).await;
+        insert_account_and_player(&pool, account_id, player_id).await;
+
+        // Instance A: original copy of design T at slot 1.
+        let instance_a = insert_bandolier_item(&pool, player_id, design_t, 1, 10, 0).await;
+        // Swap: delete A, re-insert the SAME design T at the same slot.
+        // Postgres hands out a fresh item_id PK, so instance_b != instance_a.
+        let _ = sqlx::query("DELETE FROM sgw_inventory WHERE item_id = $1")
+            .bind(instance_a)
+            .execute(&pool)
+            .await;
+        let instance_b = insert_bandolier_item(&pool, player_id, design_t, 1, 5, 1).await;
+        assert_ne!(
+            instance_a, instance_b,
+            "same-design re-insert must get a distinct instance PK for this test to be meaningful",
+        );
+
+        // Persist using the STALE instance A id (computed before the swap).
+        update_bandolier_ammo(&pool, player_id, 1, instance_a, 999, 99)
+            .await
+            .expect("must NOT error on a same-type-swap stale instance; just no-op");
+
+        // Instance B (the live row) must be untouched.
+        assert_eq!(
+            ammo_state_of(&pool, player_id, 1).await,
+            Some((design_t, 5, 1)),
+            "same-type swap to a new instance must reject the stale writeback \
+             (reverting the WHERE to type_id = $5 makes this fail — both rows \
+             share design T so the predicate would match instance B)",
         );
 
         cleanup(&pool, account_id, player_id).await;

--- a/crates/services/src/base/world_entry/methods/inventory/grant/mod.rs
+++ b/crates/services/src/base/world_entry/methods/inventory/grant/mod.rs
@@ -206,7 +206,7 @@ pub async fn handle_grant_item(
 
     if let Some(target) = merge_candidate {
         // Merge into the existing stack. The UPDATE is keyed by
-        // item_id (the primary key of sgw_inventory) so it can
+        // item_id (the per-row instance id of sgw_inventory) so it can
         // only touch the exact row we locked above.
         if let Err(e) =
             sqlx::query("UPDATE sgw_inventory SET stack_size = stack_size + $1 WHERE item_id = $2")
@@ -347,7 +347,12 @@ pub async fn handle_grant_item(
     // a single round-trip and gives us COALESCE for ammo_type so items with
     // a NULL default still get a sane sentinel rather than NULL (the column
     // is NOT NULL in the schema).
-    let result = sqlx::query(
+    // `RETURNING item_id` hands back the freshly-allocated `sgw_inventory.item_id`
+    // per-row instance id, which the bandolier fast-path below needs
+    // as the ammo-persist TOCTOU guard. The design id is the `item_id` param; the
+    // instance id is unique per physical row and is what distinguishes two copies
+    // of the same weapon design occupying the bandolier over time.
+    let result = sqlx::query_scalar::<_, i32>(
         "INSERT INTO sgw_inventory \
             (character_id, type_id, stack_size, slot_id, container_id, \
              bound, durability, charges, \
@@ -355,7 +360,8 @@ pub async fn handle_grant_item(
          SELECT $1, ri.item_id, $2, $3, $4, false, 100, $5, \
                 COALESCE(ri.default_ammo_type, 'AMMO_NONE'::resources.\"EAmmoType\"), \
                 ri.ammo_types, ri.charges, 0 \
-         FROM resources.items ri WHERE ri.item_id = $6",
+         FROM resources.items ri WHERE ri.item_id = $6 \
+         RETURNING item_id",
     )
     .bind(player_id)
     .bind(count)
@@ -363,24 +369,28 @@ pub async fn handle_grant_item(
     .bind(container_id)
     .bind(default_charges)
     .bind(item_id)
-    .execute(&mut *db_tx)
+    .fetch_one(&mut *db_tx)
     .await;
 
-    match result {
-        Ok(_) => tracing::debug!(
-            player_id,
-            item_id,
-            container_id,
-            slot = next_slot,
-            charges = default_charges,
-            "Item persisted to inventory"
-        ),
+    let instance_id: i32 = match result {
+        Ok(id) => {
+            tracing::debug!(
+                player_id,
+                item_id,
+                instance_id = id,
+                container_id,
+                slot = next_slot,
+                charges = default_charges,
+                "Item persisted to inventory"
+            );
+            id
+        }
         Err(e) => {
             let _ = db_tx.rollback().await;
             tracing::error!(player_id, item_id, "Failed to persist item: {e}");
             return;
         }
-    }
+    };
 
     // For bandolier grants, persist `bandolier_slot` in the SAME transaction so
     // the inventory insert and the active-slot move are atomic — a separate
@@ -555,6 +565,10 @@ pub async fn handle_grant_item(
             match row {
                 Ok(Some(row)) => {
                     let item = cimmeria_entity::cell_entity::BandolierItem {
+                        // The instance PK captured from the grant INSERT's
+                        // RETURNING above — this is the ammo-persist TOCTOU
+                        // guard, distinct from the design id (`row.item_id`).
+                        instance_id,
                         item_id: row.item_id,
                         clip_size: row.clip_size,
                         default_ammo_type: row.default_ammo_type_id,

--- a/crates/services/src/base/world_entry/methods/player_load/meta.rs
+++ b/crates/services/src/base/world_entry/methods/player_load/meta.rs
@@ -50,6 +50,9 @@ pub fn default_player_load_data() -> PlayerLoadData {
 #[derive(sqlx::FromRow)]
 struct BandolierItemRow {
     slot_id: i32,
+    /// `sgw_inventory.item_id` — the per-row instance id used as the ammo-persist
+    /// TOCTOU guard (distinct from the design `item_id` below).
+    instance_id: i32,
     item_id: i32,
     clip_size: i32,
     default_ammo_type_id: i32,
@@ -63,7 +66,7 @@ struct BandolierItemRow {
 }
 
 const BANDOLIER_ITEMS_QUERY: &str = r#"
-SELECT inv.slot_id, inv.type_id AS item_id, COALESCE(ri.clip_size, 0) AS clip_size,
+SELECT inv.slot_id, inv.item_id AS instance_id, inv.type_id AS item_id, COALESCE(ri.clip_size, 0) AS clip_size,
        CASE WHEN ri.default_ammo_type IS NULL THEN 0
             ELSE array_position(enum_range(NULL::resources."EAmmoType"), ri.default_ammo_type) - 1
        END AS default_ammo_type_id,
@@ -91,6 +94,7 @@ fn map_bandolier_rows(
             (
                 row.slot_id,
                 cimmeria_entity::cell_entity::BandolierItem {
+                    instance_id: row.instance_id,
                     item_id: row.item_id,
                     clip_size: row.clip_size,
                     default_ammo_type: row.default_ammo_type_id,

--- a/crates/services/src/cell/abilities/cone_aoe.rs
+++ b/crates/services/src/cell/abilities/cone_aoe.rs
@@ -611,6 +611,7 @@ mod tests {
             e.bandolier_items.insert(
                 0,
                 BandolierItem {
+                    instance_id: 0,
                     item_id: 1,
                     clip_size: 30,
                     default_ammo_type: 2,

--- a/crates/services/src/cell/abilities/dispatch.rs
+++ b/crates/services/src/cell/abilities/dispatch.rs
@@ -432,6 +432,7 @@ mod tests {
             e.bandolier_items.insert(
                 0,
                 BandolierItem {
+                    instance_id: 0,
                     item_id: 1,
                     clip_size: 30,
                     default_ammo_type: 2,

--- a/crates/services/src/cell/abilities/resolve.rs
+++ b/crates/services/src/cell/abilities/resolve.rs
@@ -133,6 +133,7 @@ mod tests {
             e.bandolier_items.insert(
                 slot,
                 BandolierItem {
+                    instance_id: 0,
                     item_id,
                     clip_size: 30,
                     default_ammo_type: 0,

--- a/crates/services/src/cell/abilities/tests.rs
+++ b/crates/services/src/cell/abilities/tests.rs
@@ -118,6 +118,7 @@ async fn consume_ammo_writes_ammoslot_stat_and_marks_dirty() {
         e.bandolier_items.insert(
             0,
             BandolierItem {
+                instance_id: 0,
                 item_id: 1,
                 clip_size: 30,
                 default_ammo_type: 2,

--- a/crates/services/src/cell/abilities/use_ability/tests.rs
+++ b/crates/services/src/cell/abilities/use_ability/tests.rs
@@ -179,6 +179,7 @@ async fn no_ammo_for_player_blocks_fire() {
         p.bandolier_items.insert(
             0,
             BandolierItem {
+                instance_id: 0,
                 item_id: 1,
                 clip_size: 30,
                 default_ammo_type: 2,
@@ -395,6 +396,7 @@ async fn attack_while_holstered_queues_and_draws_without_committing() {
         p.bandolier_items.insert(
             0,
             BandolierItem {
+                instance_id: 0,
                 item_id: 1,
                 clip_size: 30,
                 default_ammo_type: 2,
@@ -487,6 +489,7 @@ async fn attack_while_queued_is_rejected_input() {
         p.bandolier_items.insert(
             0,
             BandolierItem {
+                instance_id: 0,
                 item_id: 1,
                 clip_size: 30,
                 default_ammo_type: 2,
@@ -845,6 +848,7 @@ async fn weapon_granted_ability_commits_even_when_not_in_known_set() {
         p.bandolier_items.insert(
             0,
             BandolierItem {
+                instance_id: 0,
                 item_id: 55,
                 clip_size: 30,
                 default_ammo_type: 2,
@@ -906,6 +910,7 @@ async fn ungranted_ability_still_rejected_when_active_weapon_does_not_grant_it()
         p.bandolier_items.insert(
             0,
             BandolierItem {
+                instance_id: 0,
                 item_id: 55,
                 clip_size: 30,
                 default_ammo_type: 2,
@@ -963,6 +968,7 @@ async fn use_ability_redirects_pistol_shot_to_smg_when_p90_equipped() {
         p.bandolier_items.insert(
             0,
             BandolierItem {
+                instance_id: 0,
                 item_id: 21,
                 clip_size: 30,
                 default_ammo_type: 2,
@@ -1062,6 +1068,7 @@ async fn use_ability_does_not_redirect_when_called_ability_is_already_weapon_bin
         p.bandolier_items.insert(
             0,
             BandolierItem {
+                instance_id: 0,
                 item_id: 21,
                 clip_size: 30,
                 default_ammo_type: 2,

--- a/crates/services/src/cell/cell_methods/inventory/bandolier.rs
+++ b/crates/services/src/cell/cell_methods/inventory/bandolier.rs
@@ -28,19 +28,27 @@ pub async fn flush_dirty_bandolier_ammo(
     // marker in place and the next flush retries it.
     let dirty: Vec<i32> = entity.bandolier_ammo_dirty.iter().copied().collect();
     for slot_id in dirty {
-        let (item_id, current_ammo, cur_ammo_type) = match entity.bandolier_items.get(&slot_id) {
-            Some(item) => (item.item_id, item.current_ammo, item.cur_ammo_type),
-            None => {
-                // Dirty slot with no item -- nothing to persist. Drop marker.
-                entity.bandolier_ammo_dirty.remove(&slot_id);
-                continue;
-            }
-        };
+        // `instance_id` is the persist TOCTOU guard (`sgw_inventory.item_id` PK);
+        // `item_id` (design id) is kept only for log context here.
+        let (instance_id, item_id, current_ammo, cur_ammo_type) =
+            match entity.bandolier_items.get(&slot_id) {
+                Some(item) => (
+                    item.instance_id,
+                    item.item_id,
+                    item.current_ammo,
+                    item.cur_ammo_type,
+                ),
+                None => {
+                    // Dirty slot with no item -- nothing to persist. Drop marker.
+                    entity.bandolier_ammo_dirty.remove(&slot_id);
+                    continue;
+                }
+            };
         match tx
             .send(CellToBaseMsg::BandolierAmmoUpdate {
                 player_id,
                 slot_id,
-                expected_item_id: item_id,
+                expected_instance_id: instance_id,
                 current_ammo,
                 cur_ammo_type,
             })
@@ -51,7 +59,7 @@ pub async fn flush_dirty_bandolier_ammo(
             }
             Err(e) => {
                 tracing::warn!(
-                    player_id, slot_id, item_id, current_ammo, cur_ammo_type,
+                    player_id, slot_id, instance_id, item_id, current_ammo, cur_ammo_type,
                     error = %e,
                     "BandolierAmmoUpdate send failed; leaving slot dirty for retry"
                 );
@@ -248,8 +256,11 @@ pub(crate) async fn handle_request_active_slot_change(
     // drains the active slot when reloads finish; this catches
     // mid-magazine swaps where the player swaps weapons before
     // reloading the empty one.
+    // prev_persist tuple: (prev_slot, instance_id, item_id, current_ammo,
+    // cur_ammo_type). `instance_id` (sgw_inventory.item_id PK) is the persist
+    // TOCTOU guard; `item_id` (design id) is carried only for log context.
     let (prev_persist, new_ammo_type, prev_slot_for_log, auto_cycle_clear_state): (
-        Option<(i32, i32, i32, i32)>,
+        Option<(i32, i32, i32, i32, i32)>,
         Option<i32>,
         i32,
         Option<u32>,
@@ -263,6 +274,7 @@ pub(crate) async fn handle_request_active_slot_change(
             entity.bandolier_items.get(&prev_slot).map(|item| {
                 (
                     prev_slot,
+                    item.instance_id,
                     item.item_id,
                     item.current_ammo,
                     item.cur_ammo_type,
@@ -392,12 +404,12 @@ pub(crate) async fn handle_request_active_slot_change(
     // dirty marker for the previously-active slot only after the persist
     // message is accepted by the channel.
     if let Some(player_id) = player_id {
-        if let Some((p_slot, item_id, current_ammo, cur_ammo_type)) = prev_persist {
+        if let Some((p_slot, instance_id, item_id, current_ammo, cur_ammo_type)) = prev_persist {
             match tx
                 .send(CellToBaseMsg::BandolierAmmoUpdate {
                     player_id,
                     slot_id: p_slot,
-                    expected_item_id: item_id,
+                    expected_instance_id: instance_id,
                     current_ammo,
                     cur_ammo_type,
                 })
@@ -411,7 +423,7 @@ pub(crate) async fn handle_request_active_slot_change(
                 Err(e) => {
                     tracing::warn!(
                         entity_id, player_id, slot_id = p_slot,
-                        expected_item_id = item_id,
+                        expected_instance_id = instance_id, item_id,
                         error = %e,
                         "BandolierAmmoUpdate (slot swap) send failed; dirty marker preserved for retry"
                     );
@@ -780,14 +792,23 @@ pub(super) async fn handle_request_ammo_change(
         // channel; if the send fails the next flush picks the change up.
         let item = entity.bandolier_items.get_mut(&slot).unwrap();
         item.cur_ammo_type = ammo_type;
-        let item_id_for_persist = item.item_id;
+        // `instance_id` (sgw_inventory.item_id PK) is the persist TOCTOU guard;
+        // `item_id` (design id) is carried only for log context.
+        let instance_id_for_persist = item.instance_id;
+        let item_id_for_log = item.item_id;
         let current_ammo = item.current_ammo;
         entity.bandolier_ammo_dirty.insert(slot);
         let is_active = slot == entity.active_bandolier_slot;
         let player_id = entity.player_id;
         (
             player_id,
-            (slot, item_id_for_persist, current_ammo, ammo_type),
+            (
+                slot,
+                instance_id_for_persist,
+                item_id_for_log,
+                current_ammo,
+                ammo_type,
+            ),
             is_active,
         )
     };
@@ -799,12 +820,12 @@ pub(super) async fn handle_request_ammo_change(
     // "no player_id, skipped." Without this distinction the operator
     // sees "ammo type changed" and assumes the slot stuck.
     let persistence: &'static str = if let Some(player_id) = player_id {
-        let (slot_id, expected_item_id, current_ammo, cur_ammo_type) = persist;
+        let (slot_id, expected_instance_id, item_id_for_log, current_ammo, cur_ammo_type) = persist;
         match tx
             .send(CellToBaseMsg::BandolierAmmoUpdate {
                 player_id,
                 slot_id,
-                expected_item_id,
+                expected_instance_id,
                 current_ammo,
                 cur_ammo_type,
             })
@@ -818,7 +839,8 @@ pub(super) async fn handle_request_ammo_change(
             }
             Err(e) => {
                 tracing::warn!(
-                    entity_id, player_id, slot_id, expected_item_id, cur_ammo_type,
+                    entity_id, player_id, slot_id, expected_instance_id,
+                    item_id = item_id_for_log, cur_ammo_type,
                     error = %e,
                     "BandolierAmmoUpdate (ammo change) send failed; dirty marker preserved for retry"
                 );

--- a/crates/services/src/cell/cell_methods/inventory/tests/active_slot_change.rs
+++ b/crates/services/src/cell/cell_methods/inventory/tests/active_slot_change.rs
@@ -95,6 +95,7 @@ async fn request_active_slot_change_translates_wire_to_server_slot() {
                 e.bandolier_items.insert(
                     slot_id,
                     BandolierItem {
+                        instance_id: 0,
                         item_id: 100 + slot_id,
                         clip_size: 30,
                         default_ammo_type: 1,
@@ -202,6 +203,7 @@ async fn weapon_to_weapon_swap_ooc_defers_via_item_unequip() {
         e.bandolier_items.insert(
             0,
             BandolierItem {
+                instance_id: 0,
                 item_id: 10,
                 clip_size: 30,
                 default_ammo_type: 1,
@@ -212,6 +214,7 @@ async fn weapon_to_weapon_swap_ooc_defers_via_item_unequip() {
         e.bandolier_items.insert(
             1,
             BandolierItem {
+                instance_id: 0,
                 item_id: 11,
                 clip_size: 12,
                 default_ammo_type: 7,
@@ -328,6 +331,7 @@ async fn slot_swap_uses_outgoing_weapon_holster_duration() {
         e.bandolier_items.insert(
             0,
             BandolierItem {
+                instance_id: 0,
                 item_id: 50,
                 clip_size: 50,
                 default_ammo_type: 1,
@@ -338,6 +342,7 @@ async fn slot_swap_uses_outgoing_weapon_holster_duration() {
         e.bandolier_items.insert(
             1,
             BandolierItem {
+                instance_id: 0,
                 item_id: 51,
                 clip_size: 8,
                 default_ammo_type: 2,
@@ -403,6 +408,7 @@ async fn weapon_to_empty_slot_skips_choreography() {
         e.bandolier_items.insert(
             0,
             BandolierItem {
+                instance_id: 0,
                 item_id: 10,
                 clip_size: 30,
                 default_ammo_type: 1,
@@ -465,6 +471,7 @@ async fn weapon_to_weapon_swap_in_combat_still_triggers_choreography() {
         e.bandolier_items.insert(
             0,
             BandolierItem {
+                instance_id: 0,
                 item_id: 10,
                 clip_size: 30,
                 default_ammo_type: 1,
@@ -475,6 +482,7 @@ async fn weapon_to_weapon_swap_in_combat_still_triggers_choreography() {
         e.bandolier_items.insert(
             1,
             BandolierItem {
+                instance_id: 0,
                 item_id: 11,
                 clip_size: 12,
                 default_ammo_type: 7,
@@ -545,6 +553,7 @@ async fn weapon_attack_blocked_while_slot_swap_in_progress() {
         e.bandolier_items.insert(
             0,
             BandolierItem {
+                instance_id: 0,
                 item_id: 10,
                 clip_size: 30,
                 default_ammo_type: 1,
@@ -625,6 +634,7 @@ async fn slot_change_clears_auto_cycle_stash_and_broadcasts() {
             e.bandolier_items.insert(
                 slot_id,
                 BandolierItem {
+                    instance_id: 0,
                     item_id: 100 + slot_id,
                     clip_size: 30,
                     default_ammo_type: 1,
@@ -728,6 +738,7 @@ async fn same_slot_change_preserves_auto_cycle_stash() {
         e.bandolier_items.insert(
             0,
             BandolierItem {
+                instance_id: 0,
                 item_id: 100,
                 clip_size: 30,
                 default_ammo_type: 1,
@@ -810,6 +821,7 @@ async fn slot_change_to_p90_revokes_pistol_abilities_grants_smg_and_broadcasts()
         e.bandolier_items.insert(
             0,
             BandolierItem {
+                instance_id: 0,
                 item_id: PISTOL_ITEM_ID,
                 clip_size: 12,
                 default_ammo_type: 1,
@@ -820,6 +832,7 @@ async fn slot_change_to_p90_revokes_pistol_abilities_grants_smg_and_broadcasts()
         e.bandolier_items.insert(
             1,
             BandolierItem {
+                instance_id: 0,
                 item_id: P90_ITEM_ID,
                 clip_size: 30,
                 default_ammo_type: 2,
@@ -955,6 +968,7 @@ async fn slot_change_to_empty_slot_revokes_weapon_abilities_and_broadcasts() {
         e.bandolier_items.insert(
             0,
             BandolierItem {
+                instance_id: 0,
                 item_id: PISTOL_ITEM_ID,
                 clip_size: 12,
                 default_ammo_type: 1,
@@ -1042,6 +1056,7 @@ async fn same_slot_swap_does_not_broadcast_known_abilities_update() {
         e.bandolier_items.insert(
             0,
             BandolierItem {
+                instance_id: 0,
                 item_id: PISTOL_ITEM_ID,
                 clip_size: 12,
                 default_ammo_type: 1,

--- a/crates/services/src/cell/cell_methods/inventory/tests/ammo_change.rs
+++ b/crates/services/src/cell/cell_methods/inventory/tests/ammo_change.rs
@@ -24,6 +24,10 @@ async fn request_ammo_change_updates_slot_and_sends_property() {
         e.bandolier_items.insert(
             0,
             BandolierItem {
+                // Distinct from item_id (design id) so the BandolierAmmoUpdate
+                // assertion proves the guard now keys on the instance PK, not
+                // the design id.
+                instance_id: 4242,
                 item_id: 42,
                 clip_size: 30,
                 default_ammo_type: 1,
@@ -58,15 +62,15 @@ async fn request_ammo_change_updates_slot_and_sends_property() {
         CellToBaseMsg::BandolierAmmoUpdate {
             player_id,
             slot_id,
-            expected_item_id,
+            expected_instance_id,
             current_ammo,
             cur_ammo_type,
         } => {
             assert_eq!(player_id, 100);
             assert_eq!(slot_id, 0);
             assert_eq!(
-                expected_item_id, 42,
-                "should carry the slot's item_id for TOCTOU guard"
+                expected_instance_id, 4242,
+                "should carry the slot's instance PK (sgw_inventory.item_id) for TOCTOU guard, not the design id"
             );
             assert_eq!(current_ammo, 20);
             assert_eq!(cur_ammo_type, 3);
@@ -117,6 +121,7 @@ async fn request_ammo_change_rejects_non_positive() {
             e.bandolier_items.insert(
                 0,
                 BandolierItem {
+                    instance_id: 0,
                     item_id: 42,
                     clip_size: 30,
                     default_ammo_type: 1,
@@ -186,6 +191,7 @@ async fn request_ammo_change_rejects_unlisted_subtype() {
         e.bandolier_items.insert(
             0,
             BandolierItem {
+                instance_id: 0,
                 item_id: 42,
                 clip_size: 30,
                 default_ammo_type: 1,

--- a/crates/services/src/cell/cell_methods/inventory/tests/slot_swap.rs
+++ b/crates/services/src/cell/cell_methods/inventory/tests/slot_swap.rs
@@ -38,6 +38,9 @@ async fn slot_swap_preserves_per_slot_ammo() {
         e.bandolier_items.insert(
             0,
             BandolierItem {
+                // Distinct from item_id (design id) so the swap-flush
+                // assertion proves the guard keys on the instance PK.
+                instance_id: 1010,
                 item_id: 10,
                 clip_size: 30,
                 default_ammo_type: 1,
@@ -48,6 +51,7 @@ async fn slot_swap_preserves_per_slot_ammo() {
         e.bandolier_items.insert(
             1,
             BandolierItem {
+                instance_id: 1011,
                 item_id: 11,
                 clip_size: 12,
                 default_ammo_type: 7,
@@ -124,15 +128,15 @@ async fn slot_swap_preserves_per_slot_ammo() {
         CellToBaseMsg::BandolierAmmoUpdate {
             player_id,
             slot_id,
-            expected_item_id,
+            expected_instance_id,
             current_ammo,
             cur_ammo_type,
         } => {
             assert_eq!(player_id, 100);
             assert_eq!(slot_id, 0, "first swap msg should flush prev slot 0");
             assert_eq!(
-                expected_item_id, 10,
-                "should carry slot 0's item_id for TOCTOU guard"
+                expected_instance_id, 1010,
+                "should carry slot 0's instance PK (sgw_inventory.item_id) for TOCTOU guard, not the design id"
             );
             assert_eq!(current_ammo, 28);
             assert_eq!(cur_ammo_type, 1);
@@ -269,6 +273,7 @@ async fn slot_swap_cancels_in_flight_reload() {
         e.bandolier_items.insert(
             0,
             BandolierItem {
+                instance_id: 0,
                 item_id: 10,
                 clip_size: 30,
                 default_ammo_type: 1,
@@ -279,6 +284,7 @@ async fn slot_swap_cancels_in_flight_reload() {
         e.bandolier_items.insert(
             1,
             BandolierItem {
+                instance_id: 0,
                 item_id: 11,
                 clip_size: 12,
                 default_ammo_type: 7,
@@ -353,6 +359,7 @@ async fn slot_swap_cancels_pending_attack_queue() {
         e.bandolier_items.insert(
             0,
             BandolierItem {
+                instance_id: 0,
                 item_id: 10,
                 clip_size: 30,
                 default_ammo_type: 1,
@@ -363,6 +370,7 @@ async fn slot_swap_cancels_pending_attack_queue() {
         e.bandolier_items.insert(
             1,
             BandolierItem {
+                instance_id: 0,
                 item_id: 11,
                 clip_size: 12,
                 default_ammo_type: 7,
@@ -428,6 +436,7 @@ async fn slot_swap_cancels_pending_reload_phase_a() {
         e.bandolier_items.insert(
             0,
             BandolierItem {
+                instance_id: 0,
                 item_id: 10,
                 clip_size: 30,
                 default_ammo_type: 1,
@@ -438,6 +447,7 @@ async fn slot_swap_cancels_pending_reload_phase_a() {
         e.bandolier_items.insert(
             1,
             BandolierItem {
+                instance_id: 0,
                 item_id: 11,
                 clip_size: 12,
                 default_ammo_type: 7,
@@ -492,6 +502,7 @@ async fn same_slot_no_op_preserves_pending_attack_queue() {
         e.bandolier_items.insert(
             0,
             BandolierItem {
+                instance_id: 0,
                 item_id: 10,
                 clip_size: 30,
                 default_ammo_type: 1,

--- a/crates/services/src/cell/cell_methods/player/world/system_options_tests.rs
+++ b/crates/services/src/cell/cell_methods/player/world/system_options_tests.rs
@@ -68,6 +68,7 @@ fn make_player_with_ability() -> SpaceManager {
         p.bandolier_items.insert(
             0,
             BandolierItem {
+                instance_id: 0,
                 item_id: 55,
                 clip_size: 30,
                 default_ammo_type: 1,
@@ -404,6 +405,7 @@ async fn auto_reload_skips_for_melee_weapon_with_zero_clip_size() {
         p.bandolier_items.insert(
             0,
             cimmeria_entity::cell_entity::BandolierItem {
+                instance_id: 0,
                 item_id: 99,
                 clip_size: 0,
                 default_ammo_type: 0,

--- a/crates/services/src/cell/cell_methods/player/world/tests.rs
+++ b/crates/services/src/cell/cell_methods/player/world/tests.rs
@@ -607,6 +607,7 @@ async fn handle_reload_no_op_when_already_full() {
         e.bandolier_items.insert(
             0,
             BandolierItem {
+                instance_id: 0,
                 item_id: 1,
                 clip_size: 30,
                 default_ammo_type: 2,
@@ -642,6 +643,7 @@ async fn handle_reload_pins_reload_slot_id_to_current_active_slot() {
         e.bandolier_items.insert(
             2,
             BandolierItem {
+                instance_id: 0,
                 item_id: 1,
                 clip_size: 30,
                 default_ammo_type: 2,
@@ -713,6 +715,7 @@ async fn handle_reload_sends_item_reload_sequence() {
         e.bandolier_items.insert(
             0,
             BandolierItem {
+                instance_id: 0,
                 item_id: 1,
                 clip_size: 30,
                 default_ammo_type: 2,
@@ -854,6 +857,7 @@ async fn handle_reload_emits_ammo_type_under_correct_propid() {
         e.bandolier_items.insert(
             0,
             BandolierItem {
+                instance_id: 0,
                 item_id: 1,
                 clip_size: 30,
                 default_ammo_type: AMMO_TYPE,
@@ -932,6 +936,7 @@ async fn reload_while_holstered_phase_a_defers_reload() {
         e.bandolier_items.insert(
             0,
             BandolierItem {
+                instance_id: 0,
                 item_id: 1,
                 clip_size: 30,
                 default_ammo_type: 2,
@@ -1009,6 +1014,7 @@ async fn reload_phase_a_to_phase_b_clears_pending_and_starts_reload() {
         e.bandolier_items.insert(
             0,
             BandolierItem {
+                instance_id: 0,
                 item_id: 1,
                 clip_size: 30,
                 default_ammo_type: 2,
@@ -1070,6 +1076,7 @@ async fn reload_during_ooc_grace_resets_holster_timer() {
         e.bandolier_items.insert(
             0,
             BandolierItem {
+                instance_id: 0,
                 item_id: 1,
                 clip_size: 30,
                 default_ammo_type: 2,
@@ -1116,6 +1123,7 @@ async fn reload_second_press_during_draw_window_is_ignored() {
         e.bandolier_items.insert(
             0,
             BandolierItem {
+                instance_id: 0,
                 item_id: 1,
                 clip_size: 30,
                 default_ammo_type: 2,
@@ -1165,6 +1173,7 @@ async fn reload_in_isolation_does_not_flip_bsf_in_combat() {
         e.bandolier_items.insert(
             0,
             BandolierItem {
+                instance_id: 0,
                 item_id: 1,
                 clip_size: 30,
                 default_ammo_type: 2,
@@ -1359,6 +1368,7 @@ async fn handle_reload_phase_b_cancels_in_flight_holster_phase_2() {
         e.bandolier_items.insert(
             0,
             BandolierItem {
+                instance_id: 0,
                 item_id: 1,
                 clip_size: 30,
                 default_ammo_type: 2,

--- a/crates/services/src/cell/content/executor/inventory.rs
+++ b/crates/services/src/cell/content/executor/inventory.rs
@@ -80,6 +80,15 @@ pub(super) async fn grant(
                 entity.bandolier_items.insert(
                     slot_id,
                     cimmeria_entity::cell_entity::BandolierItem {
+                        // Optimistic cell-side insert: the base hasn't run the
+                        // grant INSERT yet, so the `sgw_inventory.item_id` PK
+                        // instance id is unknown here. Seed 0 — any ammo persist
+                        // fired in this brief pre-round-trip window carries
+                        // instance_id 0, which the base-side bound check drops
+                        // (there's no committed row to write anyway). Base then
+                        // replays `UpdateBandolierItem` carrying the real
+                        // instance id, which overwrites this entry.
+                        instance_id: 0,
                         item_id,
                         clip_size: clip,
                         default_ammo_type,

--- a/crates/services/src/cell/dispatch/tests.rs
+++ b/crates/services/src/cell/dispatch/tests.rs
@@ -253,6 +253,7 @@ async fn dispatch_reload_sends_entity_property() {
         e.bandolier_items.insert(
             0,
             BandolierItem {
+                instance_id: 0,
                 item_id: 1,
                 clip_size: 30,
                 default_ammo_type: 2,
@@ -446,6 +447,7 @@ async fn dispatch_reload_already_full_no_message() {
         e.bandolier_items.insert(
             0,
             BandolierItem {
+                instance_id: 0,
                 item_id: 1,
                 clip_size: 30,
                 default_ammo_type: 0,

--- a/crates/services/src/cell/messages/cell_to_base.rs
+++ b/crates/services/src/cell/messages/cell_to_base.rs
@@ -338,14 +338,18 @@ pub enum CellToBaseMsg {
     /// docs/gameplay/weapon-ammo-reload.md (TBD). `player_id` here matches the
     /// DB `character_id`, mirroring the field naming used by `ActiveSlotUpdate`.
     ///
-    /// `expected_item_id` guards against TOCTOU: if the slot's item changes
-    /// between the cell sending this message and the base writing the row,
-    /// the SQL `WHERE type_id = $expected_item_id` clause skips the write
-    /// rather than scribbling stale ammo onto the new weapon.
+    /// `expected_instance_id` guards against TOCTOU: it is the
+    /// `sgw_inventory.item_id` per-row instance id (NOT the design id) of the
+    /// slot's item at the time the writeback was computed.
+    /// If the slot's physical item changes between the cell sending this
+    /// message and the base writing the row, the SQL
+    /// `WHERE item_id = $expected_instance_id` clause skips the write rather
+    /// than scribbling stale ammo onto the new weapon — even when the new
+    /// weapon shares the same design as the old one.
     BandolierAmmoUpdate {
         player_id: i32,
         slot_id: i32,
-        expected_item_id: i32,
+        expected_instance_id: i32,
         current_ammo: i32,
         cur_ammo_type: i32,
     },

--- a/crates/services/src/cell/service/base_messages/player_init.rs
+++ b/crates/services/src/cell/service/base_messages/player_init.rs
@@ -1069,6 +1069,7 @@ mod system_options_assignment_tests {
             vec![(
                 0,
                 cimmeria_entity::cell_entity::BandolierItem {
+                    instance_id: 0,
                     item_id: 55,
                     clip_size: 30,
                     default_ammo_type: 1,

--- a/crates/services/src/cell/service/base_messages/tests/bandolier_sync.rs
+++ b/crates/services/src/cell/service/base_messages/tests/bandolier_sync.rs
@@ -38,6 +38,7 @@ async fn sync_bandolier_items_active_slot_gained_weapon_draws_and_animates() {
         .insert((804, crate::cell::spawner::EVENT_ITEM_EQUIP), 1872);
 
     let item = BandolierItem {
+        instance_id: 0,
         item_id: 55,
         clip_size: 15,
         default_ammo_type: 2,
@@ -139,6 +140,7 @@ async fn sync_bandolier_items_active_slot_lost_weapon_fires_unequip_and_schedule
         e.bandolier_items.insert(
             0,
             BandolierItem {
+                instance_id: 0,
                 item_id: 55,
                 clip_size: 15,
                 default_ammo_type: 2,
@@ -231,6 +233,7 @@ async fn sync_bandolier_items_active_slot_unchanged_does_not_re_animate() {
         e.bandolier_items.insert(
             0,
             BandolierItem {
+                instance_id: 0,
                 item_id: 55,
                 clip_size: 15,
                 default_ammo_type: 2,
@@ -259,6 +262,7 @@ async fn sync_bandolier_items_active_slot_unchanged_does_not_re_animate() {
                 (
                     0,
                     BandolierItem {
+                        instance_id: 0,
                         item_id: 55,
                         clip_size: 15,
                         default_ammo_type: 2,
@@ -269,6 +273,7 @@ async fn sync_bandolier_items_active_slot_unchanged_does_not_re_animate() {
                 (
                     2,
                     BandolierItem {
+                        instance_id: 0,
                         item_id: 99,
                         clip_size: 30,
                         default_ammo_type: 1,
@@ -354,6 +359,7 @@ async fn sync_bandolier_items_active_slot_gained_weapon_emits_ammo_type_id() {
         .insert((804, crate::cell::spawner::EVENT_ITEM_EQUIP), 1872);
 
     let item = BandolierItem {
+        instance_id: 0,
         item_id: 55,
         clip_size: 15,
         default_ammo_type: AMMO_TYPE,
@@ -438,6 +444,7 @@ async fn sync_bandolier_items_active_slot_lost_weapon_emits_ammo_type_id_zero() 
         e.bandolier_items.insert(
             0,
             BandolierItem {
+                instance_id: 0,
                 item_id: 55,
                 clip_size: 15,
                 default_ammo_type: 2,
@@ -520,6 +527,7 @@ async fn sync_bandolier_items_active_slot_unchanged_does_not_emit_ammo_type_id()
         e.bandolier_items.insert(
             0,
             BandolierItem {
+                instance_id: 0,
                 item_id: 55,
                 clip_size: 15,
                 default_ammo_type: 2,
@@ -540,6 +548,7 @@ async fn sync_bandolier_items_active_slot_unchanged_does_not_emit_ammo_type_id()
             bandolier_items: vec![(
                 0,
                 BandolierItem {
+                    instance_id: 0,
                     item_id: 55,
                     clip_size: 15,
                     default_ammo_type: 2,
@@ -632,6 +641,7 @@ async fn sync_bandolier_items_active_slot_gained_partial_clip_triggers_reload_on
 
     // The item to drag into slot 0 — partial clip (10 of 15).
     let item = BandolierItem {
+        instance_id: 0,
         item_id: 55,
         clip_size: 15,
         default_ammo_type: 2,
@@ -706,6 +716,7 @@ async fn sync_bandolier_items_with_option_off_does_not_reload_on_activate() {
     mgr.connect_entity(1);
 
     let item = BandolierItem {
+        instance_id: 0,
         item_id: 55,
         clip_size: 15,
         default_ammo_type: 2,

--- a/crates/services/src/cell/service/base_messages/tests/bandolier_update.rs
+++ b/crates/services/src/cell/service/base_messages/tests/bandolier_update.rs
@@ -11,6 +11,7 @@ async fn update_bandolier_item_inserts_slot_and_sets_active() {
         .unwrap();
 
     let item = BandolierItem {
+        instance_id: 0,
         item_id: 42,
         clip_size: 25,
         default_ammo_type: 2,
@@ -80,6 +81,7 @@ async fn update_bandolier_item_draws_weapon_and_arms_holster_timer_when_active()
         .insert((804, crate::cell::spawner::EVENT_ITEM_EQUIP), 1872);
 
     let item = BandolierItem {
+        instance_id: 0,
         item_id: 42,
         clip_size: 25,
         default_ammo_type: 2,
@@ -183,6 +185,7 @@ async fn update_bandolier_item_make_active_false_but_slot_matches_active_still_d
         .insert((804, crate::cell::spawner::EVENT_ITEM_EQUIP), 1872);
 
     let item = BandolierItem {
+        instance_id: 0,
         item_id: 42,
         clip_size: 25,
         default_ammo_type: 2,
@@ -280,6 +283,7 @@ async fn update_bandolier_item_make_active_false_into_non_active_slot_does_not_d
     mgr.connect_entity(1);
 
     let item = BandolierItem {
+        instance_id: 0,
         item_id: 99,
         clip_size: 30,
         default_ammo_type: 1,
@@ -383,6 +387,7 @@ async fn update_bandolier_item_in_combat_does_not_arm_holster_timer() {
     mgr.connect_entity(1);
 
     let item = BandolierItem {
+        instance_id: 0,
         item_id: 42,
         clip_size: 25,
         default_ammo_type: 2,
@@ -455,6 +460,7 @@ async fn update_bandolier_item_active_emits_ammo_type_id() {
         .insert((804, crate::cell::spawner::EVENT_ITEM_EQUIP), 1872);
 
     let item = BandolierItem {
+        instance_id: 0,
         item_id: 77,
         clip_size: 30,
         default_ammo_type: AMMO_TYPE,

--- a/crates/services/src/cell/service/base_messages/tests/general.rs
+++ b/crates/services/src/cell/service/base_messages/tests/general.rs
@@ -15,6 +15,7 @@ async fn destroy_entity_flushes_dirty_bandolier_and_destroys_entity() {
         e.bandolier_items.insert(
             0,
             BandolierItem {
+                instance_id: 0,
                 item_id: 10,
                 clip_size: 30,
                 default_ammo_type: 1,

--- a/crates/services/src/cell/service/tests/bandolier.rs
+++ b/crates/services/src/cell/service/tests/bandolier.rs
@@ -26,6 +26,7 @@ async fn init_player_state_seeds_ammo_stats() {
         (
             0,
             BandolierItem {
+                instance_id: 0,
                 item_id: 100,
                 clip_size: 30,
                 default_ammo_type: 2,
@@ -36,6 +37,7 @@ async fn init_player_state_seeds_ammo_stats() {
         (
             1,
             BandolierItem {
+                instance_id: 0,
                 item_id: 101,
                 clip_size: 12,
                 default_ammo_type: 5,
@@ -108,6 +110,9 @@ async fn logout_flushes_all_dirty_bandolier_slots() {
         e.bandolier_items.insert(
             0,
             BandolierItem {
+                // Distinct from item_id (design id) so the flush assertion
+                // proves the guard keys on the instance PK.
+                instance_id: 1010,
                 item_id: 10,
                 clip_size: 30,
                 default_ammo_type: 1,
@@ -118,6 +123,7 @@ async fn logout_flushes_all_dirty_bandolier_slots() {
         e.bandolier_items.insert(
             1,
             BandolierItem {
+                instance_id: 1011,
                 item_id: 11,
                 clip_size: 12,
                 default_ammo_type: 7,
@@ -151,13 +157,13 @@ async fn logout_flushes_all_dirty_bandolier_slots() {
         if let CellToBaseMsg::BandolierAmmoUpdate {
             player_id,
             slot_id,
-            expected_item_id,
+            expected_instance_id,
             current_ammo,
             cur_ammo_type,
         } = msg
         {
             assert_eq!(player_id, 100);
-            updates.insert(slot_id, (expected_item_id, current_ammo, cur_ammo_type));
+            updates.insert(slot_id, (expected_instance_id, current_ammo, cur_ammo_type));
         }
     }
     assert_eq!(
@@ -165,8 +171,9 @@ async fn logout_flushes_all_dirty_bandolier_slots() {
         2,
         "expected one BandolierAmmoUpdate per dirty slot"
     );
-    assert_eq!(updates.get(&0), Some(&(10, 17, 1)));
-    assert_eq!(updates.get(&1), Some(&(11, 4, 7)));
+    // Guard carries the instance PK (sgw_inventory.item_id), not the design id.
+    assert_eq!(updates.get(&0), Some(&(1010, 17, 1)));
+    assert_eq!(updates.get(&1), Some(&(1011, 4, 7)));
 
     // Entity removed from the space manager.
     assert!(
@@ -196,6 +203,9 @@ async fn disconnect_entity_flushes_dirty_ammo_before_destroy() {
         e.bandolier_items.insert(
             0,
             BandolierItem {
+                // Distinct from item_id (design id) so the flush assertion
+                // proves the guard keys on the instance PK.
+                instance_id: 1010,
                 item_id: 10,
                 clip_size: 30,
                 default_ammo_type: 1,
@@ -228,14 +238,17 @@ async fn disconnect_entity_flushes_dirty_ammo_before_destroy() {
         if let CellToBaseMsg::BandolierAmmoUpdate {
             player_id,
             slot_id,
-            expected_item_id,
+            expected_instance_id,
             current_ammo,
             cur_ammo_type,
         } = msg
         {
             assert_eq!(player_id, 100);
             assert_eq!(slot_id, 0);
-            assert_eq!(expected_item_id, 10, "should carry the slot's item_id");
+            assert_eq!(
+                expected_instance_id, 1010,
+                "should carry the slot's instance PK (sgw_inventory.item_id), not the design id"
+            );
             assert_eq!(current_ammo, 17);
             assert_eq!(cur_ammo_type, 1);
             got_ammo_update = true;

--- a/crates/services/src/cell/service/tests/reload.rs
+++ b/crates/services/src/cell/service/tests/reload.rs
@@ -24,6 +24,9 @@ async fn reload_completion_tick_refills_and_sends_stat() {
         e.bandolier_items.insert(
             0,
             BandolierItem {
+                // Distinct from item_id (design id) so the reload-tick persist
+                // assertion proves the guard keys on the instance PK.
+                instance_id: 1001,
                 item_id: 1,
                 clip_size: 30,
                 default_ammo_type: 2,
@@ -113,15 +116,15 @@ async fn reload_completion_tick_refills_and_sends_stat() {
         CellToBaseMsg::BandolierAmmoUpdate {
             player_id,
             slot_id,
-            expected_item_id,
+            expected_instance_id,
             current_ammo,
             cur_ammo_type,
         } => {
             assert_eq!(player_id, 100);
             assert_eq!(slot_id, 0);
             assert_eq!(
-                expected_item_id, 1,
-                "should carry the slot's item_id for TOCTOU guard"
+                expected_instance_id, 1001,
+                "should carry the slot's instance PK (sgw_inventory.item_id) for TOCTOU guard, not the design id"
             );
             assert_eq!(current_ammo, 30);
             assert_eq!(cur_ammo_type, 2);
@@ -161,6 +164,7 @@ async fn reload_completion_tick_emits_ability_end_sequence_when_event_set_presen
         e.bandolier_items.insert(
             0,
             BandolierItem {
+                instance_id: 1001,
                 item_id: 1,
                 clip_size: 30,
                 default_ammo_type: 2,

--- a/crates/services/src/cell/service/ticks/mod.rs
+++ b/crates/services/src/cell/service/ticks/mod.rs
@@ -119,13 +119,16 @@ pub(super) async fn reload_completion_tick(
             let payload = entity.stats.serialize_dirty();
             entity.stats.clear_dirty();
 
-            let (item_id, cur_ammo, cur_ammo_type) = entity
-                .bandolier_items
-                .get(&slot_id)
-                .map_or((0, 0, 0), |i| (i.item_id, i.current_ammo, i.cur_ammo_type));
+            // `instance_id` (sgw_inventory.item_id PK) is the persist TOCTOU
+            // guard; the design id is not used here. A missing slot yields
+            // instance_id 0, which the base-side bound check (`<= 0`) drops.
+            let (instance_id, cur_ammo, cur_ammo_type) =
+                entity.bandolier_items.get(&slot_id).map_or((0, 0, 0), |i| {
+                    (i.instance_id, i.current_ammo, i.cur_ammo_type)
+                });
             let persist = entity
                 .player_id
-                .map(|pid| (pid, slot_id, item_id, cur_ammo, cur_ammo_type));
+                .map(|pid| (pid, slot_id, instance_id, cur_ammo, cur_ammo_type));
 
             (payload, persist)
         };
@@ -147,12 +150,14 @@ pub(super) async fn reload_completion_tick(
 
         // Phase 3: persistence. CellToBaseMsg::BandolierAmmoUpdate is consumed
         // by base's existing handler that writes `sgw_inventory.ammo`.
-        if let Some((player_id, slot_id, expected_item_id, current_ammo, cur_ammo_type)) = persist {
+        if let Some((player_id, slot_id, expected_instance_id, current_ammo, cur_ammo_type)) =
+            persist
+        {
             let _ = tx
                 .send(CellToBaseMsg::BandolierAmmoUpdate {
                     player_id,
                     slot_id,
-                    expected_item_id,
+                    expected_instance_id,
                     current_ammo,
                     cur_ammo_type,
                 })

--- a/crates/services/src/mercury/world_data/tests/bandolier.rs
+++ b/crates/services/src/mercury/world_data/tests/bandolier.rs
@@ -47,6 +47,7 @@ fn build_map_loaded_seeds_ammo_slot_stats_from_bandolier_items() {
             (
                 0,
                 BandolierItem {
+                    instance_id: 0,
                     item_id: 100,
                     clip_size: 15,
                     default_ammo_type: 1,
@@ -57,6 +58,7 @@ fn build_map_loaded_seeds_ammo_slot_stats_from_bandolier_items() {
             (
                 2,
                 BandolierItem {
+                    instance_id: 0,
                     item_id: 101,
                     clip_size: 12,
                     default_ammo_type: 7,
@@ -164,6 +166,7 @@ fn build_map_loaded_seeds_active_slot_indicator_from_persisted_slot() {
         bandolier_items: vec![(
             2,
             BandolierItem {
+                instance_id: 0,
                 item_id: 100,
                 clip_size: 30,
                 default_ammo_type: 1,
@@ -224,6 +227,7 @@ fn active_bandolier_slot_drives_ammo_type_id_property() {
         (
             0,
             BandolierItem {
+                instance_id: 0,
                 item_id: 100,
                 clip_size: 15,
                 default_ammo_type: 1,
@@ -234,6 +238,7 @@ fn active_bandolier_slot_drives_ammo_type_id_property() {
         (
             2,
             BandolierItem {
+                instance_id: 0,
                 item_id: 200,
                 clip_size: 12,
                 default_ammo_type: 7,
@@ -284,6 +289,7 @@ fn active_bandolier_slot_with_no_item_emits_ammo_type_zero() {
     data.bandolier_items = vec![(
         0,
         BandolierItem {
+            instance_id: 0,
             item_id: 100,
             clip_size: 15,
             default_ammo_type: 9,


### PR DESCRIPTION
Closes #445.

## In plain terms

Each weapon in your bandolier remembers how much ammo is in its magazine, and the server saves that per-weapon. The bug: the server saved ammo by the weapon's **design** ("a P90"), not by the **specific physical weapon** you were holding. So if you owned **two** of the same weapon, the save could land on the wrong one — swap one out of a slot and the game would copy ammo onto your *other* copy of that weapon. A player could exploit this to effectively **double their ammo reserves** by carrying two of the same gun.

The fix makes the server save ammo against the exact physical item instance instead of the design, so two copies of the same weapon can no longer bleed ammo into each other. There's no change a player would notice in normal play — it just closes the duplication hole.

> No client/protocol change: the affected types are server-internal only (they travel between two server threads, never to the game client).

## Technical summary

`BandolierAmmoUpdate` persistence (`update_bandolier_ammo`) keyed its SQL `WHERE` on `type_id` (the weapon **design** id) rather than `item_id` (the per-row **instance** id). Two physical `sgw_inventory` rows of the same design share `type_id`, so the predicate matched both — a same-design swap into a vacated slot scribbled the writeback across instances (the canonical SGW same-type-swap TOCTOU dupe).

### The fix

- **`BandolierItem`** gains `instance_id` (`sgw_inventory.item_id`), kept distinct from the design `item_id` (design lookups — clip size, abilities, holster anim — still use `item_id`).
- **Provenance — always server DB state, never client-supplied:**
  - World-entry + move/equip: the shared `BANDOLIER_ITEMS_QUERY` now `SELECT`s `inv.item_id AS instance_id` (the PK was already in the FROM).
  - Grant fast-path: captured from a new `RETURNING item_id` on the grant INSERT (the plan's claim that this was already in scope was **wrong** — the param was the design id; corrected during implementation).
  - Content-engine optimistic grant: seeds `instance_id: 0`, corrected by the base's `UpdateBandolierItem` replay. The base `expected_instance_id > 0` guard drops any persist in that pre-row window — safe, since no committed row exists yet.
- **Sink:** `update_bandolier_ammo` WHERE → `item_id = $5`; `expected_item_id` → `expected_instance_id` through all **4** senders (flush / slot-swap / ammo-change / reload-completion tick — the 4th was found via compile errors, not in the original plan).
- The client's `requestAmmoChange` carries a design id used **only** to resolve the slot; the persisted guard is always the slot's server-side `instance_id`.

### Audit + scope

- **server-authority-enforcer: SHIP.** Traced every `BandolierItem` construction site — `instance_id` is always server-sourced; the client design id never reaches it; the `instance_id: 0` window loses nothing. Confirmed `ammo.rs` was the **only** production `sgw_inventory` mutation keyed on `type_id` (`remove_by_type`, `grant` stack-merge, `move_`, `remove_instance` all key on `item_id` or `container+slot`).
- **Doc caveat (from the audit):** `sgw_inventory.item_id` is unique **by sequence allocation + the `sgw_inventory_unique_slot` index**, not by a declared PK/UNIQUE constraint. The comments were corrected to say so. A defense-in-depth `UNIQUE INDEX` on `item_id` is a reasonable **separate** PR (needs a pre-deploy dup check + migration).

### Tests

- **New revert-verifying live-DB guard** `update_no_op_for_same_type_swap_different_instance`: inserts two distinct rows of the **same design** at one slot, persists for the stale instance, asserts the live row is untouched + `rows_affected == 0`. Reverting the WHERE to `type_id = $5` makes it fail (both rows share the design).
- Existing different-type / happy-path / empty-slot live-DB guards updated to pass real `RETURNING` instance ids.
- ~62 `BandolierItem` test fixtures updated (`instance_id` field); assertion-bearing ones use distinct non-zero ids.

Validation: `fmt` / `clippy -D warnings` / `nextest` (1428 pass, live-DB self-skips) / workspace check — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)