### PR TITLE
feat(observability): surface silent AoI introduction drops as warn!

### DIFF
--- a/crates/services/src/base/world_entry/cell_dispatch/mod.rs
+++ b/crates/services/src/base/world_entry/cell_dispatch/mod.rs
@@ -112,6 +112,24 @@ pub(crate) async fn handle_cell_message(
                     );
                     return;
                 }
+            } else {
+                // No addr mapping for this witness yet. `entered_aoi` below will
+                // call `send_to_witness_reliable`, which silently no-ops with no
+                // resolvable address — the CREATE_ENTITY + cascade are lost. The
+                // cell has ALREADY marked this entity in the witness set, so the
+                // idempotent AoI tick will NOT re-introduce it: the entity stays
+                // invisible to this witness for the whole session and only heals
+                // on relog (which resets the witness set). This is the suspected
+                // mechanism behind "static NPC missing until relog" — surface it
+                // loudly. See docs/architecture/negative-logging-convention.md.
+                tracing::warn!(
+                    target: "aoi.entered_no_witness_addr",
+                    witness_id,
+                    entity_id,
+                    class_id,
+                    reason = "witness_addr_unmapped",
+                    "EnteredAoI for unmapped witness — CREATE_ENTITY + cascade will be dropped; entity invisible to witness until relog"
+                );
             }
             aoi::entered_aoi(
                 witness_id,

--- a/crates/services/src/mercury/aoi/create.rs
+++ b/crates/services/src/mercury/aoi/create.rs
@@ -373,8 +373,25 @@ fn append_appearance(body: &mut Vec<u8>, entity_id: u32, idbase: u8, d: &NpcAoID
             write_wstring(&mut args, body_set_str);
             // onStaticMeshNameUpdate is method index 0
             append_entity_method(body, 0, idbase, entity_id, &args);
+            return;
         }
     }
+
+    // Neither appearance branch fired. The cascade still sends onVisible(1),
+    // but with no mesh the client builds an unrenderable entity that reads as
+    // "missing" to every witness — and because the witness set is marked
+    // before delivery, the idempotent AoI tick won't re-introduce it. This is
+    // a template-data gap (null/empty static_mesh AND body_set/components);
+    // surface it loudly. See docs/architecture/negative-logging-convention.md.
+    tracing::warn!(
+        target: "aoi.cascade_appearance_missing",
+        entity_id,
+        body_set = d.body_set.as_deref().unwrap_or("<none>"),
+        static_mesh = d.static_mesh.as_deref().unwrap_or("<none>"),
+        components_count = d.components.len(),
+        reason = "no_appearance_data",
+        "AoI cascade: NPC has no appearance data — entity will be invisible to witnesses (check template static_mesh / body_set / components)"
+    );
 }
 
 #[cfg(test)]

--- a/crates/services/src/mercury/aoi/create.rs
+++ b/crates/services/src/mercury/aoi/create.rs
@@ -411,3 +411,67 @@ mod cascade_idbase_tests {
         assert_eq!(cascade_idbase(None), IDBASE_SGW_PLAYER);
     }
 }
+
+#[cfg(test)]
+mod appearance_cascade_tests {
+    use super::*;
+
+    /// A cascade whose NPC has NO appearance data (no static_mesh, no
+    /// body_set/components) emits the `aoi.cascade_appearance_missing`
+    /// negative-log — the seam that surfaces an entity which will be
+    /// invisible to witnesses. Reverting the `warn!` in `append_appearance`
+    /// trips this. (`#[tokio::test]` because `LogCapture::install` requires
+    /// the current-thread runtime.)
+    #[tokio::test]
+    async fn no_appearance_data_emits_warn() {
+        let capture = crate::test_support::LogCapture::install();
+
+        let npc = NpcAoIData {
+            static_mesh: None,
+            body_set: None,
+            components: vec![],
+            ..NpcAoIData::default()
+        };
+        let _ = compose_create_entity_cascade_body(4242, 0x00, 1, Some(&npc));
+
+        let event = capture
+            .find_event(
+                tracing::Level::WARN,
+                "no appearance data",
+                "no_appearance_data",
+            )
+            .expect("missing appearance must emit the aoi.cascade_appearance_missing warn");
+        assert!(
+            event.has_field("entity_id", "4242"),
+            "warn must carry the entity_id field: {event:#?}"
+        );
+    }
+
+    /// Companion guard: an NPC WITH a static mesh (the real Castle_CellBlock
+    /// corpse shape — body_set present but components empty, so the
+    /// static-mesh branch fires) must NOT trip the appearance-missing warn.
+    /// Proves the seam doesn't false-positive on well-formed props.
+    #[tokio::test]
+    async fn static_mesh_present_does_not_warn() {
+        let capture = crate::test_support::LogCapture::install();
+
+        let npc = NpcAoIData {
+            static_mesh: Some("CA-Props.CA-GuardCorpse02".to_string()),
+            body_set: Some("GLB_Components.WorldObject_Small".to_string()),
+            components: vec![],
+            ..NpcAoIData::default()
+        };
+        let _ = compose_create_entity_cascade_body(4243, 0x00, 1, Some(&npc));
+
+        assert!(
+            capture
+                .find_event(
+                    tracing::Level::WARN,
+                    "no appearance data",
+                    "no_appearance_data",
+                )
+                .is_none(),
+            "a static-mesh NPC must not trip the appearance-missing warn"
+        );
+    }
+}


### PR DESCRIPTION
## What

Adds two negative-log (`warn!`) seams to surface a class of silently-dropped AoI entity introductions — the suspected mechanism behind a "static NPC shows as empty space until relog" bug observed in the instanced **Castle_CellBlock** spawn room (spawn_id 15 / template 21 "Cellblock guard corpse", `class_id 0x00`).

**Instrumentation only — no behavior change.** The behavioral fix is deliberately deferred until a colo repro confirms which seam fires.

## Why

Investigation ruled out: the `class_id != 0x00` cascade gate (runs every entry; relog contradicts), spawn-population failure (deterministic; entity is in `space.entities`), the `create.rs:136-142` same-entity bundling footgun (phase1/phase2 are independent reliable sends, guarded in the flush path), and missing template mesh data (`static_mesh` flows end-to-end and the corpse renders correctly after relog).

Leading mechanism: `witnesses` is marked at AoI-compute time (`cell/space_manager/aoi.rs:232`) **before** delivery. In the base-side EnteredAoI gate, when the witness addr is unmapped in `entity_to_addr`, the event skips the defer-buffer and falls through to `entered_aoi` → `send_to_witness_reliable`, which silently no-ops without an address. The cell already marked the witness, so the idempotent 100 ms tick never re-introduces the entity → invisible for the whole session, heals only on relog (which resets the per-player witness set). PR #525 (`fix/aoi-entry-race`) likely *exposed* this by emitting AoI immediately on `ConnectEntity`.

## Changes

- **`base/world_entry/cell_dispatch/mod.rs`** — `warn!(target: "aoi.entered_no_witness_addr", witness_id, entity_id, class_id, reason)` in the EnteredAoI gate's unmapped-witness branch. The targeting seam.
- **`mercury/aoi/create.rs`** (`append_appearance`) — `warn!(target: "aoi.cascade_appearance_missing", entity_id, body_set, static_mesh, components_count, reason)` when no appearance is emitted. Defense-in-depth; won't fire for the corpse (it has a mesh).

Both route to the Discord errors channel via `DiscordLayer`, so the next colo deploy makes the bug self-report.

## Testing

Instrumentation-only; `LogCapture` tests for the two warns will land with the behavioral fix once the repro confirms the trigger. Not run locally per build-workflow preference — CI gates fmt / clippy / build / test.

## Follow-up

Behavioral fix candidates (pending repro): (a) don't commit the cell-side `witnesses` mark for an entity whose intro couldn't be delivered (let the tick recover); (b) gate the #525 ConnectEntity-path AoI emit until the witness addr is mapped. Fix spans cell + base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_0151DAFJemGM1jhv8sfPBVki


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added enhanced diagnostic logging for edge cases where entity appearance data is missing or witness visibility information is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->