### PR TITLE
feat(discord): wire auth/world/gm/gameplay/errors emit sites (#527)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -978,6 +978,7 @@ dependencies = [
  "cimmeria-commands",
  "cimmeria-common",
  "cimmeria-content-engine",
+ "cimmeria-discord",
  "cimmeria-entity",
  "cimmeria-game",
  "cimmeria-mercury",

--- a/crates/discord/src/event.rs
+++ b/crates/discord/src/event.rs
@@ -513,6 +513,23 @@ impl DisconnectReason {
             Self::ServerInitiated => "server_initiated",
         }
     }
+
+    /// Map the stable internal disconnect label that
+    /// `base::helpers::destroy_client_entities` stamps on every teardown
+    /// (`"client_disconnect"`, `"logoff"`, `"inactivity_timeout"`,
+    /// `"send_error"`, `"duplicate_login"`) onto a typed reason for the
+    /// embed. Unknown labels collapse to [`Self::ServerInitiated`] — the
+    /// conservative "the server closed this" bucket — so a new label added
+    /// upstream degrades to a sane default rather than failing to compile
+    /// at a distance.
+    pub fn from_label(label: &str) -> Self {
+        match label {
+            "client_disconnect" | "logoff" => Self::Clean,
+            "inactivity_timeout" => Self::Timeout,
+            "send_error" => Self::PeerReset,
+            _ => Self::ServerInitiated,
+        }
+    }
 }
 
 /// Chat channel sub-kind. Mapped to its own `EventKind` for routing.
@@ -676,6 +693,40 @@ mod tests {
             assert!(seen.insert(c.as_str()));
         }
         assert_eq!(seen.len(), ChannelKind::ALL.len());
+    }
+
+    /// `DisconnectReason::from_label` is the single mapping the auth-channel
+    /// `player_disconnect` seam relies on. Pin every label the
+    /// `destroy_client_entities` choke point stamps, plus the unknown-label
+    /// fallback. Reverting the mapping (or renaming a label upstream without
+    /// updating it) trips this.
+    #[test]
+    fn disconnect_reason_from_label_maps_every_teardown_label() {
+        assert_eq!(
+            DisconnectReason::from_label("client_disconnect"),
+            DisconnectReason::Clean
+        );
+        assert_eq!(
+            DisconnectReason::from_label("logoff"),
+            DisconnectReason::Clean
+        );
+        assert_eq!(
+            DisconnectReason::from_label("inactivity_timeout"),
+            DisconnectReason::Timeout
+        );
+        assert_eq!(
+            DisconnectReason::from_label("send_error"),
+            DisconnectReason::PeerReset
+        );
+        assert_eq!(
+            DisconnectReason::from_label("duplicate_login"),
+            DisconnectReason::ServerInitiated
+        );
+        // Unknown label degrades to the conservative server-initiated bucket.
+        assert_eq!(
+            DisconnectReason::from_label("something_new"),
+            DisconnectReason::ServerInitiated
+        );
     }
 
     /// `EventKind::ALL` length is the canonical count of toggleable event

--- a/crates/discord/src/lib.rs
+++ b/crates/discord/src/lib.rs
@@ -319,6 +319,85 @@ pub fn emit_gm_command(
     });
 }
 
+pub fn emit_item_used(
+    character_name: impl Into<String>,
+    item_type_id: i32,
+    target: Option<String>,
+) {
+    emit(Event::ItemUsed {
+        character_name: character_name.into(),
+        item_type_id,
+        target,
+        timestamp: chrono::Utc::now(),
+    });
+}
+
+pub fn emit_wire_format_error(
+    kind: impl Into<String>,
+    addr: Option<SocketAddr>,
+    details: impl Into<String>,
+) {
+    emit(Event::WireFormatError {
+        kind: kind.into(),
+        addr,
+        details: details.into(),
+        timestamp: chrono::Utc::now(),
+    });
+}
+
+pub fn emit_db_error(operation: impl Into<String>, details: impl Into<String>) {
+    emit(Event::DbError {
+        operation: operation.into(),
+        details: details.into(),
+        timestamp: chrono::Utc::now(),
+    });
+}
+
+pub fn emit_mercury_timeout(addr: SocketAddr, account_id: Option<u32>, silence_secs: u64) {
+    emit(Event::MercuryTimeout {
+        addr,
+        account_id,
+        silence_secs,
+        timestamp: chrono::Utc::now(),
+    });
+}
+
+pub fn emit_mission_failed(
+    character_name: impl Into<String>,
+    mission_id: i32,
+    mission_name: Option<String>,
+    reason: impl Into<String>,
+) {
+    emit(Event::MissionFailed {
+        character_name: character_name.into(),
+        mission_id,
+        mission_name,
+        reason: reason.into(),
+        timestamp: chrono::Utc::now(),
+    });
+}
+
+pub fn emit_player_death(
+    character_name: impl Into<String>,
+    killer: Option<String>,
+    cause: impl Into<String>,
+) {
+    emit(Event::PlayerDeath {
+        character_name: character_name.into(),
+        killer,
+        cause: cause.into(),
+        timestamp: chrono::Utc::now(),
+    });
+}
+
+pub fn emit_player_respawn(character_name: impl Into<String>, world_name: impl Into<String>) {
+    emit(Event::PlayerRespawn {
+        character_name: character_name.into(),
+        world_name: world_name.into(),
+        timestamp: chrono::Utc::now(),
+    });
+}
+
 /// Install a panic hook that posts a [`Event::ServerPanic`] to the
 /// lifecycle channel before the default hook aborts the process.
 ///
@@ -489,7 +568,7 @@ mod tests {
             .await;
 
         let cfg = all_on_config(&server.uri());
-        let _rt = init_with_config(cfg);
+        let rt = init_with_config(cfg);
         // Belt-and-braces: if a stale GLOBAL slipped in from a
         // future test, mark the guard so the next reader of this
         // file knows what's going on. (No actual coordination —
@@ -518,21 +597,44 @@ mod tests {
         emit_mission_accepted("alice", 1234, Some("Find Ambernol".into()));
         emit_mission_completed("alice", 1234, Some("Find Ambernol".into()));
         emit_gm_command("steve", "/teleport", "alice 1,2,3");
+        emit_item_used("alice", 5001, Some("self".into()));
+        emit_wire_format_error(
+            "seq_out_of_range",
+            Some(addr),
+            "seq 0x1fffffff >= NULL_SEQUENCE",
+        );
+        emit_db_error("auth_user", "connection refused");
+        emit_mercury_timeout(addr, Some(1), 60);
+        emit_mission_failed("alice", 1234, Some("Find Ambernol".into()), "timer expired");
+        emit_player_death("alice", Some("Jaffa Guard".into()), "staff blast");
+        emit_player_respawn("alice", "Castle");
 
-        const EXPECTED_EMITS: usize = 13;
+        const EXPECTED_EMITS: u64 = 20;
 
-        // Drain the queue. The send task is async; give it a
-        // generous wait but bounded so a hung test doesn't hang the
-        // suite. 2 s is well above the steady-state turnaround for
-        // a localhost wiremock + 150/min rate-limit budget.
+        // The typed-wrapper regression target: every `emit_*` helper must
+        // enqueue exactly one event. `enqueued` is bumped synchronously in
+        // `SenderHandle::try_send` BEFORE the per-channel token bucket, so
+        // this count is immune to rate-limit drops — which matters now that
+        // the gameplay channel has 7 helper types but only a 5-msg burst
+        // budget (the tight loop here would otherwise drop ~2 gameplay
+        // posts). A future hand that drops `emit_player_login` or stops a
+        // helper from constructing its event trips this.
+        assert_eq!(
+            rt.stats().enqueued,
+            EXPECTED_EMITS,
+            "every emit_* helper must enqueue exactly one event through the global runtime"
+        );
+
+        // Drain briefly so the routing-diversity check below has traffic to
+        // inspect. Not pinning an exact POST count — the gameplay burst cap
+        // drops a couple, and the enqueue assertion above already guards the
+        // count. 15 is comfortably below 20-minus-drops and above the
+        // 5-channel diversity floor.
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
         loop {
             let count = server.received_requests().await.unwrap().len();
-            if count >= EXPECTED_EMITS {
+            if count >= 15 || std::time::Instant::now() >= deadline {
                 break;
-            }
-            if std::time::Instant::now() >= deadline {
-                panic!("drained {count} requests but expected ≥ {EXPECTED_EMITS} within deadline");
             }
             tokio::time::sleep(std::time::Duration::from_millis(20)).await;
         }

--- a/crates/entity/src/cell_entity/mod.rs
+++ b/crates/entity/src/cell_entity/mod.rs
@@ -198,6 +198,14 @@ pub struct CellEntity {
     /// Display name for NPCs (sent in dialog headers, etc.).
     pub npc_name: Option<String>,
 
+    /// Display name for player entities, cached from the base
+    /// `ConnectedClientState.player_name` via `BaseToCellMsg::InitPlayerState`.
+    /// The cell has no other source for a player's name — it's needed so
+    /// cell-side seams (the `.`-console GM audit trail, mission/death/respawn
+    /// Discord emits) can attribute events to a name rather than a bare
+    /// entity id. `None` for NPCs and until `InitPlayerState` arrives.
+    pub character_name: Option<String>,
+
     /// Mission tracking for player entities.
     pub missions: MissionManager,
 
@@ -916,6 +924,7 @@ impl CellEntity {
             abilities: AbilityManager::new(),
             interaction_type: None,
             npc_name: None,
+            character_name: None,
             missions: MissionManager::new(),
             player_id: None,
             archetype_id: None,

--- a/crates/services/Cargo.toml
+++ b/crates/services/Cargo.toml
@@ -13,6 +13,10 @@ cimmeria-game = { workspace = true }
 cimmeria-content-engine = { workspace = true }
 cimmeria-commands = { workspace = true }
 cimmeria-observability = { workspace = true }
+# Discord notification emits at semantic seams (login/world-entry/disconnect/
+# errors/…). The crate's global-singleton `emit_*` API means no handle
+# threading — calls are no-ops until the server bin runs `cimmeria_discord::init`.
+cimmeria-discord = { workspace = true }
 tokio = { workspace = true }
 axum = { workspace = true }
 rand = { workspace = true }

--- a/crates/services/src/auth/handlers.rs
+++ b/crates/services/src/auth/handlers.rs
@@ -122,17 +122,28 @@ pub(super) async fn handle_user_auth(
             Err(AuthCredError::InvalidCredentials) => {
                 tracing::info!(user = %req.account_name, "Invalid credentials");
                 audit!("invalid_credentials");
+                cimmeria_discord::emit_player_auth_failed(
+                    req.account_name.as_str(),
+                    addr,
+                    "invalid_credentials",
+                );
                 // C++ FailureCode::BadUserPassword = 4 (not 3, which is InvalidService).
                 return login_error(4, "The account name or password is incorrect.");
             }
             Err(AuthCredError::AccountDisabled) => {
                 tracing::info!(user = %req.account_name, "Account disabled");
                 audit!("account_disabled");
+                cimmeria_discord::emit_player_auth_failed(
+                    req.account_name.as_str(),
+                    addr,
+                    "account_disabled",
+                );
                 return login_error(5, "This account has been suspended.");
             }
             Err(AuthCredError::DbError(e)) => {
                 tracing::error!(user = %req.account_name, error = %e, "DB query failed");
                 audit!("db_error");
+                cimmeria_discord::emit_db_error("auth_credential_check", e.to_string());
                 return login_error(10, "A request to the database server failed.");
             }
         }

--- a/crates/services/src/base/connect_loop/encrypted/mod.rs
+++ b/crates/services/src/base/connect_loop/encrypted/mod.rs
@@ -83,6 +83,11 @@ pub(crate) async fn handle_encrypted_datagram(
         Ok(p) => p,
         Err(e) => {
             tracing::warn!(%addr, "Packet parse failed after decrypt: {e}");
+            // Discord errors-channel: a decrypted-but-undecodable datagram is
+            // a wire-format break worth a structured embed (the generic warn
+            // harvest would lose the addr/kind structure). The sender's
+            // bounded queue + per-channel rate limit absorb a flood.
+            cimmeria_discord::emit_wire_format_error("parse_incoming", Some(addr), e.to_string());
             return Ok(());
         }
     };

--- a/crates/services/src/base/helpers/mod.rs
+++ b/crates/services/src/base/helpers/mod.rs
@@ -261,7 +261,7 @@ pub(crate) fn destroy_client_entities(
     entity_to_addr: &Arc<Mutex<HashMap<u32, SocketAddr>>>,
     reason: &'static str,
 ) {
-    let (account_eid, player_eid) = {
+    let (account_eid, player_eid, account_id, player_name, session_secs) = {
         let mut clients = match connected.lock() {
             Ok(c) => c,
             Err(_) => return,
@@ -274,8 +274,19 @@ pub(crate) fn destroy_client_entities(
         c.cancelled.store(true, Ordering::Relaxed);
         let account_eid = c.account_entity_id;
         let player_eid = c.player_entity_id;
+        // Snapshot identity + session length for the Discord disconnect emit
+        // before `remove` drops the state.
+        let account_id = c.account_id;
+        let player_name = c.player_name.clone();
+        let session_secs = c.connected_at.elapsed().as_secs();
         clients.remove(&addr);
-        (account_eid, player_eid)
+        (
+            account_eid,
+            player_eid,
+            account_id,
+            player_name,
+            session_secs,
+        )
     };
 
     let mut mgr = entity_manager.lock().unwrap();
@@ -303,6 +314,17 @@ pub(crate) fn destroy_client_entities(
         account_entity_id = account_eid,
         player_entity_id = ?player_eid,
         "Client entities cleaned up"
+    );
+
+    // Discord auth-channel: every teardown path funnels through here, so this
+    // is the one place that reports *why* a player dropped. The stable
+    // `reason` label maps to a typed `DisconnectReason` for the embed.
+    cimmeria_discord::emit_player_disconnect(
+        Some(account_id),
+        player_name,
+        addr,
+        cimmeria_discord::DisconnectReason::from_label(reason),
+        session_secs,
     );
 }
 

--- a/crates/services/src/base/login/mod.rs
+++ b/crates/services/src/base/login/mod.rs
@@ -163,6 +163,7 @@ pub(crate) async fn handle_login(
                 next_seq_unreliable,
                 pending_acks,
                 last_recv,
+                connected_at: Instant::now(),
                 account_entity_id: entity_manager.lock().unwrap().create_entity("Account").0 as u32,
                 next_data_id: 0,
                 pending_world_entry: None,
@@ -190,6 +191,11 @@ pub(crate) async fn handle_login(
     };
 
     tracing::info!(%addr, "Phase 3 complete -- channel registered, starting tick-sync");
+
+    // Discord auth-channel ping. Character isn't selected yet at Phase 3
+    // (that happens at playCharacter), so the name is `None` here — the
+    // world-entry emit carries the character once it's known.
+    cimmeria_discord::emit_player_login(login.account_id, None, addr);
 
     // Start tick-sync immediately after Phase 3 (matches C++ onConnected() behavior).
     // The C++ server starts gameTick() as soon as the Account entity is created,
@@ -310,7 +316,10 @@ pub(crate) async fn handle_log_off(
     tracing::info!(%addr, "Client requests logOff -- sending LOGGED_OFF and cleaning up");
 
     // Signal the tick-sync loop to stop and grab seq/acks for the final packet.
-    let (acks, seq) = {
+    // Snapshot the identity + session duration here too, before
+    // `destroy_client_entities` removes the session from the map — the
+    // Discord logout emit below needs them.
+    let (acks, seq, account_id, player_name, session_secs) = {
         let mut clients = connected.lock().map_err(|_| "connected lock poisoned")?;
         let client = clients.get_mut(&addr).ok_or("no session for addr")?;
         client
@@ -321,7 +330,10 @@ pub(crate) async fn handle_log_off(
             .next_seq
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
             & cimmeria_mercury::packet::SEQUENCE_MASK;
-        (acks, seq)
+        let account_id = client.account_id;
+        let player_name = client.player_name.clone();
+        let session_secs = client.connected_at.elapsed().as_secs();
+        (acks, seq, account_id, player_name, session_secs)
     };
 
     // Send LOGGED_OFF (0x37) with reason=0 to trigger immediate client-side
@@ -340,6 +352,13 @@ pub(crate) async fn handle_log_off(
         entity_to_addr,
         "logoff",
     );
+
+    // Discord auth-channel: clean logout carries the session length. The
+    // lower-level teardown in `destroy_client_entities` also fires a
+    // `PlayerDisconnect { reason: Clean }` — by design (see the
+    // `DisconnectReason::Clean` doc): logout is the gameplay-level event,
+    // disconnect the connection-level one.
+    cimmeria_discord::emit_player_logout(account_id, player_name, session_secs);
 
     Ok(())
 }

--- a/crates/services/src/base/login/tests.rs
+++ b/crates/services/src/base/login/tests.rs
@@ -250,6 +250,69 @@ async fn login_consumes_ticket_and_registers_connected_client_state() {
     cancel_session(&connected, addr);
 }
 
+/// Regression guard for the Discord auth-channel wiring: a successful
+/// `handle_login` must push a `player_login` event into the Discord pipeline.
+/// Inits the global runtime with a *disabled* config so no webhook/HTTP is
+/// involved — `try_send`'s pre-filter short-circuits a disabled config into
+/// the `filtered` counter rather than `enqueued`, and both mean "the emit
+/// fired and the event reached the pipeline", so we sum them. Reverting the
+/// `emit_player_login` call in `handle_login` leaves the sum flat and trips
+/// this.
+///
+/// Reliable under nextest (process-per-test isolates the global counters).
+/// The strict-`>` on the summed delta still can't false-fail under parallel
+/// `cargo test` — a concurrent login sharing the process-global only adds to
+/// the count.
+#[tokio::test]
+async fn login_pushes_discord_player_login_event() {
+    let rt = cimmeria_discord::init_with_config(cimmeria_discord::Config::disabled());
+    // "Entered the pipeline" = enqueued (would post) + filtered (toggle/
+    // disabled short-circuit). Summing keeps the guard config-agnostic.
+    let pipelined = |rt: &cimmeria_discord::DiscordRuntime| {
+        let s = rt.stats();
+        s.enqueued + s.filtered
+    };
+    let before = pipelined(rt);
+
+    let transport = make_transport();
+    let addr: SocketAddr = "127.0.0.1:55557".parse().unwrap();
+    let pending_logins = Arc::new(Mutex::new(HashMap::new()));
+    let connected = Arc::new(Mutex::new(HashMap::new()));
+    let entity_manager = Arc::new(Mutex::new(EntityManager::new()));
+    let entity_to_addr = Arc::new(Mutex::new(HashMap::new()));
+    let cell_tx = None;
+
+    let pending = make_pending_login(0x0000_1234, 0xCD);
+    let ticket = pending.ticket.clone();
+    pending_logins
+        .lock()
+        .unwrap()
+        .insert(ticket.clone(), pending);
+
+    handle_login(
+        &transport,
+        addr,
+        0x1234_5678,
+        &ticket,
+        &pending_logins,
+        &connected,
+        &entity_manager,
+        &cell_tx,
+        &entity_to_addr,
+    )
+    .await
+    .expect("Phase 3 handoff");
+
+    let after = pipelined(rt);
+    assert!(
+        after > before,
+        "successful handle_login must push a player_login Discord event into \
+         the pipeline (enqueued+filtered {before} -> {after})"
+    );
+
+    cancel_session(&connected, addr);
+}
+
 /// Domain F (fan-out byte test): with no duplicate session, `handle_login`
 /// emits exactly two packets, in order — the Phase 3 connect-reply (seq 1)
 /// then the initial time-sync bundle (seq 2) — both to the connecting

--- a/crates/services/src/base/mod.rs
+++ b/crates/services/src/base/mod.rs
@@ -151,6 +151,13 @@ pub(crate) struct ConnectedClientState {
     pub next_seq_unreliable: Arc<AtomicU32>,
     pub pending_acks: Arc<Mutex<Vec<u32>>>,
     pub last_recv: Arc<Mutex<Instant>>,
+    /// Wall-clock instant the session completed Phase 3 (channel registered).
+    /// Distinct from [`last_recv`], which slides forward on every packet —
+    /// this one is fixed at connect so logout/disconnect emits can report a
+    /// true `session_secs` rather than idle time.
+    ///
+    /// [`last_recv`]: Self::last_recv
+    pub connected_at: Instant,
     pub account_entity_id: u32,
     pub next_data_id: u16,
     pub pending_world_entry: Option<WorldEntryInfo>,

--- a/crates/services/src/base/tick_sync.rs
+++ b/crates/services/src/base/tick_sync.rs
@@ -96,6 +96,14 @@ pub(crate) async fn run_tick_loop(
                 "Tick-sync stopping: client inactive for {}s",
                 idle.as_secs()
             );
+            // Discord errors-channel: the peer went silent past the dead
+            // threshold. Account id is best-effort — the session is still
+            // in the map at this point (teardown runs after the loop).
+            let account_id = connected
+                .lock()
+                .ok()
+                .and_then(|c| c.get(&addr).map(|s| s.account_id));
+            cimmeria_discord::emit_mercury_timeout(addr, account_id, idle.as_secs());
             break "inactivity_timeout";
         }
 

--- a/crates/services/src/base/world_entry/gate_travel/mod.rs
+++ b/crates/services/src/base/world_entry/gate_travel/mod.rs
@@ -83,16 +83,6 @@ pub(crate) async fn handle_gate_travel(
         "Gate travel: sending RESET_ENTITIES for world transition"
     );
 
-    // Discord world-channel: leaving the current world for the gate target.
-    // `from_world` is whatever the session was last in; the emit's `to_world`
-    // is the gate destination.
-    cimmeria_discord::emit_player_world_exit(
-        account_id,
-        exit_name.unwrap_or_else(|| "<unknown>".to_string()),
-        exit_from_world.unwrap_or_else(|| "<unknown>".to_string()),
-        Some(target_world_name.to_string()),
-    );
-
     // Tell CellService to create the entity in the new space and await the
     // resolved space_id via oneshot (needed for the world-entry wire packet).
     let space_id = if let Some(tx) = cell_tx {
@@ -223,6 +213,20 @@ pub(crate) async fn handle_gate_travel(
         addr,
         seq,
         cimmeria_mercury::packet::Bytes::copy_from_slice(&pkt),
+    );
+
+    // Discord world-channel: emit only here, once the transition is
+    // committed — past the active_player_id fail-closed early-returns and
+    // the RESET_ENTITIES send (which `?`-returns on a send error). Firing it
+    // at the top of the handler would post a false "world exit" whenever
+    // gate travel aborts. `from_world` is the session's last world; `to_world`
+    // is the gate destination. (Snapshotted above before the new world
+    // overwrites the connected state.)
+    cimmeria_discord::emit_player_world_exit(
+        account_id,
+        exit_name.unwrap_or_else(|| "<unknown>".to_string()),
+        exit_from_world.unwrap_or_else(|| "<unknown>".to_string()),
+        Some(target_world_name.to_string()),
     );
 
     // Store pending world entry for the create-player step (ENABLE_ENTITIES handler)

--- a/crates/services/src/base/world_entry/gate_travel/mod.rs
+++ b/crates/services/src/base/world_entry/gate_travel/mod.rs
@@ -60,8 +60,9 @@ pub(crate) async fn handle_gate_travel(
         .copied()
         .ok_or("Gate travel: no client addr for entity")?;
 
-    // Get client state
-    let (key, account_id, _access_level, pending_acks_arc, next_seq) = {
+    // Get client state. Also snapshot the name + current world for the
+    // Discord world-exit emit before they're overwritten by the new world.
+    let (key, account_id, _access_level, pending_acks_arc, next_seq, exit_name, exit_from_world) = {
         let clients = connected.lock().map_err(|_| "connected lock poisoned")?;
         let c = clients
             .get(&addr)
@@ -72,12 +73,24 @@ pub(crate) async fn handle_gate_travel(
             c.access_level,
             Arc::clone(&c.pending_acks),
             Arc::clone(&c.next_seq),
+            c.player_name.clone(),
+            c.world_name.clone(),
         )
     };
 
     tracing::info!(
         entity_id, %addr, world = %target_world_name,
         "Gate travel: sending RESET_ENTITIES for world transition"
+    );
+
+    // Discord world-channel: leaving the current world for the gate target.
+    // `from_world` is whatever the session was last in; the emit's `to_world`
+    // is the gate destination.
+    cimmeria_discord::emit_player_world_exit(
+        account_id,
+        exit_name.unwrap_or_else(|| "<unknown>".to_string()),
+        exit_from_world.unwrap_or_else(|| "<unknown>".to_string()),
+        Some(target_world_name.to_string()),
     );
 
     // Tell CellService to create the entity in the new space and await the

--- a/crates/services/src/base/world_entry/gate_travel/tests.rs
+++ b/crates/services/src/base/world_entry/gate_travel/tests.rs
@@ -53,6 +53,7 @@ fn make_state() -> ConnectedClientState {
         next_seq_unreliable: Arc::new(AtomicU32::new(0)),
         pending_acks: Arc::new(Mutex::new(Vec::new())),
         last_recv: Arc::new(Mutex::new(Instant::now())),
+        connected_at: Instant::now(),
         account_entity_id: 1,
         next_data_id: 0,
         pending_world_entry: None,

--- a/crates/services/src/base/world_entry/methods/inventory/appearance.rs
+++ b/crates/services/src/base/world_entry/methods/inventory/appearance.rs
@@ -136,6 +136,7 @@ mod tests {
             next_seq_unreliable: Arc::new(AtomicU32::new(0)),
             pending_acks: Arc::new(Mutex::new(Vec::new())),
             last_recv: Arc::new(Mutex::new(Instant::now())),
+            connected_at: Instant::now(),
             account_entity_id: 1,
             next_data_id: 0,
             pending_world_entry: None,

--- a/crates/services/src/base/world_entry/methods/inventory/core/use_instance.rs
+++ b/crates/services/src/base/world_entry/methods/inventory/core/use_instance.rs
@@ -227,6 +227,25 @@ pub async fn handle_use_inventory_item(
         "UseInventoryItem: firing ItemUsed (no consumption — chain decides)"
     );
 
+    // Discord gameplay-channel (off by default — high volume). Resolve the
+    // player's name through entity_to_addr → connected; skip the emit if the
+    // name isn't cached. `target` carries the numeric target id when one was
+    // supplied (cell-side has the name; base only has the id).
+    if let Some(character_name) = entity_to_addr
+        .lock()
+        .ok()
+        .and_then(|m| m.get(&entity_id).copied())
+        .and_then(|a| {
+            connected
+                .lock()
+                .ok()
+                .and_then(|c| c.get(&a).and_then(|s| s.player_name.clone()))
+        })
+    {
+        let target = (target_id != 0).then(|| format!("entity:{target_id}"));
+        cimmeria_discord::emit_item_used(character_name, type_id, target);
+    }
+
     let payload = CellOutboxPayload::ItemUsed {
         instance_id: item_id,
         type_id,

--- a/crates/services/src/base/world_entry/methods/progression/mod.rs
+++ b/crates/services/src/base/world_entry/methods/progression/mod.rs
@@ -65,7 +65,7 @@ pub async fn handle_grant_xp(
     // a failed grant onto the next successful one: the next GrantXP would
     // saturate-add on top of the unpersisted value and then write the
     // combined sum, effectively persisting the grant we tried to drop.
-    let (player_id, total_xp, new_level, training_points, levels_gained) = {
+    let (player_id, total_xp, new_level, training_points, levels_gained, player_name) = {
         // Tolerate poison instead of panicking — another thread crashing the
         // mutex shouldn't stop XP grants from continuing on the recovered state.
         let map = match connected.lock() {
@@ -97,7 +97,7 @@ pub async fn handle_grant_xp(
             gained.push(level);
         }
 
-        (player_id, xp, level, tp, gained)
+        (player_id, xp, level, tp, gained, state.player_name.clone())
     };
 
     // Persist first. On DB failure we return WITHOUT mutating in-memory
@@ -183,6 +183,15 @@ pub async fn handle_grant_xp(
         levels_up = levels_gained.len(),
         "GrantXP processed"
     );
+
+    // Discord gameplay-channel: only on an actual level boundary crossing,
+    // and only once per grant (reporting the final level even on a multi-level
+    // catch-up grant). Skipped when the name isn't cached yet (pre-character).
+    if !levels_gained.is_empty() {
+        if let Some(name) = &player_name {
+            cimmeria_discord::emit_level_up(name.clone(), new_level);
+        }
+    }
 
     // Bundle the post-grant notifications into a single Mercury frame.
     //

--- a/crates/services/src/base/world_entry/play_character.rs
+++ b/crates/services/src/base/world_entry/play_character.rs
@@ -148,6 +148,12 @@ pub(crate) async fn handle_play_character(
         cimmeria_mercury::packet::Bytes::copy_from_slice(&pkt),
     );
 
+    // Snapshot the world-channel emit fields before the store block below
+    // moves `entry_info` / `player_load_data` into the connected state.
+    let entry_character_name = player_load_data.player_name.clone();
+    let entry_world_name = entry_info.world_name.clone();
+    let entry_position = entry_info.pos;
+
     // Store the world entry info and player load data for the create-player step.
     {
         let mut clients = connected.lock().map_err(|_| "connected lock poisoned")?;
@@ -172,6 +178,15 @@ pub(crate) async fn handle_play_character(
     }
 
     tracing::info!(%addr, "Entity teardown sent -- waiting for ENABLE_ENTITIES from client");
+
+    // Discord world-channel: the character is now known (unlike the auth-time
+    // login emit), so this carries name + world + spawn position.
+    cimmeria_discord::emit_player_world_entry(
+        account_id,
+        entry_character_name,
+        entry_world_name,
+        entry_position,
+    );
 
     Ok(())
 }
@@ -218,6 +233,7 @@ mod tests {
             next_seq_unreliable: Arc::new(AtomicU32::new(0)),
             pending_acks: Arc::new(Mutex::new(Vec::new())),
             last_recv: Arc::new(Mutex::new(Instant::now())),
+            connected_at: Instant::now(),
             account_entity_id: 1,
             next_data_id: 0,
             pending_world_entry: None,

--- a/crates/services/src/base/world_entry_appearance.rs
+++ b/crates/services/src/base/world_entry_appearance.rs
@@ -379,6 +379,7 @@ pub(crate) async fn handle_on_client_ready(
                 system_options,
                 state_field,
                 access_level,
+                character_name: player_name.clone(),
             })
             .await
         {

--- a/crates/services/src/cell/abilities/death.rs
+++ b/crates/services/src/cell/abilities/death.rs
@@ -52,6 +52,25 @@ pub(super) async fn apply_death_transition(
     tx: &mpsc::Sender<CellToBaseMsg>,
     space_mgr: &mut SpaceManager,
 ) {
+    // Discord gameplay-channel (off by default — content/debug signal). Only
+    // player deaths post. Killer name + pvp/pve cause are best-effort from the
+    // attacker entity; read before the mutation bursts below.
+    if target_is_player {
+        let character_name = space_mgr
+            .get_entity(target_eid)
+            .and_then(|e| e.character_name.clone())
+            .unwrap_or_else(|| format!("entity:{target_eid}"));
+        let killer = space_mgr.get_entity(attacker_id).and_then(|e| {
+            if attacker_is_player {
+                e.character_name.clone()
+            } else {
+                e.npc_name.clone()
+            }
+        });
+        let cause = if attacker_is_player { "pvp" } else { "pve" };
+        cimmeria_discord::emit_player_death(character_name, killer, cause);
+    }
+
     // Phase J: any channelled effects the dying target was running die
     // with them. `cancel_channels_from_attacker` walks every entity's
     // active_effects list looking for entries sourced by this target,

--- a/crates/services/src/cell/cell_methods/player/combat/respawn.rs
+++ b/crates/services/src/cell/cell_methods/player/combat/respawn.rs
@@ -100,6 +100,16 @@ pub(crate) async fn handle_respawn(
     span.record("target_world", target_world.as_str());
     span.record("same_world", same_world);
 
+    // Discord gameplay-channel (off by default). Fires for both the
+    // same-world reanchor and the cross-world gate path; `target_world` is the
+    // world the player comes back up in. Cloned because it's moved into the
+    // GateTravel message on the cross-world branch below.
+    let respawn_character_name = space_mgr
+        .get_entity(entity_id)
+        .and_then(|e| e.character_name.clone())
+        .unwrap_or_else(|| format!("entity:{entity_id}"));
+    cimmeria_discord::emit_player_respawn(respawn_character_name, target_world.clone());
+
     // Close the Defeat Window first.
     let _ = tx
         .send(CellToBaseMsg::EntityMethodCall {

--- a/crates/services/src/cell/console/mission.rs
+++ b/crates/services/src/cell/console/mission.rs
@@ -71,6 +71,15 @@ pub(super) async fn fail(
         .await;
 
     tracing::info!(entity_id = target, mission_id, "GM .missionfail");
+
+    // Discord gameplay-channel. This path is GM-forced, so the reason is
+    // fixed; mission defs carry no name cell-side.
+    let character_name = space_mgr
+        .get_entity(target)
+        .and_then(|e| e.character_name.clone())
+        .unwrap_or_else(|| format!("entity:{target}"));
+    cimmeria_discord::emit_mission_failed(character_name, mission_id, None, "gm_forced");
+
     send_gm_feedback(
         caller_id,
         &format!("missionfail [{target}] mission {mission_id} -> FAILED"),

--- a/crates/services/src/cell/console/mod.rs
+++ b/crates/services/src/cell/console/mod.rs
@@ -756,6 +756,16 @@ pub(crate) async fn handle_console_command(
         "GM .-console command accepted"
     );
 
+    // Discord gm-channel audit trail. Attribute to the caller's cached name
+    // (threaded in via InitPlayerState); fall back to the entity id if the
+    // name isn't cached yet. Args are name/position tokens, never secrets —
+    // the same privacy balance as the audit log above.
+    let gm_name = space_mgr
+        .get_entity(caller_id)
+        .and_then(|e| e.character_name.clone())
+        .unwrap_or_else(|| format!("entity:{caller_id}"));
+    cimmeria_discord::emit_gm_command(gm_name, format!(".{name}"), args.join(" "));
+
     exec(name, caller_id, &args, target_id, tx, space_mgr, engine).await;
 }
 

--- a/crates/services/src/cell/console/tests.rs
+++ b/crates/services/src/cell/console/tests.rs
@@ -355,6 +355,46 @@ async fn missionfail_on_absent_mission_reports_no_active() {
     );
 }
 
+/// `.missionfail` happy path: a target holding an ACTIVE mission transitions
+/// it to FAILED and reports the transition. Complements
+/// `missionfail_on_absent_mission_reports_no_active` (the guard branch) and
+/// exercises the success branch's `mission_failed` Discord seam — a no-op
+/// without a runtime, but the character-name capture path runs.
+#[tokio::test]
+async fn missionfail_on_active_mission_transitions_to_failed() {
+    use cimmeria_entity::missions::{MissionInstance, MISSION_ACTIVE, MISSION_FAILED};
+
+    let (mut mgr, gm, npc) = setup();
+    if let Some(e) = mgr.get_entity_mut(npc) {
+        e.is_player = true;
+        e.player_id = Some(500);
+        // The name the missionfail seam reads when attributing the emit.
+        e.character_name = Some("Bra'tac".into());
+        let m = MissionInstance::new(687, 2113, vec![]);
+        assert_eq!(m.status, MISSION_ACTIVE, "seeded mission starts ACTIVE");
+        e.missions.add_mission(m);
+    }
+    let engine = ChainEngine::new();
+    let (tx, mut rx) = mpsc::channel(16);
+    handle_console_command(gm, ".missionfail 687", &tx, &mut mgr, &engine).await;
+
+    assert_eq!(
+        mgr.get_entity(npc)
+            .unwrap()
+            .missions
+            .get_mission(687)
+            .unwrap()
+            .status,
+        MISSION_FAILED,
+        "an ACTIVE mission must transition to FAILED via .missionfail",
+    );
+    let (_, feedback) = drain_grant_and_feedback(&mut rx);
+    assert!(
+        feedback.as_deref().is_some_and(|t| t.contains("FAILED")),
+        "missionfail success must report the FAILED transition; got {feedback:?}"
+    );
+}
+
 /// Critical-fix guard: a GM's session buffers (`authoring_changes`,
 /// `autosave_spawns`, both keyed by entity_id) must be dropped when the entity
 /// is destroyed, so pending authoring SQL / the autosave flag can't leak or

--- a/crates/services/src/cell/content/executor/mission.rs
+++ b/crates/services/src/cell/content/executor/mission.rs
@@ -105,6 +105,15 @@ pub(super) async fn accept_or_advance(
             entity_id, player_id, mission_id, engine, tx, space_mgr,
         )
         .await;
+
+        // Discord gameplay-channel. Mission defs carry no name cell-side, so
+        // the mission id is the identifier; the player name comes from the
+        // entity's InitPlayerState-cached value.
+        let character_name = space_mgr
+            .get_entity(entity_id)
+            .and_then(|e| e.character_name.clone())
+            .unwrap_or_else(|| format!("entity:{entity_id}"));
+        cimmeria_discord::emit_mission_accepted(character_name, mission_id, None);
     } else {
         tracing::warn!(
             mission_id,
@@ -184,6 +193,15 @@ pub(super) async fn complete(
             entity_id, player_id, mission_id, engine, tx, space_mgr,
         )
         .await;
+
+        // Discord gameplay-channel — only on the real active→completed
+        // transition (guarded by `transitioned_from_active`), so retries and
+        // failure-conversions don't post.
+        let character_name = space_mgr
+            .get_entity(entity_id)
+            .and_then(|e| e.character_name.clone())
+            .unwrap_or_else(|| format!("entity:{entity_id}"));
+        cimmeria_discord::emit_mission_completed(character_name, mission_id, None);
     } else {
         tracing::debug!(
             entity_id,

--- a/crates/services/src/cell/content/executor/tests.rs
+++ b/crates/services/src/cell/content/executor/tests.rs
@@ -1330,3 +1330,99 @@ async fn set_npc_ai_state_idle_on_patroller_preserves_patrol_index() {
         "patrol_next_index must persist across SetNpcAiState(Idle) so the AI tick can resume the route",
     );
 }
+
+/// `Action::AcceptMission` happy path: a known mission def with the player
+/// having no prior instance inserts a fresh ACTIVE mission. Also exercises
+/// the accept-side Discord `mission_accepted` seam (no-op without a runtime,
+/// but the name-capture path runs). The complement of the offer-refused
+/// branch — without this, the accepted path had no executor-level coverage.
+#[tokio::test]
+async fn accept_mission_action_inserts_active_instance() {
+    use crate::cell::spawner::{MissionDefEntry, MissionObjectiveDef};
+    use cimmeria_entity::missions::MISSION_ACTIVE;
+
+    let mut mgr = make_space_mgr();
+    mgr.create_entity(1, "Agnos", [0.0; 3], [0.0; 3]).unwrap();
+    if let Some(e) = mgr.get_entity_mut(1) {
+        e.is_player = true;
+        e.player_id = Some(42);
+        // Cached name the accept seam reads when attributing the emit.
+        e.character_name = Some("Teal'c".into());
+    }
+    mgr.connect_entity(1);
+    mgr.mission_defs.insert(
+        700,
+        MissionDefEntry {
+            step_id: 2100,
+            objectives: vec![MissionObjectiveDef {
+                objective_id: 3000,
+                is_hidden: false,
+                is_optional: false,
+            }],
+            is_hidden: false,
+            num_repeats: 0,
+            can_repeat_on_fail: false,
+        },
+    );
+
+    let (tx, _rx) = mpsc::channel(64);
+    let engine = ChainEngine::new();
+    let resolved = ResolvedActions {
+        params: std::collections::HashMap::new(),
+        actions: vec![(9000, Action::AcceptMission { mission_id: 700 })],
+    };
+    execute_actions(resolved, 1, 42, &tx, &mut mgr, &engine).await;
+
+    let m = mgr
+        .get_entity(1)
+        .unwrap()
+        .missions
+        .get_mission(700)
+        .expect("AcceptMission must insert a mission instance");
+    assert_eq!(
+        m.status, MISSION_ACTIVE,
+        "a freshly accepted mission is ACTIVE"
+    );
+}
+
+/// `Action::CompleteMission` happy path: an ACTIVE mission transitions to
+/// COMPLETED. This is the positive complement of
+/// `complete_mission_action_against_failed_mission_does_not_fire_completion_event`
+/// and exercises the complete-side `mission_completed` seam (the
+/// `transitioned_from_active` branch that the failure test deliberately
+/// avoids).
+#[tokio::test]
+async fn complete_mission_action_against_active_mission_marks_completed() {
+    use cimmeria_entity::missions::{MissionInstance, MISSION_ACTIVE, MISSION_COMPLETED};
+
+    let mut mgr = make_space_mgr();
+    mgr.create_entity(1, "Agnos", [0.0; 3], [0.0; 3]).unwrap();
+    if let Some(e) = mgr.get_entity_mut(1) {
+        e.is_player = true;
+        e.player_id = Some(42);
+        e.character_name = Some("Teal'c".into());
+        let m = MissionInstance::new(700, 2100, vec![]);
+        assert_eq!(m.status, MISSION_ACTIVE, "new mission starts ACTIVE");
+        e.missions.add_mission(m);
+    }
+    mgr.connect_entity(1);
+
+    let (tx, _rx) = mpsc::channel(64);
+    let engine = ChainEngine::new();
+    let resolved = ResolvedActions {
+        params: std::collections::HashMap::new(),
+        actions: vec![(9000, Action::CompleteMission { mission_id: 700 })],
+    };
+    execute_actions(resolved, 1, 42, &tx, &mut mgr, &engine).await;
+
+    let m = mgr
+        .get_entity(1)
+        .unwrap()
+        .missions
+        .get_mission(700)
+        .expect("mission instance must still exist after completion");
+    assert_eq!(
+        m.status, MISSION_COMPLETED,
+        "an ACTIVE mission must transition to COMPLETED"
+    );
+}

--- a/crates/services/src/cell/messages/base_to_cell.rs
+++ b/crates/services/src/cell/messages/base_to_cell.rs
@@ -100,6 +100,14 @@ pub enum BaseToCellMsg {
         /// `gm*`/debug methods from non-privileged callers. Authoritative
         /// server-side value — never client-supplied. (#475 / CAT-N-03)
         access_level: u32,
+        /// The selected character's display name, sourced from the base
+        /// `ConnectedClientState.player_name`. Cached on
+        /// `CellEntity::character_name` so cell-side seams (the `.`-console
+        /// GM audit trail, mission/death/respawn notifications) can attribute
+        /// events to a name instead of a bare entity id — the cell otherwise
+        /// has no name for a player. `None` only if the base session somehow
+        /// reached world entry without a cached name.
+        character_name: Option<String>,
     },
 
     /// Update one bandolier slot after a runtime item grant.

--- a/crates/services/src/cell/service/base_messages/mod.rs
+++ b/crates/services/src/cell/service/base_messages/mod.rs
@@ -344,6 +344,16 @@ pub(super) async fn handle_base_message(
             // already exists (created by the prior `ConnectEntity`).
             if let Some(entity) = space_mgr.get_entity_mut(entity_id) {
                 entity.character_name = character_name;
+            } else {
+                // The entity should already exist (ConnectEntity precedes
+                // InitPlayerState). If it doesn't, the name cache silently
+                // fails and every cell-side emit for this player degrades to
+                // `entity:<id>` — surface the ordering bug rather than hiding it.
+                tracing::warn!(
+                    entity_id,
+                    "InitPlayerState: entity absent when caching character_name -- \
+                     ConnectEntity ordering bug; cell-side emits will fall back to entity id"
+                );
             }
             player_init::handle_init_player_state(
                 entity_id,

--- a/crates/services/src/cell/service/base_messages/mod.rs
+++ b/crates/services/src/cell/service/base_messages/mod.rs
@@ -334,7 +334,17 @@ pub(super) async fn handle_base_message(
             system_options,
             state_field,
             access_level,
+            character_name,
         } => {
+            // Cache the display name on the cell entity so cell-side seams (GM
+            // `.`-console audit, mission/death/respawn Discord emits) can
+            // attribute events to a name — the cell has no other source for it.
+            // Set here rather than threaded through `handle_init_player_state`
+            // to keep that function under the argument-count lint; the entity
+            // already exists (created by the prior `ConnectEntity`).
+            if let Some(entity) = space_mgr.get_entity_mut(entity_id) {
+                entity.character_name = character_name;
+            }
             player_init::handle_init_player_state(
                 entity_id,
                 player_id,

--- a/crates/services/src/cell/service/base_messages/tests/general.rs
+++ b/crates/services/src/cell/service/base_messages/tests/general.rs
@@ -1197,3 +1197,57 @@ async fn item_used_drops_event_when_no_player_id() {
         "entity without player_id must drop ItemUsed event silently"
     );
 }
+
+/// `InitPlayerState` threads the base-side player name onto the cell entity
+/// (`CellEntity::character_name`). The cell otherwise has no display name for
+/// a player, and the cell-side Discord seams (GM `.`-console audit trail,
+/// mission/death/respawn emits) attribute events to it. The dispatcher sets
+/// it before delegating to `handle_init_player_state`; dropping that line
+/// would silently regress every cell-side emit to `entity:<id>` and trips
+/// this guard.
+#[tokio::test]
+async fn init_player_state_caches_character_name_on_cell_entity() {
+    let mut mgr = SpaceManager::new(1);
+    let xml = r#"<?xml version="1.0"?><Spaces><Space WorldName="Castle_CellBlock" Instanced="true" MinX="-800" MaxX="800" MinY="-800" MaxY="800" /></Spaces>"#;
+    mgr.parse_spaces_xml(xml).unwrap();
+    mgr.create_startup_spaces(r#"<?xml version="1.0"?><Spaces></Spaces>"#)
+        .unwrap();
+    mgr.create_entity(1, "Castle_CellBlock", [0.0; 3], [0.0; 3])
+        .unwrap();
+    if let Some(e) = mgr.get_entity_mut(1) {
+        e.is_player = true;
+    }
+    mgr.connect_entity(1);
+
+    let (tx, _rx) = mpsc::channel(16);
+    let engine = ChainEngine::new();
+
+    handle_base_message(
+        BaseToCellMsg::InitPlayerState {
+            entity_id: 1,
+            player_id: 100,
+            world_name: "Castle_CellBlock".into(),
+            archetype_id: 1,
+            saved_missions: vec![],
+            abilities: vec![],
+            active_bandolier_slot: 0,
+            bandolier_items: vec![],
+            system_options: cimmeria_entity::cell_entity::SystemOptions::default(),
+            state_field: 0,
+            access_level: 0,
+            character_name: Some("Daniel".into()),
+        },
+        &tx,
+        &mut mgr,
+        &engine,
+        &[],
+    )
+    .await;
+
+    assert_eq!(
+        mgr.get_entity(1).unwrap().character_name.as_deref(),
+        Some("Daniel"),
+        "InitPlayerState must cache the player name on the cell entity so \
+         cell-side seams can attribute events to a name rather than an id",
+    );
+}

--- a/crates/services/src/test_support.rs
+++ b/crates/services/src/test_support.rs
@@ -155,6 +155,7 @@ pub(crate) fn test_default_connected_client_state() -> ConnectedClientState {
         next_seq_unreliable: Arc::new(AtomicU32::new(0)),
         pending_acks: Arc::new(Mutex::new(Vec::new())),
         last_recv: Arc::new(Mutex::new(Instant::now())),
+        connected_at: Instant::now(),
         account_entity_id: 0,
         next_data_id: 0,
         pending_world_entry: None,

--- a/docs/architecture/discord-notifications.md
+++ b/docs/architecture/discord-notifications.md
@@ -146,7 +146,7 @@ Helpers live in [`crates/discord/src/lib.rs`](../../crates/discord/src/lib.rs); 
 
 ## Emit-site coverage
 
-Wiring `emit_*` calls into the server is incremental (issue #527). Current state:
+Wiring `emit_*` calls into the server is incremental. Current state:
 
 | Channel | Live emit sites | Notes |
 |---|---|---|

--- a/docs/architecture/discord-notifications.md
+++ b/docs/architecture/discord-notifications.md
@@ -144,6 +144,57 @@ Helpers live in [`crates/discord/src/lib.rs`](../../crates/discord/src/lib.rs); 
 
 **For existing `warn!`/`error!` sites with structured fields**, do nothing — the tracing layer already harvests them into `Event::TracingEvent` automatically. The [negative-logging convention](negative-logging-convention.md) (`reason=`, `entity_id=`, `rows_affected=`, etc.) is what gives those tracing events their structure; the embed builder reads the fields into the embed's `fields` array.
 
+## Emit-site coverage
+
+Wiring `emit_*` calls into the server is incremental (issue #527). Current state:
+
+| Channel | Live emit sites | Notes |
+|---|---|---|
+| `lifecycle` | `ServerStartup`, `ServerShutdown`, `ServerPanic` | from `server/src/main.rs` |
+| `auth` | `PlayerLogin`, `PlayerLogout`, `PlayerDisconnect`, `PlayerAuthFailed` | login/logoff/teardown in `base/`; auth-fail in `auth/handlers.rs` |
+| `world` | `PlayerWorldEntry`, `PlayerWorldExit` | entry in `play_character.rs`; exit on gate travel |
+| `gameplay` | `PlayerLevelUp`, `ItemUsed`, `MissionAccepted`, `MissionCompleted`, `MissionFailed`, `PlayerDeath`, `PlayerRespawn` | level-up/item-used base-layer; mission/death/respawn cell-side (see name cache below) |
+| `errors` | `Warning`/`Error` (harvest), `WireFormatError`, `DbError`, `MercuryTimeout` | decode/db/peer-silence seams in `base/` + `auth/` |
+| `gm` | `GmCommand` | `.`-console dispatch in `cell/console/mod.rs` |
+| `ops` | — | **deferred**: needs measurement infra |
+
+**`player_disconnect` is the single choke point.** Every teardown path
+(`logoff`, `inactivity_timeout`, `send_error`, `duplicate_login`,
+`client_disconnect`) funnels through `base::helpers::destroy_client_entities`,
+which maps the stable label to a typed [`DisconnectReason`] via
+`DisconnectReason::from_label`. A clean logoff fires *both* `PlayerLogout`
+(gameplay-level) and `PlayerDisconnect { reason: Clean }` (connection-level) —
+by design.
+
+**Cell-side name cache.** The cell service has no character/GM display name of
+its own — names live in the base `ConnectedClientState`. `GmCommand` and the
+cell-side gameplay events (`MissionAccepted/Completed/Failed`, `PlayerDeath`,
+`PlayerRespawn`) read `CellEntity::character_name`, which is threaded in from the
+base via `BaseToCellMsg::InitPlayerState` at world entry. Emits fall back to
+`entity:<id>` if the name isn't cached yet. (Mission embeds carry no mission
+*name* — `MissionDefEntry` has none cell-side — only the id.)
+
+### Deferred seams and why
+
+- **`LootGenerated`**: loot is rolled onto an NPC corpse at death
+  (`cell/abilities/loot_drop.rs`); the *looter* isn't known until someone takes
+  it, so there's no single character to attribute the generation to. Needs a
+  decision on whether to attribute to the killer or the looter before wiring.
+- **`GmTeleport` / `GmSpawn` / `GmItemGrant`**: the GM teleport/spawn/give command
+  *execution* is still TODO in `game/src/commands/gm_cmds.rs` — there's no
+  resolved position/template/quantity to put in the typed embed yet.
+- **`MissionRewardGranted`**: reward dispatch isn't implemented cell-side (no
+  reward catalog; see `cell/console/mission.rs`).
+- **`AssertionFailure`**: no explicit assertion-failure log site exists today;
+  invariant violations surface as generic `error!` and are caught by the
+  `errors` harvest.
+- **`ops` channel** (`HighLatency`, `PacketLossSpike`, `MemoryWarning`,
+  `TickStall`, `AoiBurstWarning`, `OutboxLag`): each needs a measurement +
+  threshold loop (RSS sampling, tick-duration timing, RTT thresholding) that
+  doesn't exist yet. Tracked separately.
+
+[`DisconnectReason`]: ../../crates/discord/src/event.rs
+
 ## Operations
 
 - **Stats**: `SenderStats { enqueued, sent, filtered, dropped_full, dropped_closed, dropped_rate_limit, retried, rate_limited_429, failed }`. Available via `cimmeria_discord::global().unwrap().stats()`.


### PR DESCRIPTION
Closes #527 (the feasible portion — deferrals documented below).

The `cimmeria-discord` crate was fully built but almost none of its `emit_*` helpers were actually called — only `lifecycle` + the generic `warn!`/`error!` harvest produced live output. This wires the seams where the required data is in scope.

## Foundation
- Add `cimmeria-discord` as a dependency of `cimmeria-services` (cycle-free; the crate's global-singleton `emit_*` API needs no handle threading).
- New typed helpers: `item_used`, `wire_format_error`, `db_error`, `mercury_timeout`, `mission_failed`, `player_death`, `player_respawn`.
- `DisconnectReason::from_label` maps the stable teardown labels to typed reasons (unit-tested).
- `ConnectedClientState.connected_at` for accurate `session_secs`.
- **`CellEntity.character_name`**, threaded from the base `ConnectedClientState` through `BaseToCellMsg::InitPlayerState` — the cell otherwise has no display name, which is what unblocks the GM + cell-side gameplay emits.

## Live emit sites (17 across 6 channels)
| Channel | Events |
|---|---|
| auth | `player_login`, `player_logout`, `player_disconnect` (single teardown choke point, typed reason), `player_auth_failed` |
| world | `player_world_entry`, `player_world_exit` (gate travel) |
| gameplay | `player_level_up`, `item_used` *(base)*; `mission_accepted`, `mission_completed`, `mission_failed`, `player_death`, `player_respawn` *(cell, via name cache)* |
| gm | `gm_command` — `.`-console audit trail |
| errors | `db_error`, `wire_format_error`, `mercury_timeout` |

`player_death` gates on `target_is_player`; `mission_completed` only on the real active→completed transition; cell-side emits fall back to `entity:<id>` if the name isn't cached yet.

## Deferred (documented in `discord-notifications.md`)
- `loot_generated` — loot is rolled onto an NPC corpse at death; the looter isn't known until pickup (needs a killer-vs-looter decision).
- `gm_teleport` / `gm_spawn` / `gm_item_grant` — command execution is still TODO in `gm_cmds.rs`.
- `mission_reward_granted` — reward dispatch unimplemented cell-side.
- `assertion_failure` — no soft-assert concept exists yet; would be a focused follow-up (panic-hook reclassification + a `soft_assert!` macro).
- `ops` channel (all 6) — needs new measurement/threshold loops.

## Testing
- Helper-routing test extended to **20 helpers**, rebased onto the `enqueued` stat so the count is immune to the gameplay channel's 5-msg burst cap (it now has 7 helper types).
- New `DisconnectReason::from_label` mapping test.
- `cargo nextest run`: **1845 passed, 1 skipped**. `clippy -D warnings`, `cargo fmt --check`, `cargo check` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated Discord event notifications for player activities: login, logout, disconnect events, character death, respawn, and item usage
  * Added real-time server activity logging to Discord channels for improved monitoring and administration
  * Enhanced game event tracking for better server visibility and player activity oversight

<!-- end of auto-generated comment: release notes by coderabbit.ai -->