### PR TITLE
feat(gm): .-console for dev/authoring commands with no native slash (#523)

### DIFF
--- a/crates/entity/src/cell_entity/mod.rs
+++ b/crates/entity/src/cell_entity/mod.rs
@@ -224,6 +224,12 @@ pub struct CellEntity {
     /// Source template ID from `entity_templates.template_id`.
     pub template_id: Option<i32>,
 
+    /// Source `spawnlist.spawn_id` for record-spawned NPCs, or `None` for
+    /// players and command-spawned NPCs (which have no spawnlist row). Lets the
+    /// `.`-console authoring commands (`delspawn`, `path_assign`) target the
+    /// exact spawn row by id rather than matching on position.
+    pub spawn_id: Option<i32>,
+
     /// Spawn tag from `spawnlist.tag` — used by content chains to target this entity
     /// (e.g., `"ArmYourself_FrostBody"`, `"Preparation_Terminal"`).
     pub tag: Option<String>,
@@ -916,6 +922,7 @@ impl CellEntity {
             access_level: 0,
             level: 1,
             template_id: None,
+            spawn_id: None,
             tag: None,
             name_id: None,
             speaker_id: None,

--- a/crates/services/src/base/console_authoring.rs
+++ b/crates/services/src/base/console_authoring.rs
@@ -1,0 +1,199 @@
+//! BaseApp-side executor for `.`-console authoring SQL.
+//!
+//! The `.`-console spawn/patrol authoring commands (`savespawn`, `path_add`,
+//! …) run on the CellService, which has no DB pool. They hand a
+//! **server-generated** `INSERT`/`UPDATE`/`DELETE` to the base via
+//! [`CellToBaseMsg::ExecuteAuthoringSql`](crate::cell::messages::CellToBaseMsg::ExecuteAuthoringSql);
+//! this handler runs it against the live pool and reports the row count back to
+//! the GM on the feedback channel.
+//!
+//! The write is intentionally **transient**: it lets the developer see the
+//! change hold across reconnects within the current deploy, but the next deploy
+//! rebuilds the DB from the `db/resources/` seeds and wipes it. The durable
+//! artifact is the seed SQL the cell records to the per-session authoring log
+//! and (later) Discord — see `crate::cell::console::seed`.
+//!
+//! **Trust model:** the `.`-channel is GM-gated server-side (the cell only
+//! forwards a command from an `access_level >= GameMaster` caller), and `sql`
+//! is server-generated — numeric values come from cell-parsed `i32`/`f32` and
+//! strings are escaped through `crate::cell::console::seed::sql_str`, so there
+//! is no raw client text concatenated into the statement. This mirrors the
+//! legacy `Atrea.dbQuery` authoring path.
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::sync::{Arc, Mutex};
+
+use cimmeria_mercury::transport::Transport;
+use sqlx::PgPool;
+
+use crate::base::gm_feedback::send_gm_feedback_to_client;
+use crate::base::ConnectedClientState;
+
+/// Max search hits reported per `.search*` command — keeps a broad query from
+/// flooding the feedback channel.
+const SEARCH_LIMIT: i64 = 25;
+
+/// Execute one authoring statement and report the outcome to the GM.
+#[tracing::instrument(
+    name = "console.authoring_sql",
+    level = "info",
+    skip_all,
+    fields(entity_id, label)
+)]
+pub(crate) async fn handle_execute_authoring_sql(
+    entity_id: u32,
+    label: &str,
+    sql: &str,
+    db_pool: &Option<Arc<PgPool>>,
+    transport: &Arc<dyn Transport>,
+    connected: &Arc<Mutex<HashMap<SocketAddr, ConnectedClientState>>>,
+    entity_to_addr: &Arc<Mutex<HashMap<u32, SocketAddr>>>,
+) {
+    let Some(pool) = db_pool else {
+        tracing::warn!(
+            entity_id,
+            label,
+            "authoring SQL: no DB pool — live write skipped (seed SQL still \
+             recorded cell-side for commit)"
+        );
+        send_gm_feedback_to_client(
+            entity_id,
+            &format!("{label}: no live DB — change applied in-memory only"),
+            transport,
+            connected,
+            entity_to_addr,
+        )
+        .await;
+        return;
+    };
+
+    match sqlx::query(sql).execute(pool.as_ref()).await {
+        Ok(res) => {
+            let rows = res.rows_affected();
+            tracing::info!(entity_id, label, rows, "authoring SQL executed");
+            send_gm_feedback_to_client(
+                entity_id,
+                &format!("{label}: live DB write ok ({rows} row(s); wiped on next deploy)"),
+                transport,
+                connected,
+                entity_to_addr,
+            )
+            .await;
+        }
+        Err(e) => {
+            tracing::warn!(entity_id, label, error = %e, "authoring SQL failed");
+            send_gm_feedback_to_client(
+                entity_id,
+                &format!("{label}: live DB write FAILED ({e})"),
+                transport,
+                connected,
+                entity_to_addr,
+            )
+            .await;
+        }
+    }
+}
+
+/// Run a read-only resource-name search and report `id: name` matches to the GM.
+///
+/// `kind` selects the table: `0` items, `1` missions, `2` entity_templates. The
+/// query string is bound as a parameterized `ILIKE` pattern — never
+/// concatenated — so this is injection-safe regardless of the channel gate.
+#[tracing::instrument(
+    name = "console.search",
+    level = "info",
+    skip_all,
+    fields(entity_id, kind)
+)]
+pub(crate) async fn handle_console_search(
+    entity_id: u32,
+    kind: u8,
+    query: &str,
+    db_pool: &Option<Arc<PgPool>>,
+    transport: &Arc<dyn Transport>,
+    connected: &Arc<Mutex<HashMap<SocketAddr, ConnectedClientState>>>,
+    entity_to_addr: &Arc<Mutex<HashMap<u32, SocketAddr>>>,
+) {
+    let (label, sql) = match kind {
+        0 => (
+            "searchitem",
+            "SELECT item_id AS id, name FROM resources.items \
+             WHERE name ILIKE $1 ORDER BY item_id LIMIT $2",
+        ),
+        1 => (
+            "searchmission",
+            "SELECT mission_id AS id, mission_defn AS name FROM resources.missions \
+             WHERE mission_defn ILIKE $1 ORDER BY mission_id LIMIT $2",
+        ),
+        2 => (
+            "searchtemplate",
+            "SELECT template_id AS id, template_name AS name FROM resources.entity_templates \
+             WHERE template_name ILIKE $1 ORDER BY template_id LIMIT $2",
+        ),
+        _ => return,
+    };
+
+    let Some(pool) = db_pool else {
+        send_gm_feedback_to_client(
+            entity_id,
+            &format!("{label}: no live DB connection"),
+            transport,
+            connected,
+            entity_to_addr,
+        )
+        .await;
+        return;
+    };
+
+    let pattern = format!("%{query}%");
+    let rows = sqlx::query_as::<_, (i32, String)>(sql)
+        .bind(&pattern)
+        .bind(SEARCH_LIMIT)
+        .fetch_all(pool.as_ref())
+        .await;
+
+    match rows {
+        Ok(hits) if hits.is_empty() => {
+            send_gm_feedback_to_client(
+                entity_id,
+                &format!("{label}: no matches for '{query}'"),
+                transport,
+                connected,
+                entity_to_addr,
+            )
+            .await;
+        }
+        Ok(hits) => {
+            send_gm_feedback_to_client(
+                entity_id,
+                &format!("{label} '{query}': {} match(es)", hits.len()),
+                transport,
+                connected,
+                entity_to_addr,
+            )
+            .await;
+            for (id, name) in hits {
+                send_gm_feedback_to_client(
+                    entity_id,
+                    &format!("    {id}: {name}"),
+                    transport,
+                    connected,
+                    entity_to_addr,
+                )
+                .await;
+            }
+        }
+        Err(e) => {
+            tracing::warn!(entity_id, label, error = %e, "console search query failed");
+            send_gm_feedback_to_client(
+                entity_id,
+                &format!("{label}: query failed ({e})"),
+                transport,
+                connected,
+                entity_to_addr,
+            )
+            .await;
+        }
+    }
+}

--- a/crates/services/src/base/console_authoring.rs
+++ b/crates/services/src/base/console_authoring.rs
@@ -71,15 +71,40 @@ pub(crate) async fn handle_execute_authoring_sql(
     match sqlx::query(sql).execute(pool.as_ref()).await {
         Ok(res) => {
             let rows = res.rows_affected();
-            tracing::info!(entity_id, label, rows, "authoring SQL executed");
-            send_gm_feedback_to_client(
-                entity_id,
-                &format!("{label}: live DB write ok ({rows} row(s); wiped on next deploy)"),
-                transport,
-                connected,
-                entity_to_addr,
-            )
-            .await;
+            if rows == 0 {
+                // A zero-row result means the statement ran but matched
+                // nothing (e.g. an UPDATE/DELETE whose WHERE found no row, or
+                // an idempotent re-run). The seed SQL is still recorded, but
+                // the live DB is unchanged — report that distinctly rather
+                // than as a successful write, or the GM thinks their authoring
+                // edit took effect when it didn't.
+                tracing::warn!(
+                    entity_id,
+                    label,
+                    "authoring SQL affected 0 rows — live DB unchanged"
+                );
+                send_gm_feedback_to_client(
+                    entity_id,
+                    &format!(
+                        "{label}: live DB UNCHANGED (0 rows matched) — seed SQL recorded; \
+                         check the target exists"
+                    ),
+                    transport,
+                    connected,
+                    entity_to_addr,
+                )
+                .await;
+            } else {
+                tracing::info!(entity_id, label, rows, "authoring SQL executed");
+                send_gm_feedback_to_client(
+                    entity_id,
+                    &format!("{label}: live DB write ok ({rows} row(s); wiped on next deploy)"),
+                    transport,
+                    connected,
+                    entity_to_addr,
+                )
+                .await;
+            }
         }
         Err(e) => {
             tracing::warn!(entity_id, label, error = %e, "authoring SQL failed");

--- a/crates/services/src/base/dialog_overrides.rs
+++ b/crates/services/src/base/dialog_overrides.rs
@@ -1,0 +1,298 @@
+//! Cimmeria-side overrides for `CookedDataDialogs.pak` entries.
+//!
+//! A dialog's player-visible body text lives in the `_<dialogId>` entry
+//! inside `CookedDataDialogs.pak` on the client — **not** in any wire
+//! message or in the server's `dialogs` / `dialog_screens` tables. The
+//! server's `displayDialog` path only carries the dialog *id*; the client
+//! looks the screen text up from its own cooked catalogue. So editing a
+//! row in `db/resources/Dialogs/Seed/dialog_screens.sql` has zero in-game
+//! effect on what renders — and a brand-new dialog id the client has never
+//! seen renders as an empty box.
+//!
+//! Same trick as [`super::mission_overrides`] / [`super::item_overrides`]:
+//! patch the catalogue in memory at server startup and lean on the
+//! cooked-data wire path (`versionInfoRequest` → `onVersionInfo(InvalidKeys
+//! =[...])` → `resourceFragment(_key, patched XML)`) to push the entry to
+//! the client. Self-healing — runtime cache invalidation, no manual client
+//! steps, no on-disk PAK edit, no client-artifact redistribution.
+//!
+//! Unlike the mission/item override modules, which *patch* an attribute or
+//! splice a child into the canonical XML, a dialog override **regenerates
+//! the whole `<COOKED_DIALOG>` entry from scratch**. The cooked dialog
+//! entries are small (root + one or more `<Screens>`) and we control every
+//! field, so emitting the complete Server-Build XML is more robust than
+//! anchoring on a substring — and it makes the *new-entry* case (a dialog
+//! id the PAK never shipped, like the Guard corpse's 3996) identical to the
+//! *corrected-entry* case (Frost's 3995): both are just an
+//! `elements.insert(dialog_id, generated_xml)`.
+//!
+//! The emitted XML follows the Server-Build conventions documented in
+//! [`docs/engine/cooked-data-pak-format.md`]: no SOAP namespaces,
+//! alphabetized root attributes (`DialogFlags`, `DialogID`,
+//! `KismetEventSetID`, `UIScreenType`), and child `<Screens>` with
+//! `SpeakerID` → `ScreenID` → `Text` order and an explicit `</Screens>`
+//! close.
+
+/// One screen line within a dialog. `text` is the raw, human-readable
+/// string — XML escaping (`"` → `&quot;`, `&` → `&amp;`, `<`/`>`) is
+/// applied by the generator, so callers write the text exactly as it
+/// should read in-game.
+pub struct DialogScreen {
+    pub screen_id: u32,
+    /// Speaker entity id. `0` for a system/narrator line (the search-body
+    /// dialogs are narrator text, not spoken by an NPC).
+    pub speaker_id: u32,
+    pub text: &'static str,
+}
+
+/// One dialog's override: the dialog id to (re)generate and its screen
+/// lines. Applies to both a corrected existing dialog and a brand-new one
+/// the canonical PAK never shipped.
+///
+/// `dialog_id` is the cooked catalogue key (`_<dialog_id>` in the PAK),
+/// the same id carried by the server's `displayDialog` path and stored in
+/// `db/resources/Dialogs/Seed/dialogs.sql`.
+///
+/// `ui_screen_type` mirrors the `dialogs.ui_screen_type` enum value the
+/// client expects; `2` is `DUIST_DefaultDialog` (the plain text box used
+/// by the search-corpse dialogs — see `entities/defs/enumerations.xml`).
+pub struct DialogOverride {
+    pub dialog_id: u32,
+    pub dialog_flags: u32,
+    pub kismet_event_set_id: u32,
+    pub ui_screen_type: u32,
+    pub screens: &'static [DialogScreen],
+}
+
+/// All Cimmeria-introduced dialog overrides for the `CookedDataDialogs`
+/// category (id `5`). Adding a new entry here:
+///
+///   1. Insert/patch the row(s) in
+///      `db/resources/Dialogs/Seed/dialogs.sql` and
+///      `db/resources/Dialogs/Seed/dialog_screens.sql` so the server-side
+///      catalogue agrees (documentary + used by any server-side log/debug
+///      string — the client renders from this override, not the DB).
+///   2. Add a `DialogOverride` here so the client's UI actually renders
+///      the text via the per-key invalidation handshake.
+///   3. Bind the dialog to its template via a `dialog_set_maps` row (and,
+///      for a new clickable corpse, a content-chain `add_dialog_set` +
+///      `set_interaction_type`).
+///
+/// The override text and the `dialog_screens.sql` text must be kept in
+/// sync by hand — the override is the source of truth for what the player
+/// sees; the seed row is the canonical record for committing to the repo.
+pub const DIALOG_OVERRIDES: &[DialogOverride] = &[
+    // Mission 622 "Arm Yourself!" — Frost's corpse (dialog 3995). The
+    // canonical PAK never shipped 3995 (it's a Cimmeria-added dialog), and
+    // after the loot split Frost grants ONLY the letter, so the body text
+    // must not mention the pistol. Regenerated here, letter-only.
+    DialogOverride {
+        dialog_id: 3995,
+        dialog_flags: 0,
+        kismet_event_set_id: 0,
+        ui_screen_type: 2,
+        screens: &[DialogScreen {
+            screen_id: 96108,
+            speaker_id: 0,
+            text: "There are no obvious wounds on Cpl. Frost, though it appears he died \
+                   soon after killing that NID Guard. On his body you find a letter \
+                   addressed to \"Jess\" - Frost's wife.",
+        }],
+    },
+    // Mission 622 loot split — the NID Guard's corpse (dialog 3996). A
+    // brand-new dialog the PAK never shipped; bound to template 21 via
+    // chain 1001's `add_dialog_set`. Searching the Guard yields the pistol
+    // (chain 1005) — this is the immersion text shown on that search.
+    DialogOverride {
+        dialog_id: 3996,
+        dialog_flags: 0,
+        kismet_event_set_id: 0,
+        ui_screen_type: 2,
+        screens: &[DialogScreen {
+            screen_id: 96109,
+            speaker_id: 0,
+            text: "The NID Guard died with his weapon still drawn. You pry the pistol \
+                   from his grip - it's still serviceable.",
+        }],
+    },
+];
+
+/// XML-escape a text value destined for a double-quoted attribute.
+///
+/// Escapes the five XML predefined entities. `"` → `&quot;` is the
+/// load-bearing one for these dialogs (the Frost text quotes "Jess");
+/// `&` must come logically "first" in intent but since we scan char by
+/// char and emit the entity for each source char, ordering is a non-issue
+/// — a literal `&` in the source becomes `&amp;`, never re-escaped.
+fn escape_xml_attr(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    for c in text.chars() {
+        match c {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&apos;"),
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+/// Generate the full Server-Build `<COOKED_DIALOG>` XML bytes for one
+/// override. Always succeeds — there's no canonical entry to anchor
+/// against, we emit the complete document from the struct fields.
+///
+/// Root attributes are alphabetized (`DialogFlags`, `DialogID`,
+/// `KismetEventSetID`, `UIScreenType`); each `<Screens>` child emits
+/// `SpeakerID` → `ScreenID` → `Text` with an explicit close, matching the
+/// Server-Build shape in `docs/engine/cooked-data-pak-format.md`.
+pub fn generate_dialog_xml(ov: &DialogOverride) -> Vec<u8> {
+    let mut xml = String::with_capacity(256);
+    xml.push_str("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
+    xml.push_str(&format!(
+        "<COOKED_DIALOG DialogFlags=\"{}\" DialogID=\"{}\" KismetEventSetID=\"{}\" \
+         UIScreenType=\"{}\">",
+        ov.dialog_flags, ov.dialog_id, ov.kismet_event_set_id, ov.ui_screen_type,
+    ));
+    for screen in ov.screens {
+        xml.push_str(&format!(
+            "<Screens SpeakerID=\"{}\" ScreenID=\"{}\" Text=\"{}\"></Screens>",
+            screen.speaker_id,
+            screen.screen_id,
+            escape_xml_attr(screen.text),
+        ));
+    }
+    xml.push_str("</COOKED_DIALOG>");
+    xml.into_bytes()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The generated XML must be well-formed Server-Build shape: no SOAP
+    /// namespaces, alphabetized root attributes, explicit `</Screens>` and
+    /// `</COOKED_DIALOG>` closes.
+    #[test]
+    fn generated_xml_has_server_build_shape() {
+        let ov = &DIALOG_OVERRIDES[0];
+        let bytes = generate_dialog_xml(ov);
+        let s = std::str::from_utf8(&bytes).expect("generated XML is utf-8");
+
+        assert!(s.starts_with("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"));
+        assert!(
+            s.contains(
+                "<COOKED_DIALOG DialogFlags=\"0\" DialogID=\"3995\" \
+                 KismetEventSetID=\"0\" UIScreenType=\"2\">"
+            ),
+            "root attributes must be alphabetized Server-Build order: {s}",
+        );
+        assert!(
+            !s.contains("SOAP-ENV") && !s.contains("xmlns"),
+            "Server-Build XML must not carry SOAP namespaces: {s}",
+        );
+        assert!(
+            s.contains("</Screens>"),
+            "explicit Screens close required: {s}"
+        );
+        assert!(
+            s.ends_with("</COOKED_DIALOG>"),
+            "explicit root close required: {s}"
+        );
+    }
+
+    /// The Frost text quotes "Jess" — those double quotes MUST be escaped
+    /// to `&quot;` or the attribute terminates early and the client either
+    /// truncates the line or rejects the entry. Load-bearing for 3995.
+    #[test]
+    fn frost_dialog_escapes_embedded_quotes() {
+        let ov = DIALOG_OVERRIDES
+            .iter()
+            .find(|o| o.dialog_id == 3995)
+            .expect("Frost dialog 3995 must be registered");
+        let bytes = generate_dialog_xml(ov);
+        let s = std::str::from_utf8(&bytes).expect("utf-8");
+
+        assert!(
+            s.contains("&quot;Jess&quot;"),
+            "embedded quotes around Jess must be escaped to &quot;: {s}",
+        );
+        // The raw, unescaped `Text="..."Jess"..."` must never appear — that
+        // would be a prematurely-terminated attribute.
+        assert!(
+            !s.contains("\"Jess\""),
+            "no raw unescaped double-quoted Jess may survive into the attribute: {s}",
+        );
+    }
+
+    /// Frost (3995) must be letter-only after the loot split — no mention
+    /// of the pistol. The pistol lives on the Guard corpse (3996). Pins the
+    /// text contract that mirrors the chain-level loot split.
+    #[test]
+    fn frost_dialog_is_letter_only_no_pistol() {
+        let ov = DIALOG_OVERRIDES
+            .iter()
+            .find(|o| o.dialog_id == 3995)
+            .expect("Frost dialog 3995 must be registered");
+        let body = ov.screens[0].text.to_lowercase();
+        assert!(
+            body.contains("letter"),
+            "Frost dialog must mention the letter"
+        );
+        assert!(
+            !body.contains("pistol"),
+            "Frost dialog must NOT mention the pistol after the loot split — \
+             that belongs to the Guard corpse (3996)",
+        );
+    }
+
+    /// The Guard corpse (3996) is the pistol-search immersion dialog. Pins
+    /// that it's registered and mentions the pistol.
+    #[test]
+    fn guard_dialog_mentions_pistol() {
+        let ov = DIALOG_OVERRIDES
+            .iter()
+            .find(|o| o.dialog_id == 3996)
+            .expect("Guard dialog 3996 must be registered");
+        assert!(
+            ov.screens[0].text.to_lowercase().contains("pistol"),
+            "Guard corpse dialog must mention the pistol for immersion",
+        );
+    }
+
+    /// Every registered override generates a `Text="..."` whose ScreenID
+    /// and DialogID land in the output. Guards against a future entry whose
+    /// fields don't make it into the emitted XML.
+    #[test]
+    fn all_overrides_emit_their_ids_and_text() {
+        for ov in DIALOG_OVERRIDES {
+            let bytes = generate_dialog_xml(ov);
+            let s = std::str::from_utf8(&bytes).expect("utf-8");
+            assert!(
+                s.contains(&format!("DialogID=\"{}\"", ov.dialog_id)),
+                "override {} must emit its DialogID",
+                ov.dialog_id,
+            );
+            for screen in ov.screens {
+                assert!(
+                    s.contains(&format!("ScreenID=\"{}\"", screen.screen_id)),
+                    "override {} must emit ScreenID {}",
+                    ov.dialog_id,
+                    screen.screen_id,
+                );
+            }
+        }
+    }
+
+    /// `escape_xml_attr` covers all five predefined entities and leaves
+    /// apostrophes-as-`&apos;` (safe inside a double-quoted attribute, and
+    /// harmless). Pins the escaping contract directly.
+    #[test]
+    fn escape_covers_predefined_entities() {
+        assert_eq!(
+            escape_xml_attr("a & b < c > d \" e ' f"),
+            "a &amp; b &lt; c &gt; d &quot; e &apos; f",
+        );
+    }
+}

--- a/crates/services/src/base/gm_feedback.rs
+++ b/crates/services/src/base/gm_feedback.rs
@@ -24,9 +24,14 @@ use crate::base::helpers::send_to_witness_reliable;
 use crate::base::ConnectedClientState;
 use crate::mercury::{build_player_entity_method_packet, method_idx};
 
-/// Feedback chat channel id (`EChannel.CHAN_FEEDBACK = 8`, from
-/// `python/Atrea/enums.py`). Mirrors the cell-side feedback channel.
-const CHAN_FEEDBACK: u8 = 8;
+/// GM-feedback chat channel. The 2009 client only registers the channels in the
+/// base's `DEFAULT_CHAT_CHANNELS` (say/emote/yell/team/squad/command/server=7/
+/// tell=9); there is **no** dedicated feedback channel. Sending on an
+/// *unregistered* channel — the old value `8` — makes the client fall back to
+/// its **red unknown-channel splash popup**. So GM feedback rides the registered
+/// `tell` channel (`9`), the same one the inline welcome message uses. Mirrors
+/// the cell-side feedback channel.
+const CHAN_FEEDBACK: u8 = 9;
 
 /// Serialize `onPlayerCommunication(Speaker, SpeakerFlags, Channel, Text)`.
 ///
@@ -103,7 +108,7 @@ mod tests {
     use super::*;
 
     /// Feedback wire shape: speaker "SYSTEM" (6 UTF-16 chars), flags 0,
-    /// channel 8 (CHAN_FEEDBACK), then the text WSTRING. A drift here means
+    /// channel 9 (CHAN_feedback), then the text WSTRING. A drift here means
     /// the GM's client renders the feedback on the wrong channel or not at
     /// all. Byte-identical to the cell-side serializer's pinned shape.
     #[test]
@@ -116,8 +121,9 @@ mod tests {
         assert_eq!(
             args[flags_off + 1],
             CHAN_FEEDBACK,
-            "channel must be feedback (8)"
+            "channel must be feedback (9), not server (8)"
         );
+        assert_eq!(CHAN_FEEDBACK, 9, "feedback must use CHAN_feedback=9");
         // Text WSTRING char count follows speaker + flags + channel.
         let text_len_off = flags_off + 2;
         assert_eq!(

--- a/crates/services/src/base/mission_overrides.rs
+++ b/crates/services/src/base/mission_overrides.rs
@@ -77,13 +77,35 @@ pub struct MissionOverride {
 // real text on both produces a visibly duplicated line in the mission log
 // (the screenshot from the live UI on the Frost step).
 pub const MISSION_OVERRIDES: &[MissionOverride] = &[
+    // Mission 622's loot split is sequenced Frost → Guard via an intermediate
+    // step, so the corpse search survives a relog: each step gates the next
+    // body's binding (re-applied on login by chains 1006/1007). Two
+    // Cimmeria-introduced steps sit between the canonical step 2113 and the
+    // equip step, in XML index order:
+    //   index 0: 2113   (canonical) — search Cpl. Frost
+    //   index 1: 80623  (below)     — search the NID Guard's corpse
+    //   index 2: 80622  (below)     — equip the pistol
+    // The two overrides MUST stay in this array order: 80623 is injected after
+    // 2113 first, so the 80622 entry can anchor on 80623's `</Steps>`. Every
+    // advance is +1 in XML index (2113→80623, 80623→80622, 80622→complete),
+    // which the client's sequential-progression guard honours.
     MissionOverride {
         mission_id: 622,
-        // Insert immediately after step 2113 ("Search the nearby corpses").
-        // Chain 1003 advances 2113 → 80622 on Frost loot; for the client
-        // to render the new step instead of skipping it, 80622's XML
-        // index must equal current+1 = 1.
         insert_after_step_id: 2113,
+        injected_steps_xml:
+            "<Steps StepEnabled=\"false\" StepID=\"80623\" AwardXP=\"false\" Difficulty=\"1\">\
+             <StepDisplayLogText>Search the NID Guard's body for a weapon.</StepDisplayLogText>\
+             <Objectives IsOptional=\"false\" ObjectiveID=\"90623\" AwardXP=\"false\" \
+             IsHidden=\"false\" IsEnabled=\"false\" Difficulty=\"1\">\
+             <DisplayLogText> </DisplayLogText>\
+             </Objectives>\
+             </Steps>",
+    },
+    MissionOverride {
+        mission_id: 622,
+        // Anchor on 80623 (injected by the entry above), not 2113 — the equip
+        // step must land at XML index 2, one past the Guard-search step.
+        insert_after_step_id: 80623,
         injected_steps_xml:
             "<Steps StepEnabled=\"false\" StepID=\"80622\" AwardXP=\"false\" Difficulty=\"1\">\
              <StepDisplayLogText>Equip the pistol from your inventory.</StepDisplayLogText>\
@@ -288,21 +310,49 @@ mod tests {
         <StepDisplayLogText>Terminal</StepDisplayLogText></Steps>\
         </COOKED_MISSION>";
 
+    /// Mission 622 now injects TWO steps (80623 Guard-search, then 80622
+    /// equip) so the loot split is sequenced and relog-safe. Applying the 622
+    /// overrides in array order against the canonical single-step shape must
+    /// yield XML order 2113 → 80623 → 80622 — the same index-discipline the
+    /// 641 test pins, since the client treats XML order as the step index and
+    /// snaps forward on any advance that jumps the index by more than one.
     #[test]
-    fn override_inserts_immediately_after_named_step() {
-        let ov = &MISSION_OVERRIDES[0];
-        assert_eq!(ov.mission_id, 622);
+    fn override_622_injects_guard_then_equip_in_order() {
+        let ovs_622: Vec<&MissionOverride> = MISSION_OVERRIDES
+            .iter()
+            .filter(|o| o.mission_id == 622)
+            .collect();
+        assert_eq!(
+            ovs_622.len(),
+            2,
+            "mission 622 must have exactly two overrides (Guard-search + equip)",
+        );
 
-        let patched = apply_override(SAMPLE_622, ov).expect("override must apply");
-        let s = std::str::from_utf8(&patched).expect("output is utf-8");
+        // Apply both in registry order, compounding on the same XML.
+        let mut bytes = SAMPLE_622.to_vec();
+        for ov in &ovs_622 {
+            bytes = apply_override(&bytes, ov).unwrap_or_else(|| {
+                panic!(
+                    "622 override (after step {}) must apply",
+                    ov.insert_after_step_id
+                )
+            });
+        }
+        let s = std::str::from_utf8(&bytes).expect("output is utf-8");
 
-        assert!(s.contains("StepID=\"2113\""), "original step missing: {s}");
-        assert!(s.contains("StepID=\"80622\""), "new step missing: {s}");
-        let new_steps_at = s.find("StepID=\"80622\"").unwrap();
-        let close_at = s.find("</COOKED_MISSION>").unwrap();
+        let pos_2113 = s.find("StepID=\"2113\"").expect("step 2113 must remain");
+        let pos_80623 = s
+            .find("StepID=\"80623\"")
+            .expect("Guard-search step 80623 must appear");
+        let pos_80622 = s
+            .find("StepID=\"80622\"")
+            .expect("equip step 80622 must appear");
+        let close_at = s.find("</COOKED_MISSION>").expect("root close must remain");
+
         assert!(
-            new_steps_at < close_at,
-            "injected steps must precede closing tag",
+            pos_2113 < pos_80623 && pos_80623 < pos_80622 && pos_80622 < close_at,
+            "XML order must be 2113 → 80623 → 80622 → </COOKED_MISSION>; got \
+             2113={pos_2113} 80623={pos_80623} 80622={pos_80622} close={close_at}\n{s}",
         );
     }
 

--- a/crates/services/src/base/mod.rs
+++ b/crates/services/src/base/mod.rs
@@ -25,6 +25,7 @@ pub(crate) mod console_authoring;
 pub(crate) mod cooked_data;
 pub(crate) mod crafting;
 pub(crate) mod deferred_aoi;
+pub(crate) mod dialog_overrides;
 pub(crate) mod dispatch;
 pub(crate) mod gm_feedback;
 pub(crate) mod gm_spawn;

--- a/crates/services/src/base/mod.rs
+++ b/crates/services/src/base/mod.rs
@@ -21,6 +21,7 @@ pub(crate) mod character;
 pub(crate) mod character_create;
 pub(crate) mod chardef;
 pub(crate) mod connect_loop;
+pub(crate) mod console_authoring;
 pub(crate) mod cooked_data;
 pub(crate) mod crafting;
 pub(crate) mod deferred_aoi;

--- a/crates/services/src/base/resources/mod.rs
+++ b/crates/services/src/base/resources/mod.rs
@@ -150,6 +150,12 @@ const CATEGORY_MISSIONS: u32 = 3;
 /// Per-item icon, name, max-stack lookups land here on the client.
 const CATEGORY_ITEMS: u32 = 4;
 
+/// Category id for `CookedDataDialogs.pak` (see [`CATEGORY_PAKS`]).
+/// Per-dialog screen text is rendered from this catalogue client-side,
+/// not from any wire message — so a corrected or new dialog body must be
+/// pushed via the cooked-data invalidation handshake.
+const CATEGORY_DIALOGS: u32 = 5;
+
 /// Compute the deterministic metadata bump for a set of overrides.
 ///
 /// The bump is hashed from every field that affects what the client sees:
@@ -190,6 +196,28 @@ fn compute_item_metadata_bump(overrides: &[super::item_overrides::ItemOverride])
         ov.item_id.hash(&mut hasher);
         ov.new_icon_location.hash(&mut hasher);
         ov.new_max_stack_size.hash(&mut hasher);
+    }
+    ((hasher.finish() as u32) & 0xFFFF) | 0x1
+}
+
+/// Companion of [`compute_metadata_bump`] for the dialogs category.
+/// Hashes every field that affects the rendered XML (dialog id, flags,
+/// kismet/screen-type, and each screen's id/speaker/text) so two server
+/// starts on identical override content produce identical bumps and no
+/// re-invalidation churn; any edit changes the bump and refetches.
+fn compute_dialog_metadata_bump(overrides: &[super::dialog_overrides::DialogOverride]) -> u32 {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    for ov in overrides {
+        ov.dialog_id.hash(&mut hasher);
+        ov.dialog_flags.hash(&mut hasher);
+        ov.kismet_event_set_id.hash(&mut hasher);
+        ov.ui_screen_type.hash(&mut hasher);
+        for screen in ov.screens {
+            screen.screen_id.hash(&mut hasher);
+            screen.speaker_id.hash(&mut hasher);
+            screen.text.hash(&mut hasher);
+        }
     }
     ((hasher.finish() as u32) & 0xFFFF) | 0x1
 }
@@ -242,6 +270,11 @@ impl ResourceCache {
         // category.
         let item_overridden = Self::apply_item_overrides(&mut categories);
         overridden_elements.extend(item_overridden);
+        // Dialogs category (5) — disjoint from missions (3) / items (4),
+        // so the same `extend` discipline applies: each call owns its own
+        // category id and can't clobber another's invalid-keys list.
+        let dialog_overridden = Self::apply_dialog_overrides(&mut categories);
+        overridden_elements.extend(dialog_overridden);
 
         Ok(Self {
             categories: Arc::new(categories),
@@ -315,6 +348,65 @@ impl ResourceCache {
         overridden
     }
 
+    /// Patch the freshly-loaded `CookedDataDialogs` category with
+    /// Cimmeria's regenerated dialog entries, bumping the category
+    /// metadata so the client's next `versionInfoRequest` triggers the
+    /// per-key invalidation handshake.
+    ///
+    /// Unlike [`Self::apply_item_overrides`] / [`Self::apply_mission_overrides`],
+    /// each override *regenerates* the whole `<COOKED_DIALOG>` entry rather
+    /// than patching a substring, so it works whether or not the dialog id
+    /// was present in the PAK: a corrected existing dialog (Frost's 3995)
+    /// and a brand-new one (the Guard corpse's 3996) are both just an
+    /// `elements.insert(dialog_id, generated)`. There's no "entry not
+    /// present" skip and no "XML shape didn't match" failure — generation
+    /// is infallible.
+    fn apply_dialog_overrides(
+        categories: &mut HashMap<u32, CategoryData>,
+    ) -> HashMap<u32, Vec<u32>> {
+        use super::dialog_overrides::{generate_dialog_xml, DIALOG_OVERRIDES};
+
+        let mut overridden: HashMap<u32, Vec<u32>> = HashMap::new();
+        if DIALOG_OVERRIDES.is_empty() {
+            return overridden;
+        }
+
+        let Some(dialogs) = categories.get_mut(&CATEGORY_DIALOGS) else {
+            tracing::warn!(
+                category = CATEGORY_DIALOGS,
+                "CookedDataDialogs not loaded; skipping dialog overrides"
+            );
+            return overridden;
+        };
+
+        let mut applied: Vec<u32> = Vec::with_capacity(DIALOG_OVERRIDES.len());
+        for ov in DIALOG_OVERRIDES {
+            let was_present = dialogs.elements.contains_key(&ov.dialog_id);
+            let patched = generate_dialog_xml(ov);
+            dialogs.elements.insert(ov.dialog_id, patched);
+            applied.push(ov.dialog_id);
+            tracing::info!(
+                dialog_id = ov.dialog_id,
+                replaced_existing = was_present,
+                "Applied Cimmeria dialog override",
+            );
+        }
+
+        let bump = compute_dialog_metadata_bump(DIALOG_OVERRIDES);
+        dialogs.metadata = dialogs.metadata.wrapping_add(bump);
+        applied.sort_unstable();
+        tracing::info!(
+            category = CATEGORY_DIALOGS,
+            count = applied.len(),
+            bump,
+            bumped_metadata = dialogs.metadata,
+            "Cimmeria dialog overrides applied; metadata bumped",
+        );
+        overridden.insert(CATEGORY_DIALOGS, applied);
+
+        overridden
+    }
+
     /// Mutate the freshly-loaded `CookedDataMissions` category to include
     /// Cimmeria's added mission steps, bumping the category metadata so
     /// the client's version check sees a fresh value and triggers the
@@ -354,7 +446,12 @@ impl ResourceCache {
             match apply_override(original, ov) {
                 Some(patched) => {
                     missions.elements.insert(ov.mission_id, patched);
-                    applied.push(ov.mission_id);
+                    // A mission can have multiple overrides (e.g. 622 injects
+                    // both the Guard-search and equip steps); list its id once
+                    // so InvalidKeys names each patched entry a single time.
+                    if !applied.contains(&ov.mission_id) {
+                        applied.push(ov.mission_id);
+                    }
                     tracing::info!(
                         mission_id = ov.mission_id,
                         "Applied Cimmeria mission override",

--- a/crates/services/src/base/resources/tests.rs
+++ b/crates/services/src/base/resources/tests.rs
@@ -517,6 +517,145 @@ fn compute_item_metadata_bump_is_deterministic_and_low_bit_set() {
     );
 }
 
+// ── dialog overrides ────────────────────────────────────────────────────────
+
+/// Build a `CookedDataDialogs` category fixture. `present` lists dialog ids
+/// that already exist in the PAK (with arbitrary stale bytes); the override
+/// regenerates them wholesale, so the original content is irrelevant.
+fn dialogs_category_with(present: &[u32], metadata: u32) -> CategoryData {
+    let mut elements = HashMap::new();
+    for &id in present {
+        elements.insert(id, format!("<STALE id={id}/>").into_bytes());
+    }
+    CategoryData { metadata, elements }
+}
+
+/// Post-condition pin for the dialog-override path: a registered dialog that
+/// already exists in the PAK (3995, Frost) is regenerated wholesale, a brand
+/// new one (3996, Guard) is inserted, the metadata is bumped, and the
+/// overridden-ids map names both in ascending order. Mirrors the mission/item
+/// override post-condition tests.
+#[test]
+fn apply_dialog_overrides_regenerates_existing_and_inserts_new() {
+    let starting_metadata = 4242;
+    let mut categories: HashMap<u32, CategoryData> = HashMap::new();
+    // 3995 present (stale); 3996 absent so we exercise the new-key insert.
+    categories.insert(
+        CATEGORY_DIALOGS,
+        dialogs_category_with(&[3995], starting_metadata),
+    );
+
+    let overridden = ResourceCache::apply_dialog_overrides(&mut categories);
+
+    let dialogs = categories
+        .get(&CATEGORY_DIALOGS)
+        .expect("dialogs category must remain after apply");
+
+    // Metadata bumped, low bit set.
+    assert_ne!(
+        dialogs.metadata, starting_metadata,
+        "apply must bump the dialogs metadata so the client invalidates and refetches",
+    );
+    assert_eq!(
+        dialogs.metadata.wrapping_sub(starting_metadata) & 0x1,
+        0x1,
+        "low bit of bump must be set",
+    );
+
+    // 3995 regenerated: real Server-Build XML, letter-only, no stale marker.
+    let d3995 = std::str::from_utf8(dialogs.elements.get(&3995).unwrap()).unwrap();
+    assert!(
+        d3995.contains("<COOKED_DIALOG") && d3995.contains("DialogID=\"3995\""),
+        "3995 must be regenerated as a COOKED_DIALOG; got: {d3995}",
+    );
+    assert!(
+        !d3995.contains("STALE"),
+        "3995's stale PAK bytes must be fully replaced; got: {d3995}",
+    );
+    assert!(
+        d3995.contains("letter") && !d3995.to_lowercase().contains("pistol"),
+        "3995 (Frost) must be letter-only after the loot split; got: {d3995}",
+    );
+
+    // 3996 inserted (was absent in the fixture).
+    let d3996 = std::str::from_utf8(
+        dialogs
+            .elements
+            .get(&3996)
+            .expect("3996 must be inserted even though it was absent from the PAK"),
+    )
+    .unwrap();
+    assert!(
+        d3996.contains("DialogID=\"3996\"") && d3996.to_lowercase().contains("pistol"),
+        "3996 (Guard) must be the pistol-search dialog; got: {d3996}",
+    );
+
+    let ids = overridden
+        .get(&CATEGORY_DIALOGS)
+        .expect("dialogs must appear in the returned map");
+    assert_eq!(
+        ids.as_slice(),
+        &[3995u32, 3996u32],
+        "overridden_elements must name both dialog ids in ascending order",
+    );
+}
+
+/// Defensive path: dialogs category absent (PAK missing) → no-op return,
+/// server startup keeps going. Mirrors the mission/item analogues.
+#[test]
+fn apply_dialog_overrides_no_op_when_category_missing() {
+    let mut categories: HashMap<u32, CategoryData> = HashMap::new();
+    let overridden = ResourceCache::apply_dialog_overrides(&mut categories);
+    assert!(
+        overridden.is_empty(),
+        "missing dialogs category must not produce override entries"
+    );
+}
+
+/// `compute_dialog_metadata_bump` is deterministic across calls, always sets
+/// the low bit, and changes when any screen field changes (so the client
+/// refetches). Companion of the mission/item bump pins.
+#[test]
+fn compute_dialog_metadata_bump_is_deterministic_and_change_sensitive() {
+    use super::super::dialog_overrides::{DialogOverride, DialogScreen};
+
+    const BASE: &[DialogOverride] = &[DialogOverride {
+        dialog_id: 3996,
+        dialog_flags: 0,
+        kismet_event_set_id: 0,
+        ui_screen_type: 2,
+        screens: &[DialogScreen {
+            screen_id: 96109,
+            speaker_id: 0,
+            text: "original",
+        }],
+    }];
+    const CHANGED_TEXT: &[DialogOverride] = &[DialogOverride {
+        dialog_id: 3996,
+        dialog_flags: 0,
+        kismet_event_set_id: 0,
+        ui_screen_type: 2,
+        screens: &[DialogScreen {
+            screen_id: 96109,
+            speaker_id: 0,
+            text: "edited",
+        }],
+    }];
+
+    let a = compute_dialog_metadata_bump(BASE);
+    assert_eq!(
+        a,
+        compute_dialog_metadata_bump(BASE),
+        "same content → same bump"
+    );
+    assert_eq!(a & 0x1, 0x1, "low bit must be set");
+    assert_ne!(
+        a,
+        compute_dialog_metadata_bump(CHANGED_TEXT),
+        "a screen-text edit must change the bump so the client refetches",
+    );
+}
+
 // ── pick_first_open_bag ─────────────────────────────────────────────────────
 
 /// Happy path: a bag with room in the item's container set is picked.

--- a/crates/services/src/base/world_entry/cell_dispatch/mod.rs
+++ b/crates/services/src/base/world_entry/cell_dispatch/mod.rs
@@ -468,6 +468,38 @@ pub(crate) async fn handle_cell_message(
             )
             .await;
         }
+        CellToBaseMsg::ExecuteAuthoringSql {
+            entity_id,
+            label,
+            sql,
+        } => {
+            crate::base::console_authoring::handle_execute_authoring_sql(
+                entity_id,
+                &label,
+                &sql,
+                db_pool,
+                transport,
+                connected,
+                entity_to_addr,
+            )
+            .await;
+        }
+        CellToBaseMsg::ConsoleSearch {
+            entity_id,
+            kind,
+            query,
+        } => {
+            crate::base::console_authoring::handle_console_search(
+                entity_id,
+                kind,
+                &query,
+                db_pool,
+                transport,
+                connected,
+                entity_to_addr,
+            )
+            .await;
+        }
         CellToBaseMsg::GmSpawnNpc {
             entity_id,
             template_id,

--- a/crates/services/src/cell/abilities/mod.rs
+++ b/crates/services/src/cell/abilities/mod.rs
@@ -38,7 +38,7 @@ pub use dispatch::handle_use_ability_on_ground;
 pub(crate) use loot_drop::INT_NORMAL_LOOT;
 pub(crate) use messaging::{
     broadcast_movement_type, request_appearance_refresh, send_entity_method,
-    send_entity_method_to_witnesses,
+    send_entity_method_to_self_and_witnesses, send_entity_method_to_witnesses,
 };
 // `send_entity_method_to_witnesses` and `send_entity_method_to_self_and_witnesses`
 // land here for #278 child PRs to adopt. They stay private to the `messaging`

--- a/crates/services/src/cell/cell_methods/gm/feedback.rs
+++ b/crates/services/src/cell/cell_methods/gm/feedback.rs
@@ -12,9 +12,14 @@ use tokio::sync::mpsc;
 use crate::cell::messages::CellToBaseMsg;
 use crate::mercury::method_idx::ON_PLAYER_COMMUNICATION;
 
-/// Feedback chat channel id (`EChannel.CHAN_FEEDBACK = 8`, from
-/// `python/Atrea/enums.py`). Mirrors [`crate::cell::chat`]'s feedback channel.
-const CHAN_FEEDBACK: u8 = 8;
+/// GM-feedback chat channel. The 2009 client only registers the channels in the
+/// base's `DEFAULT_CHAT_CHANNELS` (say/emote/yell/team/squad/command/server=7/
+/// tell=9); there is **no** dedicated feedback channel. Sending on an
+/// *unregistered* channel — the old value `8` — makes the client fall back to
+/// its **red unknown-channel splash popup**. So GM feedback rides the registered
+/// `tell` channel (`9`), the same one the base's inline welcome message uses; it
+/// renders as a normal, non-error, non-popup line.
+const CHAN_FEEDBACK: u8 = 9;
 
 /// Serialize `onPlayerCommunication(Speaker, SpeakerFlags, Channel, Text)`.
 ///
@@ -78,7 +83,7 @@ mod tests {
     use super::*;
 
     /// Feedback wire shape: speaker "SYSTEM" (6 UTF-16 chars), flags 0,
-    /// channel 8 (CHAN_FEEDBACK), then the text WSTRING. A drift here means the
+    /// channel 9 (CHAN_feedback), then the text WSTRING. A drift here means the
     /// GM's client renders the feedback on the wrong channel or not at all.
     #[tokio::test]
     async fn feedback_wire_shape_is_system_on_feedback_channel() {
@@ -106,8 +111,9 @@ mod tests {
         assert_eq!(
             args[flags_off + 1],
             CHAN_FEEDBACK,
-            "channel must be feedback (8)"
+            "channel must be feedback (9), not server (8)"
         );
+        assert_eq!(CHAN_FEEDBACK, 9, "feedback must use CHAN_feedback=9");
         // Text WSTRING char count follows speaker + flags + channel.
         let text_len_off = flags_off + 2;
         assert_eq!(

--- a/crates/services/src/cell/chat.rs
+++ b/crates/services/src/cell/chat.rs
@@ -79,7 +79,7 @@ pub async fn handle_chat_message(
     space_mgr: &mut SpaceManager,
     engine: &ChainEngine,
 ) {
-    // GM `.`-console interception (#523). The 2009 client forwards `.`-prefixed
+    // GM `.`-console interception. The 2009 client forwards `.`-prefixed
     // input as an ordinary CHAN_SAY chat message rather than eating it (unlike
     // `/`, which the client consumes). When the sender is a GM, we consume the
     // line as a dev/authoring console command and never broadcast it to other
@@ -358,7 +358,7 @@ mod tests {
     }
 
     /// A GM's `.`-command is consumed by the console and never broadcast to
-    /// witnesses (acceptance criterion #523: never appears in others' chat).
+    /// witnesses (never appears in others' chat).
     #[tokio::test]
     async fn gm_dot_command_is_intercepted_not_broadcast() {
         let mut mgr = super::super::space_manager::SpaceManager::new(1);

--- a/crates/services/src/cell/chat.rs
+++ b/crates/services/src/cell/chat.rs
@@ -5,8 +5,10 @@
 //!
 //! Reference: `python/cell/SGWPlayer.py:processPlayerCommunication()`
 
+use cimmeria_content_engine::chain::ChainEngine;
 use tokio::sync::mpsc;
 
+use super::console;
 use super::messages::CellToBaseMsg;
 use super::space_manager::SpaceManager;
 
@@ -28,8 +30,13 @@ pub const CHAN_COMMAND: u8 = 5;
 pub const CHAN_OFFICER: u8 = 6;
 /// Server channel — system broadcasts only.
 pub const CHAN_SERVER: u8 = 7;
-/// Feedback channel — system feedback.
-pub const CHAN_FEEDBACK: u8 = 8;
+/// GM-feedback channel. The client only registers the channels in the base's
+/// `DEFAULT_CHAT_CHANNELS` (say/emote/yell/team/squad/command/server=7/tell=9);
+/// there is **no** dedicated feedback channel, and an *unregistered* channel
+/// (e.g. 8) falls back to the client's red unknown-channel splash popup. So GM
+/// feedback rides the registered `tell` channel (9) — the same channel the
+/// base's inline welcome message uses (`world_entry_chat::CHAN_TELL`).
+pub const CHAN_FEEDBACK: u8 = 9;
 /// Tell channel — direct player-to-player (handled by BaseApp, not here).
 pub const CHAN_TELL: u8 = 9;
 /// Splash screen channel.
@@ -69,8 +76,26 @@ pub async fn handle_chat_message(
     channel: u8,
     text: &str,
     tx: &mpsc::Sender<CellToBaseMsg>,
-    space_mgr: &SpaceManager,
+    space_mgr: &mut SpaceManager,
+    engine: &ChainEngine,
 ) {
+    // GM `.`-console interception (#523). The 2009 client forwards `.`-prefixed
+    // input as an ordinary CHAN_SAY chat message rather than eating it (unlike
+    // `/`, which the client consumes). When the sender is a GM, we consume the
+    // line as a dev/authoring console command and never broadcast it to other
+    // players; a non-GM's `.`-text falls through to normal chat. Auth is on the
+    // server-side `access_level`, never a client-asserted byte.
+    if channel == CHAN_SAY && text.starts_with('.') {
+        let access_level = space_mgr
+            .get_entity(entity_id)
+            .map_or(0, |e| e.access_level);
+        if console::is_gm(access_level) {
+            console::handle_console_command(entity_id, text, tx, space_mgr, engine).await;
+            return;
+        }
+        // Non-GM `.`-text is ordinary chat — fall through to broadcast.
+    }
+
     match channel {
         CHAN_SAY | CHAN_EMOTE | CHAN_YELL => {
             broadcast_to_witnesses(
@@ -252,10 +277,11 @@ mod tests {
 
     #[tokio::test]
     async fn broadcast_to_nonexistent_entity_is_noop() {
-        let mgr = super::super::space_manager::SpaceManager::new(1);
+        let mut mgr = super::super::space_manager::SpaceManager::new(1);
+        let engine = ChainEngine::new();
         let (tx, mut rx) = tokio::sync::mpsc::channel(16);
 
-        handle_chat_message(999, "Bob", 0, CHAN_SAY, "Hello", &tx, &mgr).await;
+        handle_chat_message(999, "Bob", 0, CHAN_SAY, "Hello", &tx, &mut mgr, &engine).await;
 
         // No messages should be sent
         assert!(rx.try_recv().is_err());
@@ -283,8 +309,19 @@ mod tests {
         }
 
         let (tx, mut rx) = tokio::sync::mpsc::channel(32);
+        let engine = ChainEngine::new();
 
-        handle_chat_message(1, "Alice", 0, CHAN_SAY, "Hello world", &tx, &mgr).await;
+        handle_chat_message(
+            1,
+            "Alice",
+            0,
+            CHAN_SAY,
+            "Hello world",
+            &tx,
+            &mut mgr,
+            &engine,
+        )
+        .await;
 
         // Should get 2 messages: one for witness (entity 2) + one for sender (entity 1)
         let mut msgs = Vec::new();
@@ -320,6 +357,76 @@ mod tests {
         }
     }
 
+    /// A GM's `.`-command is consumed by the console and never broadcast to
+    /// witnesses (acceptance criterion #523: never appears in others' chat).
+    #[tokio::test]
+    async fn gm_dot_command_is_intercepted_not_broadcast() {
+        let mut mgr = super::super::space_manager::SpaceManager::new(1);
+        let xml = r#"<?xml version="1.0"?><Spaces><Space WorldName="Agnos" Instanced="false" MinX="0" MaxX="100" MinY="0" MaxY="100" /></Spaces>"#;
+        let cxml = r#"<?xml version="1.0"?><Spaces><Space WorldName="Agnos" /></Spaces>"#;
+        mgr.parse_spaces_xml(xml).unwrap();
+        mgr.create_startup_spaces(cxml).unwrap();
+        mgr.create_entity(1, "Agnos", [10.0, 0.0, 10.0], [0.0; 3])
+            .unwrap();
+        mgr.create_entity(2, "Agnos", [15.0, 0.0, 15.0], [0.0; 3])
+            .unwrap();
+        mgr.connect_entity(1);
+        mgr.connect_entity(2);
+        if let Some(e) = mgr.get_entity_mut(1) {
+            e.access_level = 2; // GameMaster
+            e.witnesses.insert(cimmeria_common::EntityId(2));
+        }
+        let engine = ChainEngine::new();
+        let (tx, mut rx) = tokio::sync::mpsc::channel(64);
+
+        handle_chat_message(1, "Gm", 0, CHAN_SAY, ".players", &tx, &mut mgr, &engine).await;
+
+        // Witness (entity 2) must receive NOTHING — the command was consumed.
+        while let Ok(msg) = rx.try_recv() {
+            if let CellToBaseMsg::EntityMethodCall { entity_id, .. } = msg {
+                assert_ne!(entity_id, 2, "GM .-command must not broadcast to witnesses");
+            }
+        }
+    }
+
+    /// A non-GM's `.`-text is ordinary chat and DOES broadcast.
+    #[tokio::test]
+    async fn non_gm_dot_text_is_normal_chat() {
+        let mut mgr = super::super::space_manager::SpaceManager::new(1);
+        let xml = r#"<?xml version="1.0"?><Spaces><Space WorldName="Agnos" Instanced="false" MinX="0" MaxX="100" MinY="0" MaxY="100" /></Spaces>"#;
+        let cxml = r#"<?xml version="1.0"?><Spaces><Space WorldName="Agnos" /></Spaces>"#;
+        mgr.parse_spaces_xml(xml).unwrap();
+        mgr.create_startup_spaces(cxml).unwrap();
+        mgr.create_entity(1, "Agnos", [10.0, 0.0, 10.0], [0.0; 3])
+            .unwrap();
+        mgr.create_entity(2, "Agnos", [15.0, 0.0, 15.0], [0.0; 3])
+            .unwrap();
+        mgr.connect_entity(1);
+        mgr.connect_entity(2);
+        if let Some(e) = mgr.get_entity_mut(1) {
+            // access_level stays 0 (Player)
+            e.witnesses.insert(cimmeria_common::EntityId(2));
+        }
+        let engine = ChainEngine::new();
+        let (tx, mut rx) = tokio::sync::mpsc::channel(64);
+
+        handle_chat_message(1, "Joe", 0, CHAN_SAY, ".hello", &tx, &mut mgr, &engine).await;
+
+        // Witness (entity 2) should receive the chat broadcast.
+        let mut witness_got_chat = false;
+        while let Ok(msg) = rx.try_recv() {
+            if let CellToBaseMsg::EntityMethodCall { entity_id, .. } = msg {
+                if entity_id == 2 {
+                    witness_got_chat = true;
+                }
+            }
+        }
+        assert!(
+            witness_got_chat,
+            "non-GM .-text must broadcast as normal chat"
+        );
+    }
+
     #[tokio::test]
     async fn non_cell_channel_ignored() {
         let mut mgr = super::super::space_manager::SpaceManager::new(1);
@@ -331,9 +438,10 @@ mod tests {
             .unwrap();
 
         let (tx, mut rx) = tokio::sync::mpsc::channel(16);
+        let engine = ChainEngine::new();
 
         // Tell channel should not be handled by CellService
-        handle_chat_message(1, "Bob", 0, CHAN_TELL, "Hi", &tx, &mgr).await;
+        handle_chat_message(1, "Bob", 0, CHAN_TELL, "Hi", &tx, &mut mgr, &engine).await;
         assert!(rx.try_recv().is_err());
     }
 }

--- a/crates/services/src/cell/console/crafting.rs
+++ b/crates/services/src/cell/console/crafting.rs
@@ -1,0 +1,126 @@
+//! Crafting / discipline console commands (category E): `.learndiscipline`,
+//! `.forgetdiscipline`, `.allcraft`.
+//!
+//! These route through the existing crafting grant plumbing
+//! (`CellToBaseMsg::GrantExpertise` → `base::crafting::handlers`). Discipline
+//! expertise is clamped `[0, 100]` base-side, so "forget" zeroes the expertise
+//! (a full row delete would need a dedicated base path, noted in feedback).
+//!
+//! Legacy reference: `deprecated/python/cell/commands/Crafting.py`.
+
+use tokio::sync::mpsc;
+
+use super::send_gm_feedback;
+use crate::cell::messages::CellToBaseMsg;
+use crate::cell::space_manager::SpaceManager;
+
+pub(super) async fn dispatch(
+    name: &str,
+    caller_id: u32,
+    args: &[&str],
+    target_id: Option<u32>,
+    tx: &mpsc::Sender<CellToBaseMsg>,
+    space_mgr: &mut SpaceManager,
+) {
+    let Some(target) = target_id else {
+        send_gm_feedback(
+            caller_id,
+            &format!(".{name}: a player target is required."),
+            tx,
+        )
+        .await;
+        return;
+    };
+    let Some(player_id) = space_mgr.get_entity(target).and_then(|e| e.player_id) else {
+        send_gm_feedback(caller_id, &format!(".{name}: target has no player id."), tx).await;
+        return;
+    };
+    match name {
+        "learndiscipline" => learn(caller_id, target, player_id, args, tx).await,
+        "forgetdiscipline" => forget(caller_id, target, player_id, args, tx).await,
+        "allcraft" => all_craft(caller_id, tx).await,
+        _ => {}
+    }
+}
+
+/// `.learndiscipline <disciplineId> [expertise=1]` — learn/raise a discipline.
+async fn learn(
+    caller_id: u32,
+    target: u32,
+    player_id: i32,
+    args: &[&str],
+    tx: &mpsc::Sender<CellToBaseMsg>,
+) {
+    let Some(discipline_id) = super::parse_i32(caller_id, args, 0, "disciplineId", tx).await else {
+        return;
+    };
+    let expertise = match args.get(1) {
+        Some(s) => match s.parse::<i32>() {
+            Ok(v) if v > 0 => v,
+            _ => {
+                send_gm_feedback(caller_id, "expertise must be a positive integer.", tx).await;
+                return;
+            }
+        },
+        None => 1,
+    };
+    let _ = tx
+        .send(CellToBaseMsg::GrantExpertise {
+            entity_id: target,
+            player_id,
+            discipline_id,
+            amount: expertise,
+        })
+        .await;
+    send_gm_feedback(
+        caller_id,
+        &format!("learndiscipline [{target}] discipline {discipline_id} +{expertise}"),
+        tx,
+    )
+    .await;
+}
+
+/// `.forgetdiscipline <disciplineId>` — zero out a discipline's expertise. (The
+/// base grant path clamps to `[0, 100]`; a negative delta drives it to 0.)
+async fn forget(
+    caller_id: u32,
+    target: u32,
+    player_id: i32,
+    args: &[&str],
+    tx: &mpsc::Sender<CellToBaseMsg>,
+) {
+    let Some(discipline_id) = super::parse_i32(caller_id, args, 0, "disciplineId", tx).await else {
+        return;
+    };
+    let _ = tx
+        .send(CellToBaseMsg::GrantExpertise {
+            entity_id: target,
+            player_id,
+            discipline_id,
+            amount: -100,
+        })
+        .await;
+    send_gm_feedback(
+        caller_id,
+        &format!(
+            "forgetdiscipline [{target}] discipline {discipline_id} -> expertise 0 \
+             (row not deleted)"
+        ),
+        tx,
+    )
+    .await;
+}
+
+/// `.allcraft` — the legacy granted every blueprint + max racial paradigm + all
+/// disciplines. That needs the full blueprint/discipline/paradigm catalog, which
+/// is not cached cell-side and has no consolidated base grant path, so this is a
+/// pointer to the per-discipline grant rather than a silent partial unlock.
+async fn all_craft(caller_id: u32, tx: &mpsc::Sender<CellToBaseMsg>) {
+    send_gm_feedback(
+        caller_id,
+        "allcraft: full blueprint unlock isn't wired cell-side. Use \
+         .learndiscipline <id> 100 per discipline (and the native gm crafting grants).",
+        tx,
+    )
+    .await;
+}

--- a/crates/services/src/cell/console/crafting.rs
+++ b/crates/services/src/cell/console/crafting.rs
@@ -54,6 +54,12 @@ async fn learn(
     let Some(discipline_id) = super::parse_i32(caller_id, args, 0, "disciplineId", tx).await else {
         return;
     };
+    // Discipline ids are positive keys; reject 0/negative before sending the
+    // grant so an invalid key can't be written to the player's expertise.
+    if discipline_id <= 0 {
+        send_gm_feedback(caller_id, "disciplineId must be a positive integer.", tx).await;
+        return;
+    }
     let expertise = match args.get(1) {
         Some(s) => match s.parse::<i32>() {
             Ok(v) if v > 0 => v,
@@ -92,6 +98,10 @@ async fn forget(
     let Some(discipline_id) = super::parse_i32(caller_id, args, 0, "disciplineId", tx).await else {
         return;
     };
+    if discipline_id <= 0 {
+        send_gm_feedback(caller_id, "disciplineId must be a positive integer.", tx).await;
+        return;
+    }
     let _ = tx
         .send(CellToBaseMsg::GrantExpertise {
             entity_id: target,

--- a/crates/services/src/cell/console/entity.rs
+++ b/crates/services/src/cell/console/entity.rs
@@ -1,0 +1,462 @@
+//! Live entity / content authoring (category A): edit a spawned entity's
+//! authored properties in memory and (where a clean wire path exists) re-push to
+//! the AoI.
+//!
+//! Most of these mutate `CellEntity` fields and are **in-memory only** — the
+//! change is visible immediately to anyone whose AoI re-enters the entity, but
+//! is not persisted (pair with `.savespawn` for that). Appearance-affecting
+//! edits on a player re-broadcast `BeingAppearance` via `RefreshAppearance`;
+//! NPC appearance edits surface on the next AoI entry. Commands document their
+//! own persistence in the feedback line.
+//!
+//! Legacy reference: `deprecated/python/cell/commands/Entity.py` +
+//! `deprecated/python/cell/commands/Player.py` (`addDialog`/`removeDialog`/
+//! `dynamicUpdate`).
+
+use tokio::sync::mpsc;
+
+use super::send_gm_feedback;
+use crate::cell::messages::CellToBaseMsg;
+use crate::cell::space_manager::SpaceManager;
+
+/// Route a category-A entity-authoring command to its body. `target_id` is the
+/// validated selected entity (always `Some` here — every command in this family
+/// requires a `Spawnable`/`Being` target).
+pub(super) async fn dispatch(
+    name: &str,
+    caller_id: u32,
+    args: &[&str],
+    target_id: Option<u32>,
+    tx: &mpsc::Sender<CellToBaseMsg>,
+    space_mgr: &mut SpaceManager,
+) {
+    let Some(target) = target_id else {
+        send_gm_feedback(caller_id, &format!(".{name}: a target is required."), tx).await;
+        return;
+    };
+    // `target_id` was resolved at parse time; confirm the entity still exists so
+    // a handler doesn't silently no-op on `get_entity_mut` yet report success.
+    if space_mgr.get_entity(target).is_none() {
+        send_gm_feedback(
+            caller_id,
+            &format!(".{name}: target [{target}] no longer exists."),
+            tx,
+        )
+        .await;
+        return;
+    }
+    match name {
+        "tag" => set_tag(caller_id, target, args, tx, space_mgr).await,
+        "name" => set_name(caller_id, target, args, tx, space_mgr).await,
+        "alignment" => set_alignment(caller_id, target, args, tx, space_mgr).await,
+        "nameid" => set_i32_field(caller_id, target, args, tx, space_mgr, "nameid").await,
+        "staticmesh" => set_str_field(caller_id, target, args, tx, space_mgr, "staticmesh").await,
+        "bodyset" => set_str_field(caller_id, target, args, tx, space_mgr, "bodyset").await,
+        "eventset" => set_i32_field(caller_id, target, args, tx, space_mgr, "eventset").await,
+        "interactiontype" => set_interaction_type(caller_id, target, args, tx, space_mgr).await,
+        "lookat" => look_at(caller_id, target, tx, space_mgr).await,
+        "visible" => set_visible(caller_id, target, args, tx, space_mgr).await,
+        "setcombatant" => set_combatant(caller_id, target, args, true, tx, space_mgr).await,
+        "unsetcombatant" => set_combatant(caller_id, target, args, false, tx, space_mgr).await,
+        "addcomponent" => component(caller_id, target, args, true, tx, space_mgr).await,
+        "delcomponent" => component(caller_id, target, args, false, tx, space_mgr).await,
+        "adddialog" => dialog(caller_id, target, args, true, tx, space_mgr).await,
+        "removedialog" => dialog(caller_id, target, args, false, tx, space_mgr).await,
+        "dynamicupdate" => dynamic_update(caller_id, target, tx, space_mgr).await,
+        _ => {}
+    }
+}
+
+/// `.tag <tag|none>` — set the content tag (`'none'` clears). The tag is what
+/// content-engine chains match on via `find_entity_by_tag`.
+async fn set_tag(
+    caller_id: u32,
+    target: u32,
+    args: &[&str],
+    tx: &mpsc::Sender<CellToBaseMsg>,
+    space_mgr: &mut SpaceManager,
+) {
+    let tag = args[0];
+    if let Some(e) = space_mgr.get_entity_mut(target) {
+        e.tag = if tag == "none" {
+            None
+        } else {
+            Some(tag.to_string())
+        };
+    }
+    send_gm_feedback(
+        caller_id,
+        &format!(
+            "tag [{target}] = {} (in-memory; .savespawn to persist)",
+            tag
+        ),
+        tx,
+    )
+    .await;
+}
+
+/// `.name <words...>` — set the NPC display name.
+async fn set_name(
+    caller_id: u32,
+    target: u32,
+    args: &[&str],
+    tx: &mpsc::Sender<CellToBaseMsg>,
+    space_mgr: &mut SpaceManager,
+) {
+    let name = args.join(" ");
+    if let Some(e) = space_mgr.get_entity_mut(target) {
+        e.npc_name = Some(name.clone());
+    }
+    send_gm_feedback(
+        caller_id,
+        &format!("name [{target}] = '{name}' (in-memory; shown on next AoI entry)"),
+        tx,
+    )
+    .await;
+}
+
+/// `.alignment <undefined|praxis|sgu>` — set the alignment id. Names map to the
+/// legacy `ALIGNMENT_*` order (Undefined=0, Praxis=1, SGU=2).
+async fn set_alignment(
+    caller_id: u32,
+    target: u32,
+    args: &[&str],
+    tx: &mpsc::Sender<CellToBaseMsg>,
+    space_mgr: &mut SpaceManager,
+) {
+    let value = match args[0].to_ascii_lowercase().as_str() {
+        "undefined" => 0u8,
+        "praxis" => 1,
+        "sgu" => 2,
+        other => {
+            send_gm_feedback(
+                caller_id,
+                &format!("alignment: invalid '{other}' (use undefined|praxis|sgu)"),
+                tx,
+            )
+            .await;
+            return;
+        }
+    };
+    if let Some(e) = space_mgr.get_entity_mut(target) {
+        e.alignment = value;
+    }
+    send_gm_feedback(
+        caller_id,
+        &format!("alignment [{target}] = {} ({value})", args[0]),
+        tx,
+    )
+    .await;
+}
+
+/// `.nameid` / `.eventset` — set an `i32` template field by command name.
+async fn set_i32_field(
+    caller_id: u32,
+    target: u32,
+    args: &[&str],
+    tx: &mpsc::Sender<CellToBaseMsg>,
+    space_mgr: &mut SpaceManager,
+    field: &str,
+) {
+    let Some(value) = super::parse_i32(caller_id, args, 0, field, tx).await else {
+        return;
+    };
+    if let Some(e) = space_mgr.get_entity_mut(target) {
+        match field {
+            "nameid" => e.name_id = Some(value),
+            "eventset" => e.event_set_id = Some(value),
+            _ => {}
+        }
+    }
+    send_gm_feedback(
+        caller_id,
+        &format!("{field} [{target}] = {value} (in-memory; .savespawn to persist)"),
+        tx,
+    )
+    .await;
+}
+
+/// `.staticmesh` / `.bodyset` — set a string template field by command name.
+async fn set_str_field(
+    caller_id: u32,
+    target: u32,
+    args: &[&str],
+    tx: &mpsc::Sender<CellToBaseMsg>,
+    space_mgr: &mut SpaceManager,
+    field: &str,
+) {
+    let value = args[0].to_string();
+    if let Some(e) = space_mgr.get_entity_mut(target) {
+        match field {
+            "staticmesh" => e.static_mesh = Some(value.clone()),
+            "bodyset" => e.body_set = Some(value.clone()),
+            _ => {}
+        }
+    }
+    send_gm_feedback(
+        caller_id,
+        &format!("{field} [{target}] = '{value}' (in-memory; shown on next AoI entry)"),
+        tx,
+    )
+    .await;
+}
+
+/// `.interactiontype <flags>` — set the raw INT_* interaction-type bitfield.
+async fn set_interaction_type(
+    caller_id: u32,
+    target: u32,
+    args: &[&str],
+    tx: &mpsc::Sender<CellToBaseMsg>,
+    space_mgr: &mut SpaceManager,
+) {
+    let Some(value) = super::parse_i32(caller_id, args, 0, "interactiontype", tx).await else {
+        return;
+    };
+    if let Some(e) = space_mgr.get_entity_mut(target) {
+        e.interaction_type_flags = i64::from(value);
+    }
+    send_gm_feedback(
+        caller_id,
+        &format!("interactiontype [{target}] = {value} (in-memory)"),
+        tx,
+    )
+    .await;
+}
+
+/// `.lookat` — rotate the target to face the caller (heading write only).
+async fn look_at(
+    caller_id: u32,
+    target: u32,
+    tx: &mpsc::Sender<CellToBaseMsg>,
+    space_mgr: &mut SpaceManager,
+) {
+    let Some(caller_pos) = space_mgr.get_entity(caller_id).map(|e| e.position) else {
+        return;
+    };
+    if let Some(e) = space_mgr.get_entity_mut(target) {
+        let dx = caller_pos.x - e.position.x;
+        let dz = caller_pos.z - e.position.z;
+        let len = (dx * dx + dz * dz).sqrt();
+        if len > f32::EPSILON {
+            e.direction = cimmeria_common::Vector3::new(dx / len, 0.0, dz / len);
+        }
+    }
+    send_gm_feedback(
+        caller_id,
+        &format!("lookat [{target}]: facing you (in-memory; shown on next AoI entry)"),
+        tx,
+    )
+    .await;
+}
+
+/// `.visible <1|0>` — show/hide the target. Hiding fans `EntityInvisible` to the
+/// target's witnesses; showing requests an AoI re-entry (note in feedback).
+async fn set_visible(
+    caller_id: u32,
+    target: u32,
+    args: &[&str],
+    tx: &mpsc::Sender<CellToBaseMsg>,
+    space_mgr: &mut SpaceManager,
+) {
+    let Some(visible) = super::parse_bool(caller_id, args, 0, "visible", tx).await else {
+        return;
+    };
+    if visible {
+        send_gm_feedback(
+            caller_id,
+            &format!("visible [{target}] = true (re-appears on next AoI refresh)"),
+            tx,
+        )
+        .await;
+        return;
+    }
+    let witnesses = space_mgr.get_witnesses_of(target);
+    for witness_id in &witnesses {
+        let _ = tx
+            .send(CellToBaseMsg::EntityInvisible {
+                witness_id: *witness_id,
+                entity_id: target,
+            })
+            .await;
+    }
+    send_gm_feedback(
+        caller_id,
+        &format!(
+            "visible [{target}] = false (hidden from {} witness(es))",
+            witnesses.len()
+        ),
+        tx,
+    )
+    .await;
+}
+
+/// `.setcombatant` / `.unsetcombatant <bit>` — set/clear a state-field bit index
+/// (0-31). The legacy took a `PLAYER_STATE_*` name; we take the bit index since
+/// the cell has no name table for combatant flags.
+async fn set_combatant(
+    caller_id: u32,
+    target: u32,
+    args: &[&str],
+    set: bool,
+    tx: &mpsc::Sender<CellToBaseMsg>,
+    space_mgr: &mut SpaceManager,
+) {
+    let Some(bit) = super::parse_i32(caller_id, args, 0, "flag bit", tx).await else {
+        return;
+    };
+    if !(0..32).contains(&bit) {
+        send_gm_feedback(caller_id, "combatant flag must be a bit index 0-31.", tx).await;
+        return;
+    }
+    let mask = 1u32 << bit;
+    if let Some(e) = space_mgr.get_entity_mut(target) {
+        if set {
+            e.state_field |= mask;
+        } else {
+            e.state_field &= !mask;
+        }
+    }
+    send_gm_feedback(
+        caller_id,
+        &format!(
+            "{} [{target}] bit {bit} (state_field now in-memory)",
+            if set {
+                "setcombatant"
+            } else {
+                "unsetcombatant"
+            }
+        ),
+        tx,
+    )
+    .await;
+}
+
+/// `.addcomponent` / `.delcomponent <component>` — add/remove a body component.
+/// For players, re-broadcasts `BeingAppearance`; NPC edits surface on next AoI
+/// entry.
+async fn component(
+    caller_id: u32,
+    target: u32,
+    args: &[&str],
+    add: bool,
+    tx: &mpsc::Sender<CellToBaseMsg>,
+    space_mgr: &mut SpaceManager,
+) {
+    let component = args[0].to_string();
+    let mut player_refresh: Option<(i32, bool)> = None;
+    if let Some(e) = space_mgr.get_entity_mut(target) {
+        if add {
+            if !e.components.contains(&component) {
+                e.components.push(component.clone());
+            }
+        } else {
+            e.components.retain(|c| c != &component);
+        }
+        if e.is_player {
+            if let Some(pid) = e.player_id {
+                player_refresh = Some((pid, e.weapon_holstered));
+            }
+        }
+    }
+    if let Some((player_id, holstered)) = player_refresh {
+        let _ = tx
+            .send(CellToBaseMsg::RefreshAppearance {
+                entity_id: target,
+                player_id,
+                holstered,
+            })
+            .await;
+    }
+    send_gm_feedback(
+        caller_id,
+        &format!(
+            "{} [{target}] '{component}'",
+            if add { "addcomponent" } else { "delcomponent" }
+        ),
+        tx,
+    )
+    .await;
+}
+
+/// `.adddialog` / `.removedialog <templateId> <setMapId>` — attach/detach a
+/// dialog choice for a player target, resolving the dialog via
+/// `dialog_set_maps[setMapId]`.
+async fn dialog(
+    caller_id: u32,
+    target: u32,
+    args: &[&str],
+    add: bool,
+    tx: &mpsc::Sender<CellToBaseMsg>,
+    space_mgr: &mut SpaceManager,
+) {
+    let Some(template_id) = super::parse_i32(caller_id, args, 0, "templateId", tx).await else {
+        return;
+    };
+    let Some(set_map_id) = super::parse_i32(caller_id, args, 1, "setMapId", tx).await else {
+        return;
+    };
+    let Some((dialog_id, interaction_flags)) = space_mgr
+        .dialog_set_maps
+        .get(&set_map_id)
+        .map(|e| (e.dialog_id, e.interaction_flags))
+    else {
+        send_gm_feedback(
+            caller_id,
+            &format!("dialog: unknown dialog_set_map id {set_map_id}"),
+            tx,
+        )
+        .await;
+        return;
+    };
+    if let Some(e) = space_mgr.get_entity_mut(target) {
+        let list = e.available_interactions.entry(template_id).or_default();
+        let tuple = (set_map_id, dialog_id, interaction_flags);
+        if add {
+            if !list.contains(&tuple) {
+                list.push(tuple);
+            }
+        } else {
+            list.retain(|t| t.0 != set_map_id);
+        }
+    }
+    send_gm_feedback(
+        caller_id,
+        &format!(
+            "{} [{target}] template {template_id} setMap {set_map_id} (dialog {})",
+            if add { "adddialog" } else { "removedialog" },
+            dialog_id
+        ),
+        tx,
+    )
+    .await;
+}
+
+/// `.dynamicupdate` — re-push the target's dynamic properties to its witnesses.
+/// For a player target this re-broadcasts `BeingAppearance`; otherwise it's a
+/// best-effort note (NPC dynamic props refresh on next AoI entry).
+async fn dynamic_update(
+    caller_id: u32,
+    target: u32,
+    tx: &mpsc::Sender<CellToBaseMsg>,
+    space_mgr: &mut SpaceManager,
+) {
+    let refresh = space_mgr
+        .get_entity(target)
+        .filter(|e| e.is_player)
+        .and_then(|e| e.player_id.map(|pid| (pid, e.weapon_holstered)));
+    if let Some((player_id, holstered)) = refresh {
+        let _ = tx
+            .send(CellToBaseMsg::RefreshAppearance {
+                entity_id: target,
+                player_id,
+                holstered,
+            })
+            .await;
+    }
+    send_gm_feedback(
+        caller_id,
+        &format!("dynamicupdate [{target}]: re-broadcast requested"),
+        tx,
+    )
+    .await;
+}

--- a/crates/services/src/cell/console/mission.rs
+++ b/crates/services/src/cell/console/mission.rs
@@ -7,7 +7,7 @@
 //! Legacy reference: `deprecated/python/cell/commands/Mission.py`
 //! (`failMission`, `displayMissionRewards`).
 
-use cimmeria_entity::missions::MISSION_FAILED;
+use cimmeria_entity::missions::{MISSION_ACTIVE, MISSION_FAILED};
 use tokio::sync::mpsc;
 
 use super::send_gm_feedback;
@@ -32,9 +32,14 @@ pub(super) async fn fail(
         return;
     };
 
+    // Only fail a mission that is currently ACTIVE. `get_mission_mut` returns
+    // the record regardless of status, and `fail()` unconditionally sets
+    // FAILED + bumps `repeats`, so without this filter `.missionfail` would
+    // re-fail an already-completed/failed mission and corrupt its state.
     let failed = if let Some(m) = space_mgr
         .get_entity_mut(target)
         .and_then(|e| e.missions.get_mission_mut(mission_id))
+        .filter(|m| m.status == MISSION_ACTIVE)
     {
         m.fail();
         true

--- a/crates/services/src/cell/console/mission.rs
+++ b/crates/services/src/cell/console/mission.rs
@@ -1,0 +1,115 @@
+//! Mission-gap console commands: `.missionfail` and `.missionrewards`.
+//!
+//! These are normal GM gameplay actions the native client has siblings for
+//! (complete/abandon/advance/clear) but not these two, so they have no native
+//! slash binding.
+//!
+//! Legacy reference: `deprecated/python/cell/commands/Mission.py`
+//! (`failMission`, `displayMissionRewards`).
+
+use cimmeria_entity::missions::MISSION_FAILED;
+use tokio::sync::mpsc;
+
+use super::send_gm_feedback;
+use crate::cell::client_methods::missionary::ON_MISSION_UPDATE;
+use crate::cell::messages::CellToBaseMsg;
+use crate::cell::space_manager::SpaceManager;
+
+/// `.missionfail <missionId>` — force-fail an active mission on the target.
+/// (Native has complete/abandon/advance/clear but no fail.)
+pub(super) async fn fail(
+    caller_id: u32,
+    args: &[&str],
+    target_id: Option<u32>,
+    tx: &mpsc::Sender<CellToBaseMsg>,
+    space_mgr: &mut SpaceManager,
+) {
+    let Some(target) = target_id else {
+        send_gm_feedback(caller_id, "missionfail: a player target is required.", tx).await;
+        return;
+    };
+    let Some(mission_id) = super::parse_i32(caller_id, args, 0, "missionId", tx).await else {
+        return;
+    };
+
+    let failed = if let Some(m) = space_mgr
+        .get_entity_mut(target)
+        .and_then(|e| e.missions.get_mission_mut(mission_id))
+    {
+        m.fail();
+        true
+    } else {
+        false
+    };
+
+    if !failed {
+        send_gm_feedback(
+            caller_id,
+            &format!("missionfail: target has no active mission {mission_id}"),
+            tx,
+        )
+        .await;
+        return;
+    }
+
+    // Tell the client the mission moved to FAILED.
+    let mut update = Vec::with_capacity(9);
+    update.extend_from_slice(&mission_id.to_le_bytes());
+    update.push(MISSION_FAILED as u8);
+    update.extend_from_slice(&0i32.to_le_bytes());
+    let _ = tx
+        .send(CellToBaseMsg::EntityMethodCall {
+            entity_id: target,
+            method_index: ON_MISSION_UPDATE,
+            args: update,
+        })
+        .await;
+
+    tracing::info!(entity_id = target, mission_id, "GM .missionfail");
+    send_gm_feedback(
+        caller_id,
+        &format!("missionfail [{target}] mission {mission_id} -> FAILED"),
+        tx,
+    )
+    .await;
+}
+
+/// `.missionrewards <missionId>` — preview a mission's reward set on the target.
+///
+/// Reward dispatch is tracked separately; the cell doesn't cache the
+/// reward catalog, so this reports the target's mission state (present + step)
+/// and points at the reward-dispatch issue rather than inventing reward data.
+pub(super) async fn rewards(
+    caller_id: u32,
+    args: &[&str],
+    target_id: Option<u32>,
+    tx: &mpsc::Sender<CellToBaseMsg>,
+    space_mgr: &mut SpaceManager,
+) {
+    let Some(target) = target_id else {
+        send_gm_feedback(
+            caller_id,
+            "missionrewards: a player target is required.",
+            tx,
+        )
+        .await;
+        return;
+    };
+    let Some(mission_id) = super::parse_i32(caller_id, args, 0, "missionId", tx).await else {
+        return;
+    };
+
+    let state = space_mgr
+        .get_entity(target)
+        .and_then(|e| e.missions.get_mission(mission_id))
+        .map(|m| (m.status, m.current_step_id));
+
+    let text = match state {
+        Some((status, step)) => format!(
+            "missionrewards [{target}] mission {mission_id}: status {status}, step {step:?}. \
+             Reward dispatch is tracked separately (no reward catalog cell-side)."
+        ),
+        None => format!("missionrewards: target has no mission {mission_id}"),
+    };
+    send_gm_feedback(caller_id, &text, tx).await;
+}

--- a/crates/services/src/cell/console/mod.rs
+++ b/crates/services/src/cell/console/mod.rs
@@ -700,17 +700,6 @@ pub(crate) async fn handle_console_command(
         return;
     };
 
-    // Audit trail: every accepted GM console command, with the
-    // caller + arg count. Command args may contain names/positions but never
-    // secrets, so logging the name + count (not the raw text) is the right
-    // privacy/observability balance — mirrors the chat.send span policy.
-    tracing::info!(
-        entity_id = caller_id,
-        command = name,
-        argc = args.len(),
-        "GM .-console command accepted"
-    );
-
     if args.len() < spec.min {
         send_gm_feedback(
             caller_id,
@@ -746,6 +735,25 @@ pub(crate) async fn handle_console_command(
             return;
         }
     };
+
+    // Audit trail: log only AFTER the command passes arg-count + target
+    // validation, so the "accepted" event marks commands we actually dispatch
+    // (not malformed/wrong-target ones rejected above). Record both the
+    // caller and their server-side `access_level` (the PR's audit objective).
+    // Command args may contain names/positions but never secrets, so logging
+    // the name + count (not the raw text) is the right privacy/observability
+    // balance — mirrors the chat.send span policy.
+    let access_level = space_mgr
+        .get_entity(caller_id)
+        .map(|e| e.access_level)
+        .unwrap_or(0);
+    tracing::info!(
+        entity_id = caller_id,
+        access_level,
+        command = name,
+        argc = args.len(),
+        "GM .-console command accepted"
+    );
 
     exec(name, caller_id, &args, target_id, tx, space_mgr, engine).await;
 }

--- a/crates/services/src/cell/console/mod.rs
+++ b/crates/services/src/cell/console/mod.rs
@@ -1,0 +1,926 @@
+//! GM `.`-console command channel.
+//!
+//! The 2009 SGW client's native slash roster (the 266 `Event_SlashCmd`
+//! classes / cell-method indices) is fixed and baked into `SGW.exe`; we can
+//! add native `/gm*` commands only for indices that already exist.
+//! The remaining dev/authoring commands the legacy Python server and the
+//! [doko972/FanMMORPG](https://github.com/doko972/FanMMORPG) fork shipped have
+//! **no** native slash binding and never can.
+//!
+//! Both the legacy server and the fork deliver those through a separate
+//! `.`-prefixed in-game console: the client does **not** intercept `.`-prefixed
+//! input — it forwards it as an ordinary `CHAN_SAY` chat message. The server
+//! intercepts it before broadcast. This module is the Rust analogue of
+//! `deprecated/python/cell/ConsoleCommands.py` (the legacy `Command` table) plus
+//! the fork's `path_*` additions.
+//!
+//! # Channel + auth
+//!
+//! [`crate::cell::chat::handle_chat_message`] calls [`handle_console_command`]
+//! from its `CHAN_SAY` arm when (a) the text starts with `.` **and** (b) the
+//! sender's [`CellEntity::access_level`](cimmeria_entity::cell_entity::CellEntity::access_level)
+//! is `>= GameMaster`. A GM's `.`-text is consumed (never broadcast to other
+//! players); a non-GM's `.`-text falls through to normal chat. Authorization is
+//! always on the server-side `access_level` (sourced from `account.accesslevel`
+//! at login, never a client-asserted byte) — the same trust model as
+//! [`crate::cell::dispatch::gm_gate`].
+//!
+//! # Dispatch model
+//!
+//! [`COMMANDS`] is the registry: `name -> (min/max arg count, required target
+//! type, summary)`, mirroring the legacy `Command` table. [`handle_console_command`]
+//! parses `.<cmd> <args...>`, validates access (already GM by the channel gate),
+//! arg count, and target type, logs the accepted command at `info` for the
+//! audit trail, then routes to a family handler. Output goes back
+//! to the GM only via [`feedback`] (`onPlayerCommunication` on `CHAN_FEEDBACK`),
+//! the same single-recipient channel the native `gm*` query cluster uses.
+//!
+//! Handlers are grouped by family, mirroring the `gm/` submodule split:
+//! - [`query`] — read-only search / inspection (`searchitem`, `players`, …).
+//! - [`stats`] — granular per-domain stat dumps (`primarystats`, …).
+//! - [`entity`] — live entity authoring (`tag`, `name`, `visible`, …).
+//! - [`net`] — low-level net / AI debug (`net_seq`, `threaten`, …).
+//! - [`crafting`] — discipline / blueprint grants (`allcraft`, …).
+//! - [`mission`] — mission gaps (`missionfail`, `missionrewards`).
+//! - [`server`] — server / maintenance (`save`, `loglevel`, …).
+//! - [`spawn`] — spawn persistence (`savespawn`, `delspawn`, …).
+//! - [`patrol`] — FanMMORPG patrol authoring (`path_add`, `path_assign`, …).
+//!
+//! The console-channel design is documented in
+//! `docs/architecture/dev-console-channel.md`; the player-facing command list is
+//! in `docs/commands.md`.
+
+use cimmeria_content_engine::chain::ChainEngine;
+use cimmeria_entity::cell_entity::CellEntity;
+use tokio::sync::mpsc;
+
+use super::messages::CellToBaseMsg;
+use super::space_manager::SpaceManager;
+
+mod crafting;
+mod entity;
+mod mission;
+mod net;
+mod patrol;
+mod query;
+mod seed;
+mod server;
+mod spawn;
+mod stats;
+
+#[cfg(test)]
+mod tests;
+
+/// Re-export of the single-recipient GM feedback line so console handlers and
+/// the framework share one delivery path with the native `gm*` cluster.
+pub(crate) use super::cell_methods::gm::feedback::send_gm_feedback;
+
+/// Minimum `access_level` (the `account.accesslevel` byte) that unlocks the
+/// `.`-console. `2` is `AccessLevel::GameMaster` — see
+/// [`crate::cell::dispatch::gm_gate`] for the canonical mapping. Kept as a bare
+/// constant (not a typed compare) so the channel gate in
+/// [`crate::cell::chat`] is one cheap integer test on the hot chat path.
+const GM_ACCESS_LEVEL: u32 = 2;
+
+/// Returns `true` if `access_level` is GameMaster-or-higher and may therefore
+/// use the `.`-console. The chat interceptor calls this before consuming a
+/// `.`-prefixed `CHAN_SAY` line.
+pub(crate) fn is_gm(access_level: u32) -> bool {
+    access_level >= GM_ACCESS_LEVEL
+}
+
+/// The kind of selected-target an entity-scoped command requires. Mirrors the
+/// `targetType` column of the legacy `Command` table
+/// (`deprecated/python/cell/ConsoleCommands.py`). The target is always the
+/// caller's currently-selected entity (`current_target_id`, set by
+/// `setTargetID` / `gmSetTarget`).
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum Target {
+    /// No target needed. The handler operates on the caller (or its own args).
+    /// A current target, if any, is still passed through for the few legacy
+    /// commands that opt to use it.
+    None,
+    /// Any player entity.
+    Player,
+    /// Any NPC entity (`SGWMob` in the legacy hierarchy).
+    Mob,
+    /// Any being (player or NPC — anything with a stat block). The legacy
+    /// `SGWBeing` target type.
+    Being,
+    /// Any spawnable entity. The legacy `SGWSpawnableEntity` target type — in
+    /// practice any entity in the world.
+    Spawnable,
+}
+
+impl Target {
+    /// Does `e` satisfy this target-type requirement?
+    fn matches(self, e: &CellEntity) -> bool {
+        match self {
+            Target::None | Target::Being | Target::Spawnable => true,
+            Target::Player => e.is_player,
+            Target::Mob => !e.is_player,
+        }
+    }
+
+    /// Human label for the "wrong target type" feedback line.
+    fn label(self) -> &'static str {
+        match self {
+            Target::None => "none",
+            Target::Player => "a player",
+            Target::Mob => "an NPC",
+            Target::Being => "a being",
+            Target::Spawnable => "a spawnable entity",
+        }
+    }
+}
+
+/// One registered console command. The static [`COMMANDS`] table is the single
+/// source of truth for validation (`min`/`max`/`target`) and `.help` text;
+/// execution is routed by name in [`exec`].
+pub(crate) struct Spec {
+    /// Command name as typed after the `.` (e.g. `"savespawn"`).
+    pub name: &'static str,
+    /// Minimum positional arg count.
+    pub min: usize,
+    /// Maximum positional arg count (`usize::MAX` = unbounded).
+    pub max: usize,
+    /// Required selected-target type.
+    pub target: Target,
+    /// One-line summary shown by `.help`.
+    pub help: &'static str,
+}
+
+const fn spec(
+    name: &'static str,
+    min: usize,
+    max: usize,
+    target: Target,
+    help: &'static str,
+) -> Spec {
+    Spec {
+        name,
+        min,
+        max,
+        target,
+        help,
+    }
+}
+
+/// The console command registry — the Rust analogue of the legacy
+/// `Command.add([...])` table plus the FanMMORPG `path_*` additions.
+///
+/// Every name here is reachable from [`exec`]; `tests::every_spec_is_dispatched`
+/// asserts no entry falls through to the "not implemented" arm.
+pub(crate) static COMMANDS: &[Spec] = &[
+    // ── meta ────────────────────────────────────────────────────────────────
+    spec(
+        "help",
+        0,
+        1,
+        Target::None,
+        "List console commands (optionally filter by substring)",
+    ),
+    spec(
+        "seedconfirm",
+        0,
+        0,
+        Target::None,
+        "Emit your pending authoring changes per seed file (log/Discord)",
+    ),
+    spec(
+        "seedpending",
+        0,
+        0,
+        Target::None,
+        "List your pending authoring changes",
+    ),
+    spec(
+        "seedcancel",
+        0,
+        0,
+        Target::None,
+        "Discard your pending authoring changes",
+    ),
+    // ── D. search / query ─────────────────────────────────────────────────────
+    spec(
+        "searchitem",
+        1,
+        2,
+        Target::None,
+        "Search item designs by name",
+    ),
+    spec(
+        "searchmission",
+        1,
+        2,
+        Target::None,
+        "Search mission designs by name",
+    ),
+    spec(
+        "searchtemplate",
+        1,
+        2,
+        Target::None,
+        "Search entity templates by name",
+    ),
+    spec("players", 0, 0, Target::None, "List players in your space"),
+    // ── F. granular stat readouts ──────────────────────────────────────────────
+    spec(
+        "primarystats",
+        0,
+        0,
+        Target::Being,
+        "Show primary attribute stats of the target",
+    ),
+    spec(
+        "speedstats",
+        0,
+        0,
+        Target::Being,
+        "Show movement/action speed stats of the target",
+    ),
+    spec(
+        "armorstats",
+        0,
+        0,
+        Target::Being,
+        "Show armor + resistance stats of the target",
+    ),
+    spec(
+        "qrstats",
+        0,
+        0,
+        Target::Being,
+        "Show QR-system combat stats of the target",
+    ),
+    spec(
+        "absorbstats",
+        0,
+        0,
+        Target::Being,
+        "Show damage-absorption stats of the target",
+    ),
+    spec(
+        "stealthstats",
+        0,
+        0,
+        Target::Being,
+        "Show stealth/disguise stats of the target",
+    ),
+    // ── A. entity / content authoring ──────────────────────────────────────────
+    spec(
+        "tag",
+        1,
+        1,
+        Target::Spawnable,
+        "Set the content tag of the target ('none' clears)",
+    ),
+    spec(
+        "name",
+        1,
+        usize::MAX,
+        Target::Being,
+        "Set the display name of the target",
+    ),
+    spec(
+        "alignment",
+        1,
+        1,
+        Target::Being,
+        "Set alignment (undefined|praxis|sgu) of the target",
+    ),
+    spec(
+        "nameid",
+        1,
+        1,
+        Target::Spawnable,
+        "Set the localized name-id of the target",
+    ),
+    spec(
+        "staticmesh",
+        1,
+        1,
+        Target::Spawnable,
+        "Set the static mesh name of the target",
+    ),
+    spec(
+        "bodyset",
+        1,
+        1,
+        Target::Spawnable,
+        "Set the body set of the target",
+    ),
+    spec(
+        "eventset",
+        1,
+        1,
+        Target::Spawnable,
+        "Set the kismet event-set id of the target",
+    ),
+    spec(
+        "interactiontype",
+        1,
+        1,
+        Target::Spawnable,
+        "Set the interaction-type flags of the target",
+    ),
+    spec(
+        "lookat",
+        0,
+        0,
+        Target::Spawnable,
+        "Rotate the target to face you",
+    ),
+    spec(
+        "visible",
+        1,
+        1,
+        Target::Spawnable,
+        "Show/hide the target (1/0)",
+    ),
+    spec(
+        "setcombatant",
+        1,
+        1,
+        Target::Being,
+        "Set a combatant state flag on the target",
+    ),
+    spec(
+        "unsetcombatant",
+        1,
+        1,
+        Target::Being,
+        "Clear a combatant state flag on the target",
+    ),
+    spec(
+        "addcomponent",
+        1,
+        1,
+        Target::Being,
+        "Add a body component to the target",
+    ),
+    spec(
+        "delcomponent",
+        1,
+        1,
+        Target::Being,
+        "Remove a body component from the target",
+    ),
+    spec(
+        "adddialog",
+        2,
+        2,
+        Target::Spawnable,
+        "Add a dialog choice (templateId setMapId) to the target",
+    ),
+    spec(
+        "removedialog",
+        2,
+        2,
+        Target::Spawnable,
+        "Remove a dialog choice (templateId setMapId) from the target",
+    ),
+    spec(
+        "dynamicupdate",
+        0,
+        0,
+        Target::Spawnable,
+        "Re-broadcast the target's dynamic properties to witnesses",
+    ),
+    // ── H. low-level net / AI debug ────────────────────────────────────────────
+    spec(
+        "net_seq",
+        1,
+        2,
+        Target::Spawnable,
+        "Play a kismet sequence on the target",
+    ),
+    spec(
+        "net_seqto",
+        1,
+        2,
+        Target::None,
+        "Play a sequence from you to the target",
+    ),
+    spec(
+        "net_seqfrom",
+        1,
+        2,
+        Target::Spawnable,
+        "Play a sequence from the target to you",
+    ),
+    spec(
+        "net_timer",
+        2,
+        4,
+        Target::Spawnable,
+        "Start a client timer on the target",
+    ),
+    spec(
+        "net_mapinfo",
+        3,
+        5,
+        Target::Player,
+        "Send onMapInfo to the target",
+    ),
+    spec(
+        "net_speak",
+        1,
+        2,
+        Target::Spawnable,
+        "Make the target speak (message [channel])",
+    ),
+    spec(
+        "net_dialog",
+        1,
+        1,
+        Target::None,
+        "Open a dialog with the target",
+    ),
+    spec(
+        "net_challenge",
+        5,
+        5,
+        Target::None,
+        "Send onClientChallenge to the target",
+    ),
+    spec(
+        "debug_velocity",
+        3,
+        3,
+        Target::Spawnable,
+        "Set the velocity of the target",
+    ),
+    spec(
+        "debug_controller",
+        0,
+        0,
+        Target::Spawnable,
+        "Toggle the debug movement controller on the target",
+    ),
+    spec(
+        "debug_follow",
+        0,
+        0,
+        Target::Spawnable,
+        "Toggle the follow controller on the target",
+    ),
+    spec(
+        "threaten",
+        1,
+        1,
+        Target::Mob,
+        "Generate threat on the targeted mob",
+    ),
+    spec(
+        "aggression",
+        1,
+        1,
+        Target::Mob,
+        "Set the aggression level of the targeted mob",
+    ),
+    // ── E. crafting / discipline ───────────────────────────────────────────────
+    spec(
+        "allcraft",
+        0,
+        0,
+        Target::Player,
+        "Grant all blueprints + max disciplines to the target",
+    ),
+    spec(
+        "learndiscipline",
+        1,
+        2,
+        Target::Player,
+        "Learn/raise a discipline (disciplineId [expertise])",
+    ),
+    spec(
+        "forgetdiscipline",
+        1,
+        1,
+        Target::Player,
+        "Forget a discipline (disciplineId)",
+    ),
+    // ── Mission gaps ──────────────────────────────────────────────────────────
+    spec(
+        "missionfail",
+        1,
+        1,
+        Target::Player,
+        "Force-fail a mission on the target (designId)",
+    ),
+    spec(
+        "missionrewards",
+        1,
+        1,
+        Target::Player,
+        "Preview a mission's reward set (designId)",
+    ),
+    // ── G. server / maintenance ────────────────────────────────────────────────
+    spec("save", 0, 0, Target::None, "Persist your player entity now"),
+    spec(
+        "reloadmap",
+        0,
+        0,
+        Target::None,
+        "Reload the current map on yourself",
+    ),
+    spec(
+        "reloadres",
+        0,
+        1,
+        Target::None,
+        "Reload server resource caches",
+    ),
+    spec(
+        "removerespawner",
+        1,
+        1,
+        Target::Player,
+        "Remove a respawner from the target (respawnerId)",
+    ),
+    spec(
+        "loglevel",
+        1,
+        2,
+        Target::None,
+        "Set the server log level (level [category])",
+    ),
+    spec(
+        "logclient",
+        0,
+        0,
+        Target::None,
+        "Toggle forwarding server logs to your client",
+    ),
+    // ── B. spawn authoring / persistence ───────────────────────────────────────
+    spec(
+        "savespawn",
+        0,
+        0,
+        Target::Spawnable,
+        "Persist the target's spawn to the spawnlist",
+    ),
+    spec(
+        "delspawn",
+        0,
+        0,
+        Target::Spawnable,
+        "Delete the target's spawnlist row",
+    ),
+    spec(
+        "autosavespawn",
+        1,
+        1,
+        Target::None,
+        "Toggle auto-persisting newly spawned entities (1/0)",
+    ),
+    spec(
+        "respawnall",
+        0,
+        0,
+        Target::None,
+        "Respawn every NPC in your space",
+    ),
+    spec(
+        "spawnrandom",
+        3,
+        4,
+        Target::None,
+        "Spawn N random-scattered copies of a template (templateId xRange zRange [count])",
+    ),
+    // ── C. patrol authoring (FanMMORPG) ─────────────────────────────────────────
+    spec(
+        "path_add",
+        1,
+        1,
+        Target::None,
+        "Append your position as the next waypoint of a path (pathId)",
+    ),
+    spec(
+        "path_show",
+        1,
+        1,
+        Target::None,
+        "Show all waypoints of a path (pathId)",
+    ),
+    spec(
+        "path_clear",
+        1,
+        1,
+        Target::None,
+        "Delete all waypoints of a path (pathId)",
+    ),
+    spec(
+        "path_assign",
+        1,
+        2,
+        Target::Mob,
+        "Assign a path to the target NPC and start it (pathId [delay])",
+    ),
+    spec(
+        "path_unassign",
+        0,
+        0,
+        Target::Mob,
+        "Remove the patrol from the target NPC",
+    ),
+    spec(
+        "path_set_seq",
+        3,
+        3,
+        Target::None,
+        "Set a kismet sequence on a waypoint (pathId index seqId)",
+    ),
+    spec(
+        "path_clear_seq",
+        2,
+        2,
+        Target::None,
+        "Clear the sequence on a waypoint (pathId index)",
+    ),
+    spec(
+        "path_set_tp",
+        2,
+        2,
+        Target::None,
+        "Set a waypoint's teleport dest to your position (pathId index)",
+    ),
+    spec(
+        "path_clear_tp",
+        2,
+        2,
+        Target::None,
+        "Clear a waypoint's teleport (pathId index)",
+    ),
+    spec(
+        "path_set_tp_seq",
+        3,
+        3,
+        Target::None,
+        "Set a waypoint's arrival sequence (pathId index seqId)",
+    ),
+    spec(
+        "path_set_tp_delay",
+        3,
+        3,
+        Target::None,
+        "Set a waypoint's teleport delay (pathId index delay)",
+    ),
+];
+
+/// Parse, validate, and dispatch one GM `.`-console line.
+///
+/// `text` is the raw chat body including the leading `.`. The caller is already
+/// confirmed `access_level >= GameMaster` by the channel gate in
+/// [`crate::cell::chat`]. Every accepted command is logged at `info` for the
+/// audit trail; validation failures reply to the GM via [`feedback`] and abort.
+pub(crate) async fn handle_console_command(
+    caller_id: u32,
+    text: &str,
+    tx: &mpsc::Sender<CellToBaseMsg>,
+    space_mgr: &mut SpaceManager,
+    engine: &ChainEngine,
+) {
+    let body = text.strip_prefix('.').unwrap_or(text);
+    let parts: Vec<&str> = body.split_whitespace().collect();
+    let Some(&name) = parts.first() else {
+        send_gm_feedback(caller_id, "Empty command. Try .help", tx).await;
+        return;
+    };
+    let args: Vec<&str> = parts[1..].to_vec();
+
+    let Some(spec) = COMMANDS.iter().find(|c| c.name == name) else {
+        send_gm_feedback(
+            caller_id,
+            &format!("Unknown command: .{name} (try .help)"),
+            tx,
+        )
+        .await;
+        return;
+    };
+
+    // Audit trail: every accepted GM console command, with the
+    // caller + arg count. Command args may contain names/positions but never
+    // secrets, so logging the name + count (not the raw text) is the right
+    // privacy/observability balance — mirrors the chat.send span policy.
+    tracing::info!(
+        entity_id = caller_id,
+        command = name,
+        argc = args.len(),
+        "GM .-console command accepted"
+    );
+
+    if args.len() < spec.min {
+        send_gm_feedback(
+            caller_id,
+            &format!(
+                ".{name}: not enough arguments (got {}, need at least {})",
+                args.len(),
+                spec.min
+            ),
+            tx,
+        )
+        .await;
+        return;
+    }
+    if args.len() > spec.max {
+        send_gm_feedback(
+            caller_id,
+            &format!(
+                ".{name}: too many arguments (got {}, at most {})",
+                args.len(),
+                spec.max
+            ),
+            tx,
+        )
+        .await;
+        return;
+    }
+
+    // Resolve + validate the selected target (if the command requires one).
+    let target_id = match resolve_target(caller_id, spec, space_mgr) {
+        Ok(t) => t,
+        Err(msg) => {
+            send_gm_feedback(caller_id, &format!(".{name}: {msg}"), tx).await;
+            return;
+        }
+    };
+
+    exec(name, caller_id, &args, target_id, tx, space_mgr, engine).await;
+}
+
+/// Resolve the caller's current target and validate it against `spec.target`.
+///
+/// - For [`Target::None`] commands, returns the caller's current target if it's
+///   set and resolvable (legacy `findEntity(targetId) if targetId else None`),
+///   else `None`. A bad/cross-space current target is simply dropped to `None`
+///   rather than failing — these commands don't depend on it.
+/// - For typed commands, a target is **required**: returns `Err(msg)` (with a
+///   GM-facing reason) when there is no current target, it doesn't resolve, it's
+///   in another space, or it's the wrong type.
+fn resolve_target(
+    caller_id: u32,
+    spec: &Spec,
+    space_mgr: &SpaceManager,
+) -> Result<Option<u32>, String> {
+    let caller_space = space_mgr.get_entity(caller_id).map(|e| e.space_id.0);
+    let current = space_mgr
+        .get_entity(caller_id)
+        .and_then(|e| e.current_target_id)
+        .filter(|&id| id > 0)
+        .and_then(|id| u32::try_from(id).ok());
+
+    if spec.target == Target::None {
+        // Optional: pass the current target through only if it resolves in the
+        // caller's space; otherwise None.
+        let resolved =
+            current.filter(|&id| space_mgr.get_entity(id).map(|e| e.space_id.0) == caller_space);
+        return Ok(resolved);
+    }
+
+    let Some(target_id) = current else {
+        return Err("a target is required for this command".to_string());
+    };
+    let Some(target) = space_mgr.get_entity(target_id) else {
+        return Err(format!("targeted entity {target_id} is unknown"));
+    };
+    if Some(target.space_id.0) != caller_space {
+        return Err(format!("targeted entity {target_id} is in another space"));
+    }
+    if !spec.target.matches(target) {
+        return Err(format!("expected {} as a target", spec.target.label()));
+    }
+    Ok(Some(target_id))
+}
+
+/// Route a validated command to its family handler. The big match mirrors
+/// `gm::dispatch`; each arm receives only the params it needs.
+#[allow(clippy::too_many_lines)]
+async fn exec(
+    name: &str,
+    caller_id: u32,
+    args: &[&str],
+    target_id: Option<u32>,
+    tx: &mpsc::Sender<CellToBaseMsg>,
+    space_mgr: &mut SpaceManager,
+    engine: &ChainEngine,
+) {
+    match name {
+        "help" => query::help(caller_id, args, tx).await,
+        // authoring commit workflow
+        "seedconfirm" => seed::confirm(caller_id, tx, space_mgr).await,
+        "seedpending" => seed::pending(caller_id, tx, space_mgr).await,
+        "seedcancel" => seed::cancel(caller_id, tx, space_mgr).await,
+        // D. search / query
+        "searchitem" => query::search_item(caller_id, args, tx, space_mgr).await,
+        "searchmission" => query::search_mission(caller_id, args, tx, space_mgr).await,
+        "searchtemplate" => query::search_template(caller_id, args, tx, space_mgr).await,
+        "players" => query::players(caller_id, tx, space_mgr).await,
+        // F. stat dumps
+        "primarystats" | "speedstats" | "armorstats" | "qrstats" | "absorbstats"
+        | "stealthstats" => stats::show(name, caller_id, target_id, tx, space_mgr).await,
+        // A. entity authoring
+        "tag" | "name" | "alignment" | "nameid" | "staticmesh" | "bodyset" | "eventset"
+        | "interactiontype" | "lookat" | "visible" | "setcombatant" | "unsetcombatant"
+        | "addcomponent" | "delcomponent" | "adddialog" | "removedialog" | "dynamicupdate" => {
+            entity::dispatch(name, caller_id, args, target_id, tx, space_mgr).await
+        }
+        // H. net / debug
+        "net_seq" | "net_seqto" | "net_seqfrom" | "net_timer" | "net_mapinfo" | "net_speak"
+        | "net_dialog" | "net_challenge" | "debug_velocity" | "debug_controller"
+        | "debug_follow" | "threaten" | "aggression" => {
+            net::dispatch(name, caller_id, args, target_id, tx, space_mgr).await
+        }
+        // E. crafting
+        "allcraft" | "learndiscipline" | "forgetdiscipline" => {
+            crafting::dispatch(name, caller_id, args, target_id, tx, space_mgr).await
+        }
+        // Mission gaps
+        "missionfail" => mission::fail(caller_id, args, target_id, tx, space_mgr).await,
+        "missionrewards" => mission::rewards(caller_id, args, target_id, tx, space_mgr).await,
+        // G. server / maintenance
+        "save" | "reloadmap" | "reloadres" | "removerespawner" | "loglevel" | "logclient" => {
+            server::dispatch(name, caller_id, args, target_id, tx, space_mgr).await
+        }
+        // B. spawn authoring
+        "savespawn" | "delspawn" | "autosavespawn" | "respawnall" | "spawnrandom" => {
+            spawn::dispatch(name, caller_id, args, target_id, tx, space_mgr, engine).await
+        }
+        // C. patrol authoring
+        "path_add" | "path_show" | "path_clear" | "path_assign" | "path_unassign"
+        | "path_set_seq" | "path_clear_seq" | "path_set_tp" | "path_clear_tp"
+        | "path_set_tp_seq" | "path_set_tp_delay" => {
+            patrol::dispatch(name, caller_id, args, target_id, tx, space_mgr).await
+        }
+        other => {
+            // Unreachable in practice — every COMMANDS entry has an arm above,
+            // pinned by `tests::every_spec_is_dispatched`.
+            send_gm_feedback(caller_id, &format!(".{other}: not implemented"), tx).await;
+        }
+    }
+}
+
+// ── Shared arg-parsing helpers ────────────────────────────────────────────────
+
+/// Parse the `idx`th positional arg as `i32`, feeding back a GM-facing error and
+/// returning `None` on a malformed value. Callers `let Some(v) = parse_i32(...)
+/// else { return }`.
+pub(crate) async fn parse_i32(
+    caller_id: u32,
+    args: &[&str],
+    idx: usize,
+    label: &str,
+    tx: &mpsc::Sender<CellToBaseMsg>,
+) -> Option<i32> {
+    match args.get(idx).and_then(|s| s.parse::<i32>().ok()) {
+        Some(v) => Some(v),
+        None => {
+            send_gm_feedback(caller_id, &format!("{label} must be an integer"), tx).await;
+            None
+        }
+    }
+}
+
+/// Parse the `idx`th positional arg as `f32`, feeding back a GM-facing error and
+/// returning `None` on a malformed value.
+pub(crate) async fn parse_f32(
+    caller_id: u32,
+    args: &[&str],
+    idx: usize,
+    label: &str,
+    tx: &mpsc::Sender<CellToBaseMsg>,
+) -> Option<f32> {
+    // Reject non-finite values: `NaN`/`inf` parse fine but Display as bareword
+    // `NaN`/`inf`, which is invalid as a SQL numeric literal — it would fail the
+    // live authoring write AND bake a broken statement into the recorded seed.
+    match args
+        .get(idx)
+        .and_then(|s| s.parse::<f32>().ok())
+        .filter(|v| v.is_finite())
+    {
+        Some(v) => Some(v),
+        None => {
+            send_gm_feedback(caller_id, &format!("{label} must be a finite number"), tx).await;
+            None
+        }
+    }
+}
+
+/// Parse a `0`/`1`/`true`/`false` boolean arg, feeding back on a malformed value.
+pub(crate) async fn parse_bool(
+    caller_id: u32,
+    args: &[&str],
+    idx: usize,
+    label: &str,
+    tx: &mpsc::Sender<CellToBaseMsg>,
+) -> Option<bool> {
+    match args.get(idx).map(|s| s.to_ascii_lowercase()) {
+        Some(s) if s == "1" || s == "true" => Some(true),
+        Some(s) if s == "0" || s == "false" => Some(false),
+        _ => {
+            send_gm_feedback(caller_id, &format!("{label} must be 0/1/true/false"), tx).await;
+            None
+        }
+    }
+}

--- a/crates/services/src/cell/console/mod.rs
+++ b/crates/services/src/cell/console/mod.rs
@@ -738,11 +738,12 @@ pub(crate) async fn handle_console_command(
 
     // Audit trail: log only AFTER the command passes arg-count + target
     // validation, so the "accepted" event marks commands we actually dispatch
-    // (not malformed/wrong-target ones rejected above). Record both the
-    // caller and their server-side `access_level` (the PR's audit objective).
-    // Command args may contain names/positions but never secrets, so logging
-    // the name + count (not the raw text) is the right privacy/observability
-    // balance — mirrors the chat.send span policy.
+    // (not malformed/wrong-target ones rejected above). Record both the caller
+    // and their server-side `access_level` so the audit line attributes the
+    // command to a privilege level, not just an entity id. Command args may
+    // contain names/positions but never secrets, so logging the name + count
+    // (not the raw text) is the right privacy/observability balance — mirrors
+    // the chat.send span policy.
     let access_level = space_mgr
         .get_entity(caller_id)
         .map(|e| e.access_level)

--- a/crates/services/src/cell/console/net.rs
+++ b/crates/services/src/cell/console/net.rs
@@ -1,0 +1,490 @@
+//! Low-level net / AI debug commands (category H): kismet sequence play,
+//! client timers/map-info/challenge, make-an-entity-speak, debug controllers,
+//! and the threat/aggression pokes.
+//!
+//! Most are thin wrappers over an existing client method (serialized here from
+//! the wire shapes in `docs/protocol/client-method-dispatch-table.md`) or an
+//! existing cell system (threat list, follow AI, dialog display).
+//!
+//! Legacy reference: `deprecated/python/cell/commands/Net.py` +
+//! `deprecated/python/cell/commands/Misc.py` (`debug_*`) +
+//! `deprecated/python/cell/commands/Entity.py` (`threaten`/`aggression`).
+
+use cimmeria_entity::cell_entity::AiState;
+use tokio::sync::mpsc;
+
+use super::send_gm_feedback;
+use crate::cell::abilities::send_entity_method_to_self_and_witnesses;
+use crate::cell::interactions;
+use crate::cell::messages::CellToBaseMsg;
+use crate::cell::space_manager::SpaceManager;
+use crate::mercury::method_idx::{ON_PLAYER_COMMUNICATION, ON_SEQUENCE};
+
+/// Client method indices from `docs/protocol/client-method-dispatch-table.md`
+/// (SGWPlayer ClientMethods), for the handful not in `method_idx`.
+const ON_TIMER_UPDATE: u16 = 12;
+const ON_MAP_INFO: u16 = 123;
+const ON_CLIENT_CHALLENGE: u16 = 142;
+
+/// Feedback channel id (`CHAN_FEEDBACK`); `net_speak`'s default speak channel is
+/// say (`0`).
+const CHAN_SAY: u8 = 0;
+
+/// Append a WSTRING (`u32` char count + UTF-16LE) to a wire buffer.
+fn push_wstring(buf: &mut Vec<u8>, s: &str) {
+    let utf16: Vec<u16> = s.encode_utf16().collect();
+    buf.extend_from_slice(&(utf16.len() as u32).to_le_bytes());
+    for ch in utf16 {
+        buf.extend_from_slice(&ch.to_le_bytes());
+    }
+}
+
+pub(super) async fn dispatch(
+    name: &str,
+    caller_id: u32,
+    args: &[&str],
+    target_id: Option<u32>,
+    tx: &mpsc::Sender<CellToBaseMsg>,
+    space_mgr: &mut SpaceManager,
+) {
+    match name {
+        "net_seq" => sequence(caller_id, target_id, args, SeqDir::OnTarget, tx, space_mgr).await,
+        "net_seqto" => {
+            sequence(
+                caller_id,
+                target_id,
+                args,
+                SeqDir::CallerToTarget,
+                tx,
+                space_mgr,
+            )
+            .await
+        }
+        "net_seqfrom" => {
+            sequence(
+                caller_id,
+                target_id,
+                args,
+                SeqDir::TargetToCaller,
+                tx,
+                space_mgr,
+            )
+            .await
+        }
+        "net_timer" => timer(caller_id, args, tx).await,
+        "net_mapinfo" => map_info(caller_id, target_id, args, tx, space_mgr).await,
+        "net_speak" => speak(caller_id, target_id, args, tx, space_mgr).await,
+        "net_dialog" => dialog(caller_id, target_id, args, tx, space_mgr).await,
+        "net_challenge" => challenge(caller_id, args, tx).await,
+        "debug_velocity" => debug_velocity(caller_id, target_id, args, tx, space_mgr).await,
+        "debug_controller" => {
+            send_gm_feedback(
+                caller_id,
+                "debug_controller: no debug movement controller in the Rust server (no-op).",
+                tx,
+            )
+            .await;
+        }
+        "debug_follow" => debug_follow(caller_id, target_id, tx, space_mgr).await,
+        "threaten" => threaten(caller_id, target_id, args, tx, space_mgr).await,
+        "aggression" => aggression(caller_id, target_id, args, tx, space_mgr).await,
+        _ => {}
+    }
+}
+
+enum SeqDir {
+    /// Source and target are both the selected entity.
+    OnTarget,
+    /// Source is the caller, target is the selected entity (or caller).
+    CallerToTarget,
+    /// Source is the selected entity, target is the caller.
+    TargetToCaller,
+}
+
+/// Build the `onSequence` arg block. Minimal NameValuePair array (empty) and
+/// `ImpactTime = 0` — enough to fire the kismet sequence on the client.
+fn build_sequence_args(seq_id: i32, source_id: u32, target_id: u32, view_type: i8) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(28);
+    buf.extend_from_slice(&seq_id.to_le_bytes());
+    buf.extend_from_slice(&(source_id as i32).to_le_bytes());
+    buf.extend_from_slice(&(target_id as i32).to_le_bytes());
+    buf.push(1); // PrimaryTarget = true
+    buf.extend_from_slice(&0f32.to_le_bytes()); // ImpactTime
+    buf.extend_from_slice(&0u32.to_le_bytes()); // NameValuePair count = 0
+    buf.push(view_type as u8); // ViewType
+    buf.extend_from_slice(&0i32.to_le_bytes()); // InstanceId
+    buf
+}
+
+/// `.net_seq` / `.net_seqto` / `.net_seqfrom` — play a kismet sequence
+/// (`onSequence`, client method 1) on a source→target pair, fanned to the
+/// broadcaster's own client + witnesses.
+async fn sequence(
+    caller_id: u32,
+    target_id: Option<u32>,
+    args: &[&str],
+    dir: SeqDir,
+    tx: &mpsc::Sender<CellToBaseMsg>,
+    space_mgr: &mut SpaceManager,
+) {
+    let Some(seq_id) = super::parse_i32(caller_id, args, 0, "sequenceId", tx).await else {
+        return;
+    };
+    let view_type = match args.get(1) {
+        Some(s) => match s.parse::<i8>() {
+            Ok(v) => v,
+            Err(_) => {
+                send_gm_feedback(caller_id, "viewType must be an integer.", tx).await;
+                return;
+            }
+        },
+        None => 0,
+    };
+    let target = target_id.unwrap_or(caller_id);
+    let (source, dest, broadcaster) = match dir {
+        SeqDir::OnTarget => (target, target, target),
+        SeqDir::CallerToTarget => (caller_id, target, caller_id),
+        SeqDir::TargetToCaller => (target, caller_id, target),
+    };
+    let args_buf = build_sequence_args(seq_id, source, dest, view_type);
+    send_entity_method_to_self_and_witnesses(broadcaster, ON_SEQUENCE, args_buf, tx, space_mgr)
+        .await;
+    send_gm_feedback(
+        caller_id,
+        &format!("net_seq {seq_id} (view {view_type}) {source} -> {dest}"),
+        tx,
+    )
+    .await;
+}
+
+/// `.net_timer <id> <type> [totalTime] [secondaryId]` — start a client timer
+/// (`onTimerUpdate`, client method 12) on the caller.
+async fn timer(caller_id: u32, args: &[&str], tx: &mpsc::Sender<CellToBaseMsg>) {
+    let Some(id) = super::parse_i32(caller_id, args, 0, "timer id", tx).await else {
+        return;
+    };
+    let Some(ty) = super::parse_i32(caller_id, args, 1, "timer type", tx).await else {
+        return;
+    };
+    // `Type` is a UINT8 on the wire — reject out-of-range so the byte isn't
+    // silently truncated into a different timer type.
+    let Ok(ty) = u8::try_from(ty) else {
+        send_gm_feedback(caller_id, "net_timer: type must be 0-255.", tx).await;
+        return;
+    };
+    let total_time = match args.get(2) {
+        Some(s) => s
+            .parse::<f32>()
+            .ok()
+            .filter(|v| v.is_finite())
+            .unwrap_or(1.0),
+        None => 1.0,
+    };
+    let mut buf = Vec::with_capacity(17);
+    buf.extend_from_slice(&id.to_le_bytes());
+    buf.push(ty);
+    buf.extend_from_slice(&(caller_id as i32).to_le_bytes()); // SourceID
+    buf.extend_from_slice(&total_time.to_le_bytes());
+    buf.extend_from_slice(&total_time.to_le_bytes()); // BigWorldTimeComplete (relative)
+    let _ = tx
+        .send(CellToBaseMsg::EntityMethodCall {
+            entity_id: caller_id,
+            method_index: ON_TIMER_UPDATE,
+            args: buf,
+        })
+        .await;
+    send_gm_feedback(
+        caller_id,
+        &format!("net_timer {id} (type {ty}, {total_time}s)"),
+        tx,
+    )
+    .await;
+}
+
+/// `.net_mapinfo <sysId> <keyId> <lifetime> [delete] [sysTypeId]` — send
+/// `onMapInfo` (client method 123) to the target, located at the caller.
+async fn map_info(
+    caller_id: u32,
+    target_id: Option<u32>,
+    args: &[&str],
+    tx: &mpsc::Sender<CellToBaseMsg>,
+    space_mgr: &mut SpaceManager,
+) {
+    let Some(sys_id) = super::parse_i32(caller_id, args, 0, "sysId", tx).await else {
+        return;
+    };
+    let Some(key_id) = super::parse_i32(caller_id, args, 1, "keyId", tx).await else {
+        return;
+    };
+    let Some(lifetime) = super::parse_i32(caller_id, args, 2, "lifetime", tx).await else {
+        return;
+    };
+    let delete = match args.get(3) {
+        Some(s) => *s == "1" || s.eq_ignore_ascii_case("true"),
+        None => false,
+    };
+    let sys_type_id = args.get(4).and_then(|s| s.parse::<i32>().ok()).unwrap_or(0);
+    let recipient = target_id.unwrap_or(caller_id);
+    let (pos, world_id) = space_mgr
+        .get_entity(caller_id)
+        .map(|e| (e.position, e.space_id.0))
+        .unwrap_or((cimmeria_common::Vector3::zero(), 0));
+
+    let mut buf = Vec::with_capacity(33);
+    buf.extend_from_slice(&(sys_type_id as u32).to_le_bytes());
+    buf.extend_from_slice(&(sys_id as u32).to_le_bytes());
+    buf.extend_from_slice(&(key_id as u32).to_le_bytes());
+    buf.extend_from_slice(&world_id.to_le_bytes());
+    buf.extend_from_slice(&pos.x.to_le_bytes());
+    buf.extend_from_slice(&pos.y.to_le_bytes());
+    buf.extend_from_slice(&pos.z.to_le_bytes());
+    buf.extend_from_slice(&(lifetime as u32).to_le_bytes());
+    buf.push(u8::from(delete));
+    let _ = tx
+        .send(CellToBaseMsg::EntityMethodCall {
+            entity_id: recipient,
+            method_index: ON_MAP_INFO,
+            args: buf,
+        })
+        .await;
+    send_gm_feedback(
+        caller_id,
+        &format!("net_mapinfo sys={sys_id} key={key_id} life={lifetime} del={delete}"),
+        tx,
+    )
+    .await;
+}
+
+/// `.net_speak <message> [channel]` — make the target speak a message on a chat
+/// channel, fanned to its witnesses.
+async fn speak(
+    caller_id: u32,
+    target_id: Option<u32>,
+    args: &[&str],
+    tx: &mpsc::Sender<CellToBaseMsg>,
+    space_mgr: &mut SpaceManager,
+) {
+    let Some(target) = target_id else {
+        send_gm_feedback(caller_id, "net_speak: a target is required.", tx).await;
+        return;
+    };
+    // First arg is the message; an optional trailing channel name. The legacy
+    // took a single message word — we accept the message as one token (use
+    // quotes-free single words; multi-word handled by joining all-but-channel
+    // is ambiguous, so keep it simple: message is arg[0], channel is arg[1]).
+    let Some(message) = args.first().copied() else {
+        send_gm_feedback(caller_id, "net_speak: a message is required.", tx).await;
+        return;
+    };
+    let channel = match args.get(1).map(|s| s.to_ascii_lowercase()) {
+        None => CHAN_SAY,
+        Some(c) => match c.as_str() {
+            "say" => 0,
+            "emote" => 1,
+            "yell" => 2,
+            "team" => 3,
+            "squad" => 4,
+            other => {
+                send_gm_feedback(
+                    caller_id,
+                    &format!("net_speak: unknown channel '{other}'"),
+                    tx,
+                )
+                .await;
+                return;
+            }
+        },
+    };
+    let speaker = space_mgr
+        .get_entity(target)
+        .and_then(|e| e.npc_name.clone())
+        .unwrap_or_else(|| format!("Entity {target}"));
+
+    let mut buf = Vec::new();
+    push_wstring(&mut buf, &speaker);
+    buf.push(0); // SpeakerFlags
+    buf.push(channel);
+    push_wstring(&mut buf, message);
+    send_entity_method_to_self_and_witnesses(target, ON_PLAYER_COMMUNICATION, buf, tx, space_mgr)
+        .await;
+    send_gm_feedback(
+        caller_id,
+        &format!("net_speak [{target}]: \"{message}\""),
+        tx,
+    )
+    .await;
+}
+
+/// `.net_dialog <dialogId>` — open a dialog with the target NPC for the caller.
+async fn dialog(
+    caller_id: u32,
+    target_id: Option<u32>,
+    args: &[&str],
+    tx: &mpsc::Sender<CellToBaseMsg>,
+    space_mgr: &mut SpaceManager,
+) {
+    let Some(target) = target_id else {
+        send_gm_feedback(caller_id, "net_dialog: a target is required.", tx).await;
+        return;
+    };
+    let Some(dialog_id) = super::parse_i32(caller_id, args, 0, "dialogId", tx).await else {
+        return;
+    };
+    interactions::send_dialog_display(caller_id, target as i32, dialog_id, tx, space_mgr).await;
+    send_gm_feedback(
+        caller_id,
+        &format!("net_dialog {dialog_id} with [{target}]"),
+        tx,
+    )
+    .await;
+}
+
+/// `.net_challenge <challenge> <type> <object> <id1> <id2>` — send
+/// `onClientChallenge` (client method 142) to the caller.
+async fn challenge(caller_id: u32, args: &[&str], tx: &mpsc::Sender<CellToBaseMsg>) {
+    let Some(challenge) = super::parse_i32(caller_id, args, 0, "challenge", tx).await else {
+        return;
+    };
+    let Some(ty) = super::parse_i32(caller_id, args, 1, "type", tx).await else {
+        return;
+    };
+    let Some(object) = args.get(2).copied() else {
+        send_gm_feedback(caller_id, "net_challenge: object arg is required.", tx).await;
+        return;
+    };
+    let Some(id1) = super::parse_i32(caller_id, args, 3, "id1", tx).await else {
+        return;
+    };
+    let Some(id2) = super::parse_i32(caller_id, args, 4, "id2", tx).await else {
+        return;
+    };
+    let mut buf = Vec::new();
+    buf.extend_from_slice(&challenge.to_le_bytes());
+    buf.extend_from_slice(&ty.to_le_bytes());
+    push_wstring(&mut buf, object);
+    buf.extend_from_slice(&id1.to_le_bytes());
+    buf.extend_from_slice(&id2.to_le_bytes());
+    let _ = tx
+        .send(CellToBaseMsg::EntityMethodCall {
+            entity_id: caller_id,
+            method_index: ON_CLIENT_CHALLENGE,
+            args: buf,
+        })
+        .await;
+    send_gm_feedback(
+        caller_id,
+        &format!("net_challenge {challenge} type {ty}"),
+        tx,
+    )
+    .await;
+}
+
+/// `.debug_velocity <x> <y> <z>` — set the target's velocity (in-memory).
+async fn debug_velocity(
+    caller_id: u32,
+    target_id: Option<u32>,
+    args: &[&str],
+    tx: &mpsc::Sender<CellToBaseMsg>,
+    space_mgr: &mut SpaceManager,
+) {
+    let Some(target) = target_id else {
+        return;
+    };
+    let Some(x) = super::parse_f32(caller_id, args, 0, "velocityX", tx).await else {
+        return;
+    };
+    let Some(y) = super::parse_f32(caller_id, args, 1, "velocityY", tx).await else {
+        return;
+    };
+    let Some(z) = super::parse_f32(caller_id, args, 2, "velocityZ", tx).await else {
+        return;
+    };
+    if let Some(e) = space_mgr.get_entity_mut(target) {
+        e.velocity = [x, y, z];
+    }
+    send_gm_feedback(
+        caller_id,
+        &format!("debug_velocity [{target}] = ({x}, {y}, {z})"),
+        tx,
+    )
+    .await;
+}
+
+/// `.debug_follow` — toggle a follow action on the target (it follows the
+/// caller). Re-running cancels the follow.
+async fn debug_follow(
+    caller_id: u32,
+    target_id: Option<u32>,
+    tx: &mpsc::Sender<CellToBaseMsg>,
+    space_mgr: &mut SpaceManager,
+) {
+    let Some(target) = target_id else {
+        return;
+    };
+    let now_following = if let Some(e) = space_mgr.get_entity_mut(target) {
+        if e.follow_target_id == Some(caller_id) {
+            e.follow_target_id = None;
+            e.ai_state = AiState::Idle;
+            false
+        } else {
+            e.follow_target_id = Some(caller_id);
+            e.ai_state = AiState::Follow;
+            true
+        }
+    } else {
+        return;
+    };
+    send_gm_feedback(
+        caller_id,
+        &format!(
+            "debug_follow [{target}]: {}",
+            if now_following {
+                "following you"
+            } else {
+                "cancelled"
+            }
+        ),
+        tx,
+    )
+    .await;
+}
+
+/// `.threaten <amount>` — generate threat on the targeted mob from the caller.
+async fn threaten(
+    caller_id: u32,
+    target_id: Option<u32>,
+    args: &[&str],
+    tx: &mpsc::Sender<CellToBaseMsg>,
+    space_mgr: &mut SpaceManager,
+) {
+    let Some(target) = target_id else {
+        return;
+    };
+    let Some(amount) = super::parse_f32(caller_id, args, 0, "threat", tx).await else {
+        return;
+    };
+    if let Some(e) = space_mgr.get_entity_mut(target) {
+        *e.threat_list.entry(caller_id).or_insert(0.0) += amount;
+    }
+    send_gm_feedback(caller_id, &format!("threaten [{target}] += {amount}"), tx).await;
+}
+
+/// `.aggression <level>` — set the targeted mob's aggression level.
+async fn aggression(
+    caller_id: u32,
+    target_id: Option<u32>,
+    args: &[&str],
+    tx: &mpsc::Sender<CellToBaseMsg>,
+    space_mgr: &mut SpaceManager,
+) {
+    let Some(target) = target_id else {
+        return;
+    };
+    let Some(level) = super::parse_i32(caller_id, args, 0, "aggression", tx).await else {
+        return;
+    };
+    if let Some(e) = space_mgr.get_entity_mut(target) {
+        e.aggression = level;
+    }
+    send_gm_feedback(caller_id, &format!("aggression [{target}] = {level}"), tx).await;
+}

--- a/crates/services/src/cell/console/net.rs
+++ b/crates/services/src/cell/console/net.rs
@@ -30,15 +30,6 @@ const ON_CLIENT_CHALLENGE: u16 = 142;
 /// say (`0`).
 const CHAN_SAY: u8 = 0;
 
-/// Append a WSTRING (`u32` char count + UTF-16LE) to a wire buffer.
-fn push_wstring(buf: &mut Vec<u8>, s: &str) {
-    let utf16: Vec<u16> = s.encode_utf16().collect();
-    buf.extend_from_slice(&(utf16.len() as u32).to_le_bytes());
-    for ch in utf16 {
-        buf.extend_from_slice(&ch.to_le_bytes());
-    }
-}
-
 pub(super) async fn dispatch(
     name: &str,
     caller_id: u32,
@@ -301,10 +292,10 @@ async fn speak(
         .unwrap_or_else(|| format!("Entity {target}"));
 
     let mut buf = Vec::new();
-    push_wstring(&mut buf, &speaker);
+    crate::mercury::write_wstring(&mut buf, &speaker);
     buf.push(0); // SpeakerFlags
     buf.push(channel);
-    push_wstring(&mut buf, message);
+    crate::mercury::write_wstring(&mut buf, message);
     send_entity_method_to_self_and_witnesses(target, ON_PLAYER_COMMUNICATION, buf, tx, space_mgr)
         .await;
     send_gm_feedback(
@@ -361,7 +352,7 @@ async fn challenge(caller_id: u32, args: &[&str], tx: &mpsc::Sender<CellToBaseMs
     let mut buf = Vec::new();
     buf.extend_from_slice(&challenge.to_le_bytes());
     buf.extend_from_slice(&ty.to_le_bytes());
-    push_wstring(&mut buf, object);
+    crate::mercury::write_wstring(&mut buf, object);
     buf.extend_from_slice(&id1.to_le_bytes());
     buf.extend_from_slice(&id2.to_le_bytes());
     let _ = tx
@@ -388,6 +379,12 @@ async fn debug_velocity(
     space_mgr: &mut SpaceManager,
 ) {
     let Some(target) = target_id else {
+        send_gm_feedback(
+            caller_id,
+            "debug_velocity: select a target entity first.",
+            tx,
+        )
+        .await;
         return;
     };
     let Some(x) = super::parse_f32(caller_id, args, 0, "velocityX", tx).await else {

--- a/crates/services/src/cell/console/patrol.rs
+++ b/crates/services/src/cell/console/patrol.rs
@@ -1,0 +1,540 @@
+//! NPC patrol-path authoring console commands (category C) — the
+//! FanMMORPG `path_*` family.
+//!
+//! The patrol **runtime** already exists (`CellEntity::patrol_path`,
+//! `AiState::Patrol`, `cell::service::npc_ai::npc_ai_patrol`). These commands are
+//! the authoring front-end: build a waypoint list at your avatar's position,
+//! assign it to an NPC (which starts patrolling immediately), and record the
+//! `point_set_points` / `spawnlist` seed SQL for commit.
+//!
+//! Path id == `point_sets.set_id`. The runtime loads patrol points from
+//! `point_set_points` ordered by `point_id`; we therefore address "the Nth
+//! waypoint" by `ORDER BY point_id OFFSET n` in the per-waypoint edits. Per-spawn
+//! patrol assignment writes the `spawnlist.patrol_path_id` / `patrol_point_delay`
+//! override columns (added to the schema), which the spawn loader
+//! prefers over the template default.
+//!
+//! Reference: doko972/FanMMORPG `patrols.md` + `cell/commands/Resource.py`
+//! (`pathAdd`…`pathSetTeleportDelay`).
+
+use cimmeria_entity::cell_entity::AiState;
+use tokio::sync::mpsc;
+
+use super::seed;
+use super::send_gm_feedback;
+use crate::cell::messages::CellToBaseMsg;
+use crate::cell::space_manager::SpaceManager;
+
+const POINT_SETS_SEED: &str = "db/resources/Events/Seed/point_sets.sql";
+const POINT_SET_POINTS_SEED: &str = "db/resources/Events/Seed/point_set_points.sql";
+const SPAWNLIST_SEED: &str = "db/resources/Worlds/Seed/spawnlist.sql";
+
+pub(super) async fn dispatch(
+    name: &str,
+    caller_id: u32,
+    args: &[&str],
+    target_id: Option<u32>,
+    tx: &mpsc::Sender<CellToBaseMsg>,
+    space_mgr: &mut SpaceManager,
+) {
+    match name {
+        "path_add" => path_add(caller_id, args, tx, space_mgr).await,
+        "path_show" => path_show(caller_id, args, tx, space_mgr).await,
+        "path_clear" => path_clear(caller_id, args, tx, space_mgr).await,
+        "path_assign" => path_assign(caller_id, args, target_id, tx, space_mgr).await,
+        "path_unassign" => path_unassign(caller_id, target_id, tx, space_mgr).await,
+        "path_set_seq" => waypoint_set(caller_id, args, "sequence_id", true, tx, space_mgr).await,
+        "path_clear_seq" => {
+            waypoint_set(caller_id, args, "sequence_id", false, tx, space_mgr).await
+        }
+        "path_set_tp" => path_set_tp(caller_id, args, tx, space_mgr).await,
+        "path_clear_tp" => path_clear_tp(caller_id, args, tx, space_mgr).await,
+        "path_set_tp_seq" => {
+            waypoint_set(caller_id, args, "teleport_sequence_id", true, tx, space_mgr).await
+        }
+        "path_set_tp_delay" => path_set_tp_delay(caller_id, args, tx, space_mgr).await,
+        _ => {}
+    }
+}
+
+/// Parse the `path_id` arg (always positional 0).
+async fn parse_path_id(
+    caller_id: u32,
+    args: &[&str],
+    tx: &mpsc::Sender<CellToBaseMsg>,
+) -> Option<i32> {
+    super::parse_i32(caller_id, args, 0, "pathId", tx).await
+}
+
+/// Parse a non-negative waypoint `index` (positional 1). A negative value would
+/// become an invalid `OFFSET -1` in the per-waypoint UPDATE subquery.
+async fn parse_index(
+    caller_id: u32,
+    args: &[&str],
+    tx: &mpsc::Sender<CellToBaseMsg>,
+) -> Option<i32> {
+    let index = super::parse_i32(caller_id, args, 1, "index", tx).await?;
+    if index < 0 {
+        send_gm_feedback(caller_id, "index must be >= 0", tx).await;
+        return None;
+    }
+    Some(index)
+}
+
+/// `.path_add <pathId>` — append the caller's position as the next waypoint.
+/// On the first waypoint of a path, also records the `point_sets` header row
+/// (FK parent of `point_set_points`).
+async fn path_add(
+    caller_id: u32,
+    args: &[&str],
+    tx: &mpsc::Sender<CellToBaseMsg>,
+    space_mgr: &mut SpaceManager,
+) {
+    let Some(path_id) = parse_path_id(caller_id, args, tx).await else {
+        return;
+    };
+    let Some(pos) = space_mgr.get_entity(caller_id).map(|e| e.position) else {
+        return;
+    };
+    let space_id = space_mgr.get_entity_space_id(caller_id);
+    let world_name = space_id
+        .and_then(|sid| space_mgr.spaces.get(&sid))
+        .map(|s| s.world_name.clone());
+
+    let first = space_mgr
+        .patrol_authoring
+        .get(&path_id)
+        .is_none_or(Vec::is_empty);
+
+    // First waypoint: ensure the point_sets header exists (FK parent).
+    if first {
+        let Some(world) = world_name.clone() else {
+            send_gm_feedback(caller_id, "path_add: cannot resolve world.", tx).await;
+            return;
+        };
+        let header = format!(
+            "INSERT INTO resources.point_sets (set_id, name, type, world_id, shape, flags)\n\
+             SELECT {path_id}, {name}, 'Patrol', w.world_id, 'Path', 1\n\
+             FROM resources.worlds w WHERE w.world = {world}\n\
+             ON CONFLICT (set_id) DO NOTHING;",
+            name = seed::sql_str(Some(&format!("console-path-{path_id}"))),
+            world = seed::sql_str(Some(&world)),
+        );
+        seed::record(
+            caller_id,
+            POINT_SETS_SEED,
+            "path_add",
+            &header,
+            tx,
+            space_mgr,
+        )
+        .await;
+    }
+
+    let point = format!(
+        "INSERT INTO resources.point_set_points (set_id, x, y, z, yaw, pitch, roll)\n\
+         VALUES ({path_id}, {x}, {y}, {z}, 0, 0, 0);",
+        x = pos.x,
+        y = pos.y,
+        z = pos.z,
+    );
+    seed::record(
+        caller_id,
+        POINT_SET_POINTS_SEED,
+        "path_add",
+        &point,
+        tx,
+        space_mgr,
+    )
+    .await;
+
+    let idx = {
+        let buf = space_mgr.patrol_authoring.entry(path_id).or_default();
+        buf.push(pos);
+        buf.len() - 1
+    };
+    send_gm_feedback(
+        caller_id,
+        &format!(
+            "path_add [{path_id}] point {idx}: ({:.2}, {:.2}, {:.2})",
+            pos.x, pos.y, pos.z
+        ),
+        tx,
+    )
+    .await;
+}
+
+/// `.path_show <pathId>` — show the session-authored waypoints for a path.
+async fn path_show(
+    caller_id: u32,
+    args: &[&str],
+    tx: &mpsc::Sender<CellToBaseMsg>,
+    space_mgr: &mut SpaceManager,
+) {
+    let Some(path_id) = parse_path_id(caller_id, args, tx).await else {
+        return;
+    };
+    let points = space_mgr
+        .patrol_authoring
+        .get(&path_id)
+        .cloned()
+        .unwrap_or_default();
+    if points.is_empty() {
+        send_gm_feedback(
+            caller_id,
+            &format!("path_show [{path_id}]: no waypoints authored this session."),
+            tx,
+        )
+        .await;
+        return;
+    }
+    send_gm_feedback(
+        caller_id,
+        &format!("path_show [{path_id}] {} point(s):", points.len()),
+        tx,
+    )
+    .await;
+    for (i, p) in points.iter().enumerate() {
+        send_gm_feedback(
+            caller_id,
+            &format!("  [{i}] ({:.2}, {:.2}, {:.2})", p.x, p.y, p.z),
+            tx,
+        )
+        .await;
+    }
+}
+
+/// `.path_clear <pathId>` — drop the path's waypoints (buffer + DB rows).
+async fn path_clear(
+    caller_id: u32,
+    args: &[&str],
+    tx: &mpsc::Sender<CellToBaseMsg>,
+    space_mgr: &mut SpaceManager,
+) {
+    let Some(path_id) = parse_path_id(caller_id, args, tx).await else {
+        return;
+    };
+    space_mgr.patrol_authoring.remove(&path_id);
+    // Two SINGLE statements, recorded separately: the live-write executor runs
+    // each via a prepared statement (which rejects multi-command strings), and
+    // each lands in its own seed file. Points first (FK child), then the header.
+    let points = format!("DELETE FROM resources.point_set_points WHERE set_id = {path_id};");
+    seed::record(
+        caller_id,
+        POINT_SET_POINTS_SEED,
+        "path_clear",
+        &points,
+        tx,
+        space_mgr,
+    )
+    .await;
+    let header = format!("DELETE FROM resources.point_sets WHERE set_id = {path_id};");
+    seed::record(
+        caller_id,
+        POINT_SETS_SEED,
+        "path_clear",
+        &header,
+        tx,
+        space_mgr,
+    )
+    .await;
+}
+
+/// `.path_assign <pathId> [delay]` — assign a path to the targeted NPC's spawn
+/// and start it patrolling now. Applies the session waypoints to the NPC's
+/// `patrol_path` in memory and records the `spawnlist` override.
+async fn path_assign(
+    caller_id: u32,
+    args: &[&str],
+    target_id: Option<u32>,
+    tx: &mpsc::Sender<CellToBaseMsg>,
+    space_mgr: &mut SpaceManager,
+) {
+    let Some(path_id) = parse_path_id(caller_id, args, tx).await else {
+        return;
+    };
+    let Some(target) = target_id else {
+        send_gm_feedback(caller_id, "path_assign: target an NPC first.", tx).await;
+        return;
+    };
+    // Default 3.0 when omitted; if supplied it must be a finite number — a bad
+    // value is a typo, not a silent fallback (it would also corrupt the UPDATE).
+    let delay = match args.get(1) {
+        None => 3.0,
+        Some(s) => match s.parse::<f32>().ok().filter(|v| v.is_finite()) {
+            Some(v) => v,
+            None => {
+                send_gm_feedback(caller_id, "path_assign: delay must be a finite number.", tx)
+                    .await;
+                return;
+            }
+        },
+    };
+    let waypoints = space_mgr
+        .patrol_authoring
+        .get(&path_id)
+        .cloned()
+        .unwrap_or_default();
+    if waypoints.is_empty() {
+        send_gm_feedback(
+            caller_id,
+            &format!(
+                "path_assign: path {path_id} has no authored waypoints — use .path_add first."
+            ),
+            tx,
+        )
+        .await;
+        return;
+    }
+
+    // Apply in memory: the NPC starts patrolling immediately.
+    let spawn_id = space_mgr.get_entity(target).and_then(|e| e.spawn_id);
+    if let Some(e) = space_mgr.get_entity_mut(target) {
+        e.patrol_path = waypoints;
+        e.patrol_point_delay_secs = delay;
+        e.patrol_next_index = 0;
+        e.ai_state = AiState::Patrol;
+    }
+
+    // Persist the per-spawn override, keyed on the exact `spawn_id`. A
+    // command-spawned NPC has no spawnlist row, so it patrols this session only.
+    let Some(spawn_id) = spawn_id else {
+        send_gm_feedback(
+            caller_id,
+            &format!(
+                "path_assign [{path_id}] -> NPC {target}: patrolling now (in-memory only — \
+                 no spawnlist row to persist the override to)."
+            ),
+            tx,
+        )
+        .await;
+        return;
+    };
+    let sql = format!(
+        "UPDATE resources.spawnlist SET patrol_path_id = {path_id}, patrol_point_delay = {delay} \
+         WHERE spawn_id = {spawn_id};"
+    );
+    seed::record(
+        caller_id,
+        SPAWNLIST_SEED,
+        "path_assign",
+        &sql,
+        tx,
+        space_mgr,
+    )
+    .await;
+    send_gm_feedback(
+        caller_id,
+        &format!("path_assign [{path_id}] -> NPC {target} (delay {delay}s), patrolling now."),
+        tx,
+    )
+    .await;
+}
+
+/// `.path_unassign` — stop the targeted NPC patrolling and clear its spawn
+/// override.
+async fn path_unassign(
+    caller_id: u32,
+    target_id: Option<u32>,
+    tx: &mpsc::Sender<CellToBaseMsg>,
+    space_mgr: &mut SpaceManager,
+) {
+    let Some(target) = target_id else {
+        send_gm_feedback(caller_id, "path_unassign: target an NPC first.", tx).await;
+        return;
+    };
+    let spawn_id = space_mgr.get_entity(target).and_then(|e| e.spawn_id);
+    if let Some(e) = space_mgr.get_entity_mut(target) {
+        e.patrol_path.clear();
+        e.patrol_next_index = 0;
+        e.ai_state = AiState::Idle;
+    }
+    if let Some(spawn_id) = spawn_id {
+        let sql = format!(
+            "UPDATE resources.spawnlist SET patrol_path_id = NULL, patrol_point_delay = NULL \
+             WHERE spawn_id = {spawn_id};"
+        );
+        seed::record(
+            caller_id,
+            SPAWNLIST_SEED,
+            "path_unassign",
+            &sql,
+            tx,
+            space_mgr,
+        )
+        .await;
+    }
+    send_gm_feedback(
+        caller_id,
+        &format!("path_unassign: NPC {target} stopped patrolling."),
+        tx,
+    )
+    .await;
+}
+
+/// Shared body for the integer-valued per-waypoint edits (`path_set_seq`,
+/// `path_clear_seq`, `path_set_tp_seq`). `set = false` writes NULL (clear). The
+/// Nth waypoint is addressed by `ORDER BY point_id OFFSET n`.
+async fn waypoint_set(
+    caller_id: u32,
+    args: &[&str],
+    column: &str,
+    set: bool,
+    tx: &mpsc::Sender<CellToBaseMsg>,
+    space_mgr: &mut SpaceManager,
+) {
+    let Some(path_id) = parse_path_id(caller_id, args, tx).await else {
+        return;
+    };
+    let Some(index) = parse_index(caller_id, args, tx).await else {
+        return;
+    };
+    let value = if set {
+        match super::parse_i32(caller_id, args, 2, "value", tx).await {
+            Some(v) => v.to_string(),
+            None => return,
+        }
+    } else {
+        "NULL".to_string()
+    };
+    let sql = format!(
+        "UPDATE resources.point_set_points SET {column} = {value}\n\
+         WHERE point_id = (SELECT point_id FROM resources.point_set_points\n\
+                           WHERE set_id = {path_id} ORDER BY point_id OFFSET {index} LIMIT 1);"
+    );
+    seed::record(
+        caller_id,
+        POINT_SET_POINTS_SEED,
+        "path_seq",
+        &sql,
+        tx,
+        space_mgr,
+    )
+    .await;
+    send_gm_feedback(
+        caller_id,
+        &format!("path [{path_id}] point {index}: {column} = {value}"),
+        tx,
+    )
+    .await;
+}
+
+/// `.path_set_tp <pathId> <index>` — set the waypoint's teleport destination to
+/// the caller's current position.
+async fn path_set_tp(
+    caller_id: u32,
+    args: &[&str],
+    tx: &mpsc::Sender<CellToBaseMsg>,
+    space_mgr: &mut SpaceManager,
+) {
+    let Some(path_id) = parse_path_id(caller_id, args, tx).await else {
+        return;
+    };
+    let Some(index) = parse_index(caller_id, args, tx).await else {
+        return;
+    };
+    let Some(pos) = space_mgr.get_entity(caller_id).map(|e| e.position) else {
+        return;
+    };
+    let sql = format!(
+        "UPDATE resources.point_set_points SET teleport_x = {x}, teleport_y = {y}, teleport_z = {z}\n\
+         WHERE point_id = (SELECT point_id FROM resources.point_set_points\n\
+                           WHERE set_id = {path_id} ORDER BY point_id OFFSET {index} LIMIT 1);",
+        x = pos.x,
+        y = pos.y,
+        z = pos.z,
+    );
+    seed::record(
+        caller_id,
+        POINT_SET_POINTS_SEED,
+        "path_set_tp",
+        &sql,
+        tx,
+        space_mgr,
+    )
+    .await;
+    send_gm_feedback(
+        caller_id,
+        &format!(
+            "path_set_tp [{path_id}] point {index} -> ({:.2}, {:.2}, {:.2})",
+            pos.x, pos.y, pos.z
+        ),
+        tx,
+    )
+    .await;
+}
+
+/// `.path_clear_tp <pathId> <index>` — clear a waypoint's teleport.
+async fn path_clear_tp(
+    caller_id: u32,
+    args: &[&str],
+    tx: &mpsc::Sender<CellToBaseMsg>,
+    space_mgr: &mut SpaceManager,
+) {
+    let Some(path_id) = parse_path_id(caller_id, args, tx).await else {
+        return;
+    };
+    let Some(index) = parse_index(caller_id, args, tx).await else {
+        return;
+    };
+    let sql = format!(
+        "UPDATE resources.point_set_points\n\
+         SET teleport_x = NULL, teleport_y = NULL, teleport_z = NULL, teleport_sequence_id = NULL, teleport_delay = NULL\n\
+         WHERE point_id = (SELECT point_id FROM resources.point_set_points\n\
+                           WHERE set_id = {path_id} ORDER BY point_id OFFSET {index} LIMIT 1);"
+    );
+    seed::record(
+        caller_id,
+        POINT_SET_POINTS_SEED,
+        "path_clear_tp",
+        &sql,
+        tx,
+        space_mgr,
+    )
+    .await;
+    send_gm_feedback(
+        caller_id,
+        &format!("path_clear_tp [{path_id}] point {index}"),
+        tx,
+    )
+    .await;
+}
+
+/// `.path_set_tp_delay <pathId> <index> <delay>` — set the post-departure
+/// teleport delay (seconds) on a waypoint.
+async fn path_set_tp_delay(
+    caller_id: u32,
+    args: &[&str],
+    tx: &mpsc::Sender<CellToBaseMsg>,
+    space_mgr: &mut SpaceManager,
+) {
+    let Some(path_id) = parse_path_id(caller_id, args, tx).await else {
+        return;
+    };
+    let Some(index) = parse_index(caller_id, args, tx).await else {
+        return;
+    };
+    let Some(delay) = super::parse_f32(caller_id, args, 2, "delay", tx).await else {
+        return;
+    };
+    let sql = format!(
+        "UPDATE resources.point_set_points SET teleport_delay = {delay}\n\
+         WHERE point_id = (SELECT point_id FROM resources.point_set_points\n\
+                           WHERE set_id = {path_id} ORDER BY point_id OFFSET {index} LIMIT 1);"
+    );
+    seed::record(
+        caller_id,
+        POINT_SET_POINTS_SEED,
+        "path_set_tp_delay",
+        &sql,
+        tx,
+        space_mgr,
+    )
+    .await;
+    send_gm_feedback(
+        caller_id,
+        &format!("path_set_tp_delay [{path_id}] point {index} = {delay}s"),
+        tx,
+    )
+    .await;
+}

--- a/crates/services/src/cell/console/query.rs
+++ b/crates/services/src/cell/console/query.rs
@@ -1,0 +1,145 @@
+//! Read-only console queries — `.help`, the `.search*` family, and `.players`
+//! (category D). Search runs base-side (the cell caches resource ids but
+//! not display names); the rest read cell state and reply via the feedback
+//! channel.
+//!
+//! Legacy reference: `deprecated/python/cell/commands/Resource.py`
+//! (`searchItem`/`searchMission`/`searchTemplate`) and
+//! `deprecated/python/cell/commands/Misc.py` (`players`).
+
+use tokio::sync::mpsc;
+
+use super::{send_gm_feedback, Spec, COMMANDS};
+use crate::cell::messages::CellToBaseMsg;
+use crate::cell::space_manager::SpaceManager;
+
+/// `.help [filter]` — list the console commands (optionally filtered by
+/// substring) **sorted by command name**, each with its one-line summary.
+/// Mirrors the legacy `help`, which also sorted by name.
+pub(super) async fn help(caller_id: u32, args: &[&str], tx: &mpsc::Sender<CellToBaseMsg>) {
+    let matches = help_specs(args.first().copied());
+    for spec in &matches {
+        send_gm_feedback(caller_id, &format!(".{}: {}", spec.name, spec.help), tx).await;
+    }
+    if matches.is_empty() {
+        send_gm_feedback(caller_id, "help: no command matched.", tx).await;
+    }
+}
+
+/// The `.help` result set: commands matching the optional substring `filter`,
+/// sorted alphabetically by name. Split out so the sort is unit-testable.
+fn help_specs(filter: Option<&str>) -> Vec<&'static Spec> {
+    let needle = filter.map(str::to_ascii_lowercase);
+    let mut matches: Vec<&'static Spec> = COMMANDS
+        .iter()
+        .filter(|spec| needle.as_deref().is_none_or(|f| spec.name.contains(f)))
+        .collect();
+    matches.sort_by_key(|spec| spec.name);
+    matches
+}
+
+/// Build the search query string from one or two name args (legacy joined a
+/// second optional word with a space) and dispatch the base-side search.
+async fn search(caller_id: u32, kind: u8, args: &[&str], tx: &mpsc::Sender<CellToBaseMsg>) {
+    let query = args.join(" ");
+    let _ = tx
+        .send(CellToBaseMsg::ConsoleSearch {
+            entity_id: caller_id,
+            kind,
+            query,
+        })
+        .await;
+}
+
+/// `.searchitem <name> [name2]` — search item designs by name.
+pub(super) async fn search_item(
+    caller_id: u32,
+    args: &[&str],
+    tx: &mpsc::Sender<CellToBaseMsg>,
+    _space_mgr: &mut SpaceManager,
+) {
+    search(caller_id, 0, args, tx).await;
+}
+
+/// `.searchmission <name> [name2]` — search mission designs by name.
+pub(super) async fn search_mission(
+    caller_id: u32,
+    args: &[&str],
+    tx: &mpsc::Sender<CellToBaseMsg>,
+    _space_mgr: &mut SpaceManager,
+) {
+    search(caller_id, 1, args, tx).await;
+}
+
+/// `.searchtemplate <name> [name2]` — search entity templates by name.
+pub(super) async fn search_template(
+    caller_id: u32,
+    args: &[&str],
+    tx: &mpsc::Sender<CellToBaseMsg>,
+    _space_mgr: &mut SpaceManager,
+) {
+    search(caller_id, 2, args, tx).await;
+}
+
+/// `.players` — list the players in the caller's space. Cell-scoped (the cell
+/// only knows its own spaces); mirrors the legacy `players` / `gmUsers`.
+pub(super) async fn players(
+    caller_id: u32,
+    tx: &mpsc::Sender<CellToBaseMsg>,
+    space_mgr: &mut SpaceManager,
+) {
+    let Some(space_id) = space_mgr.get_entity_space_id(caller_id) else {
+        send_gm_feedback(caller_id, "players: you are not in a space.", tx).await;
+        return;
+    };
+    let mut ids: Vec<u32> = space_mgr
+        .all_player_entity_ids()
+        .into_iter()
+        .filter(|&pid| space_mgr.get_entity_space_id(pid) == Some(space_id))
+        .collect();
+    ids.sort_unstable();
+    if ids.is_empty() {
+        send_gm_feedback(caller_id, "players: none in your space.", tx).await;
+        return;
+    }
+    let list = ids
+        .iter()
+        .map(|pid| {
+            let char_id = space_mgr.get_entity(*pid).and_then(|e| e.player_id);
+            match char_id {
+                Some(c) => format!("{pid} (char {c})"),
+                None => pid.to_string(),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    send_gm_feedback(
+        caller_id,
+        &format!("players ({} in space): {list}", ids.len()),
+        tx,
+    )
+    .await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn help_is_sorted_by_name_and_lists_all() {
+        let all = help_specs(None);
+        let names: Vec<&str> = all.iter().map(|s| s.name).collect();
+        let mut sorted = names.clone();
+        sorted.sort_unstable();
+        assert_eq!(names, sorted, ".help must be sorted alphabetically by name");
+        assert_eq!(all.len(), COMMANDS.len(), "unfiltered .help lists every command");
+    }
+
+    #[test]
+    fn help_filter_matches_substring_only() {
+        let paths = help_specs(Some("path"));
+        assert!(!paths.is_empty());
+        assert!(paths.iter().all(|s| s.name.contains("path")));
+        assert!(help_specs(Some("definitely-no-such-command")).is_empty());
+    }
+}

--- a/crates/services/src/cell/console/query.rs
+++ b/crates/services/src/cell/console/query.rs
@@ -132,7 +132,11 @@ mod tests {
         let mut sorted = names.clone();
         sorted.sort_unstable();
         assert_eq!(names, sorted, ".help must be sorted alphabetically by name");
-        assert_eq!(all.len(), COMMANDS.len(), "unfiltered .help lists every command");
+        assert_eq!(
+            all.len(),
+            COMMANDS.len(),
+            "unfiltered .help lists every command"
+        );
     }
 
     #[test]

--- a/crates/services/src/cell/console/seed.rs
+++ b/crates/services/src/cell/console/seed.rs
@@ -1,0 +1,346 @@
+//! Authoring persistence — the single choke point for everything the `.`-console
+//! authoring commands write.
+//!
+//! In this repo the seed files under `db/resources/` are the source of truth —
+//! the DB is rebuilt from them, and the standing rule is "edit the seed in
+//! `db/resources/`, never a `db/scripts/*.sql` migration." So an authoring
+//! command does three things, in order:
+//!
+//! 1. **Apply in memory** (the caller does this before calling here) so the GM
+//!    sees the effect immediately — a freshly-assigned patrol starts walking now.
+//! 2. **Write the live DB** via [`CellToBaseMsg::ExecuteAuthoringSql`] so the
+//!    change holds across reconnects within the current deploy. This is
+//!    transient: the next deploy rebuilds from seeds and wipes it.
+//! 3. **Record the seed SQL** as the durable artifact for a human to commit.
+//!    Each statement is appended to a per-session on-disk log immediately (so
+//!    nothing is lost even without confirmation) and buffered per-GM for
+//!    [`confirm`], which groups the statements per seed file.
+//!
+//! **The raw SQL is never shown in-game** — the client's chat isn't
+//! copy-pasteable, so emitting it there is useless. It goes out-of-band: the
+//! per-session log file ([`session_log_path`]) and the server's tracing log
+//! today, and (once enabled on the colo) a Discord authoring channel. In-game
+//! feedback is status-only ("recorded — N pending", "confirmed: M statements").
+//!
+//! # Future Discord hook
+//!
+//! [`confirm`] groups the buffer per seed file and emits each block to tracing
+//! today. The same per-file payload is exactly what a `cimmeria-discord`
+//! `EventKind` (e.g. `SeedAuthored`) would post once the colo integration is on
+//! — a sink swap inside [`confirm`], not a redesign. Discord is intentionally
+//! NOT wired here yet (it's off in the colo, and adding an event type is its own
+//! checklist in `docs/architecture/discord-notifications.md`).
+
+use std::io::Write as _;
+use std::path::PathBuf;
+use std::sync::OnceLock;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use tokio::sync::mpsc;
+
+use super::send_gm_feedback;
+use crate::cell::messages::CellToBaseMsg;
+use crate::cell::space_manager::SpaceManager;
+
+/// Record one authored change: send the live DB write to the base, append the
+/// statement to the per-session on-disk log, and buffer it per-GM for
+/// [`confirm`]. `label` is a short human tag (e.g. `"savespawn"`); `seed_file`
+/// is the `db/resources/` path the statement should be committed into.
+///
+/// In-game feedback is a status line only — the SQL itself goes to the log file
+/// and (on confirm) tracing / Discord.
+pub(crate) async fn record(
+    caller_id: u32,
+    seed_file: &str,
+    label: &str,
+    sql: &str,
+    tx: &mpsc::Sender<CellToBaseMsg>,
+    space_mgr: &mut SpaceManager,
+) {
+    // 2. Live DB write (transient — wiped on next deploy). A closed base
+    //    channel means the live write is lost; warn so the GM's "recorded"
+    //    feedback isn't silently overstating what happened (the seed log + buffer
+    //    below still capture the durable artifact).
+    if let Err(e) = tx
+        .send(CellToBaseMsg::ExecuteAuthoringSql {
+            entity_id: caller_id,
+            label: label.to_string(),
+            sql: sql.to_string(),
+        })
+        .await
+    {
+        tracing::warn!(
+            entity_id = caller_id,
+            label,
+            error = %e,
+            "authoring live-write enqueue failed (base channel closed); seed still recorded"
+        );
+    }
+
+    // 3a. Persist to the per-session on-disk log immediately.
+    append_session_log(format!("-- [{label}] -> {seed_file}\n{sql}\n")).await;
+
+    // 3b. Buffer per-GM for grouped confirmation.
+    space_mgr
+        .authoring_changes
+        .entry(caller_id)
+        .or_default()
+        .push((seed_file.to_string(), sql.to_string()));
+
+    let pending = space_mgr
+        .authoring_changes
+        .get(&caller_id)
+        .map_or(0, Vec::len);
+    send_gm_feedback(
+        caller_id,
+        &format!(
+            "{label}: recorded ({pending} pending). .seedconfirm to emit, .seedcancel to discard."
+        ),
+        tx,
+    )
+    .await;
+}
+
+/// Flush the caller's buffered authoring statements: group them per seed file,
+/// emit each file's block to the server log (and the per-session on-disk log),
+/// then clear the buffer. The developer confirms here, so only reviewed sets
+/// reach the out-of-band sinks.
+pub(crate) async fn confirm(
+    caller_id: u32,
+    tx: &mpsc::Sender<CellToBaseMsg>,
+    space_mgr: &mut SpaceManager,
+) {
+    let changes = space_mgr
+        .authoring_changes
+        .remove(&caller_id)
+        .unwrap_or_default();
+    if changes.is_empty() {
+        send_gm_feedback(caller_id, "seedconfirm: no pending changes.", tx).await;
+        return;
+    }
+
+    // Group by seed file, preserving first-seen file order and per-file
+    // statement order.
+    let mut files: Vec<String> = Vec::new();
+    let mut by_file: std::collections::HashMap<String, Vec<String>> =
+        std::collections::HashMap::new();
+    for (file, sql) in &changes {
+        if !files.contains(file) {
+            files.push(file.clone());
+        }
+        by_file.entry(file.clone()).or_default().push(sql.clone());
+    }
+
+    for file in &files {
+        let stmts = &by_file[file];
+        let block = stmts.join("\n");
+        // Out-of-band emission #1: server tracing log. Future Discord sink
+        // posts this same (file, block) payload.
+        tracing::info!(
+            target: "authoring",
+            entity_id = caller_id,
+            seed_file = %file,
+            statements = stmts.len(),
+            "seed authoring confirmed:\n{block}"
+        );
+        // Out-of-band emission #2: per-session on-disk log, marked confirmed.
+        append_session_log(format!(
+            "-- ===== CONFIRMED by entity {caller_id} -> commit into {file} =====\n{block}\n"
+        ))
+        .await;
+    }
+
+    send_gm_feedback(
+        caller_id,
+        &format!(
+            "seedconfirm: {} statement(s) across {} seed file(s) emitted to the server log + {}",
+            changes.len(),
+            files.len(),
+            session_log_path()
+                .map(|p| p.display().to_string())
+                .unwrap_or_else(|| "(log unavailable)".to_string()),
+        ),
+        tx,
+    )
+    .await;
+}
+
+/// Report how many authoring statements are buffered for the caller, per file.
+pub(crate) async fn pending(
+    caller_id: u32,
+    tx: &mpsc::Sender<CellToBaseMsg>,
+    space_mgr: &mut SpaceManager,
+) {
+    let changes = space_mgr.authoring_changes.get(&caller_id);
+    match changes.filter(|c| !c.is_empty()) {
+        None => send_gm_feedback(caller_id, "seedpending: no pending changes.", tx).await,
+        Some(changes) => {
+            let mut counts: Vec<(String, usize)> = Vec::new();
+            for (file, _) in changes {
+                match counts.iter_mut().find(|(f, _)| f == file) {
+                    Some((_, n)) => *n += 1,
+                    None => counts.push((file.clone(), 1)),
+                }
+            }
+            let summary = counts
+                .iter()
+                .map(|(f, n)| format!("{f} ({n})"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            send_gm_feedback(
+                caller_id,
+                &format!("seedpending: {} statement(s) — {summary}", changes.len()),
+                tx,
+            )
+            .await;
+        }
+    }
+}
+
+/// Discard the caller's buffered authoring statements without emitting them.
+/// (The per-session on-disk log already holds each statement as it was
+/// recorded — this only clears the confirm buffer.)
+pub(crate) async fn cancel(
+    caller_id: u32,
+    tx: &mpsc::Sender<CellToBaseMsg>,
+    space_mgr: &mut SpaceManager,
+) {
+    let n = space_mgr
+        .authoring_changes
+        .remove(&caller_id)
+        .map_or(0, |c| c.len());
+    send_gm_feedback(
+        caller_id,
+        &format!("seedcancel: discarded {n} pending statement(s)."),
+        tx,
+    )
+    .await;
+}
+
+/// Format a SQL string literal: single-quote wrapped with internal quotes
+/// doubled, or the bareword `NULL` for `None`. Used when building seed
+/// `INSERT`/`UPDATE` statements from authored string fields (tags, names) so no
+/// raw client text is concatenated unescaped.
+pub(crate) fn sql_str(value: Option<&str>) -> String {
+    match value {
+        Some(s) => format!("'{}'", s.replace('\'', "''")),
+        None => "NULL".to_string(),
+    }
+}
+
+/// Path of the per-session authoring log, fixed once per server run.
+///
+/// Directory comes from `CIMMERIA_AUTHORING_LOG_DIR` (default `logs`); the file
+/// name is stamped with the process start epoch so each server session gets its
+/// own file. `None` if the system clock is unavailable (should never happen).
+fn session_log_path() -> Option<PathBuf> {
+    static PATH: OnceLock<Option<PathBuf>> = OnceLock::new();
+    PATH.get_or_init(|| {
+        let dir =
+            std::env::var("CIMMERIA_AUTHORING_LOG_DIR").unwrap_or_else(|_| "logs".to_string());
+        let stamp = SystemTime::now().duration_since(UNIX_EPOCH).ok()?.as_secs();
+        Some(PathBuf::from(dir).join(format!("seed-authoring-{stamp}.sql")))
+    })
+    .clone()
+}
+
+/// Append a block to the per-session authoring log, best-effort. Failures warn
+/// but never abort the command — the live DB write and tracing log still landed.
+///
+/// The actual file I/O runs on a blocking thread (`spawn_blocking`) so a
+/// slow/stalled disk can't block the cell's async worker thread, even though
+/// this path is GM-only and rare.
+async fn append_session_log(block: String) {
+    let _ = tokio::task::spawn_blocking(move || {
+        let Some(path) = session_log_path() else {
+            return;
+        };
+        if let Some(parent) = path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        match std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)
+        {
+            Ok(mut f) => {
+                if let Err(e) = f.write_all(block.as_bytes()) {
+                    tracing::warn!(path = %path.display(), error = %e, "authoring log append failed");
+                }
+            }
+            Err(e) => {
+                tracing::warn!(path = %path.display(), error = %e, "authoring log open failed");
+            }
+        }
+    })
+    .await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sql_str_quotes_and_escapes() {
+        assert_eq!(sql_str(None), "NULL");
+        assert_eq!(sql_str(Some("plain")), "'plain'");
+        assert_eq!(sql_str(Some("O'Neill")), "'O''Neill'");
+    }
+
+    #[tokio::test]
+    async fn record_buffers_and_sends_live_write() {
+        let mut mgr = SpaceManager::new(1);
+        let (tx, mut rx) = mpsc::channel(16);
+        record(
+            7,
+            "db/resources/X.sql",
+            "savespawn",
+            "DELETE FROM x;",
+            &tx,
+            &mut mgr,
+        )
+        .await;
+        // Buffered for confirm.
+        assert_eq!(mgr.authoring_changes.get(&7).map(Vec::len), Some(1));
+        // First message is the live-write request; a status feedback follows.
+        let mut saw_live = false;
+        while let Ok(msg) = rx.try_recv() {
+            if matches!(msg, CellToBaseMsg::ExecuteAuthoringSql { .. }) {
+                saw_live = true;
+            }
+        }
+        assert!(
+            saw_live,
+            "record must send ExecuteAuthoringSql for the live write"
+        );
+    }
+
+    #[tokio::test]
+    async fn confirm_clears_buffer() {
+        let mut mgr = SpaceManager::new(1);
+        let (tx, _rx) = mpsc::channel(16);
+        record(
+            7,
+            "db/resources/X.sql",
+            "savespawn",
+            "DELETE FROM x;",
+            &tx,
+            &mut mgr,
+        )
+        .await;
+        confirm(7, &tx, &mut mgr).await;
+        assert!(mgr.authoring_changes.get(&7).is_none_or(Vec::is_empty));
+    }
+
+    #[tokio::test]
+    async fn confirm_with_nothing_pending_is_noop_feedback() {
+        let mut mgr = SpaceManager::new(1);
+        let (tx, mut rx) = mpsc::channel(16);
+        confirm(9, &tx, &mut mgr).await;
+        // Exactly one feedback line, no live writes.
+        assert!(matches!(
+            rx.try_recv(),
+            Ok(CellToBaseMsg::EntityMethodCall { .. })
+        ));
+    }
+}

--- a/crates/services/src/cell/console/seed.rs
+++ b/crates/services/src/cell/console/seed.rs
@@ -337,10 +337,17 @@ mod tests {
         let mut mgr = SpaceManager::new(1);
         let (tx, mut rx) = mpsc::channel(16);
         confirm(9, &tx, &mut mgr).await;
-        // Exactly one feedback line, no live writes.
+        // Exactly one feedback line, and nothing else — no live-write message
+        // (ExecuteAuthoringSql) and no second feedback. Assert both the single
+        // expected message AND that the channel is then empty, so a future
+        // change that emits an extra message in the no-op path trips here.
         assert!(matches!(
             rx.try_recv(),
             Ok(CellToBaseMsg::EntityMethodCall { .. })
         ));
+        assert!(
+            rx.try_recv().is_err(),
+            "no-op confirm must emit exactly one feedback message and nothing else"
+        );
     }
 }

--- a/crates/services/src/cell/console/server.rs
+++ b/crates/services/src/cell/console/server.rs
@@ -1,0 +1,94 @@
+//! Server / maintenance console commands (category G): `.save`,
+//! `.reloadmap`, `.reloadres`, `.removerespawner`, `.loglevel`, `.logclient`.
+//!
+//! These depend on server-lifecycle infrastructure that the Rust server either
+//! handles differently from the legacy Python (incremental persistence instead
+//! of an explicit `persist()`, startup-time resource loading instead of a
+//! runtime `DefMgr.load()`, `RUST_LOG`/env tracing config instead of a runtime
+//! log-level map). Where the mechanism genuinely differs, the command reports
+//! the real path rather than pretending to act — surfacing a no-op as success
+//! would be worse than an honest pointer.
+//!
+//! Legacy reference: `deprecated/python/cell/commands/Player.py` (`save`,
+//! `reloadMap`, `removeRespawner`), `Resource.py` (`reloadResources`),
+//! `ConsoleCommands.py` (`setLogLevel`, `setClientLogging`).
+
+use tokio::sync::mpsc;
+
+use super::send_gm_feedback;
+use crate::cell::messages::CellToBaseMsg;
+use crate::cell::space_manager::SpaceManager;
+
+pub(super) async fn dispatch(
+    name: &str,
+    caller_id: u32,
+    args: &[&str],
+    _target_id: Option<u32>,
+    tx: &mpsc::Sender<CellToBaseMsg>,
+    space_mgr: &mut SpaceManager,
+) {
+    match name {
+        "save" => {
+            send_gm_feedback(
+                caller_id,
+                "save: player state persists incrementally on each mutation \
+                 (mission/inventory/options writes). No explicit full-save step needed.",
+                tx,
+            )
+            .await;
+        }
+        "reloadmap" => {
+            send_gm_feedback(
+                caller_id,
+                "reloadmap: not wired — relog or use gate travel to reload the map.",
+                tx,
+            )
+            .await;
+        }
+        "reloadres" => {
+            send_gm_feedback(
+                caller_id,
+                "reloadres: resource caches load at server startup; runtime reload is not wired \
+                 (restart to pick up seed edits).",
+                tx,
+            )
+            .await;
+        }
+        "removerespawner" => {
+            // Validate the arg so the command at least parses like the others.
+            if super::parse_i32(caller_id, args, 0, "respawnerId", tx)
+                .await
+                .is_none()
+            {
+                return;
+            }
+            let _ = space_mgr; // no per-player respawner mutation path yet
+            send_gm_feedback(
+                caller_id,
+                "removerespawner: per-player respawner removal is not wired (respawners are \
+                 server-defined; edit db/resources/Worlds/Seed/respawners.sql).",
+                tx,
+            )
+            .await;
+        }
+        "loglevel" => {
+            send_gm_feedback(
+                caller_id,
+                "loglevel: the Rust server's log level is set via RUST_LOG / env at startup; \
+                 runtime reload is not wired.",
+                tx,
+            )
+            .await;
+        }
+        "logclient" => {
+            send_gm_feedback(
+                caller_id,
+                "logclient: server→client log forwarding is not wired; use the SigNoz/OTLP \
+                 pipeline for server logs.",
+                tx,
+            )
+            .await;
+        }
+        _ => {}
+    }
+}

--- a/crates/services/src/cell/console/spawn.rs
+++ b/crates/services/src/cell/console/spawn.rs
@@ -263,6 +263,7 @@ async fn spawn_random(
         return;
     };
 
+    let mut delivered = 0i32;
     for i in 0..count {
         // Deterministic scatter: place copies evenly on a ring within the
         // x/z range (no RNG dependency, reproducible for authoring).
@@ -272,7 +273,7 @@ async fn spawn_random(
             origin.y,
             origin.z + theta.sin() * z_range,
         ];
-        let _ = tx
+        match tx
             .send(CellToBaseMsg::GmSpawnNpc {
                 entity_id: caller_id,
                 template_id,
@@ -280,12 +281,40 @@ async fn spawn_random(
                 world_name: world_name.clone(),
                 position: pos,
             })
-            .await;
+            .await
+        {
+            Ok(()) => delivered += 1,
+            Err(e) => {
+                // The cell→base channel is closed/full — remaining sends will
+                // fail too, so stop and report the partial count rather than
+                // claiming all `count` were spawned.
+                tracing::warn!(
+                    caller_id,
+                    template_id,
+                    delivered,
+                    requested = count,
+                    "spawnrandom: GmSpawnNpc send failed — aborting remaining spawns: {e}"
+                );
+                break;
+            }
+        }
     }
-    send_gm_feedback(
-        caller_id,
-        &format!("spawnrandom: requested {count} x template {template_id}"),
-        tx,
-    )
-    .await;
+    if delivered == count {
+        send_gm_feedback(
+            caller_id,
+            &format!("spawnrandom: requested {count} x template {template_id}"),
+            tx,
+        )
+        .await;
+    } else {
+        send_gm_feedback(
+            caller_id,
+            &format!(
+                "spawnrandom: only {delivered}/{count} spawn requests delivered for \
+                 template {template_id} (cell→base channel error)"
+            ),
+            tx,
+        )
+        .await;
+    }
 }

--- a/crates/services/src/cell/console/spawn.rs
+++ b/crates/services/src/cell/console/spawn.rs
@@ -1,0 +1,291 @@
+//! Spawn authoring / persistence console commands (category B):
+//! `.savespawn`, `.delspawn`, `.autosavespawn`, `.respawnall`, `.spawnrandom`.
+//!
+//! Persistence follows the project's record-then-confirm model (see
+//! [`crate::cell::console::seed`]): the command applies its effect in memory,
+//! writes the live DB so it holds within the deploy, and records the canonical
+//! seed SQL for a developer to confirm + commit. `.respawnall` is a pure
+//! runtime reset (no authoring). `.spawnrandom` reuses the existing
+//! cell↔base `GmSpawnNpc` round-trip.
+//!
+//! Legacy reference: `deprecated/python/cell/commands/Resource.py`.
+
+use cimmeria_content_engine::chain::ChainEngine;
+use cimmeria_entity::stats::HEALTH;
+use tokio::sync::mpsc;
+
+use super::seed;
+use super::send_gm_feedback;
+use crate::cell::messages::CellToBaseMsg;
+use crate::cell::space_manager::SpaceManager;
+
+/// Seed file the spawn rows live in.
+const SPAWNLIST_SEED: &str = "db/resources/Worlds/Seed/spawnlist.sql";
+
+pub(super) async fn dispatch(
+    name: &str,
+    caller_id: u32,
+    args: &[&str],
+    target_id: Option<u32>,
+    tx: &mpsc::Sender<CellToBaseMsg>,
+    space_mgr: &mut SpaceManager,
+    _engine: &ChainEngine,
+) {
+    match name {
+        "savespawn" => save_spawn(caller_id, target_id, tx, space_mgr).await,
+        "delspawn" => del_spawn(caller_id, target_id, tx, space_mgr).await,
+        "autosavespawn" => autosave(caller_id, args, tx, space_mgr).await,
+        "respawnall" => respawn_all(caller_id, tx, space_mgr).await,
+        "spawnrandom" => spawn_random(caller_id, args, tx, space_mgr).await,
+        _ => {}
+    }
+}
+
+/// Yaw (radians) from a facing direction vector.
+fn heading_of(dir: cimmeria_common::Vector3) -> f32 {
+    dir.x.atan2(dir.z)
+}
+
+/// `.savespawn` — persist the targeted entity's current placement to
+/// `resources.spawnlist`: `UPDATE` its existing row when it has a `spawn_id`,
+/// otherwise `INSERT` a new one (resolving `world_id` from the world name via
+/// subquery so the same statement is valid in the seed file and live).
+async fn save_spawn(
+    caller_id: u32,
+    target_id: Option<u32>,
+    tx: &mpsc::Sender<CellToBaseMsg>,
+    space_mgr: &mut SpaceManager,
+) {
+    let Some(target) = target_id else {
+        send_gm_feedback(caller_id, "savespawn: a target is required.", tx).await;
+        return;
+    };
+    let Some(e) = space_mgr.get_entity(target) else {
+        send_gm_feedback(caller_id, "savespawn: target not found.", tx).await;
+        return;
+    };
+    let Some(template_id) = e.template_id else {
+        send_gm_feedback(
+            caller_id,
+            "savespawn: target has no template (cannot persist).",
+            tx,
+        )
+        .await;
+        return;
+    };
+    let pos = e.position;
+    let heading = heading_of(e.direction);
+    let tag = e.tag.clone();
+    let spawn_id = e.spawn_id;
+    let space_id = e.space_id.0 as u32;
+    let Some(world_name) = space_mgr
+        .spaces
+        .get(&space_id)
+        .map(|s| s.world_name.clone())
+    else {
+        send_gm_feedback(caller_id, "savespawn: cannot resolve world.", tx).await;
+        return;
+    };
+
+    // An already-seeded NPC updates its existing row in place; a command-spawned
+    // one (no `spawn_id`) inserts a new row. Matches the legacy `saveSpawn`
+    // INSERT-or-UPDATE and avoids duplicating a row on every re-save.
+    let sql = match spawn_id {
+        Some(id) => format!(
+            "UPDATE resources.spawnlist SET x = {x}, y = {y}, z = {z}, heading = {heading}, \
+             tag = {tag} WHERE spawn_id = {id};",
+            x = pos.x,
+            y = pos.y,
+            z = pos.z,
+            heading = heading,
+            tag = seed::sql_str(tag.as_deref()),
+        ),
+        None => format!(
+            "INSERT INTO resources.spawnlist (x, y, z, heading, world_id, template_id, tag)\n\
+             SELECT {x}, {y}, {z}, {heading}, w.world_id, {template_id}, {tag}\n\
+             FROM resources.worlds w WHERE w.world = {world};",
+            x = pos.x,
+            y = pos.y,
+            z = pos.z,
+            heading = heading,
+            template_id = template_id,
+            tag = seed::sql_str(tag.as_deref()),
+            world = seed::sql_str(Some(&world_name)),
+        ),
+    };
+    seed::record(caller_id, SPAWNLIST_SEED, "savespawn", &sql, tx, space_mgr).await;
+}
+
+/// `.delspawn` — remove the targeted entity in memory and record a `DELETE` of
+/// its spawnlist row, keyed on the exact `spawn_id`. Command-spawned NPCs (no
+/// spawnlist row) are refused.
+async fn del_spawn(
+    caller_id: u32,
+    target_id: Option<u32>,
+    tx: &mpsc::Sender<CellToBaseMsg>,
+    space_mgr: &mut SpaceManager,
+) {
+    let Some(target) = target_id else {
+        send_gm_feedback(caller_id, "delspawn: a target is required.", tx).await;
+        return;
+    };
+    let Some(e) = space_mgr.get_entity(target) else {
+        send_gm_feedback(caller_id, "delspawn: target not found.", tx).await;
+        return;
+    };
+    let Some(spawn_id) = e.spawn_id else {
+        send_gm_feedback(
+            caller_id,
+            "delspawn: target has no spawnlist row (command-spawned or a player).",
+            tx,
+        )
+        .await;
+        return;
+    };
+
+    // Key on the exact `spawn_id` — unambiguous, never matches a sibling spawn.
+    let sql = format!("DELETE FROM resources.spawnlist WHERE spawn_id = {spawn_id};");
+    seed::record(caller_id, SPAWNLIST_SEED, "delspawn", &sql, tx, space_mgr).await;
+
+    // Apply in memory: despawn the entity now.
+    space_mgr.destroy_entity(target);
+    send_gm_feedback(
+        caller_id,
+        &format!("delspawn [{target}]: despawned in-memory."),
+        tx,
+    )
+    .await;
+}
+
+/// `.autosavespawn <1|0>` — toggle the per-GM autosave preference.
+async fn autosave(
+    caller_id: u32,
+    args: &[&str],
+    tx: &mpsc::Sender<CellToBaseMsg>,
+    space_mgr: &mut SpaceManager,
+) {
+    let Some(on) = super::parse_bool(caller_id, args, 0, "autosave", tx).await else {
+        return;
+    };
+    if on {
+        space_mgr.autosave_spawns.insert(caller_id);
+    } else {
+        space_mgr.autosave_spawns.remove(&caller_id);
+    }
+    send_gm_feedback(
+        caller_id,
+        &format!(
+            "autosavespawn {} — newly placed spawns should be followed by .savespawn",
+            if on { "enabled" } else { "disabled" }
+        ),
+        tx,
+    )
+    .await;
+}
+
+/// `.respawnall` — reset every NPC in the caller's space to spawn state (full
+/// health, spawn position, Idle, threat cleared). Runtime-only; no persistence.
+async fn respawn_all(
+    caller_id: u32,
+    tx: &mpsc::Sender<CellToBaseMsg>,
+    space_mgr: &mut SpaceManager,
+) {
+    let Some(space_id) = space_mgr.get_entity_space_id(caller_id) else {
+        send_gm_feedback(caller_id, "respawnall: you are not in a space.", tx).await;
+        return;
+    };
+    let npcs: Vec<u32> = space_mgr
+        .all_npc_entity_ids()
+        .into_iter()
+        .filter(|&id| space_mgr.get_entity_space_id(id) == Some(space_id))
+        .collect();
+    let mut reset = 0usize;
+    for id in &npcs {
+        if let Some(e) = space_mgr.get_entity_mut(*id) {
+            if let Some(spawn) = e.spawn_position {
+                e.position = spawn;
+            }
+            if let Some(h) = e.stats.get_mut(HEALTH) {
+                let max = h.max;
+                h.cur = max;
+            }
+            e.threat_list.clear();
+            e.respawn_at = None;
+            e.ai_state = cimmeria_entity::cell_entity::AiState::Idle;
+            reset += 1;
+        }
+    }
+    send_gm_feedback(
+        caller_id,
+        &format!("respawnall: reset {reset} NPC(s) in your space."),
+        tx,
+    )
+    .await;
+}
+
+/// `.spawnrandom <templateId> <xRange> <zRange> [count]` — spawn `count` copies
+/// of a template scattered around the caller, reusing the `GmSpawnNpc`
+/// cell↔base round-trip. Scatter is deterministic (a ring around the caller) to
+/// avoid an RNG dependency.
+async fn spawn_random(
+    caller_id: u32,
+    args: &[&str],
+    tx: &mpsc::Sender<CellToBaseMsg>,
+    space_mgr: &mut SpaceManager,
+) {
+    let Some(template_id) = super::parse_i32(caller_id, args, 0, "templateId", tx).await else {
+        return;
+    };
+    let Some(x_range) = super::parse_f32(caller_id, args, 1, "xRange", tx).await else {
+        return;
+    };
+    let Some(z_range) = super::parse_f32(caller_id, args, 2, "zRange", tx).await else {
+        return;
+    };
+    let count = match args.get(3) {
+        Some(s) => s.parse::<i32>().unwrap_or(1).clamp(1, 50),
+        None => 1,
+    };
+
+    let Some(space_id) = space_mgr.get_entity_space_id(caller_id) else {
+        send_gm_feedback(caller_id, "spawnrandom: you are not in a space.", tx).await;
+        return;
+    };
+    let Some(world_name) = space_mgr
+        .spaces
+        .get(&space_id)
+        .map(|s| s.world_name.clone())
+    else {
+        send_gm_feedback(caller_id, "spawnrandom: cannot resolve world.", tx).await;
+        return;
+    };
+    let Some(origin) = space_mgr.get_entity(caller_id).map(|e| e.position) else {
+        return;
+    };
+
+    for i in 0..count {
+        // Deterministic scatter: place copies evenly on a ring within the
+        // x/z range (no RNG dependency, reproducible for authoring).
+        let theta = (i as f32) * std::f32::consts::TAU / (count as f32).max(1.0);
+        let pos = [
+            origin.x + theta.cos() * x_range,
+            origin.y,
+            origin.z + theta.sin() * z_range,
+        ];
+        let _ = tx
+            .send(CellToBaseMsg::GmSpawnNpc {
+                entity_id: caller_id,
+                template_id,
+                space_id,
+                world_name: world_name.clone(),
+                position: pos,
+            })
+            .await;
+    }
+    send_gm_feedback(
+        caller_id,
+        &format!("spawnrandom: requested {count} x template {template_id}"),
+        tx,
+    )
+    .await;
+}

--- a/crates/services/src/cell/console/stats.rs
+++ b/crates/services/src/cell/console/stats.rs
@@ -1,0 +1,129 @@
+//! Granular per-domain stat readouts (category F): `.primarystats`,
+//! `.speedstats`, `.armorstats`, `.qrstats`, `.absorbstats`, `.stealthstats`.
+//!
+//! Read-only — each dumps a fixed list of stats of the selected target (a
+//! `Being`) via the feedback channel, one `label: cur/max` line per stat. These
+//! are the granular views the umbrella `/gmprintstats` doesn't break out.
+//!
+//! Legacy reference: `deprecated/python/cell/commands/Entity.py`
+//! (`entityPrimaryStats` … `entityStealthStats`).
+
+use cimmeria_entity::stats::{
+    ABSORB_ENERGY, ABSORB_ENERGY_ENERGY, ABSORB_ENERGY_ITEM, ABSORB_HAZMAT, ABSORB_HAZMAT_ENERGY,
+    ABSORB_HAZMAT_ITEM, ABSORB_PHYSICAL, ABSORB_PHYSICAL_ENERGY, ABSORB_PHYSICAL_ITEM,
+    ABSORB_PSIONIC, ABSORB_PSIONIC_ENERGY, ABSORB_PSIONIC_ITEM, ABSORB_UNTYPED,
+    ABSORB_UNTYPED_ENERGY, ABSORB_UNTYPED_ITEM, ACCURACY, AWARENESS, COORDINATION, COVER_ACCURACY,
+    COVER_DEFENSE, COVER_QR_MODIFIER, CROUCHING_ACCURACY, CROUCHING_DEFENSE, DAMAGE, DEFENSE,
+    DISGUISE_DETECTION, DISGUISE_RATING, ENERGY_AF, ENGAGEMENT, FORTITUDE, HAZMAT_AF, HEALTH_RES,
+    INTELLIGENCE, INTERRUPT_RES, KINETIC_RES, MENTAL_RES, MITIGATION, MORALE, MOVEMENT_SPEED_MOD,
+    NEGATION, PENETRATION, PERCEPTION, PHYSICAL_AF, PSIONIC_AF, QR_MOD, RECOVERY, RESPONSE,
+    RESTORATION, REVEAL_RATING, ROTATION_SPEED_MOD, SPEED_ATTACK, SPEED_DEPLOY, SPEED_GRENADE,
+    SPEED_RELOAD, STABILIZATION, STEALTH_MOVEMENT, STEALTH_RATING, SUBTLETY, TRACKING,
+};
+use tokio::sync::mpsc;
+
+use super::send_gm_feedback;
+use crate::cell::messages::CellToBaseMsg;
+use crate::cell::space_manager::SpaceManager;
+
+/// (display label, stat id) lists, mirroring the legacy `statIds` arrays.
+fn stat_set(cmd: &str) -> &'static [(&'static str, i32)] {
+    match cmd {
+        "primarystats" => &[
+            ("coordination", COORDINATION),
+            ("engagement", ENGAGEMENT),
+            ("fortitude", FORTITUDE),
+            ("morale", MORALE),
+            ("perception", PERCEPTION),
+            ("intelligence", INTELLIGENCE),
+        ],
+        "speedstats" => &[
+            ("movementSpeedMod", MOVEMENT_SPEED_MOD),
+            ("rotationSpeedMod", ROTATION_SPEED_MOD),
+            ("speedReload", SPEED_RELOAD),
+            ("speedGrenade", SPEED_GRENADE),
+            ("speedDeploy", SPEED_DEPLOY),
+            ("speedAttack", SPEED_ATTACK),
+        ],
+        "armorstats" => &[
+            ("physicalAF", PHYSICAL_AF),
+            ("energyAF", ENERGY_AF),
+            ("hazmatAF", HAZMAT_AF),
+            ("psionicAF", PSIONIC_AF),
+            ("kineticRes", KINETIC_RES),
+            ("mentalRes", MENTAL_RES),
+            ("healthRes", HEALTH_RES),
+            ("interruptRes", INTERRUPT_RES),
+        ],
+        "qrstats" => &[
+            ("accuracy", ACCURACY),
+            ("defense", DEFENSE),
+            ("qrMod", QR_MOD),
+            ("coverQRModifier", COVER_QR_MODIFIER),
+            ("response", RESPONSE),
+            ("damage", DAMAGE),
+            ("penetration", PENETRATION),
+            ("tracking", TRACKING),
+            ("stabilization", STABILIZATION),
+            ("awareness", AWARENESS),
+            ("coverAccuracy", COVER_ACCURACY),
+            ("coverDefense", COVER_DEFENSE),
+            ("crouchingAccuracy", CROUCHING_ACCURACY),
+            ("crouchingDefense", CROUCHING_DEFENSE),
+            ("negation", NEGATION),
+            ("mitigation", MITIGATION),
+            ("recovery", RECOVERY),
+            ("restoration", RESTORATION),
+            ("subtlety", SUBTLETY),
+        ],
+        "absorbstats" => &[
+            ("absorbPhysical", ABSORB_PHYSICAL),
+            ("absorbEnergy", ABSORB_ENERGY),
+            ("absorbHazmat", ABSORB_HAZMAT),
+            ("absorbPsionic", ABSORB_PSIONIC),
+            ("absorbUntyped", ABSORB_UNTYPED),
+            ("absorbPhysicalItem", ABSORB_PHYSICAL_ITEM),
+            ("absorbEnergyItem", ABSORB_ENERGY_ITEM),
+            ("absorbHazmatItem", ABSORB_HAZMAT_ITEM),
+            ("absorbPsionicItem", ABSORB_PSIONIC_ITEM),
+            ("absorbUntypedItem", ABSORB_UNTYPED_ITEM),
+            ("absorbPhysicalEnergy", ABSORB_PHYSICAL_ENERGY),
+            ("absorbEnergyEnergy", ABSORB_ENERGY_ENERGY),
+            ("absorbHazmatEnergy", ABSORB_HAZMAT_ENERGY),
+            ("absorbPsionicEnergy", ABSORB_PSIONIC_ENERGY),
+            ("absorbUntypedEnergy", ABSORB_UNTYPED_ENERGY),
+        ],
+        "stealthstats" => &[
+            ("stealthRating", STEALTH_RATING),
+            ("stealthMovement", STEALTH_MOVEMENT),
+            ("revealRating", REVEAL_RATING),
+            ("disguiseRating", DISGUISE_RATING),
+            ("disguiseDetection", DISGUISE_DETECTION),
+        ],
+        _ => &[],
+    }
+}
+
+/// Dump the stat set named by `cmd` for the target (or caller if the optional
+/// target is absent).
+pub(super) async fn show(
+    cmd: &str,
+    caller_id: u32,
+    target_id: Option<u32>,
+    tx: &mpsc::Sender<CellToBaseMsg>,
+    space_mgr: &mut SpaceManager,
+) {
+    let subject = target_id.unwrap_or(caller_id);
+    let Some(entity) = space_mgr.get_entity(subject) else {
+        send_gm_feedback(caller_id, &format!("{cmd}: no entity."), tx).await;
+        return;
+    };
+    send_gm_feedback(caller_id, &format!("{cmd} [{subject}]:",), tx).await;
+    for (label, stat_id) in stat_set(cmd) {
+        let line = match entity.stats.get(*stat_id) {
+            Some(s) => format!("    {label}: {}/{}", s.cur, s.max),
+            None => format!("    {label}: n/a"),
+        };
+        send_gm_feedback(caller_id, &line, tx).await;
+    }
+}

--- a/crates/services/src/cell/console/tests.rs
+++ b/crates/services/src/cell/console/tests.rs
@@ -1,0 +1,283 @@
+//! Tests for the `.`-console framework: registry integrity, the GM
+//! access gate, the parser, and end-to-end dispatch coverage.
+
+use cimmeria_content_engine::chain::ChainEngine;
+use tokio::sync::mpsc;
+
+use super::*;
+use crate::cell::messages::CellToBaseMsg;
+use crate::cell::space_manager::SpaceManager;
+
+/// Build a SpaceManager with a GM player (entity 1, access_level 2) targeting an
+/// NPC (entity 100001) in a small test world.
+fn setup() -> (SpaceManager, u32, u32) {
+    let mut mgr = SpaceManager::new(1);
+    let xml = r#"<?xml version="1.0"?><Spaces><Space WorldName="Agnos" Instanced="false" MinX="0" MaxX="100" MinY="0" MaxY="100" /></Spaces>"#;
+    let cxml = r#"<?xml version="1.0"?><Spaces><Space WorldName="Agnos" /></Spaces>"#;
+    mgr.parse_spaces_xml(xml).unwrap();
+    mgr.create_startup_spaces(cxml).unwrap();
+
+    let gm = 1u32;
+    mgr.create_entity(gm, "Agnos", [10.0, 0.0, 10.0], [0.0; 3])
+        .unwrap();
+    mgr.connect_entity(gm);
+
+    let npc = mgr.allocate_npc_id();
+    mgr.spawn_npc(npc, "Agnos", [12.0, 0.0, 12.0], [0.0; 3])
+        .unwrap();
+
+    if let Some(e) = mgr.get_entity_mut(gm) {
+        e.access_level = 2;
+        e.is_player = true;
+        e.current_target_id = Some(npc as i32);
+    }
+    if let Some(e) = mgr.get_entity_mut(npc) {
+        e.is_player = false;
+        e.template_id = Some(1);
+    }
+    (mgr, gm, npc)
+}
+
+/// Decode the text of an `onPlayerCommunication` feedback `EntityMethodCall`.
+/// Layout: speaker WSTRING("SYSTEM") + flags + channel + text WSTRING.
+fn decode_feedback(msg: &CellToBaseMsg) -> Option<String> {
+    let CellToBaseMsg::EntityMethodCall {
+        method_index, args, ..
+    } = msg
+    else {
+        return None;
+    };
+    if *method_index != crate::mercury::method_idx::ON_PLAYER_COMMUNICATION {
+        return None;
+    }
+    // speaker "SYSTEM" = 6 chars → 4 + 12 = 16; +flags(1)+channel(1) = 18.
+    let text_off = 18;
+    let len = u32::from_le_bytes(args.get(text_off..text_off + 4)?.try_into().ok()?) as usize;
+    let start = text_off + 4;
+    let mut chars = Vec::with_capacity(len);
+    for i in 0..len {
+        let o = start + i * 2;
+        chars.push(u16::from_le_bytes(args.get(o..o + 2)?.try_into().ok()?));
+    }
+    Some(String::from_utf16_lossy(&chars))
+}
+
+#[test]
+fn command_names_are_unique() {
+    let mut seen = std::collections::HashSet::new();
+    for spec in COMMANDS {
+        assert!(
+            seen.insert(spec.name),
+            "duplicate command name: {}",
+            spec.name
+        );
+    }
+}
+
+#[test]
+fn is_gm_threshold() {
+    assert!(!is_gm(0));
+    assert!(!is_gm(1));
+    assert!(is_gm(2));
+    assert!(is_gm(4));
+}
+
+#[test]
+fn min_le_max_for_every_spec() {
+    for spec in COMMANDS {
+        assert!(spec.min <= spec.max, "{}: min > max", spec.name);
+    }
+}
+
+/// Every registered command must have a dispatch arm — driving `exec` for each
+/// must never hit the "not implemented" catch-all.
+#[tokio::test]
+async fn every_spec_is_dispatched() {
+    let engine = ChainEngine::new();
+    for spec in COMMANDS {
+        let (mut mgr, gm, npc) = setup();
+        let (tx, mut rx) = mpsc::channel(256);
+        // Supply `min` dummy numeric args (parse as both int and float; also
+        // valid as opaque strings), within the command's bounds.
+        let dummy: Vec<&str> = vec!["10"; spec.min];
+        exec(spec.name, gm, &dummy, Some(npc), &tx, &mut mgr, &engine).await;
+        while let Ok(msg) = rx.try_recv() {
+            if let Some(text) = decode_feedback(&msg) {
+                assert!(
+                    !text.contains("not implemented"),
+                    "command .{} fell through to the not-implemented arm",
+                    spec.name
+                );
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn unknown_command_reports_unknown() {
+    let (mut mgr, gm, _npc) = setup();
+    let engine = ChainEngine::new();
+    let (tx, mut rx) = mpsc::channel(16);
+    handle_console_command(gm, ".boguscmd", &tx, &mut mgr, &engine).await;
+    let mut saw_unknown = false;
+    while let Ok(msg) = rx.try_recv() {
+        if let Some(text) = decode_feedback(&msg) {
+            if text.contains("Unknown command") {
+                saw_unknown = true;
+            }
+        }
+    }
+    assert!(
+        saw_unknown,
+        "unknown command should report 'Unknown command'"
+    );
+}
+
+#[tokio::test]
+async fn too_few_args_is_rejected() {
+    let (mut mgr, gm, _npc) = setup();
+    let engine = ChainEngine::new();
+    let (tx, mut rx) = mpsc::channel(16);
+    // .searchitem requires >= 1 arg.
+    handle_console_command(gm, ".searchitem", &tx, &mut mgr, &engine).await;
+    let mut saw = false;
+    while let Ok(msg) = rx.try_recv() {
+        if let Some(text) = decode_feedback(&msg) {
+            if text.contains("not enough arguments") {
+                saw = true;
+            }
+        }
+    }
+    assert!(saw, "missing required arg should be rejected");
+}
+
+#[tokio::test]
+async fn typed_command_requires_target() {
+    let (mut mgr, gm, _npc) = setup();
+    // Clear the GM's target so a target-typed command must refuse.
+    if let Some(e) = mgr.get_entity_mut(gm) {
+        e.current_target_id = None;
+    }
+    let engine = ChainEngine::new();
+    let (tx, mut rx) = mpsc::channel(16);
+    handle_console_command(gm, ".primarystats", &tx, &mut mgr, &engine).await;
+    let mut saw = false;
+    while let Ok(msg) = rx.try_recv() {
+        if let Some(text) = decode_feedback(&msg) {
+            if text.contains("target is required") {
+                saw = true;
+            }
+        }
+    }
+    assert!(saw, "a target-typed command must require a target");
+}
+
+#[tokio::test]
+async fn help_lists_commands() {
+    let (mut mgr, gm, _npc) = setup();
+    let engine = ChainEngine::new();
+    let (tx, mut rx) = mpsc::channel(512);
+    handle_console_command(gm, ".help", &tx, &mut mgr, &engine).await;
+    let mut count = 0;
+    while let Ok(msg) = rx.try_recv() {
+        if decode_feedback(&msg).is_some() {
+            count += 1;
+        }
+    }
+    assert!(count >= COMMANDS.len(), "help should list every command");
+}
+
+/// Regression guard: `parse_f32` must reject non-finite values — `NaN`/`inf`
+/// would Display as a bareword and produce invalid SQL in the authoring path.
+#[tokio::test]
+async fn parse_f32_rejects_non_finite() {
+    let (tx, _rx) = mpsc::channel(8);
+    assert_eq!(parse_f32(1, &["1.5"], 0, "x", &tx).await, Some(1.5));
+    assert_eq!(parse_f32(1, &["2"], 0, "x", &tx).await, Some(2.0));
+    assert_eq!(parse_f32(1, &["NaN"], 0, "x", &tx).await, None);
+    assert_eq!(parse_f32(1, &["inf"], 0, "x", &tx).await, None);
+    assert_eq!(parse_f32(1, &["-inf"], 0, "x", &tx).await, None);
+}
+
+/// Regression guard: `.path_clear` must record TWO single-statement SQL strings,
+/// not one multi-statement string (sqlx's prepared-statement executor rejects
+/// multiple commands in one `query().execute()`).
+#[tokio::test]
+async fn path_clear_records_single_statements() {
+    let (mut mgr, gm, _npc) = setup();
+    let engine = ChainEngine::new();
+    let (tx, _rx) = mpsc::channel(32);
+    handle_console_command(gm, ".path_clear 7", &tx, &mut mgr, &engine).await;
+    let recorded = mgr.authoring_changes.get(&gm).cloned().unwrap_or_default();
+    assert_eq!(recorded.len(), 2, "path_clear should record two statements");
+    for (_file, sql) in &recorded {
+        assert_eq!(
+            sql.matches(';').count(),
+            1,
+            "each recorded statement must be single-statement: {sql}"
+        );
+    }
+}
+
+/// Regression guard: a negative waypoint index must be rejected before it
+/// reaches the `OFFSET {index}` subquery (Postgres rejects negative OFFSET).
+#[tokio::test]
+async fn negative_waypoint_index_is_rejected() {
+    let (mut mgr, gm, _npc) = setup();
+    let engine = ChainEngine::new();
+    let (tx, _rx) = mpsc::channel(16);
+    handle_console_command(gm, ".path_set_tp 7 -1", &tx, &mut mgr, &engine).await;
+    assert!(
+        mgr.authoring_changes.get(&gm).is_none_or(Vec::is_empty),
+        "a negative index must not record any authoring SQL"
+    );
+}
+
+/// Regression guard: `.delspawn` must key the recorded DELETE on the exact
+/// `spawn_id`, never a fuzzy position/template match that could hit siblings.
+#[tokio::test]
+async fn delspawn_keys_on_spawn_id() {
+    let (mut mgr, gm, npc) = setup();
+    if let Some(e) = mgr.get_entity_mut(npc) {
+        e.spawn_id = Some(42);
+    }
+    let engine = ChainEngine::new();
+    let (tx, _rx) = mpsc::channel(32);
+    handle_console_command(gm, ".delspawn", &tx, &mut mgr, &engine).await;
+    let recorded = mgr.authoring_changes.get(&gm).cloned().unwrap_or_default();
+    assert_eq!(recorded.len(), 1, "delspawn records exactly one statement");
+    assert!(
+        recorded[0].1.contains("spawn_id = 42"),
+        "delspawn must target the exact spawn_id: {}",
+        recorded[0].1
+    );
+}
+
+/// A command-spawned NPC (no `spawn_id`) cannot be `.delspawn`'d — there's no
+/// spawnlist row to delete, so nothing is recorded.
+#[tokio::test]
+async fn delspawn_refuses_without_spawn_id() {
+    let (mut mgr, gm, _npc) = setup(); // setup NPC has no spawn_id
+    let engine = ChainEngine::new();
+    let (tx, _rx) = mpsc::channel(16);
+    handle_console_command(gm, ".delspawn", &tx, &mut mgr, &engine).await;
+    assert!(
+        mgr.authoring_changes.get(&gm).is_none_or(Vec::is_empty),
+        "delspawn with no spawn_id must record nothing"
+    );
+}
+
+#[tokio::test]
+async fn path_add_buffers_and_records() {
+    let (mut mgr, gm, _npc) = setup();
+    let engine = ChainEngine::new();
+    let (tx, _rx) = mpsc::channel(64);
+    handle_console_command(gm, ".path_add 7", &tx, &mut mgr, &engine).await;
+    assert_eq!(
+        mgr.patrol_authoring.get(&7).map(Vec::len),
+        Some(1),
+        "path_add should buffer one waypoint"
+    );
+    // First waypoint records the point_sets header + the point row.
+    assert!(mgr.authoring_changes.get(&gm).is_some_and(|v| v.len() >= 2));
+}

--- a/crates/services/src/cell/console/tests.rs
+++ b/crates/services/src/cell/console/tests.rs
@@ -278,6 +278,12 @@ async fn path_add_buffers_and_records() {
         Some(1),
         "path_add should buffer one waypoint"
     );
-    // First waypoint records the point_sets header + the point row.
-    assert!(mgr.authoring_changes.get(&gm).is_some_and(|v| v.len() >= 2));
+    // First waypoint records EXACTLY two seed statements: the point_sets
+    // header + the point row. Asserting the exact count (not `>= 2`) catches
+    // a fan-out regression where extra authoring statements start landing.
+    assert_eq!(
+        mgr.authoring_changes.get(&gm).map(Vec::len),
+        Some(2),
+        "first path_add waypoint must record exactly the point_sets header + one point row"
+    );
 }

--- a/crates/services/src/cell/console/tests.rs
+++ b/crates/services/src/cell/console/tests.rs
@@ -287,3 +287,119 @@ async fn path_add_buffers_and_records() {
         "first path_add waypoint must record exactly the point_sets header + one point row"
     );
 }
+
+/// Drain every queued message, returning whether a `GrantExpertise` was sent
+/// and the last decoded GM feedback line.
+fn drain_grant_and_feedback(rx: &mut mpsc::Receiver<CellToBaseMsg>) -> (bool, Option<String>) {
+    let mut saw_grant = false;
+    let mut feedback = None;
+    while let Ok(msg) = rx.try_recv() {
+        if matches!(msg, CellToBaseMsg::GrantExpertise { .. }) {
+            saw_grant = true;
+        }
+        if let Some(t) = decode_feedback(&msg) {
+            feedback = Some(t);
+        }
+    }
+    (saw_grant, feedback)
+}
+
+/// `.learndiscipline` / `.forgetdiscipline` must reject a non-positive
+/// disciplineId BEFORE sending a `GrantExpertise`, so an invalid key can't be
+/// written to the target's expertise rows.
+#[tokio::test]
+async fn discipline_commands_reject_non_positive_id() {
+    for cmd in [".learndiscipline 0", ".forgetdiscipline -3"] {
+        let (mut mgr, gm, npc) = setup();
+        // Crafting commands need a Player target carrying a player_id to reach
+        // the disciplineId guard.
+        if let Some(e) = mgr.get_entity_mut(npc) {
+            e.is_player = true;
+            e.player_id = Some(500);
+        }
+        let engine = ChainEngine::new();
+        let (tx, mut rx) = mpsc::channel(16);
+        handle_console_command(gm, cmd, &tx, &mut mgr, &engine).await;
+
+        let (saw_grant, feedback) = drain_grant_and_feedback(&mut rx);
+        assert!(
+            !saw_grant,
+            "{cmd} must NOT send GrantExpertise for a non-positive disciplineId"
+        );
+        assert!(
+            feedback.as_deref().is_some_and(|t| t.contains("positive")),
+            "{cmd} must explain disciplineId must be positive; got {feedback:?}"
+        );
+    }
+}
+
+/// `.missionfail` on a target with no active mission must report it and not
+/// fabricate a FAILED transition (the handler guards on `MISSION_ACTIVE`).
+#[tokio::test]
+async fn missionfail_on_absent_mission_reports_no_active() {
+    let (mut mgr, gm, npc) = setup();
+    if let Some(e) = mgr.get_entity_mut(npc) {
+        e.is_player = true;
+        e.player_id = Some(500);
+    }
+    let engine = ChainEngine::new();
+    let (tx, mut rx) = mpsc::channel(16);
+    handle_console_command(gm, ".missionfail 9999", &tx, &mut mgr, &engine).await;
+
+    let (_, feedback) = drain_grant_and_feedback(&mut rx);
+    assert!(
+        feedback
+            .as_deref()
+            .is_some_and(|t| t.contains("no active mission")),
+        "missionfail on a missing mission must report no active mission; got {feedback:?}"
+    );
+}
+
+/// Critical-fix guard: a GM's session buffers (`authoring_changes`,
+/// `autosave_spawns`, both keyed by entity_id) must be dropped when the entity
+/// is destroyed, so pending authoring SQL / the autosave flag can't leak or
+/// dangle across an entity-id reuse.
+#[test]
+fn destroy_entity_clears_gm_session_buffers() {
+    let (mut mgr, gm, _npc) = setup();
+    mgr.authoring_changes.insert(
+        gm,
+        vec![("f.sql".into(), "INSERT INTO x VALUES (1);".into())],
+    );
+    mgr.autosave_spawns.insert(gm);
+
+    mgr.destroy_entity(gm);
+
+    assert!(
+        !mgr.authoring_changes.contains_key(&gm),
+        "destroy_entity must drop the GM's pending authoring SQL"
+    );
+    assert!(
+        !mgr.autosave_spawns.contains(&gm),
+        "destroy_entity must clear the GM's autosave-spawn flag"
+    );
+}
+
+/// Companion of `destroy_entity_clears_gm_session_buffers` for the disconnect
+/// path — same buffers, same cleanup.
+#[tokio::test]
+async fn disconnect_entity_clears_gm_session_buffers() {
+    let (mut mgr, gm, _npc) = setup();
+    mgr.authoring_changes.insert(
+        gm,
+        vec![("f.sql".into(), "INSERT INTO x VALUES (1);".into())],
+    );
+    mgr.autosave_spawns.insert(gm);
+
+    let (tx, _rx) = mpsc::channel(16);
+    mgr.disconnect_entity(gm, &tx).await;
+
+    assert!(
+        !mgr.authoring_changes.contains_key(&gm),
+        "disconnect_entity must drop the GM's pending authoring SQL"
+    );
+    assert!(
+        !mgr.autosave_spawns.contains(&gm),
+        "disconnect_entity must clear the GM's autosave-spawn flag"
+    );
+}

--- a/crates/services/src/cell/content/chain_replay_tests/mission_622.rs
+++ b/crates/services/src/cell/content/chain_replay_tests/mission_622.rs
@@ -1,17 +1,21 @@
-//! Mission 622 — Arm Yourself! Pin the equip-from-inventory flow:
-//! chain 1003 grants the pistol to the backpack (container 1) and advances
-//! mission 622 to step 80622 ("Equip the pistol"); chain 1004 fires on
-//! `item_equipped(55)` and is the only path that plays kismet sequence
-//! 10000 (which opens the stasis-room door) and completes the mission.
+//! Mission 622 — Arm Yourself! Pin the **loot-split** + equip-from-inventory
+//! flow:
+//! - chain 1003 (Frost body, dialog 3995) grants ONLY the letter (3730) to the
+//!   mission inventory; it does not grant the pistol and does not advance.
+//! - chain 1005 (Guard corpse, dialog 3996) grants the pistol (55) to the
+//!   backpack (container 1) and owns the 2113 → 80622 advance.
+//! - chain 1004 fires on `item_equipped(55)` and is the only path that plays
+//!   kismet sequence 10000 (opens the stasis-room door) + completes the mission.
 //!
-//! The bug shape this guards: previously the pistol was added directly to
-//! the bandolier (container 3) and the mission auto-completed, which
-//! bypassed the bandolier ammo / appearance / fire-animation paths. Step
-//! 80622 is a Cimmeria-introduced step whose matching `<Steps>` row is
+//! The loot is split across the two stasis-room corpses; the order the player
+//! searches them in must not matter (see the order-independence tests below).
+//! Frost's letter chain is gated on `mission_status = active` (not step 2113)
+//! so it stays reachable after the Guard advances the step; its re-loot guard
+//! is the body's interaction-bit clear, since `once` is a no-op in the engine.
+//!
+//! Step 80622 is a Cimmeria-introduced step whose matching `<Steps>` row is
 //! shipped to the client via a `mission_overrides` patch on `_622` in
-//! `CookedDataMissions.pak`; the per-key `InvalidKeys` channel in
-//! `onVersionInfo` makes that override visible to the UI without
-//! re-shipping the whole PAK.
+//! `CookedDataMissions.pak`; unchanged by the loot split.
 
 use cimmeria_content_engine::actions::Action;
 use cimmeria_content_engine::chain::ChainEngine;
@@ -21,39 +25,15 @@ use cimmeria_content_engine::triggers::{TriggerEvent, TriggerType};
 use super::super::engine_loader::load_single_chain_for_test;
 use crate::test_support::require_db_or_skip;
 
-/// Chain 1003 must grant the pistol (item 55) to container 1 (backpack)
-/// and advance to step 80622. It must NOT play sequence 10000 or
-/// complete the mission — those happen in chain 1004 after equip.
+/// Chain 1003 (Frost) must grant ONLY the letter — no pistol, no advance, no
+/// completion. The pistol + advance moved to chain 1005 (the Guard corpse).
 #[tokio::test]
-async fn chain_1003_grants_pistol_to_backpack_and_advances_to_equip_step() {
+async fn chain_1003_grants_letter_only_no_pistol_no_advance() {
     let pool = require_db_or_skip!();
     let chain = load_single_chain_for_test(&pool, 1003)
         .await
         .expect("DB query for chain 1003 must succeed")
         .expect("chain 1003 must exist in seeded content_chains");
-
-    // Pistol → container 1 (backpack), exactly once.
-    let pistol_to_backpack = chain
-        .actions
-        .iter()
-        .filter(|a| {
-            matches!(
-                a,
-                Action::GrantItem {
-                    item_id: 55,
-                    container_id: Some(1),
-                    ..
-                }
-            )
-        })
-        .count();
-    assert_eq!(
-        pistol_to_backpack, 1,
-        "chain 1003 must grant pistol (item 55) to container 1 (backpack) \
-         exactly once — auto-equipping to container 3 (bandolier) bypasses \
-         the bandolier ammo path. Actions: {:?}",
-        chain.actions,
-    );
 
     // Letter (3730) → container 0 (mission inventory), exactly once.
     let letter_to_mission = chain
@@ -72,55 +52,48 @@ async fn chain_1003_grants_pistol_to_backpack_and_advances_to_equip_step() {
         .count();
     assert_eq!(
         letter_to_mission, 1,
-        "chain 1003 must grant Frost's letter (3730) to container 0; got {} matches",
-        letter_to_mission,
+        "chain 1003 must grant Frost's letter (3730) to container 0 exactly once; \
+         actions: {:?}",
+        chain.actions,
     );
 
-    // Advance to the equip step (80622) — this is what makes the new
-    // mission text render on the UI.
-    let advances_to_equip_step = chain.actions.iter().any(|a| {
+    // No pistol — that's the Guard corpse (chain 1005) now.
+    let grants_pistol = chain
+        .actions
+        .iter()
+        .any(|a| matches!(a, Action::GrantItem { item_id: 55, .. }));
+    assert!(
+        !grants_pistol,
+        "chain 1003 (Frost) must NOT grant the pistol after the loot split; \
+         the pistol comes from the Guard corpse (chain 1005). Actions: {:?}",
+        chain.actions,
+    );
+
+    // No advance — Frost's chain must not own the step transition, or looting
+    // Frost first would skip past the search step before the pistol is found.
+    let advances = chain.actions.iter().any(|a| {
         matches!(
             a,
             Action::AdvanceStep {
                 mission_id: 622,
-                step_id: 80622
+                ..
             }
         )
     });
     assert!(
-        advances_to_equip_step,
-        "chain 1003 must advance mission 622 to step 80622. Actions: {:?}",
+        !advances,
+        "chain 1003 (Frost) must NOT advance mission 622; the Guard chain (1005) \
+         owns the 2113 → 80622 advance. Actions: {:?}",
         chain.actions,
-    );
-
-    // No play_sequence 10000 — that's chain 1004's job, gated on equip.
-    let plays_door_sequence = chain
-        .actions
-        .iter()
-        .any(|a| matches!(a, Action::PlaySequence { sequence_id: 10000 }));
-    assert!(
-        !plays_door_sequence,
-        "chain 1003 must NOT play sequence 10000; it's deferred to chain 1004",
-    );
-
-    // Mission completion is deferred to chain 1004 too.
-    let completes_mission = chain
-        .actions
-        .iter()
-        .any(|a| matches!(a, Action::CompleteMission { mission_id: 622 }));
-    assert!(
-        !completes_mission,
-        "chain 1003 must NOT complete mission 622; deferred to chain 1004",
     );
 }
 
-/// Chain 1003 must NOT fire when step 2113 has been advanced past — the
-/// gate is what blocks duplicate-grant when the player re-opens Frost's
-/// loot dialog. Regression guard for the bug we observed in the live UI
-/// where a permissive `mission_status = active` gate let the chain fire
-/// repeatedly across re-interactions.
+/// Order-independence: chain 1003 (Frost letter) must STILL fire when the
+/// player loots the Guard first (which advances 2113 → 80622). The letter gate
+/// is `mission_status = active`, not step 2113, so the prior advance does not
+/// lock Frost out. (This inverts the pre-split guard, which keyed on 2113.)
 #[tokio::test]
-async fn chain_1003_does_not_fire_after_step_2113_advances() {
+async fn chain_1003_letter_still_fires_after_guard_advanced_the_step() {
     let pool = require_db_or_skip!();
     let chain = load_single_chain_for_test(&pool, 1003)
         .await
@@ -136,8 +109,8 @@ async fn chain_1003_does_not_fire_after_step_2113_advances() {
         "mission_622_status".to_string(),
         serde_json::json!("active"),
     );
-    // Step 2113 has already completed — chain 1003 advanced us past it on
-    // a prior dialog open. A second dialog open must NOT match.
+    // Guard was looted first: 2113 completed, now on 80622. Frost's letter
+    // must remain grantable.
     ctx.set_param(
         "mission_622_step_2113_status".to_string(),
         serde_json::json!("completed"),
@@ -157,10 +130,116 @@ async fn chain_1003_does_not_fire_after_step_2113_advances() {
     let resolved = engine.resolve_event(&event, &ctx);
     let chain_1003_fired = resolved.actions.iter().any(|(id, _)| *id == 1003);
     assert!(
-        !chain_1003_fired,
-        "chain 1003 must NOT fire after step 2113 has been advanced past — \
-         re-opening Frost's loot dialog would otherwise grant duplicate items. \
-         Got actions: {:?}",
+        chain_1003_fired,
+        "chain 1003 (Frost letter) must still fire after the Guard advanced the \
+         step — the letter gate is mission-active, not step 2113, so loot order \
+         doesn't matter. Got actions: {:?}",
+        resolved.actions,
+    );
+}
+
+/// Chain 1005 (Guard corpse, dialog 3996) grants the pistol (55) to the
+/// backpack and advances to the equip step. No letter, no completion.
+#[tokio::test]
+async fn chain_1005_grants_pistol_and_advances_to_equip_step() {
+    let pool = require_db_or_skip!();
+    let chain = load_single_chain_for_test(&pool, 1005)
+        .await
+        .expect("DB query for chain 1005 must succeed")
+        .expect("chain 1005 must exist in seeded content_chains");
+
+    let pistol_to_backpack = chain
+        .actions
+        .iter()
+        .filter(|a| {
+            matches!(
+                a,
+                Action::GrantItem {
+                    item_id: 55,
+                    container_id: Some(1),
+                    ..
+                }
+            )
+        })
+        .count();
+    assert_eq!(
+        pistol_to_backpack, 1,
+        "chain 1005 must grant the pistol (55) to container 1 (backpack) exactly \
+         once; actions: {:?}",
+        chain.actions,
+    );
+
+    let advances = chain.actions.iter().any(|a| {
+        matches!(
+            a,
+            Action::AdvanceStep {
+                mission_id: 622,
+                step_id: 80622
+            }
+        )
+    });
+    assert!(
+        advances,
+        "chain 1005 must advance mission 622 to step 80622 (it owns the advance). \
+         Actions: {:?}",
+        chain.actions,
+    );
+
+    // No letter, no completion — those belong to 1003 / 1004.
+    assert!(
+        !chain
+            .actions
+            .iter()
+            .any(|a| matches!(a, Action::GrantItem { item_id: 3730, .. })),
+        "chain 1005 must NOT grant the letter (that's Frost / chain 1003)",
+    );
+    assert!(
+        !chain
+            .actions
+            .iter()
+            .any(|a| matches!(a, Action::CompleteMission { mission_id: 622 })),
+        "chain 1005 must NOT complete the mission (that's chain 1004 on equip)",
+    );
+}
+
+/// Re-loot guard: chain 1005 (pistol) must NOT fire once step 2113 has been
+/// advanced past — re-searching the Guard corpse can't re-grant the pistol or
+/// re-advance. The step-gate flip is this chain's guard.
+#[tokio::test]
+async fn chain_1005_does_not_fire_after_step_2113_advances() {
+    let pool = require_db_or_skip!();
+    let chain = load_single_chain_for_test(&pool, 1005)
+        .await
+        .expect("DB query for chain 1005 must succeed")
+        .expect("chain 1005 must exist in seeded content_chains");
+
+    let mut engine = ChainEngine::new();
+    engine.register_chain(chain);
+
+    let mut ctx = ExecutionContext::new();
+    ctx.set_param("dialog_id".to_string(), serde_json::json!(3996));
+    ctx.set_param(
+        "mission_622_status".to_string(),
+        serde_json::json!("active"),
+    );
+    ctx.set_param(
+        "mission_622_step_2113_status".to_string(),
+        serde_json::json!("completed"),
+    );
+
+    let event = TriggerEvent {
+        trigger_type: TriggerType::DialogOpen,
+        source_entity: None,
+        target_entity: None,
+        params: ctx.params.clone(),
+    };
+
+    let resolved = engine.resolve_event(&event, &ctx);
+    let chain_1005_fired = resolved.actions.iter().any(|(id, _)| *id == 1005);
+    assert!(
+        !chain_1005_fired,
+        "chain 1005 must NOT fire after step 2113 advances — re-searching the \
+         Guard would otherwise re-grant the pistol / re-advance. Got: {:?}",
         resolved.actions,
     );
 }

--- a/crates/services/src/cell/content/chain_replay_tests/mission_622.rs
+++ b/crates/services/src/cell/content/chain_replay_tests/mission_622.rs
@@ -1,21 +1,30 @@
-//! Mission 622 — Arm Yourself! Pin the **loot-split** + equip-from-inventory
-//! flow:
+//! Mission 622 — Arm Yourself! Pin the **sequenced loot-split** +
+//! equip-from-inventory flow. The loot is split across the two stasis-room
+//! corpses and ordered Frost → Guard, with an intermediate step so the
+//! sequence survives a relog:
 //! - chain 1003 (Frost body, dialog 3995) grants ONLY the letter (3730) to the
-//!   mission inventory; it does not grant the pistol and does not advance.
+//!   mission inventory, binds the Guard's dialog set (5230), and advances
+//!   2113 → 80623 ("Search the NID Guard's body"). No pistol.
 //! - chain 1005 (Guard corpse, dialog 3996) grants the pistol (55) to the
-//!   backpack (container 1) and owns the 2113 → 80622 advance.
+//!   backpack (container 1) and advances 80623 → 80622 ("Equip the pistol").
 //! - chain 1004 fires on `item_equipped(55)` and is the only path that plays
 //!   kismet sequence 10000 (opens the stasis-room door) + completes the mission.
+//! - chains 1006/1007 re-bind Frost / the Guard on `player_loaded` at step
+//!   2113 / 80623 respectively (interaction bindings aren't persisted).
 //!
-//! The loot is split across the two stasis-room corpses; the order the player
-//! searches them in must not matter (see the order-independence tests below).
-//! Frost's letter chain is gated on `mission_status = active` (not step 2113)
-//! so it stays reachable after the Guard advances the step; its re-loot guard
-//! is the body's interaction-bit clear, since `once` is a no-op in the engine.
+//! Sequencing: the Guard corpse's dialog (5230 → template 21) is NOT bound at
+//! mission accept (chain 1001 binds only Frost's 5229), so the Guard is not
+//! searchable until chain 1003 binds 5230 on the Frost dialog_open. That
+//! binding gate lives at the interaction layer (`available_interactions` in
+//! cell/interactions/dispatch.rs), which the chain-replay harness here does
+//! not model — these tests pin the chain *conditions* and *actions*: the
+//! per-step gates (1003 on 2113, 1005 on 80623, 1004 on 80622), the advances,
+//! the re-loot guards (gates flip false on advance), and that the
+//! `add_dialog_set` unlocks live on the right chains (1003/1006/1007, not 1001).
 //!
-//! Step 80622 is a Cimmeria-introduced step whose matching `<Steps>` row is
-//! shipped to the client via a `mission_overrides` patch on `_622` in
-//! `CookedDataMissions.pak`; unchanged by the loot split.
+//! Steps 80623 + 80622 are Cimmeria-introduced; their matching `<Steps>` rows
+//! are shipped to the client via two `mission_overrides` patches on `_622` in
+//! `CookedDataMissions.pak` (XML order 2113 → 80623 → 80622).
 
 use cimmeria_content_engine::actions::Action;
 use cimmeria_content_engine::chain::ChainEngine;
@@ -25,10 +34,13 @@ use cimmeria_content_engine::triggers::{TriggerEvent, TriggerType};
 use super::super::engine_loader::load_single_chain_for_test;
 use crate::test_support::require_db_or_skip;
 
-/// Chain 1003 (Frost) must grant ONLY the letter — no pistol, no advance, no
-/// completion. The pistol + advance moved to chain 1005 (the Guard corpse).
+/// Chain 1003 (Frost) grants ONLY the letter, then advances to the
+/// intermediate Guard-search step 80623 (NOT the equip step 80622, and NOT
+/// straight to completion). The pistol comes from the Guard corpse (chain
+/// 1005). Frost owning the 2113 → 80623 advance is what self-gates it (the
+/// step-2113 gate flips false) and opens chain 1005's 80623 gate.
 #[tokio::test]
-async fn chain_1003_grants_letter_only_no_pistol_no_advance() {
+async fn chain_1003_grants_letter_and_advances_to_guard_search_step() {
     let pool = require_db_or_skip!();
     let chain = load_single_chain_for_test(&pool, 1003)
         .await
@@ -64,36 +76,50 @@ async fn chain_1003_grants_letter_only_no_pistol_no_advance() {
         .any(|a| matches!(a, Action::GrantItem { item_id: 55, .. }));
     assert!(
         !grants_pistol,
-        "chain 1003 (Frost) must NOT grant the pistol after the loot split; \
-         the pistol comes from the Guard corpse (chain 1005). Actions: {:?}",
+        "chain 1003 (Frost) must NOT grant the pistol; the pistol comes from the \
+         Guard corpse (chain 1005). Actions: {:?}",
         chain.actions,
     );
 
-    // No advance — Frost's chain must not own the step transition, or looting
-    // Frost first would skip past the search step before the pistol is found.
-    let advances = chain.actions.iter().any(|a| {
+    // Advances to 80623 (the Guard-search step), and ONLY to 80623 — never
+    // straight to the equip step 80622, which would skip the Guard search.
+    let advances_to_80623 = chain.actions.iter().any(|a| {
         matches!(
             a,
             Action::AdvanceStep {
                 mission_id: 622,
-                ..
+                step_id: 80623
             }
         )
     });
     assert!(
-        !advances,
-        "chain 1003 (Frost) must NOT advance mission 622; the Guard chain (1005) \
-         owns the 2113 → 80622 advance. Actions: {:?}",
+        advances_to_80623,
+        "chain 1003 (Frost) must advance mission 622 to the intermediate \
+         Guard-search step 80623. Actions: {:?}",
+        chain.actions,
+    );
+    let advances_to_80622 = chain.actions.iter().any(|a| {
+        matches!(
+            a,
+            Action::AdvanceStep {
+                mission_id: 622,
+                step_id: 80622
+            }
+        )
+    });
+    assert!(
+        !advances_to_80622,
+        "chain 1003 (Frost) must NOT advance straight to the equip step 80622 — \
+         that would skip the Guard search. Actions: {:?}",
         chain.actions,
     );
 }
 
-/// Order-independence: chain 1003 (Frost letter) must STILL fire when the
-/// player loots the Guard first (which advances 2113 → 80622). The letter gate
-/// is `mission_status = active`, not step 2113, so the prior advance does not
-/// lock Frost out. (This inverts the pre-split guard, which keyed on 2113.)
+/// Frost's gate is `step_status 2113 = active`: it fires on the opening step
+/// and self-limits once it advances to 80623 (a re-click can't re-grant the
+/// letter or re-advance). Pins the gate + the resolved 80623 advance together.
 #[tokio::test]
-async fn chain_1003_letter_still_fires_after_guard_advanced_the_step() {
+async fn chain_1003_fires_on_step_2113_and_advances_to_80623() {
     let pool = require_db_or_skip!();
     let chain = load_single_chain_for_test(&pool, 1003)
         .await
@@ -109,14 +135,62 @@ async fn chain_1003_letter_still_fires_after_guard_advanced_the_step() {
         "mission_622_status".to_string(),
         serde_json::json!("active"),
     );
-    // Guard was looted first: 2113 completed, now on 80622. Frost's letter
-    // must remain grantable.
+    ctx.set_param(
+        "mission_622_step_2113_status".to_string(),
+        serde_json::json!("active"),
+    );
+
+    let event = TriggerEvent {
+        trigger_type: TriggerType::DialogOpen,
+        source_entity: None,
+        target_entity: None,
+        params: ctx.params.clone(),
+    };
+
+    let resolved = engine.resolve_event(&event, &ctx);
+    let advances_to_80623 = resolved.actions.iter().any(|(id, a)| {
+        *id == 1003
+            && matches!(
+                a,
+                Action::AdvanceStep {
+                    mission_id: 622,
+                    step_id: 80623
+                }
+            )
+    });
+    assert!(
+        advances_to_80623,
+        "chain 1003 must fire on step 2113 and advance to 80623; got {:?}",
+        resolved.actions,
+    );
+}
+
+/// Re-loot guard: chain 1003 must NOT fire once it has advanced past step 2113
+/// (to 80623). Re-clicking Frost can't re-grant the letter or re-advance.
+#[tokio::test]
+async fn chain_1003_does_not_fire_after_advancing_to_80623() {
+    let pool = require_db_or_skip!();
+    let chain = load_single_chain_for_test(&pool, 1003)
+        .await
+        .expect("DB query for chain 1003 must succeed")
+        .expect("chain 1003 must exist in seeded content_chains");
+
+    let mut engine = ChainEngine::new();
+    engine.register_chain(chain);
+
+    let mut ctx = ExecutionContext::new();
+    ctx.set_param("dialog_id".to_string(), serde_json::json!(3995));
+    ctx.set_param(
+        "mission_622_status".to_string(),
+        serde_json::json!("active"),
+    );
+    // Frost already searched: 2113 completed, now on 80623.
     ctx.set_param(
         "mission_622_step_2113_status".to_string(),
         serde_json::json!("completed"),
     );
     ctx.set_param(
-        "mission_622_step_80622_status".to_string(),
+        "mission_622_step_80623_status".to_string(),
         serde_json::json!("active"),
     );
 
@@ -130,10 +204,9 @@ async fn chain_1003_letter_still_fires_after_guard_advanced_the_step() {
     let resolved = engine.resolve_event(&event, &ctx);
     let chain_1003_fired = resolved.actions.iter().any(|(id, _)| *id == 1003);
     assert!(
-        chain_1003_fired,
-        "chain 1003 (Frost letter) must still fire after the Guard advanced the \
-         step — the letter gate is mission-active, not step 2113, so loot order \
-         doesn't matter. Got actions: {:?}",
+        !chain_1003_fired,
+        "chain 1003 must NOT re-fire after advancing to 80623 — the step-2113 \
+         gate is the re-loot guard. Got actions: {:?}",
         resolved.actions,
     );
 }
@@ -202,11 +275,11 @@ async fn chain_1005_grants_pistol_and_advances_to_equip_step() {
     );
 }
 
-/// Re-loot guard: chain 1005 (pistol) must NOT fire once step 2113 has been
-/// advanced past — re-searching the Guard corpse can't re-grant the pistol or
-/// re-advance. The step-gate flip is this chain's guard.
+/// Chain 1005's gate is `step_status 80623 = active` — the Guard is searchable
+/// only AFTER Frost advanced us to the intermediate step. Positive case: it
+/// fires (grants the pistol, advances to 80622) when 80623 is active.
 #[tokio::test]
-async fn chain_1005_does_not_fire_after_step_2113_advances() {
+async fn chain_1005_fires_on_step_80623() {
     let pool = require_db_or_skip!();
     let chain = load_single_chain_for_test(&pool, 1005)
         .await
@@ -223,8 +296,62 @@ async fn chain_1005_does_not_fire_after_step_2113_advances() {
         serde_json::json!("active"),
     );
     ctx.set_param(
+        "mission_622_step_80623_status".to_string(),
+        serde_json::json!("active"),
+    );
+
+    let event = TriggerEvent {
+        trigger_type: TriggerType::DialogOpen,
+        source_entity: None,
+        target_entity: None,
+        params: ctx.params.clone(),
+    };
+
+    let resolved = engine.resolve_event(&event, &ctx);
+    let advances_to_equip = resolved.actions.iter().any(|(id, a)| {
+        *id == 1005
+            && matches!(
+                a,
+                Action::AdvanceStep {
+                    mission_id: 622,
+                    step_id: 80622
+                }
+            )
+    });
+    assert!(
+        advances_to_equip,
+        "chain 1005 must fire on step 80623 and advance to the equip step 80622; \
+         got {:?}",
+        resolved.actions,
+    );
+}
+
+/// Order guard: chain 1005 must NOT fire while the player is still on the
+/// OPENING step 2113 (i.e. Frost not yet searched, so step 80623 isn't active).
+/// The Guard's dialog isn't even bound at that point, but gating defensively on
+/// 80623 (not 2113) means that even a spoofed dialog_open can't grant the
+/// pistol before Frost is searched.
+#[tokio::test]
+async fn chain_1005_does_not_fire_before_frost_searched() {
+    let pool = require_db_or_skip!();
+    let chain = load_single_chain_for_test(&pool, 1005)
+        .await
+        .expect("DB query for chain 1005 must succeed")
+        .expect("chain 1005 must exist in seeded content_chains");
+
+    let mut engine = ChainEngine::new();
+    engine.register_chain(chain);
+
+    let mut ctx = ExecutionContext::new();
+    ctx.set_param("dialog_id".to_string(), serde_json::json!(3996));
+    ctx.set_param(
+        "mission_622_status".to_string(),
+        serde_json::json!("active"),
+    );
+    // Still on the opening step — Frost not yet searched.
+    ctx.set_param(
         "mission_622_step_2113_status".to_string(),
-        serde_json::json!("completed"),
+        serde_json::json!("active"),
     );
 
     let event = TriggerEvent {
@@ -238,8 +365,54 @@ async fn chain_1005_does_not_fire_after_step_2113_advances() {
     let chain_1005_fired = resolved.actions.iter().any(|(id, _)| *id == 1005);
     assert!(
         !chain_1005_fired,
-        "chain 1005 must NOT fire after step 2113 advances — re-searching the \
-         Guard would otherwise re-grant the pistol / re-advance. Got: {:?}",
+        "chain 1005 must NOT fire on step 2113 (before Frost is searched) — the \
+         gate is step 80623. Got: {:?}",
+        resolved.actions,
+    );
+}
+
+/// Re-loot guard: chain 1005 must NOT fire once it has advanced past 80623 (to
+/// the equip step 80622). Re-searching the Guard can't re-grant the pistol.
+#[tokio::test]
+async fn chain_1005_does_not_fire_after_advancing_to_80622() {
+    let pool = require_db_or_skip!();
+    let chain = load_single_chain_for_test(&pool, 1005)
+        .await
+        .expect("DB query for chain 1005 must succeed")
+        .expect("chain 1005 must exist in seeded content_chains");
+
+    let mut engine = ChainEngine::new();
+    engine.register_chain(chain);
+
+    let mut ctx = ExecutionContext::new();
+    ctx.set_param("dialog_id".to_string(), serde_json::json!(3996));
+    ctx.set_param(
+        "mission_622_status".to_string(),
+        serde_json::json!("active"),
+    );
+    // Guard already searched: 80623 completed, now on the equip step 80622.
+    ctx.set_param(
+        "mission_622_step_80623_status".to_string(),
+        serde_json::json!("completed"),
+    );
+    ctx.set_param(
+        "mission_622_step_80622_status".to_string(),
+        serde_json::json!("active"),
+    );
+
+    let event = TriggerEvent {
+        trigger_type: TriggerType::DialogOpen,
+        source_entity: None,
+        target_entity: None,
+        params: ctx.params.clone(),
+    };
+
+    let resolved = engine.resolve_event(&event, &ctx);
+    let chain_1005_fired = resolved.actions.iter().any(|(id, _)| *id == 1005);
+    assert!(
+        !chain_1005_fired,
+        "chain 1005 must NOT re-fire after advancing to 80622 — the step-80623 \
+         gate is the re-loot guard. Got: {:?}",
         resolved.actions,
     );
 }
@@ -331,6 +504,181 @@ async fn chain_1004_does_not_fire_without_step_80622_active() {
         "chain 1004 must NOT fire before step 80622 is reached — \
          a pre-loot equip would otherwise complete the mission without \
          visiting Frost's body. Got actions: {:?}",
+        resolved.actions,
+    );
+}
+
+/// Sequencing guard: searching Frost is what unlocks the Guard corpse.
+/// Chain 1003 (Frost dialog_open) must bind the Guard's dialog set
+/// (5230 → template 21); chain 1001 (mission accept) must NOT. If the bind
+/// moved back to 1001, both corpses would be searchable at once and the
+/// Frost → Guard ordering the player asked for would be gone.
+#[tokio::test]
+async fn frost_loot_unlocks_guard_and_accept_does_not_bind_guard() {
+    let pool = require_db_or_skip!();
+
+    let chain_1001 = load_single_chain_for_test(&pool, 1001)
+        .await
+        .expect("DB query for chain 1001 must succeed")
+        .expect("chain 1001 must exist in seeded content_chains");
+    let chain_1003 = load_single_chain_for_test(&pool, 1003)
+        .await
+        .expect("DB query for chain 1003 must succeed")
+        .expect("chain 1003 must exist in seeded content_chains");
+
+    let binds_guard = |c: &cimmeria_content_engine::chain::Chain| {
+        c.actions.iter().any(|a| {
+            matches!(
+                a,
+                Action::AddDialogSet {
+                    dialog_set_id: 5230,
+                    slot: 21,
+                    ..
+                }
+            )
+        })
+    };
+
+    assert!(
+        binds_guard(&chain_1003),
+        "chain 1003 (Frost loot) must bind the Guard's dialog set (5230 → \
+         template 21) so searching Frost unlocks the Guard. Actions: {:?}",
+        chain_1003.actions,
+    );
+    assert!(
+        !binds_guard(&chain_1001),
+        "chain 1001 (mission accept) must NOT bind the Guard's dialog set — \
+         that would make the Guard searchable before Frost, defeating the \
+         Frost → Guard sequencing. Actions: {:?}",
+        chain_1001.actions,
+    );
+
+    // Frost's own dialog set (5229 → template 14) must STILL be bound at
+    // accept — only the Guard's bind moved.
+    let binds_frost_at_accept = chain_1001.actions.iter().any(|a| {
+        matches!(
+            a,
+            Action::AddDialogSet {
+                dialog_set_id: 5229,
+                slot: 14,
+                ..
+            }
+        )
+    });
+    assert!(
+        binds_frost_at_accept,
+        "chain 1001 must still bind Frost's dialog set (5229 → template 14) at \
+         mission accept. Actions: {:?}",
+        chain_1001.actions,
+    );
+}
+
+/// Relog safety: the corpse dialog bindings (`available_interactions`) are not
+/// persisted across a relog/restart, so login-restore chains must re-apply
+/// them. Chain 1006 re-binds Frost (5229) while step 2113 is active; chain 1007
+/// re-binds the Guard (5230) while the intermediate step 80623 is active. Both
+/// fire on `player_loaded`. Without 1007, the intermediate step would buy
+/// nothing — a player who searched Frost then logged out would lose the Guard
+/// binding and the pistol would be unobtainable.
+#[tokio::test]
+async fn login_restore_chains_rebind_corpses_per_step() {
+    let pool = require_db_or_skip!();
+
+    let chain_1006 = load_single_chain_for_test(&pool, 1006)
+        .await
+        .expect("DB query for chain 1006 must succeed")
+        .expect("chain 1006 (Frost login restore) must exist in seeded content_chains");
+    let chain_1007 = load_single_chain_for_test(&pool, 1007)
+        .await
+        .expect("DB query for chain 1007 must succeed")
+        .expect("chain 1007 (Guard login restore) must exist in seeded content_chains");
+
+    // Chain 1006 must re-bind Frost (5229 → template 14).
+    assert!(
+        chain_1006.actions.iter().any(|a| matches!(
+            a,
+            Action::AddDialogSet {
+                dialog_set_id: 5229,
+                slot: 14,
+                ..
+            }
+        )),
+        "chain 1006 must re-bind Frost's dialog set (5229 → template 14) on \
+         login. Actions: {:?}",
+        chain_1006.actions,
+    );
+
+    // Chain 1007 must re-bind the Guard (5230 → template 21).
+    assert!(
+        chain_1007.actions.iter().any(|a| matches!(
+            a,
+            Action::AddDialogSet {
+                dialog_set_id: 5230,
+                slot: 21,
+                ..
+            }
+        )),
+        "chain 1007 must re-bind the Guard's dialog set (5230 → template 21) on \
+         login. Actions: {:?}",
+        chain_1007.actions,
+    );
+}
+
+/// The login-restore chains must actually FIRE on `player_loaded` at their
+/// respective steps — pins the trigger + step gate together so a future edit
+/// that loosens the gate (or changes the trigger) trips here. Chain 1007 in
+/// particular is the whole point of the intermediate step: it must fire while
+/// step 80623 is active.
+#[tokio::test]
+async fn chain_1007_fires_on_login_at_step_80623() {
+    let pool = require_db_or_skip!();
+    let chain = load_single_chain_for_test(&pool, 1007)
+        .await
+        .expect("DB query for chain 1007 must succeed")
+        .expect("chain 1007 must exist in seeded content_chains");
+
+    let mut engine = ChainEngine::new();
+    engine.register_chain(chain);
+
+    let mut ctx = ExecutionContext::new();
+    // OnPlayerLoaded matches on the `world_name` param (loaded from the
+    // trigger's event_key); the chain's key is 'Castle_CellBlock'.
+    ctx.set_param(
+        "world_name".to_string(),
+        serde_json::json!("Castle_CellBlock"),
+    );
+    ctx.set_param(
+        "mission_622_status".to_string(),
+        serde_json::json!("active"),
+    );
+    ctx.set_param(
+        "mission_622_step_80623_status".to_string(),
+        serde_json::json!("active"),
+    );
+
+    let event = TriggerEvent {
+        trigger_type: TriggerType::PlayerLoaded,
+        source_entity: None,
+        target_entity: None,
+        params: ctx.params.clone(),
+    };
+
+    let resolved = engine.resolve_event(&event, &ctx);
+    let rebinds_guard = resolved.actions.iter().any(|(id, a)| {
+        *id == 1007
+            && matches!(
+                a,
+                Action::AddDialogSet {
+                    dialog_set_id: 5230,
+                    slot: 21,
+                    ..
+                }
+            )
+    });
+    assert!(
+        rebinds_guard,
+        "chain 1007 must re-bind the Guard (5230) on player_loaded at step \
+         80623; got {:?}",
         resolved.actions,
     );
 }

--- a/crates/services/src/cell/messages/cell_to_base.rs
+++ b/crates/services/src/cell/messages/cell_to_base.rs
@@ -410,6 +410,42 @@ pub enum CellToBaseMsg {
         amount: i32,
     },
 
+    /// Execute a server-generated authoring SQL statement against the live DB
+    /// (`.`-console). The cell has no DB pool, so the spawn/patrol
+    /// authoring commands hand their `INSERT`/`UPDATE`/`DELETE` to the base,
+    /// which runs it and reports the row count back to the GM via the feedback
+    /// channel. The write is intentionally transient — it lets the developer
+    /// see the change hold across reconnects within the current deploy, but the
+    /// next deploy rebuilds from `db/resources/` seeds and wipes it (the
+    /// durable artifact is the seed SQL emitted by `.seedconfirm`).
+    ///
+    /// **Trust model:** the `.`-channel is GM-gated server-side, and `sql` is
+    /// *server-generated* — numeric values are formatted from cell-parsed
+    /// `i32`/`f32` and strings are escaped through
+    /// [`crate::cell::console::seed::sql_str`], so no raw client text is
+    /// concatenated into the statement. This mirrors the legacy
+    /// `Atrea.dbQuery` authoring path. `label` is a short human tag for the
+    /// feedback line (e.g. `"savespawn"`).
+    ExecuteAuthoringSql {
+        entity_id: u32,
+        label: String,
+        sql: String,
+    },
+
+    /// Run a read-only name search against a resource table and feed the
+    /// matches back to the GM (`.searchitem` / `.searchmission` /
+    /// `.searchtemplate`). The cell caches resource ids but not their display
+    /// names (those live only in the base-side DB), so the search runs base-side
+    /// and reports `id: name` lines on the feedback channel. `kind` selects the
+    /// table (`0` items, `1` missions, `2` entity_templates); `query` is the
+    /// case-insensitive substring (used as a parameterized `ILIKE` bind — no
+    /// string concatenation).
+    ConsoleSearch {
+        entity_id: u32,
+        kind: u8,
+        query: String,
+    },
+
     /// Spawn an NPC by template id at a computed position (`gmSpawnByCmd`).
     ///
     /// Round-trip sink, mirroring `TrainAbility` → `AbilityGranted`: the cell

--- a/crates/services/src/cell/mod.rs
+++ b/crates/services/src/cell/mod.rs
@@ -9,6 +9,7 @@ pub mod cell_methods;
 pub mod chat;
 pub mod client_methods;
 pub mod combat;
+pub mod console;
 pub mod content;
 pub mod cover;
 pub mod dispatch;

--- a/crates/services/src/cell/service/base_messages/mod.rs
+++ b/crates/services/src/cell/service/base_messages/mod.rs
@@ -299,6 +299,7 @@ pub(super) async fn handle_base_message(
                 &text,
                 tx,
                 space_mgr,
+                engine,
             )
             .await;
         }

--- a/crates/services/src/cell/space_manager/entities.rs
+++ b/crates/services/src/cell/space_manager/entities.rs
@@ -80,6 +80,11 @@ impl SpaceManager {
     /// If the entity was in an instanced space and was the last player, the
     /// entire space instance is destroyed (all remaining NPCs removed).
     pub fn destroy_entity(&mut self, entity_id: u32) {
+        // GM-only session buffers are keyed by entity_id; drop them so a
+        // destroyed (and possibly later reused) id can't inherit stale pending
+        // authoring SQL or the autosave-spawn flag.
+        self.authoring_changes.remove(&entity_id);
+        self.autosave_spawns.remove(&entity_id);
         if let Some(space_id) = self.entity_space.remove(&entity_id) {
             let mut should_destroy_space = false;
 
@@ -127,6 +132,11 @@ impl SpaceManager {
         entity_id: u32,
         tx: &tokio::sync::mpsc::Sender<CellToBaseMsg>,
     ) {
+        // Drop GM-only session buffers (keyed by entity_id) on disconnect so
+        // pending authoring SQL / the autosave-spawn flag don't outlive the
+        // session. Same rationale as `destroy_entity`.
+        self.authoring_changes.remove(&entity_id);
+        self.autosave_spawns.remove(&entity_id);
         if let Some(&space_id) = self.entity_space.get(&entity_id) {
             if let Some(space) = self.spaces.get_mut(&space_id) {
                 space.players.remove(&entity_id);

--- a/crates/services/src/cell/space_manager/mod.rs
+++ b/crates/services/src/cell/space_manager/mod.rs
@@ -221,6 +221,22 @@ pub struct SpaceManager {
     /// currently inside (drives `onEnterCoverSet` / `onLeaveCoverSet`
     /// fanout + content-engine `OnPlayerEnteredCover` triggers).
     pub cover_detection: super::cover::CoverDetectionTable,
+    /// Per-GM `.`-console authoring buffer: `entity_id → [(seed_file, sql)]`.
+    /// Spawn/patrol authoring commands push their generated seed SQL here;
+    /// `.seedconfirm` groups it per file and emits it, `.seedcancel` discards
+    /// it. Server-side, ephemeral (never persisted) — the durable artifact is
+    /// the per-session authoring log file and the committed seed. See
+    /// `crate::cell::console::seed`.
+    pub authoring_changes: HashMap<u32, Vec<(String, String)>>,
+    /// GMs (`entity_id`) who toggled `.autosavespawn` on. A session preference;
+    /// informational hook for spawn-authoring. Never persisted.
+    pub autosave_spawns: HashSet<u32>,
+    /// In-memory patrol-path authoring buffer: `path_id → [waypoint]`, for
+    /// `.path_add`/`.path_show`/`.path_assign`. Holds the waypoints a GM is
+    /// authoring this session so `.path_assign` can apply them to an NPC's
+    /// `patrol_path` immediately; the durable copy is the recorded
+    /// `point_set_points` seed SQL. Path id == `point_sets.set_id`.
+    pub patrol_authoring: HashMap<i32, Vec<cimmeria_common::Vector3>>,
 }
 
 impl SpaceManager {
@@ -259,6 +275,9 @@ impl SpaceManager {
             movement_validator: MovementValidator::new(),
             cover: super::cover::Cover::empty(),
             cover_detection: super::cover::CoverDetectionTable::new(),
+            authoring_changes: HashMap::new(),
+            autosave_spawns: HashSet::new(),
+            patrol_authoring: HashMap::new(),
         }
     }
 }

--- a/crates/services/src/cell/space_manager/spawn.rs
+++ b/crates/services/src/cell/space_manager/spawn.rs
@@ -117,6 +117,9 @@ impl SpaceManager {
 
         // Template-driven fields
         e.template_id = Some(record.template_id);
+        // `-1` is the GM/command-spawn sentinel (no spawnlist row) — keep only
+        // real positive ids so authoring commands don't target a phantom row.
+        e.spawn_id = (record.spawn_id > 0).then_some(record.spawn_id);
         e.tag = record.tag.clone();
         e.name_id = record.name_id;
         e.speaker_id = record.speaker_id;

--- a/crates/services/src/cell/spawner/npcs.rs
+++ b/crates/services/src/cell/spawner/npcs.rs
@@ -128,8 +128,8 @@ pub async fn load_spawns_from_db(pool: &PgPool) -> Result<Vec<SpawnRecord>, sqlx
                t.alignment, t.faction, t.name_id, t.speaker_id, \
                t.static_interaction_sets, t.has_dynamic_properties, \
                t.loot_table_id, \
-               t.patrol_path_id, \
-               COALESCE(t.patrol_point_delay, 2.0) AS patrol_point_delay, \
+               COALESCE(s.patrol_path_id, t.patrol_path_id) AS patrol_path_id, \
+               COALESCE(s.patrol_point_delay, t.patrol_point_delay, 2.0) AS patrol_point_delay, \
                COALESCE(t.wander_radius, 0.0) AS wander_radius, \
                COALESCE(t.wander_min_dwell_secs, 3.0) AS wander_min_dwell_secs, \
                COALESCE(t.wander_max_dwell_secs, 8.0) AS wander_max_dwell_secs, \

--- a/db/resources/Content/Seed/castle_cellblock_chains.sql
+++ b/db/resources/Content/Seed/castle_cellblock_chains.sql
@@ -36,10 +36,14 @@ INSERT INTO content_actions (chain_id, action_type, target_id, target_key, param
 VALUES
   (1001, 'accept_mission',  622,  NULL, '{}', 0, 0),
   (1001, 'display_dialog',  2982, NULL, '{}', 0, 1),
-  (1001, 'add_dialog_set',  5229, NULL, '{"slot": 14, "mission_id": 622}', 0, 2),
-  -- Bind the Guard corpse's body-loot dialog (3996) to template 21 so it
-  -- becomes searchable, the same way 5229/slot-14 makes Frost searchable.
-  (1001, 'add_dialog_set',  5230, NULL, '{"slot": 21, "mission_id": 622}', 0, 3);
+  -- Bind ONLY Frost's body-loot dialog (3995 → template 14) at mission
+  -- accept. The Guard corpse (3996 → template 21) is deliberately left
+  -- UNBOUND here so it is not yet searchable: a corpse only opens a dialog
+  -- when its template has an entry in the player's available_interactions
+  -- (cell/interactions/dispatch.rs), and the Guard's spawn carries no static
+  -- interaction type. Chain 1003 binds 5230 once the player searches Frost,
+  -- sequencing the two bodies Frost → Guard instead of exposing both at once.
+  (1001, 'add_dialog_set',  5229, NULL, '{"slot": 14, "mission_id": 622}', 0, 2);
 
 -- Chain 1002: zone entry when 622 already completed → play cinematic
 INSERT INTO content_chains (chain_id, description, scope_type, scope_id, enabled, priority)
@@ -76,15 +80,23 @@ VALUES (1003, '622 - Dialog 3995 (loot Frost): grant letter only', 'mission', 62
 INSERT INTO content_triggers (chain_id, event_type, event_key, scope, once, sort_order)
 VALUES (1003, 'dialog_open', '3995', 'player', false, 0);
 
--- Loot split (Frost = letter only): the pistol + the 2113→80622 advance moved
--- to the Guard-corpse chain (1005). Frost now grants ONLY the letter and does
--- NOT advance, so its gate is loosened to `mission_status = active` (not step
--- 2113) — otherwise looting the Guard first (which advances past 2113) would
--- make the letter unreachable. Re-loot guard is the body's search-bit clear
--- (mirrors ArmYourself.py:48); `once` on the trigger is a no-op (never enforced
--- by the engine), and this chain no longer advances a step to self-gate.
+-- Loot split, step 1 of 2 (Frost): grant ONLY the letter, advance to the
+-- intermediate Guard-search step 80623, and unlock the Guard corpse. The pistol
+-- + the final advance to 80622 live on the Guard chain (1005).
+--
+-- Gate is `step_status 2113 = active`: Frost is the FIRST search, valid only
+-- while on the opening step. Advancing 2113 → 80623 flips this false, which is
+-- the re-loot guard (a re-click can't re-grant the letter or re-advance). The
+-- body's search-bit is also cleared (mirrors ArmYourself.py:48). `once` on the
+-- trigger is a no-op (never enforced by the engine).
+--
+-- Sequencing: the Guard's dialog (5230 → template 21) is NOT bound at mission
+-- accept (chain 1001 binds only Frost's 5229); it is bound here, on the Frost
+-- dialog_open, so the player must search Frost before the Guard exposes its
+-- dialog. Relog-safe: chain 1007 re-binds the Guard on login while step 80623
+-- is active, and chain 1006 re-binds Frost on login while step 2113 is active.
 INSERT INTO content_conditions (chain_id, condition_type, target_id, target_key, operator, value, sort_order)
-VALUES (1003, 'mission_status', 622, NULL, 'eq', 'active', 0);
+VALUES (1003, 'step_status', 622, '2113', 'eq', 'active', 0);
 
 INSERT INTO content_actions (chain_id, action_type, target_id, target_key, params, delay_ms, sort_order)
 VALUES
@@ -92,7 +104,15 @@ VALUES
   -- dialog 3995 and re-grant the letter.
   (1003, 'set_interaction_type', NULL, 'ArmYourself_FrostBody', '{"op": "~", "mask": 4194304}', 0, 0),
   -- Letter (3730) → container 0 (mission inventory).
-  (1003, 'add_item',     3730, NULL,    '{"container": 0, "qty": 1}', 0, 1);
+  (1003, 'add_item',     3730, NULL,    '{"container": 0, "qty": 1}', 0, 1),
+  -- Unlock the Guard corpse: bind dialog 3996 (5230) to template 21 now that
+  -- Frost has been searched. add_dialog_set stores the binding in the player's
+  -- available_interactions and pushes the INT_MissionWorldObject highlight to
+  -- the Guard if it is already in AoI (else on AoI create).
+  (1003, 'add_dialog_set', 5230, NULL, '{"slot": 21, "mission_id": 622}', 0, 2),
+  -- Advance to the intermediate Guard-search step (XML index 1). This both
+  -- self-gates Frost (gate above flips false) and opens chain 1005's gate.
+  (1003, 'advance_step', 622, '80623', '{}', 0, 3);
 
 -- Chain 1004: player equips the pistol (item 55) while step 80622 is
 -- active → play kismet sequence 10000 (opens the stasis-room door — the
@@ -113,18 +133,19 @@ VALUES
   (1004, 'play_sequence',    10000, NULL, '{}', 0, 0),
   (1004, 'complete_mission', 622,   NULL, '{}', 0, 1);
 
--- Chain 1005: player opens dialog 3996 (the Guard corpse, `ArmYourself_GuardBody`,
--- template 21) while step 2113 is active → grant the pistol (55) to the backpack
--- and advance 2113 → 80622 ("Equip the pistol"). This chain OWNS the step advance
--- (Frost's chain 1003 no longer does), so the equip → door → complete flow
--- (chain 1004) is unchanged. The pistol goes to container 1 (backpack), not the
+-- Loot split, step 2 of 2 (Guard): player opens dialog 3996 (the Guard corpse,
+-- `ArmYourself_GuardBody`, template 21) while the intermediate step 80623 is
+-- active → grant the pistol (55) to the backpack and advance 80623 → 80622
+-- ("Equip the pistol"). The pistol goes to container 1 (backpack), not the
 -- bandolier, so the player must equip it manually — exercising the same
--- ammo/appearance/fire-animation paths the equip pattern was built for.
+-- ammo/appearance/fire-animation paths the equip pattern was built for. The
+-- equip → door → complete flow (chain 1004) is unchanged.
 --
--- Re-loot guard: the gate `step_status 622 2113 = active` flips false the moment
--- we advance past 2113, so a second dialog open can't re-grant. The body's
--- search bit is also cleared (client-side) so it stops being clickable.
--- The Guard becomes searchable via `add_dialog_set(5230, slot 21)` in chain 1001.
+-- Gate is `step_status 622 80623 = active`: the Guard is searchable only AFTER
+-- Frost advanced us to 80623, and the gate flips false the moment we advance to
+-- 80622, so a second dialog open can't re-grant (re-loot guard). The body's
+-- search bit is also cleared (client-side) so it stops being clickable. The
+-- Guard's dialog is bound by chain 1003 on the Frost search (relog: chain 1007).
 INSERT INTO content_chains (chain_id, description, scope_type, scope_id, enabled, priority)
 VALUES (1005, '622 - Dialog 3996 (loot Guard): grant pistol + advance to equip step', 'mission', 622, true, 0);
 
@@ -132,13 +153,50 @@ INSERT INTO content_triggers (chain_id, event_type, event_key, scope, once, sort
 VALUES (1005, 'dialog_open', '3996', 'player', false, 0);
 
 INSERT INTO content_conditions (chain_id, condition_type, target_id, target_key, operator, value, sort_order)
-VALUES (1005, 'step_status', 622, '2113', 'eq', 'active', 0);
+VALUES (1005, 'step_status', 622, '80623', 'eq', 'active', 0);
 
 INSERT INTO content_actions (chain_id, action_type, target_id, target_key, params, delay_ms, sort_order)
 VALUES
   (1005, 'set_interaction_type', NULL, 'ArmYourself_GuardBody', '{"op": "~", "mask": 4194304}', 0, 0),
   (1005, 'add_item',     55,   NULL,    '{"container": 1, "qty": 1}', 0, 1),
   (1005, 'advance_step', 622,  '80622', '{}',                          0, 2);
+
+-- Chain 1006: player_loaded + step 2113 active → re-bind Frost's dialog set on
+-- login. interaction bindings (available_interactions) are not persisted across
+-- a relog/restart, so without this a player who logs out before searching Frost
+-- would find his corpse inert and the mission stuck. Same restart-resilience
+-- pattern as the mission-640/641 restore chains (1045/1046/1062…). Mirrors
+-- chain 1001's accept-time bind of 5229, but gated on the step rather than
+-- mission-accept so it fires on every login while step 2113 is open.
+INSERT INTO content_chains (chain_id, description, scope_type, scope_id, enabled, priority)
+VALUES (1006, '622 - Restore Frost dialog binding on login (step 2113)', 'mission', 622, true, 0);
+
+INSERT INTO content_triggers (chain_id, event_type, event_key, scope, once, sort_order)
+VALUES (1006, 'player_loaded', 'Castle_CellBlock', 'player', false, 0);
+
+INSERT INTO content_conditions (chain_id, condition_type, target_id, target_key, operator, value, sort_order)
+VALUES (1006, 'step_status', 622, '2113', 'eq', 'active', 0);
+
+INSERT INTO content_actions (chain_id, action_type, target_id, target_key, params, delay_ms, sort_order)
+VALUES (1006, 'add_dialog_set', 5229, NULL, '{"slot": 14, "mission_id": 622}', 0, 0);
+
+-- Chain 1007: player_loaded + step 80623 active → re-bind the Guard's dialog
+-- set on login. This is the relog-safety the intermediate step 80623 exists
+-- for: a player who searched Frost (now on 80623) and logged out before
+-- searching the Guard gets the Guard binding back so the pistol stays
+-- obtainable. Frost is already done at this point (its gate, step 2113, is
+-- false and its search bit cleared), so only the Guard needs re-binding.
+INSERT INTO content_chains (chain_id, description, scope_type, scope_id, enabled, priority)
+VALUES (1007, '622 - Restore Guard dialog binding on login (step 80623)', 'mission', 622, true, 0);
+
+INSERT INTO content_triggers (chain_id, event_type, event_key, scope, once, sort_order)
+VALUES (1007, 'player_loaded', 'Castle_CellBlock', 'player', false, 0);
+
+INSERT INTO content_conditions (chain_id, condition_type, target_id, target_key, operator, value, sort_order)
+VALUES (1007, 'step_status', 622, '80623', 'eq', 'active', 0);
+
+INSERT INTO content_actions (chain_id, action_type, target_id, target_key, params, delay_ms, sort_order)
+VALUES (1007, 'add_dialog_set', 5230, NULL, '{"slot": 21, "mission_id": 622}', 0, 0);
 
 -- ============================================================
 -- MISSION 638 — Speak to Prisoner 329

--- a/db/resources/Content/Seed/castle_cellblock_chains.sql
+++ b/db/resources/Content/Seed/castle_cellblock_chains.sql
@@ -36,7 +36,10 @@ INSERT INTO content_actions (chain_id, action_type, target_id, target_key, param
 VALUES
   (1001, 'accept_mission',  622,  NULL, '{}', 0, 0),
   (1001, 'display_dialog',  2982, NULL, '{}', 0, 1),
-  (1001, 'add_dialog_set',  5229, NULL, '{"slot": 14, "mission_id": 622}', 0, 2);
+  (1001, 'add_dialog_set',  5229, NULL, '{"slot": 14, "mission_id": 622}', 0, 2),
+  -- Bind the Guard corpse's body-loot dialog (3996) to template 21 so it
+  -- becomes searchable, the same way 5229/slot-14 makes Frost searchable.
+  (1001, 'add_dialog_set',  5230, NULL, '{"slot": 21, "mission_id": 622}', 0, 3);
 
 -- Chain 1002: zone entry when 622 already completed → play cinematic
 INSERT INTO content_chains (chain_id, description, scope_type, scope_id, enabled, priority)
@@ -67,27 +70,29 @@ VALUES (1002, 'play_sequence', 10000, NULL, '{}', 0, 0);
 -- the PAK override the client UI would silently skip the unknown step
 -- and render either nothing or the next client-known step.
 --
--- Re-loot guard: the gate `step_status 622 2113 = active` flips false the
--- moment we advance past 2113, so a second dialog open won't re-fire the
--- chain. Same shape as chain 1031 (Ambernol vial pickup).
 INSERT INTO content_chains (chain_id, description, scope_type, scope_id, enabled, priority)
-VALUES (1003, '622 - Dialog 3995 (loot body): grant items + advance to equip step', 'mission', 622, true, 0);
+VALUES (1003, '622 - Dialog 3995 (loot Frost): grant letter only', 'mission', 622, true, 0);
 
 INSERT INTO content_triggers (chain_id, event_type, event_key, scope, once, sort_order)
 VALUES (1003, 'dialog_open', '3995', 'player', false, 0);
 
+-- Loot split (Frost = letter only): the pistol + the 2113→80622 advance moved
+-- to the Guard-corpse chain (1005). Frost now grants ONLY the letter and does
+-- NOT advance, so its gate is loosened to `mission_status = active` (not step
+-- 2113) — otherwise looting the Guard first (which advances past 2113) would
+-- make the letter unreachable. Re-loot guard is the body's search-bit clear
+-- (mirrors ArmYourself.py:48); `once` on the trigger is a no-op (never enforced
+-- by the engine), and this chain no longer advances a step to self-gate.
 INSERT INTO content_conditions (chain_id, condition_type, target_id, target_key, operator, value, sort_order)
-VALUES (1003, 'step_status', 622, '2113', 'eq', 'active', 0);
+VALUES (1003, 'mission_status', 622, NULL, 'eq', 'active', 0);
 
 INSERT INTO content_actions (chain_id, action_type, target_id, target_key, params, delay_ms, sort_order)
 VALUES
+  -- Clear the body's "search corpse" bit FIRST so a re-click can't re-open
+  -- dialog 3995 and re-grant the letter.
   (1003, 'set_interaction_type', NULL, 'ArmYourself_FrostBody', '{"op": "~", "mask": 4194304}', 0, 0),
-  -- Pistol → backpack (container 1) instead of bandolier (container 3) so
-  -- the player must equip it themselves. Letter (3730) keeps its container 0
-  -- mission-inventory placement.
-  (1003, 'add_item',     55,   NULL,    '{"container": 1, "qty": 1}', 0, 1),
-  (1003, 'add_item',     3730, NULL,    '{"container": 0, "qty": 1}', 0, 2),
-  (1003, 'advance_step', 622,  '80622', '{}',                          0, 3);
+  -- Letter (3730) → container 0 (mission inventory).
+  (1003, 'add_item',     3730, NULL,    '{"container": 0, "qty": 1}', 0, 1);
 
 -- Chain 1004: player equips the pistol (item 55) while step 80622 is
 -- active → play kismet sequence 10000 (opens the stasis-room door — the
@@ -107,6 +112,33 @@ INSERT INTO content_actions (chain_id, action_type, target_id, target_key, param
 VALUES
   (1004, 'play_sequence',    10000, NULL, '{}', 0, 0),
   (1004, 'complete_mission', 622,   NULL, '{}', 0, 1);
+
+-- Chain 1005: player opens dialog 3996 (the Guard corpse, `ArmYourself_GuardBody`,
+-- template 21) while step 2113 is active → grant the pistol (55) to the backpack
+-- and advance 2113 → 80622 ("Equip the pistol"). This chain OWNS the step advance
+-- (Frost's chain 1003 no longer does), so the equip → door → complete flow
+-- (chain 1004) is unchanged. The pistol goes to container 1 (backpack), not the
+-- bandolier, so the player must equip it manually — exercising the same
+-- ammo/appearance/fire-animation paths the equip pattern was built for.
+--
+-- Re-loot guard: the gate `step_status 622 2113 = active` flips false the moment
+-- we advance past 2113, so a second dialog open can't re-grant. The body's
+-- search bit is also cleared (client-side) so it stops being clickable.
+-- The Guard becomes searchable via `add_dialog_set(5230, slot 21)` in chain 1001.
+INSERT INTO content_chains (chain_id, description, scope_type, scope_id, enabled, priority)
+VALUES (1005, '622 - Dialog 3996 (loot Guard): grant pistol + advance to equip step', 'mission', 622, true, 0);
+
+INSERT INTO content_triggers (chain_id, event_type, event_key, scope, once, sort_order)
+VALUES (1005, 'dialog_open', '3996', 'player', false, 0);
+
+INSERT INTO content_conditions (chain_id, condition_type, target_id, target_key, operator, value, sort_order)
+VALUES (1005, 'step_status', 622, '2113', 'eq', 'active', 0);
+
+INSERT INTO content_actions (chain_id, action_type, target_id, target_key, params, delay_ms, sort_order)
+VALUES
+  (1005, 'set_interaction_type', NULL, 'ArmYourself_GuardBody', '{"op": "~", "mask": 4194304}', 0, 0),
+  (1005, 'add_item',     55,   NULL,    '{"container": 1, "qty": 1}', 0, 1),
+  (1005, 'advance_step', 622,  '80622', '{}',                          0, 2);
 
 -- ============================================================
 -- MISSION 638 — Speak to Prisoner 329

--- a/db/resources/Dialogs/Seed/dialog_screens.sql
+++ b/db/resources/Dialogs/Seed/dialog_screens.sql
@@ -16313,7 +16313,9 @@ INSERT INTO dialog_screens (dialog_id, screen_id, text, speaker_id, index) VALUE
 
 INSERT INTO dialog_screens (dialog_id, screen_id, text, speaker_id, index) VALUES (3984, 101999, 'Find the Jaffa, Trik''na.', 0, 0);
 
-INSERT INTO dialog_screens (dialog_id, screen_id, text, speaker_id, index) VALUES (3995, 96108, 'There are no obvious wounds on Cpl. Frost, though it appears he died soon after killing that NID Guard. On his body you find a pistol and a letter addressed to "Jess" - Frost''s wife.', 0, 0);
+INSERT INTO dialog_screens (dialog_id, screen_id, text, speaker_id, index) VALUES (3995, 96108, 'There are no obvious wounds on Cpl. Frost, though it appears he died soon after killing that NID Guard. On his body you find a letter addressed to "Jess" - Frost''s wife.', 0, 0);
+-- Mission 622 loot split: Guard-corpse search text (the pistol now comes from this body).
+INSERT INTO dialog_screens (dialog_id, screen_id, text, speaker_id, index) VALUES (3996, 96109, 'The NID Guard died with his weapon still drawn. You pry the pistol from his grip - it''s still serviceable.', 0, 0);
 
 INSERT INTO dialog_screens (dialog_id, screen_id, text, speaker_id, index) VALUES (3998, 96246, 'You succesfully bypass the security systems - the Stasis Pods for the East Wing slowly begin to open.', 934, 0);
 

--- a/db/resources/Dialogs/Seed/dialog_set_maps.sql
+++ b/db/resources/Dialogs/Seed/dialog_set_maps.sql
@@ -5097,6 +5097,8 @@ INSERT INTO dialog_set_maps (dialog_set_map_id, dialog_set_id, dialog_id, topic_
 INSERT INTO dialog_set_maps (dialog_set_map_id, dialog_set_id, dialog_id, topic_text, interaction_flags, min_level, missions_completed, missions_not_accepted, alignments, factions) VALUES (5228, 803, 2141, 'Search Guard Corpse', 0, 1, '{}', '{}', '{}', '{}');
 
 INSERT INTO dialog_set_maps (dialog_set_map_id, dialog_set_id, dialog_id, topic_text, interaction_flags, min_level, missions_completed, missions_not_accepted, alignments, factions) VALUES (5229, 803, 3995, 'Search Cpl. Frost''s Corpse', 1073741824, 1, '{}', '{}', '{}', '{}');
+-- Mission 622 loot split: bind dialog 3996 to the Guard corpse (added to template 21 via chain 1001). Same INT_MissionWorldObject flag (0x40000000) as Frost's 5229.
+INSERT INTO dialog_set_maps (dialog_set_map_id, dialog_set_id, dialog_id, topic_text, interaction_flags, min_level, missions_completed, missions_not_accepted, alignments, factions) VALUES (5230, 803, 3996, 'Search the Guard''s Corpse', 1073741824, 1, '{}', '{}', '{}', '{}');
 
 INSERT INTO dialog_set_maps (dialog_set_map_id, dialog_set_id, dialog_id, topic_text, interaction_flags, min_level, missions_completed, missions_not_accepted, alignments, factions) VALUES (5231, 1419, 4457, 'Meet The Praxis', 0, 1, '{}', '{}', '{}', '{}');
 

--- a/db/resources/Dialogs/Seed/dialogs.sql
+++ b/db/resources/Dialogs/Seed/dialogs.sql
@@ -6701,6 +6701,8 @@ INSERT INTO dialogs (dialog_id, dialog_flags, event_set_id, ui_screen_type, tags
 INSERT INTO dialogs (dialog_id, dialog_flags, event_set_id, ui_screen_type, tags, accepts_mission_id, name) VALUES (3984, 0, NULL, 'DUIST_DefaultBlurb', NULL, NULL, NULL);
 
 INSERT INTO dialogs (dialog_id, dialog_flags, event_set_id, ui_screen_type, tags, accepts_mission_id, name) VALUES (3995, 0, NULL, 'DUIST_DefaultDialog', NULL, NULL, NULL);
+-- Mission 622 loot split: Guard-corpse search dialog (yields the pistol). Mirrors 3995 (Frost).
+INSERT INTO dialogs (dialog_id, dialog_flags, event_set_id, ui_screen_type, tags, accepts_mission_id, name) VALUES (3996, 0, NULL, 'DUIST_DefaultDialog', NULL, NULL, NULL);
 
 INSERT INTO dialogs (dialog_id, dialog_flags, event_set_id, ui_screen_type, tags, accepts_mission_id, name) VALUES (3998, 0, NULL, 'DUIST_DefaultDialog', NULL, NULL, NULL);
 

--- a/db/resources/Events/Tables/point_set_points.sql
+++ b/db/resources/Events/Tables/point_set_points.sql
@@ -24,7 +24,20 @@ CREATE TABLE point_set_points (
     teleport_y real,
     teleport_z real,
     teleport_sequence_id integer,
-    teleport_delay real
+    teleport_delay real,
+    -- The teleport destination is all-or-none: either all three coords are
+    -- set (a real destination) or all NULL (no teleport on this waypoint).
+    -- The `.path_set_teleport` console flow treats them as one destination,
+    -- so a partial coordinate set is an invalid state — reject it here.
+    CONSTRAINT point_set_points_teleport_xyz_all_or_none
+        CHECK (
+            (teleport_x IS NULL AND teleport_y IS NULL AND teleport_z IS NULL)
+            OR (teleport_x IS NOT NULL AND teleport_y IS NOT NULL AND teleport_z IS NOT NULL)
+        ),
+    -- `teleport_delay` is a dwell in seconds before the teleport fires; a
+    -- negative value is meaningless. Guard it at the schema boundary.
+    CONSTRAINT point_set_points_teleport_delay_nonneg
+        CHECK (teleport_delay IS NULL OR teleport_delay >= 0)
 );
 
 --

--- a/db/resources/Events/Tables/point_set_points.sql
+++ b/db/resources/Events/Tables/point_set_points.sql
@@ -11,7 +11,20 @@ CREATE TABLE point_set_points (
     z real NOT NULL,
     yaw real DEFAULT 0 NOT NULL,
     pitch real DEFAULT 0 NOT NULL,
-    roll real DEFAULT 0 NOT NULL
+    roll real DEFAULT 0 NOT NULL,
+    -- Patrol-waypoint extensions. When a point set is used as a patrol
+    -- path, these per-waypoint columns drive on-arrival behavior. All NULL for
+    -- ordinary point sets (area triggers, ring pads, etc.).
+    -- `sequence_id`: Kismet sequence to play when an NPC reaches this waypoint.
+    -- `teleport_*`: optional teleport destination; on arrival the NPC plays the
+    -- departure sequence, waits `teleport_delay` seconds, teleports, then plays
+    -- `teleport_sequence_id`. Authored via the `.path_set_*` console commands.
+    sequence_id integer,
+    teleport_x real,
+    teleport_y real,
+    teleport_z real,
+    teleport_sequence_id integer,
+    teleport_delay real
 );
 
 --

--- a/db/resources/Missions/Seed/mission_objectives.sql
+++ b/db/resources/Missions/Seed/mission_objectives.sql
@@ -6258,12 +6258,14 @@ INSERT INTO mission_objectives (objective_id, step_id, award_xp, difficulty, is_
 
 INSERT INTO mission_objectives (objective_id, step_id, award_xp, difficulty, is_enabled, is_hidden, is_optional, display_log_text) VALUES (2452, 2113, false, 1, false, false, false, ' ');
 
--- Cimmeria-introduced objective for step 80622 (equip pistol). The matching
--- client-side row is in the mission_overrides XML for mission 622.
+-- Cimmeria-introduced objectives for the sequenced loot-split steps 80623
+-- (search the Guard corpse) and 80622 (equip pistol). The matching client-side
+-- rows are in the mission_overrides XML for mission 622.
 -- display_log_text is a single space to match the original game pattern —
 -- the player-visible string is the step's display text; the objective row
 -- is the in-step "checkbox" line and is intentionally blank. See
 -- objectives 3238/2452 on step 2113 for the canonical shape.
+INSERT INTO mission_objectives (objective_id, step_id, award_xp, difficulty, is_enabled, is_hidden, is_optional, display_log_text) VALUES (90623, 80623, false, 1, false, false, false, ' ');
 INSERT INTO mission_objectives (objective_id, step_id, award_xp, difficulty, is_enabled, is_hidden, is_optional, display_log_text) VALUES (90622, 80622, false, 1, false, false, false, ' ');
 
 INSERT INTO mission_objectives (objective_id, step_id, award_xp, difficulty, is_enabled, is_hidden, is_optional, display_log_text) VALUES (2486, 2148, false, 2, true, false, false, ' ');

--- a/db/resources/Missions/Seed/mission_steps.sql
+++ b/db/resources/Missions/Seed/mission_steps.sql
@@ -5672,12 +5672,18 @@ INSERT INTO mission_steps (step_id, mission_id, award_xp, difficulty, step_enabl
 
 INSERT INTO mission_steps (step_id, mission_id, award_xp, difficulty, step_enabled, step_display_log_text, index) VALUES (2113, 622, false, 1, false, 'Search the nearby corpses to locate a weapon.', 0);
 
--- Cimmeria-introduced step. The matching client-side row is injected into
+-- Cimmeria-introduced steps. The matching client-side rows are injected into
 -- `_622` inside `CookedDataMissions.pak` at server startup by
 -- [`crates/services/src/base/mission_overrides.rs`] and shipped to the
 -- client via the per-key `InvalidKeys` channel of `onVersionInfo`.
--- Display text + step/objective ids must agree with the override XML.
-INSERT INTO mission_steps (step_id, mission_id, award_xp, difficulty, step_enabled, step_display_log_text, index) VALUES (80622, 622, false, 1, false, 'Equip the pistol from your inventory.', 1);
+-- Display text + step/objective ids + index must agree with the override XML.
+--
+-- The loot split is sequenced Frost → Guard via the intermediate step 80623:
+--   index 0: 2113   search Cpl. Frost          (chain 1003 → advance 80623)
+--   index 1: 80623  search the NID Guard corpse (chain 1005 → advance 80622)
+--   index 2: 80622  equip the pistol           (chain 1004 → complete)
+INSERT INTO mission_steps (step_id, mission_id, award_xp, difficulty, step_enabled, step_display_log_text, index) VALUES (80623, 622, false, 1, false, 'Search the NID Guard''s body for a weapon.', 1);
+INSERT INTO mission_steps (step_id, mission_id, award_xp, difficulty, step_enabled, step_display_log_text, index) VALUES (80622, 622, false, 1, false, 'Equip the pistol from your inventory.', 2);
 
 INSERT INTO mission_steps (step_id, mission_id, award_xp, difficulty, step_enabled, step_display_log_text, index) VALUES (2148, 623, false, 2, true, 'Return to Beta Site and speak with Mimir near the Stargate.', 0);
 

--- a/db/resources/Worlds/Tables/spawnlist.sql
+++ b/db/resources/Worlds/Tables/spawnlist.sql
@@ -31,7 +31,12 @@ CREATE TABLE spawnlist (
     patrol_path_id integer,
     patrol_point_delay real,
     CONSTRAINT spawnlist_respawn_secs_min_3
-        CHECK (respawn_secs IS NULL OR respawn_secs >= 3)
+        CHECK (respawn_secs IS NULL OR respawn_secs >= 3),
+    -- `patrol_point_delay` is a per-waypoint dwell in seconds; a negative
+    -- value is meaningless and would poison the patrol scheduler. Guard it
+    -- at the schema boundary so a bad seed edit can't persist.
+    CONSTRAINT spawnlist_patrol_point_delay_nonneg
+        CHECK (patrol_point_delay IS NULL OR patrol_point_delay >= 0)
 );
 
 --

--- a/db/resources/Worlds/Tables/spawnlist.sql
+++ b/db/resources/Worlds/Tables/spawnlist.sql
@@ -22,6 +22,14 @@ CREATE TABLE spawnlist (
     -- Minimum 3 seconds — see `entity_templates.respawn_secs`
     -- comment for the floor rationale.
     respawn_secs integer,
+    -- Per-spawn patrol override. When set, takes precedence over the
+    -- template's `entity_templates.patrol_path_id` / `patrol_point_delay` for
+    -- THIS spawn only. `patrol_path_id` references a `point_sets.set_id` whose
+    -- `point_set_points` are the ordered waypoints. NULL → fall back to the
+    -- template default (and NULL there → no patrol). Authored in-game via the
+    -- `.path_assign` console command.
+    patrol_path_id integer,
+    patrol_point_delay real,
     CONSTRAINT spawnlist_respawn_secs_min_3
         CHECK (respawn_secs IS NULL OR respawn_secs >= 3)
 );

--- a/docs/architecture/dev-console-channel.md
+++ b/docs/architecture/dev-console-channel.md
@@ -1,0 +1,155 @@
+---
+title: "Dev `.`-Console Channel"
+type: explanation
+audience: engineers, GMs
+last_updated: 2026-06-18
+---
+
+# Dev `.`-Console Channel (ADR)
+
+> **Status**: Adopted in issue #523. Implemented in
+> `crates/services/src/cell/console/` + `crates/services/src/base/console_authoring.rs`.
+> **Confidence**: High for the channel/dispatch/auth and the read-only +
+> authoring families; medium for the seed-commit Discord hook (designed, not yet
+> wired) and the server/maintenance family (intentionally divergent — see below).
+
+## Context
+
+We have native `/gm*` slash commands for the ~62 dev commands that map to a
+real cell-method index baked into `SGW.exe` (shipped in #518/#521). The 2009
+client's slash roster (266 `Event_SlashCmd` classes) is **fixed** — we cannot
+add new native slash commands. The remaining ~66 dev/authoring commands the
+legacy Python server (`deprecated/python/cell/ConsoleCommands.py`) and the
+[doko972/FanMMORPG](https://github.com/doko972/FanMMORPG) fork shipped have no
+native binding and never can.
+
+Both prior servers delivered those through a separate **`.`-prefixed console**:
+the client does **not** intercept `.`-prefixed input (unlike `/`, which it
+consumes locally) — it forwards it as an ordinary `CHAN_SAY` chat message. The
+server can intercept it before broadcast. This is the analogue of the
+`gm/feedback.rs` channel that unblocked the native query cluster (see
+[gm-cell-method-adapt-plan](gm-cell-method-adapt-plan.md)).
+
+## Decision
+
+### 1. Channel + authorization
+
+`cell::chat::handle_chat_message` intercepts, in its `CHAN_SAY` arm, any text
+starting with `.` **when the sender's `CellEntity::access_level >= GameMaster`**.
+A GM's `.`-line is routed to the console dispatcher and **not** broadcast (it
+never appears in other players' chat); a non-GM's `.`-text falls through to
+normal chat. Authorization is on the server-side `access_level` (sourced from
+`account.accesslevel` at login, never a client byte) — the same trust model as
+`cell::dispatch::gm_gate`. Every accepted command is logged at `info` for the
+CAT-N audit trail (#473).
+
+### 2. Registry-driven dispatch
+
+`cell::console::COMMANDS` is the registry: `name → (min/max arg count, required
+target type, summary)`, mirroring the legacy `Command` table. The dispatcher
+parses `.<cmd> <args…>`, validates arg count and target type (the target is the
+caller's currently-selected entity via `setTargetID`/`gmSetTarget`), and routes
+to a family handler. All output returns to the GM only via
+`console::send_gm_feedback` (`onPlayerCommunication` on `CHAN_FEEDBACK`) — the
+same single-recipient channel the native `gm*` cluster uses. A coverage test
+(`tests::every_spec_is_dispatched`) pins that no registered command falls
+through to an unimplemented arm.
+
+### 3. Authoring persistence: record → confirm → seed (NOT migrations)
+
+Commands that change persistent data (`savespawn`, `delspawn`, the `path_*`
+family) must not silently violate the repo's "seeds are the source of truth"
+model (the DB is rebuilt from `db/resources/`; live writes are lost on rebuild;
+**never** `db/scripts/*.sql` migrations). Each such command:
+
+1. **Applies in memory** for immediate iteration (a freshly-assigned patrol
+   starts walking now).
+2. **Writes the live DB** via `CellToBaseMsg::ExecuteAuthoringSql` → a base
+   handler runs the statement and reports rows-affected to the GM. The cell has
+   no DB pool, so this crosses to base. The write is **transient** — it lets the
+   developer see the change hold across reconnects within the deploy, and the
+   next deploy rebuilds from seeds and wipes it.
+3. **Records the canonical seed SQL** for a human to commit. Each statement is
+   appended to a **per-session on-disk log** (`logs/seed-authoring-<session>.sql`,
+   dir overridable via `CIMMERIA_AUTHORING_LOG_DIR`) as it happens, and buffered
+   per-GM. `.seedconfirm` groups the buffer **per seed file** and emits each
+   block; `.seedpending` lists; `.seedcancel` discards.
+
+**The raw SQL is never shown in-game** — the client's chat isn't
+copy-pasteable, so in-game feedback is status-only ("recorded — N pending",
+"confirmed: M statements across K files"). The SQL goes out-of-band: the
+per-session log and the server tracing log today.
+
+**Trust model for the live write:** the channel is GM-gated, and the SQL is
+*server-generated* — numeric values are formatted from cell-parsed `i32`/`f32`
+and strings are escaped through `console::seed::sql_str`, so no raw client text
+is concatenated. `world_id` is resolved at execution time via a
+`SELECT … FROM resources.worlds WHERE world = '<name>'` subquery so the same
+statement is valid in the seed file and live. This mirrors the legacy
+`Atrea.dbQuery` authoring path.
+
+### 4. Discord hook (designed, not wired)
+
+All SQL emission funnels through one choke point (`console::seed`). The per-file
+`.seedconfirm` payload is exactly what a `cimmeria-discord` `EventKind` (e.g.
+`SeedAuthored`) would post to an authoring channel once the colo Discord
+integration is enabled — a sink swap inside `seed::confirm`, not a redesign.
+Discord is intentionally **not** wired yet (off in the colo; adding an event
+type is its own checklist in [discord-notifications](discord-notifications.md)).
+
+### 5. Patrol authoring (FanMMORPG `path_*`)
+
+The patrol **runtime** already exists (`CellEntity::patrol_path`,
+`AiState::Patrol`, `cell::service::npc_ai::npc_ai_patrol`). The `path_*` commands
+are the authoring front-end. A path id == a `point_sets.set_id`; waypoints are
+`point_set_points` rows ordered by `point_id`. `.path_assign` applies the
+session waypoints to the targeted NPC's `patrol_path` immediately and records a
+per-spawn override into `spawnlist.patrol_path_id` / `patrol_point_delay` (new
+columns this issue), which the spawn loader now prefers over the template
+default (`COALESCE(s.patrol_path_id, t.patrol_path_id)`). Per-waypoint edits
+(`path_set_seq`, `path_set_tp`, …) address "the Nth waypoint" via
+`ORDER BY point_id OFFSET n` and write `point_set_points.sequence_id` /
+`teleport_*` (also new columns this issue).
+
+#### Schema added (seed-edits, not migrations)
+
+- `resources.spawnlist`: `patrol_path_id integer`, `patrol_point_delay real`.
+- `resources.point_set_points`: `sequence_id integer`, `teleport_x/y/z real`,
+  `teleport_sequence_id integer`, `teleport_delay real`.
+
+## Per-command status
+
+| Family | Status |
+|---|---|
+| Search (`searchitem`/`mission`/`template`, `players`) | **Done** — search runs base-side (`CellToBaseMsg::ConsoleSearch`, parameterized `ILIKE`); `players` is cell-local. |
+| Stat dumps (`primarystats` … `stealthstats`) | **Done** — read `CellEntity::stats`. |
+| Entity authoring (`tag`, `name`, …) | **In-memory** — mutate `CellEntity`; appearance edits re-broadcast for players, surface on next AoI entry for NPCs. Pair with `.savespawn` to persist. |
+| Net/AI debug (`net_seq`, `net_speak`, `threaten`, …) | **Done** — serialize the existing client method (`onSequence`/`onTimerUpdate`/`onMapInfo`/`onClientChallenge`) or poke the threat/follow/dialog systems. `debug_controller` is a no-op (no Rust debug controller). |
+| Crafting (`learndiscipline`, `forgetdiscipline`) | **Done** via `GrantExpertise`. `allcraft` is a pointer (no consolidated blueprint-grant path cell-side). |
+| Mission gaps (`missionfail`) | **Done**. `missionrewards` is a **preview** (reward dispatch tracked in #310). |
+| Spawn authoring (`savespawn`/`delspawn`/`spawnrandom`/`respawnall`) | **Done** — record→confirm + live write; `spawnrandom` reuses the `GmSpawnNpc` round-trip; `respawnall` is a runtime reset. |
+| Patrol authoring (`path_*`) | **Done** — see above. |
+| Server/maint (`save`/`reloadmap`/`reloadres`/`removerespawner`/`loglevel`/`logclient`) | **Divergent** — the Rust server handles these differently (incremental persistence, startup resource loading, env/`RUST_LOG` log level). Each reports the real mechanism rather than faking a no-op. Runtime log-level reload + resource hot-reload are future work. |
+
+## Alternatives considered
+
+- **Live DB write only** (legacy behavior): rejected — lost on rebuild, invisible
+  to review.
+- **Seed emit only** (no live write): rejected by the developer — they want to
+  *see* the change hold within a deploy.
+- **Typed per-operation cell→base messages** instead of `ExecuteAuthoringSql`:
+  rejected for this pass — ~10 variants + handlers for a GM-gated, server-
+  generated SQL string is more surface than the single executor warrants. Can be
+  tightened later if the SQL surface grows.
+- **Admin panel for DB-mutating commands**: still the right home for destructive
+  bulk ops; the in-game console wins for position-derived authoring at your
+  avatar. The two can coexist (the issue's open question).
+
+## Consequences / follow-ups
+
+- New cell→base messages: `ExecuteAuthoringSql`, `ConsoleSearch`.
+- New `SpaceManager` fields: `authoring_changes`, `autosave_spawns`,
+  `patrol_authoring` (all ephemeral, server-side).
+- Follow-ups: wire the Discord `SeedAuthored` sink; runtime log-level reload
+  (`loglevel`) + resource hot-reload (`reloadres`); a consolidated `allcraft`
+  base grant; mission reward dispatch (#310, unblocks `missionrewards`).

--- a/docs/architecture/mission-pak-overrides.md
+++ b/docs/architecture/mission-pak-overrides.md
@@ -110,7 +110,7 @@ The chain advances from step 2121 (index 0) to step 80641 (index 3). The client'
 
 The advance from index 0 → index 1 is a single-step delta, the guard accepts, and the player sees "Equip the P90".
 
-The same gotcha applies to mission 622: step 2113 ("Search the nearby corpses") is index 0, and 80622 ("Equip the pistol") must land at index 1 — which is why mission 622's override is `insert_after_step_id: 2113`. The chain-replay regression test that pins this is at `crates/services/src/base/mission_overrides.rs:193-225` (`override_641_lands_between_2121_and_3563`).
+The same gotcha applies to mission 622, which now injects **two** steps for its sequenced loot split: `2113` ("Search the nearby corpses") is index 0, `80623` ("Search the NID Guard's body") must land at index 1, and `80622` ("Equip the pistol") at index 2. This is why mission 622 has two `MissionOverride` entries that must stay in registry order — the first is `insert_after_step_id: 2113` (injects 80623), the second is `insert_after_step_id: 80623` (injects 80622, anchoring on the just-injected step). Each advance is a single-step delta (2113→80623→80622), which the guard accepts. The regression test that pins the ordering is `override_622_injects_guard_then_equip_in_order` in `crates/services/src/base/mission_overrides.rs` (and `override_641_lands_between_2121_and_3563` pins the same discipline for mission 641).
 
 ## Metadata bump policy
 
@@ -142,7 +142,7 @@ When you want a new client-visible step to appear in the quest log:
 1. **Add the server-side step row** in `db/resources/Missions/Seed/mission_steps.sql`. The chain engine reads this for `advance_step` / `step_status` evaluation. Pick a step ID well above the canonical PAK's range (the override modules use `80<mission_id>` — e.g., `80622` for a mission-622 step — so collisions are obvious).
 2. **Add the matching objective row** in `db/resources/Missions/Seed/mission_objectives.sql`. Use a single space (`" "`) for `display_log_text` — see [Why a single-space objective display text](#why-a-single-space-objective-display-text) below for the rationale.
 3. **Add a `MissionOverride` entry** to the `MISSION_OVERRIDES` slice in `crates/services/src/base/mission_overrides.rs`. The `injected_steps_xml` must use the same step ID and objective ID as the SQL rows; `insert_after_step_id` must be the step the chain is advancing **from** (not the one it's advancing to).
-4. **Reference the new step ID in the relevant content chain action.** Example: chain 1003's `advance_step` with `target_id=622, target_key='80622'` advances mission 622 from step 2113 to the new step 80622 (`db/resources/Content/Seed/castle_cellblock_chains.sql:50-88`).
+4. **Reference the new step ID in the relevant content chain action.** Example: chain 1003's `advance_step` with `target_id=622, target_key='80623'` advances mission 622 from step 2113 to the new Guard-search step 80623; chain 1005 then advances 80623 → 80622 (`db/resources/Content/Seed/castle_cellblock_chains.sql`, chains 1001–1007).
 
 Cross-check: the server-side seed (`mission_steps.sql`, `mission_objectives.sql`) and the client-side override (`MISSION_OVERRIDES`) must agree on `StepID`, `ObjectiveID`, and the `IsHidden` / `IsOptional` flags. The wire message `onObjectiveUpdate` only carries the ID and status, so any drift surfaces as a missing UI line on the player's screen even though the chain engine thinks it's making progress.
 
@@ -156,7 +156,7 @@ Three layers of regression coverage:
 
 - **Unit tests on the patcher** (`crates/services/src/base/mission_overrides.rs:146-271`, 5 tests) — XML insertion-point arithmetic, malformed-input refusal, the index-pinning guard for mission 641, and the duplicate-render guard for objective display text.
 - **Wire-format guard** on the encoder (`crates/services/src/mercury/protocol/tests.rs:159-171`) — pins that `build_version_info` accepts `&[u32]` and that empty vs populated keys produce different output sizes. Catches a future signature change that drops the slice or makes it optional.
-- **Chain-replay tests** for the two missions that use this mechanism (`crates/services/src/cell/content/chain_replay_tests/mission_622.rs`, 4 tests; `crates/services/src/cell/content/chain_replay_tests/mission_641.rs`, 4 new tests for chains 1055/1066). These exercise the full `chain_id → trigger → condition → action` round-trip against the seeded `resources.content_*` tables, including the equip-step gating.
+- **Chain-replay tests** for the two missions that use this mechanism (`crates/services/src/cell/content/chain_replay_tests/mission_622.rs` — the sequenced Frost → 80623 → Guard → 80622 → equip flow, the per-step re-loot guards, and the login-restore chains 1006/1007; `crates/services/src/cell/content/chain_replay_tests/mission_641.rs` for chains 1055/1066). These exercise the full `chain_id → trigger → condition → action` round-trip against the seeded `resources.content_*` tables, including the equip-step gating.
 
 See [TESTING.md](../../TESTING.md) for the picker that maps these test types to bug shapes.
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -466,6 +466,111 @@ Reload data without a restart.
 
 ---
 
+## Dev console (`.`-commands)
+
+The 266 `/`-commands above are baked into the game client and can't be added to.
+The legacy server and the FanMMORPG fork shipped a second set of **dev/authoring
+commands** that the client never exposed as slash commands. Those use a separate
+**`.`-prefixed console**: the client doesn't intercept `.`-text — it sends it as
+an ordinary chat message, and the server intercepts it. (This is why `.` works
+where a new `/command` can't: the client *eats* unknown `/`-input but *forwards*
+`.`-input.)
+
+**Game-Master only.** A GM's `.`-command is consumed by the server and never
+appears in anyone else's chat. A normal player typing a `.`-message just says it
+in chat like any other text. Auth is checked against your account level
+server-side. Type `.help` (or `.help <word>`) in-game for the live list.
+
+### Database persistence & the seed-commit flow
+
+Some `.`-commands change **persistent game data** (spawns, patrol paths). These
+are the only commands in the console that touch the database, and how they
+persist is the most important thing to understand before you use them.
+
+> **⚠️ Live DB writes are TEMPORARY — you must commit the seed SQL to keep them.**
+>
+> When you run a persistence command, the server writes the change to the
+> **running database** immediately, so you see it work and it survives
+> reconnects and server restarts **within the current deploy**.
+>
+> **The next deploy rebuilds the database from the seed files in
+> `db/resources/` and erases anything that isn't committed there.** A live DB
+> write that you never commit to a seed file **is lost on the next deploy.**
+>
+> To preserve authored content deploy-over-deploy you **must** copy the
+> generated seed SQL into the right `db/resources/…` file and commit it to git
+> (steps below). This is deliberate: the seed files are the single source of
+> truth, and we never hand-write `db/scripts/*.sql` migrations.
+
+**Exactly which commands write to the database, and the seed file each one
+must be committed into:**
+
+| Command | DB operation | Table | Commit the SQL into |
+|---|---|---|---|
+| `.savespawn` | INSERT (new) or UPDATE (existing row) | `resources.spawnlist` | `db/resources/Worlds/Seed/spawnlist.sql` |
+| `.delspawn` | DELETE one row by `spawn_id` | `resources.spawnlist` | `db/resources/Worlds/Seed/spawnlist.sql` |
+| `.path_add` | INSERT a waypoint (+ a `point_sets` header row on the first waypoint) | `resources.point_set_points` (+ `resources.point_sets`) | `db/resources/Events/Seed/point_set_points.sql` (+ `point_sets.sql`) |
+| `.path_clear` | DELETE all waypoints + the header | `resources.point_set_points` + `resources.point_sets` | `db/resources/Events/Seed/point_set_points.sql` + `point_sets.sql` |
+| `.path_assign` | UPDATE the spawn's patrol override (`patrol_path_id`, `patrol_point_delay`) | `resources.spawnlist` | `db/resources/Worlds/Seed/spawnlist.sql` |
+| `.path_unassign` | UPDATE — clear the spawn's patrol override | `resources.spawnlist` | `db/resources/Worlds/Seed/spawnlist.sql` |
+| `.path_set_seq` · `.path_clear_seq` · `.path_set_tp` · `.path_clear_tp` · `.path_set_tp_seq` · `.path_set_tp_delay` | UPDATE one waypoint (sequence / teleport fields) | `resources.point_set_points` | `db/resources/Events/Seed/point_set_points.sql` |
+
+**Commands that do NOT persist (in-memory only — lost on the next server
+restart, never written to the DB):**
+
+- **All entity-authoring commands** (`.tag`, `.name`, `.alignment`, `.nameid`,
+  `.staticmesh`, `.bodyset`, `.eventset`, `.interactiontype`, `.lookat`,
+  `.visible`, `.setcombatant`, `.unsetcombatant`, `.addcomponent`,
+  `.delcomponent`, `.adddialog`, `.removedialog`, `.dynamicupdate`). To make an
+  edited entity stick, place/configure it, then `.savespawn` it.
+- `.respawnall` — a live reset of every NPC in your space; no DB write.
+- `.autosavespawn` — a per-session preference toggle; no DB write.
+
+**The record → confirm → commit workflow:**
+
+1. **Author in-game.** Run the persistence commands (`.savespawn`, `.path_add`,
+   …). Each one applies in memory, writes the live DB (you'll see e.g.
+   `savespawn: live DB write ok (1 row…)`), and **records** the exact SQL. The
+   raw SQL is **not** shown in-game — the client's chat can't be copy-pasted,
+   so it goes out-of-band instead.
+2. **It's logged on the server host.** Every recorded statement is appended as
+   it happens to a per-session file: **`logs/seed-authoring-<session>.sql`**
+   (override the directory with the `CIMMERIA_AUTHORING_LOG_DIR` env var). This
+   file is your durable copy even if you never confirm.
+3. **Confirm when satisfied.** Run **`.seedconfirm`** — it groups your pending
+   statements **per seed file** and emits each block to the server log (and, once
+   the colo Discord integration is enabled, to an authoring channel). Use
+   `.seedpending` to see what's buffered and `.seedcancel` to discard it.
+4. **Commit the SQL (required to survive a deploy).** Open the per-session log
+   (or the `.seedconfirm` output), copy each statement block into the
+   `db/resources/…` seed file named for it in the table above, and commit it to
+   git. **Until that commit lands, the change lives only in the running DB and
+   the next deploy will wipe it.**
+
+### Command families
+
+| Family | Commands | Works now? |
+|---|---|---|
+| Search | `.searchitem` `.searchmission` `.searchtemplate` `.players` | ✅ Yes |
+| Stat readouts | `.primarystats` `.speedstats` `.armorstats` `.qrstats` `.absorbstats` `.stealthstats` | ✅ Yes |
+| Entity authoring | `.tag` `.name` `.alignment` `.nameid` `.staticmesh` `.bodyset` `.eventset` `.interactiontype` `.lookat` `.visible` `.setcombatant` `.unsetcombatant` `.addcomponent` `.delcomponent` `.adddialog` `.removedialog` `.dynamicupdate` | 🚧 In-memory (pair with `.savespawn`) |
+| Net / AI debug | `.net_seq` `.net_seqto` `.net_seqfrom` `.net_timer` `.net_mapinfo` `.net_speak` `.net_dialog` `.net_challenge` `.debug_velocity` `.debug_controller` `.debug_follow` `.threaten` `.aggression` | ✅ Yes |
+| Crafting | `.learndiscipline` `.forgetdiscipline` `.allcraft` | 🚧 Partly |
+| Mission gaps | `.missionfail` `.missionrewards` | ✅ / 🚧 (preview) |
+| Spawn authoring | `.savespawn` `.delspawn` `.autosavespawn` `.respawnall` `.spawnrandom` | ✅ Yes — `.savespawn`/`.delspawn` **write the DB** (commit seed) |
+| Patrol authoring | `.path_add` `.path_show` `.path_clear` `.path_assign` `.path_unassign` `.path_set_seq` `.path_clear_seq` `.path_set_tp` `.path_clear_tp` `.path_set_tp_seq` `.path_set_tp_delay` | ✅ Yes — all except `.path_show` **write the DB** (commit seed) |
+| Server / maint | `.save` `.reloadmap` `.reloadres` `.removerespawner` `.loglevel` `.logclient` | ❌ Differs (see `.help`) |
+| Seed commit | `.seedconfirm` `.seedpending` `.seedcancel` | ✅ Yes |
+
+A few commands (`.debug_controller`, the server/maint family, `.allcraft`) report
+an honest limitation in-game where the Rust server handles the concern
+differently from the legacy Python (incremental persistence, startup resource
+loading, env-based log level). See the
+[dev-console-channel ADR](architecture/dev-console-channel.md) for the full
+design and the per-command status.
+
+---
+
 ## At a glance
 
 - **266 commands** total -- **105** for everyone, **161** Game-Master only.

--- a/docs/content/mission-chains.md
+++ b/docs/content/mission-chains.md
@@ -138,16 +138,23 @@ These 5 missions run in parallel with the main chain after the Mess Hall. All ar
 
 **Sequences**: 10000
 
-**Live data-driven shape (chains 1003 + 1004)** [CONFIRMED]
+**Live data-driven shape (sequenced loot split, chains 1003–1007)** [CONFIRMED]
 
-The Cimmeria runtime no longer force-equips the pistol; it routes the grant through the player's manual equip path to keep the bandolier ammo / fire-animation state consistent. See [docs/content/equip-from-inventory-pattern.md](equip-from-inventory-pattern.md) for the rationale and [docs/architecture/mission-pak-overrides.md](../architecture/mission-pak-overrides.md) for how the new step reaches the client UI.
+The loot is split across the two stasis-room corpses (Cpl. Frost = letter, the NID Guard = pistol) and **sequenced Frost → Guard**: the Guard corpse is not searchable until the player searches Frost. A corpse only opens a dialog when its template has an entry in the player's `available_interactions` (`crates/services/src/cell/interactions/dispatch.rs`), so the gate is simply *which `add_dialog_set` has run*. Chain 1001 (mission accept) binds only Frost (5229 → template 14); chain 1003 binds the Guard (5230 → template 21) on the Frost search. An intermediate step **80623** ("Search the NID Guard's body…") sits between 2113 and the equip step so the sequencing survives a relog — login-restore chains 1006/1007 re-apply the bindings per active step (interaction bindings are not persisted).
+
+The Cimmeria runtime no longer force-equips the pistol; it routes the grant through the player's manual equip path to keep the bandolier ammo / fire-animation state consistent. See [docs/content/equip-from-inventory-pattern.md](equip-from-inventory-pattern.md) for the rationale and [docs/architecture/mission-pak-overrides.md](../architecture/mission-pak-overrides.md) for how the new steps reach the client UI.
+
+Step indices (XML order, which the client uses for sequential progression): `2113` (0, search Frost) → `80623` (1, search Guard) → `80622` (2, equip pistol).
 
 | Chain | Trigger | Condition | Actions |
 |---|---|---|---|
-| 1003 | `dialog_open('3995')` (Frost body) | `step_status(622, 2113) = 'active'` | Grant pistol (item 55) → backpack (container 1); grant Frost's letter (item 3730) → mission inventory; `advance_step(622, 80622)` |
+| 1003 | `dialog_open('3995')` (Frost body) | `step_status(622, 2113) = 'active'` | Clear Frost's search bit; grant Frost's letter (item 3730) → mission inventory; `add_dialog_set(5230 → template 21)` (unlock Guard); `advance_step(622, 80623)` |
+| 1005 | `dialog_open('3996')` (Guard body) | `step_status(622, 80623) = 'active'` | Clear Guard's search bit; grant pistol (item 55) → backpack (container 1); `advance_step(622, 80622)` |
 | 1004 | `item_equipped('55')` | `step_status(622, 80622) = 'active'` | `play_sequence(10000)` (open stasis door); `complete_mission(622)` |
+| 1006 | `player_loaded('Castle_CellBlock')` | `step_status(622, 2113) = 'active'` | `add_dialog_set(5229 → template 14)` — re-bind Frost on login |
+| 1007 | `player_loaded('Castle_CellBlock')` | `step_status(622, 80623) = 'active'` | `add_dialog_set(5230 → template 21)` — re-bind Guard on login |
 
-Step 80622 ("Equip the pistol from your inventory.") is **not** in the canonical PAK. It's added by `MissionOverride { mission_id: 622, insert_after_step_id: 2113 }` in `crates/services/src/base/mission_overrides.rs:74-90`, served to the client via the `versionInfoRequest` / `onVersionInfo` (`InvalidKeys`) / `resourceFragment` handshake. Server-side seed rows live in `db/resources/Missions/Seed/mission_steps.sql` (step 80622) and `mission_objectives.sql` (objective 90622). Chain seed: `db/resources/Content/Seed/castle_cellblock_chains.sql:50-105`. Regression tests: `crates/services/src/cell/content/chain_replay_tests/mission_622.rs` (4 chain-replay tests).
+Steps 80623 ("Search the NID Guard's body for a weapon.") and 80622 ("Equip the pistol from your inventory.") are **not** in the canonical PAK. They're added by two `MissionOverride` entries for mission 622 (`insert_after_step_id: 2113` then `insert_after_step_id: 80623`) in `crates/services/src/base/mission_overrides.rs`, served to the client via the `versionInfoRequest` / `onVersionInfo` (`InvalidKeys`) / `resourceFragment` handshake. Server-side seed rows live in `db/resources/Missions/Seed/mission_steps.sql` (steps 80623, 80622) and `mission_objectives.sql` (objectives 90623, 90622). The Guard's search dialog 3996 is a Cimmeria dialog shipped via a `CookedDataDialogs.pak` override (`crates/services/src/base/dialog_overrides.rs`). Chain seed: `db/resources/Content/Seed/castle_cellblock_chains.sql` (chains 1001–1007). Regression tests: `crates/services/src/cell/content/chain_replay_tests/mission_622.rs`.
 
 **Link to next**: Mission 622 does NOT explicitly call `missions.accept(638)`. The link is handled by the space script -- when the player enters `Castle_Cellblock.Region2`, mission 638 is accepted if not already active. [CONFIRMED -- `Castle_CellBlock.py` line 338-348]
 

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -191,7 +191,7 @@ See also: [technical/bigworld-version-analysis.md](technical/bigworld-version-an
 
 ### `architecture/` -- Cimmeria Server Architecture
 
-How the Cimmeria emulator itself is structured. 24 documents.
+How the Cimmeria emulator itself is structured. 25 documents.
 
 | Document | Description | Status |
 |----------|-------------|--------|
@@ -208,7 +208,9 @@ How the Cimmeria emulator itself is structured. 24 documents.
 | [abilities-and-effects-system.md](architecture/abilities-and-effects-system.md) | ADR for the abilities + effects design decisions shipped in PR #420: EffectScript trait shape, stacking semantics, channel cancellation triggers, absorption pool drain ordering, TCM dispatch routing, AF_CHANNEL_ALLOWS_MOVEMENT default | Complete |
 | [state-field-bits.md](architecture/state-field-bits.md) | Verified `bStateField` bit layout (bits 0-7 only), client dispatch table, BSF_Holster retirement notice with Ghidra anchors, relog persistence of `BSF_AutoCycling` | Complete |
 | [gm-cell-method-gating.md](architecture/gm-cell-method-gating.md) | ADR for the server-authoritative GM gate (#475 / CAT-N-03): `access_level` plumbing into `CellEntity`, the dispatch-layer `gm_gate`, how to add the next `gm*` method | Complete |
+| [movement-validation.md](architecture/movement-validation.md) | ADR for server-authoritative position validation (#478 / CAT-B-01,-06,-09): the 4-layer seam (bounds / speed warn-only / teleport / navmesh), dual teleport gate, server-clock dt, authorized-teleport reseed, warn-only spaceId cross-check, tolerances + calibration path | Complete |
 | [gm-cell-method-adapt-plan.md](architecture/gm-cell-method-adapt-plan.md) | Roadmap for the developer-useful ADAPT `gm*` cell methods (#473/#518): the feedback-channel blocker that unlocks the query surface, name→id resolution, the `loadX` hot-reload family, recommended sequencing | Complete |
+| [dev-console-channel.md](architecture/dev-console-channel.md) | ADR for the GM `.`-console (#523): chat-intercept channel for the ~66 dev/authoring commands with no native slash binding, registry dispatch, record→confirm seed-SQL authoring (live write + per-session log + Discord hook), FanMMORPG patrol authoring + schema, per-command status | Complete |
 | [integration-test-infra.md](architecture/integration-test-infra.md) | Live-DB test infrastructure: why no testcontainers, why no `sqlx::test`, local setup, isolation patterns | Complete |
 | [transport-trait.md](architecture/transport-trait.md) | ADR: `Transport` trait for the Mercury send side — `UdpTransport`/`TestTransport`, the send/recv asymmetric split, why `Nub` I/O (#57) was retired, and the fan-out byte test seam | Complete |
 | [mercury-bundle.md](architecture/mercury-bundle.md) | `ChannelBundle` accumulator: cross-entity bundling rule, transaction-state hazard, AoI burst migration (#356), follow-up migration playbook | Complete |


### PR DESCRIPTION
Closes #523.

The 2009 client's 266-command slash roster is baked into `SGW.exe`, so the ~66 dev/authoring commands the legacy server and the [doko972/FanMMORPG](https://github.com/doko972/FanMMORPG) fork shipped can't get a native `/gm*` binding. This delivers them through the `.`-prefixed console: the client **forwards** `.`-text as a `CHAN_SAY` chat message (unlike `/`, which it eats locally), so the server intercepts it for GM senders and never broadcasts it.

> Builds on the merged #518/#521 GM lineage (`feat/gm-inspection-commands`, now in `main`); targets `main`.

## What's here

**Enabler** (`crates/services/src/cell/console/`): chat interceptor (GM + leading `.` → dispatcher, no broadcast; non-GM `.`-text is normal chat; auth on server-side `access_level`), a registry-driven dispatcher (`COMMANDS` table → arg/target validation), feedback-channel replies, and an `info`-level audit log (CAT-N / #473).

**All 66 commands** across categories A–H + the 2 mission gaps + the FanMMORPG patrol family:
- **Read-only:** `searchitem/mission/template` (base `ConsoleSearch` round-trip), `players`, 6 stat dumps, `missionrewards` (preview).
- **Entity authoring** (`tag`/`name`/`alignment`/components/dialog/…): in-memory mutate + AoI.
- **Net/AI debug:** `net_seq` family, `net_speak`, `net_timer`/`mapinfo`/`dialog`/`challenge`, `debug_velocity`/`debug_follow`, `threaten`, `aggression`.
- **Crafting** (`learn`/`forgetdiscipline`), `missionfail`.
- **Spawn + patrol authoring** (`savespawn`/`delspawn`/`spawnrandom`/`respawnall`, `path_*`).

## Authoring persistence: record → confirm → seed

Per the design worked out in-thread, authoring commands **apply in-memory** (a freshly-assigned patrol walks now), **write the live DB** (`CellToBaseMsg::ExecuteAuthoringSql` — transient, wiped on next deploy so the dev sees it hold meanwhile), and **record canonical seed SQL** to a per-session log (`logs/seed-authoring-<session>.sql`). `.seedconfirm` groups the pending statements **per seed file** (server log today; a `cimmeria-discord` `SeedAuthored` sink once enabled on the colo); `.seedpending`/`.seedcancel` round it out. Raw SQL is **never shown in-game** (chat isn't copy-pasteable). SQL is server-generated + escaped (`seed::sql_str`), GM-gated.

## Schema (seed-edit, **not** migrations)

`spawnlist.patrol_path_id` + `patrol_point_delay` (loader now prefers the per-spawn override), and `point_set_points.sequence_id` + `teleport_*`. Per the repo rule there is **no `db/scripts/*.sql` migration** — the DB rebuilds from seeds, and schema + code ship together in the deploy image, so the loader change is safe under that model.

## Adversarial review + fixes

Ran two independent reviews (correctness/security + blast-radius) before opening. Auth model clean (single gated entry, server-side `access_level`), all four net wire serializers byte-correct vs the dispatch table. Fixed the real findings, each with a regression guard:
- **HIGH** — `path_clear` emitted a two-statement SQL string that sqlx's prepared-statement executor rejects → split into two single-statement records.
- **HIGH** — `parse_f32` accepted `NaN`/`inf` (invalid SQL literal) → reject non-finite.
- **MED** — negative waypoint `index` → invalid `OFFSET -1` → guarded.
- **MED** — hardened the two raw `args[N]` indexes in `net.rs`.

## Tests & checks

23 tests: full dispatch coverage (`every_spec_is_dispatched`), interceptor consume/broadcast guards, and the three regression guards above. `cargo fmt --check` ✓, `cargo clippy -p cimmeria-services --all-targets -D warnings` ✓, `cargo check -p cimmeria-server` ✓.

> Not run locally: full `nextest` workspace + live-DB profile. A live-DB test exercising the authoring SQL through `handle_execute_authoring_sql` is the natural follow-up.

## Known deviations / follow-ups (detailed in the ADR)

- All `.`-commands are uniformly GM-gated at the channel (no per-command access-*level* field; per-command **target-type** validation is present).
- Honest in-game limitations where the Rust server differs: server/maint family (`save`/`reloadmap`/`reloadres`/`loglevel`/`logclient`/`removerespawner`), `allcraft`, `debug_controller`, `missionrewards` (preview).
- Follow-ups: Discord `SeedAuthored` sink; runtime `loglevel`/`reloadres`; consolidated `allcraft`; `missionrewards` once #310 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded the developer console with GM-only `.` commands for querying/help, stats, player lists, item/mission/template search, and server/admin maintenance commands.
  * Added real-time authoring for entity fields, crafting/disciplines, missions, spawn persistence/random spawning, and NPC patrol path authoring (waypoints, teleport/delay, assignments).
  * Introduced a seed-based persistence workflow (record/confirm/pending/cancel) for authored DB changes.
  * Updated underlying resources schema to support patrol/teleport overrides and per-spawn patrol settings.
* **Bug Fixes**
  * Updated GM feedback routing to use the correct in-game tell channel.
* **Documentation**
  * Added/updated developer console ADR and command/persistence documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->