### PR TITLE
docs: clarify bandolier item_id PK wording

### DIFF
--- a/crates/entity/src/cell_entity/mod.rs
+++ b/crates/entity/src/cell_entity/mod.rs
@@ -814,11 +814,10 @@ pub struct LootItem {
 pub struct BandolierItem {
     /// The `sgw_inventory.item_id` value — the per-row *instance* id of the
     /// physical item row backing this slot. It's a server-allocated surrogate
-    /// (sequence default, never reused), unique per slot via the
-    /// `sgw_inventory_unique_slot` index — unique by construction rather than
-    /// by a declared PK/UNIQUE constraint. This is the TOCTOU guard for
-    /// ammo persistence: it flows into `BandolierAmmoUpdate.expected_instance_id`
-    /// and the WHERE clause of `update_bandolier_ammo`. Two physical items of
+    /// (sequence default, never reused), and it is stored as `sgw_inventory_pkey`
+    /// on `sgw_inventory`. This PK is the TOCTOU guard for ammo persistence:
+    /// it flows into `BandolierAmmoUpdate.expected_instance_id` and the WHERE
+    /// clause of `update_bandolier_ammo`. Two physical items of
     /// the same weapon *design* share `item_id` (the design id below) but have
     /// distinct `instance_id`, so keying the persist guard on this — not the
     /// design id — is what closes the same-type-swap dupe window.

--- a/crates/services/src/base/world_entry/methods/inventory/ammo.rs
+++ b/crates/services/src/base/world_entry/methods/inventory/ammo.rs
@@ -11,10 +11,10 @@ use sqlx::PgPool;
 /// `expected_instance_id` is added to the WHERE clause as a TOCTOU guard.
 /// Between the cell sending `BandolierAmmoUpdate` and this UPDATE running, the
 /// player could have swapped the slot's weapon. The predicate keys on the
-/// `sgw_inventory.item_id` per-row instance id (a server-allocated surrogate,
-/// unique per slot via `sgw_inventory_unique_slot`), so it fires even
-/// when the swapped-in weapon shares the same *design* (`type_id`) as the one
-/// the ammo writeback was computed for. Keying on `type_id` instead — as an
+/// `sgw_inventory.item_id` per-row instance id (the declared
+/// `sgw_inventory_pkey`), so it fires even when the swapped-in weapon shares
+/// the same *design* (`type_id`) as the one the ammo writeback was computed
+/// for. Keying on `type_id` instead — as an
 /// earlier version did — left a same-type-swap window: two physical instances
 /// of the same weapon design passed the predicate and could scribble each
 /// other's ammo (a dupe vector). A zero-row result here means the slot is


### PR DESCRIPTION
## Summary
- Corrected two doc comments that described `sgw_inventory.item_id` as only unique by construction in bandolier persistence logic.
- Updated `crates/entity/src/cell_entity/mod.rs` and `crates/services/src/base/world_entry/methods/inventory/ammo.rs` to explicitly reference the declared PK (`sgw_inventory_pkey`) while preserving the same TOCTOU intent.

## Related issue
- Closes #533

## Test plan
- `cargo fmt --all -- --check`
- `cargo check -p cimmeria-services` (fails in this environment: missing `external/recast/Detour` files required by the `cimmeria-entity` native build step).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified internal documentation regarding ammo inventory persistence and item identification mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->