### PR TITLE
docs(434): RE findings + ADR for encryption modernization

### DIFF
--- a/docs/architecture/encryption-modernization.md
+++ b/docs/architecture/encryption-modernization.md
@@ -1,0 +1,169 @@
+# Encryption modernization — auth TLS, password hashing, Mercury v2
+
+**Status:** Proposed
+**Confidence:** RE targets High (binary-validated); client-patch engineering Medium (per-hook runtime confirmation pending)
+**Issue:** [#434](https://github.com/SandboxServers/Cimmeria/issues/434) (encryption modernization, as rewritten)
+
+This ADR records the design that consumes the binary-validated targets in
+[../reverse-engineering/findings/auth-and-crypto-modernization-targets.md](../reverse-engineering/findings/auth-and-crypto-modernization-targets.md).
+Read that finding first — every address and hook point cited here is sourced
+there.
+
+## Context
+
+Cimmeria's current cryptographic posture inherits three weaknesses from the 2009
+Stargate Worlds stack, each of which a modern emulator should not ship with:
+
+1. **Plain-HTTP SOAP login.** The auth login is a SOAP POST over **plain HTTP**
+   via statically-linked libcurl 7.17.0. Credentials cross the network
+   unencrypted. (gSOAP is XML-serialization only — it does not own the socket;
+   any prior note implying a gSOAP TCP hook is wrong. See finding §1.)
+2. **Unsalted SHA-1 passwords.** The client hashes the password inline with
+   SHA-1 (uppercase hex, no salt) before sending it. SHA-1 of an unsalted
+   password is trivially rainbow-table-able and offers no server-side defense.
+   (Finding §3.)
+3. **Zero-IV AES-256-CBC + HMAC-MD5, shared-key Mercury.** Packet encryption
+   reuses a single 16-byte **zero IV** for every packet, derives no keys (the
+   session key is the AES key *and* the HMAC key verbatim), MACs with **HMAC-MD5**,
+   and verifies in non-constant time. (Finding §5.) The zero-IV reuse is the
+   most serious flaw: identical plaintext blocks produce identical ciphertext,
+   leaking structure.
+
+**The hard constraint:** the 2009 client is the only client. There is no source,
+and its bundled OpenSSL is **0.9.8g (2007)** — too old to speak modern TLS. Every
+client-side change must therefore be a **binary patch via injection + hooking**.
+
+- **Non-goal:** vanilla-client compatibility. We are explicitly patching the
+  client; an unpatched client is not a supported configuration for the modernized
+  crypto paths.
+- **Enabling fact:** the binary has **no anti-debug and no anti-tamper** (finding
+  §4) — injection and inline/IAT/vtable hooking are all safe with no
+  neutralization step.
+
+## Decision
+
+A four-phase rollout, plus one deliberate non-change.
+
+### Phase 0 — shared hook foundation
+
+Build a **shared inline / IAT / vtable hooking crate** as the foundation for all
+client patching.
+
+*Rationale:* the existing `cimmeria-client-telemetry` cdylib already has the
+injection vehicle (it loads into the client) but **no general hook layer** —
+nothing to place an inline detour, swap an IAT slot, or replace a vtable entry.
+Phases 1–3 all need that layer, so it is built once, first.
+
+### Phase 1 — auth TLS
+
+- **Server side:** terminate TLS with **tokio-rustls**, with **arc-swap**-based
+  hot certificate reload (rotate the cert without dropping the listener).
+- **Client side:** hook `curl_easy_setopt` (`0x013A96E0`), intercept
+  `CURLOPT_URL` (`0x2712`), and rewrite the URL to a **localhost loopback**. A
+  **local rustls proxy inside the injected shim** then re-originates the request
+  as modern TLS upstream.
+
+*Rationale (the key non-obvious decision):* login is **libcurl**, and curl's
+bundled **OpenSSL 0.9.8g** cannot complete a modern TLS handshake. So we do
+**not** try to make curl speak TLS. curl talks plain HTTP to `127.0.0.1`; the
+shim's rustls proxy does the real TLS. This sidesteps the dead OpenSSL entirely.
+
+### Phase 2 — argon2id password hashing
+
+- **Schema:** a **dual-column** scheme (legacy SHA-1 column retained alongside a
+  new argon2id column), edited directly in the `db/sgw/` schema and the
+  `db/resources/` seed — **not** in `db/scripts/` (per project convention: never
+  hand-write migration scripts; edit the seed).
+- **Migration:** **opportunistic, on-login.** When a user authenticates and only
+  the legacy hash exists, verify against it, then compute and store the argon2id
+  hash transparently. No mass re-hash, no forced reset.
+- **Client side:** patch the `LoginReplyHandler` ctor (`0x00DDED60`) to send the
+  **plaintext** password (read from `ServerConnection + 0x3C`) over the
+  now-TLS-protected channel, in place of the client SHA-1 hash. The server does
+  the modern hashing.
+
+*Rationale:* sending plaintext is only acceptable **because Phase 1 wrapped the
+transport in TLS**. Server-side argon2id is the actual defense; the client can no
+longer dictate the hash. Dual-column + opportunistic migration avoids a flag day.
+
+### Phase 3 — Mercury v2 packet crypto
+
+- **Wire format:** version-byte-gated
+  `[ version ][ IV ][ ciphertext ][ HMAC ]`, with a **random per-packet IV**,
+  **HKDF-SHA256** splitting separate encryption and MAC keys from the session
+  key, and **HMAC-SHA256** (truncated to 16 bytes) over `IV || ciphertext`.
+- **Client side:** patch at **`Mercury::Channel::send` (`0x01576F90`)** via a
+  vtable hook on the heap channel object — **not** the CryptoPP `filterOut` /
+  `filterIn` functions.
+
+*Rationale:* the CryptoPP filter objects are stack-allocated and rebuilt per call
+behind an SEH frame, which makes a stable inline patch on the filters fragile.
+Hooking one layer up at `Channel::send` gives a clean, heap-resident vtable
+target. The version byte lets v1 and v2 coexist during transition.
+
+### Non-change — leave the session-key handshake as-is
+
+The Mercury session key continues to be exchanged as it is today.
+
+*Rationale:* once Phase 1 is in place, the handshake rides inside **HTTPS**, so
+the key is not exposed in transit. Combined with the Phase 3 **per-packet random
+IV** and periodic **key rotation** (which gives forward secrecy across rotation
+boundaries), a bespoke key-agreement step adds complexity without closing a real
+gap.
+
+## Alternatives considered
+
+| Alternative | Rejected because |
+|---|---|
+| **gSOAP TCP hook for login interception** | Login transport is **libcurl, not gSOAP**. gSOAP only serializes XML; it never owns the socket (finding §1). The hook would never fire on the real I/O path. |
+| **Reuse curl's bundled OpenSSL 0.9.8g for TLS** | OpenSSL 0.9.8g (2007) predates TLS 1.2 and SNI and cannot handshake with a modern endpoint. This is exactly why Phase 1 uses a loopback + rustls proxy instead. |
+| **Inline-patch the `PacketEncrypter` filters directly** | The CryptoPP filters are stack-allocated, rebuilt per call, and wrapped in an SEH frame — an inline detour there is fragile. The `Channel::send` vtable hook is stable. |
+| **Diffie-Hellman key agreement on `baseAppLogin`** | Redundant. HTTPS already protects the session-key exchange, the per-packet random IV removes the zero-IV reuse problem, and rotation provides forward secrecy. DH adds a handshake round-trip and code surface for no additional protection given the rest of the design. |
+
+## Consequences
+
+- **Transition windows.** Two overlapping dual-stack windows exist:
+  - **Auth:** the server accepts **both plain HTTP and HTTPS** until all patched
+    clients are confirmed on TLS, then HTTP is retired.
+  - **Mercury:** the server speaks **both v1 and v2** (selected by the version
+    byte) until v1 is retired.
+- **v1 → v2 downgrade-gating risk.** While both Mercury versions are live, an
+  attacker (or a stale client) could force a downgrade to v1's weaker scheme. The
+  version gate must be **monotonic per session** — once a session negotiates v2
+  it must refuse v1 frames — and v1 acceptance must be **removed on a schedule**,
+  not left open indefinitely.
+- **AV / injection considerations.** DLL injection into a game client is a
+  pattern antivirus heuristics flag. Expect to document the shim, possibly sign
+  it, and account for EDR false positives in the launcher/runbook. (The client
+  itself has no anti-tamper to fight — the concern is host AV, not the binary.)
+- **Cert-pin rotation.** If the client shim pins the server certificate, rotation
+  must be coordinated: the **arc-swap** server reload and the shim's pin set have
+  to move together, or a rotated cert locks out patched clients. Plan a pin
+  rollover window (accept old + new pin) mirroring the transport dual-stack
+  windows above.
+- **Schema.** Dual-column auth lands in `db/sgw/` + the `db/resources/` seed; the
+  legacy SHA-1 column is retained until opportunistic migration has covered the
+  active player base, then it can be dropped.
+
+## Confidence Level
+
+- **RE targets: HIGH.** Every address, call chain, CURLOPT code, struct offset,
+  and crypto-scheme detail is binary-validated against `SGW.exe` (image base
+  `0x00400000`, ASLR disabled). The v1 Mercury scheme is a byte-exact match with
+  `crates/mercury/src/encryption.rs`.
+- **Client-patch engineering: MEDIUM.** Each hook (curl URL rewrite, password
+  swap, `Channel::send` vtable replacement) is *located* with high confidence but
+  not yet *built and runtime-confirmed*. Confidence promotes to HIGH per hook as
+  the x64dbg confirmations in finding §6 are executed and the shim is exercised
+  against a live client. The second `logOnBegin` variant (no separate SHA-1 path)
+  is an explicit open verification item for Phase 2.
+
+## See also
+
+- [../reverse-engineering/findings/auth-and-crypto-modernization-targets.md](../reverse-engineering/findings/auth-and-crypto-modernization-targets.md)
+  — the binary-validated targets and exact addresses this design consumes.
+- [../reverse-engineering/findings/mercury-protocol-internals.md](../reverse-engineering/findings/mercury-protocol-internals.md)
+  — `Mercury::Channel::send` context (the Phase 3 hook point).
+- [`crates/mercury/src/encryption.rs`](../../crates/mercury/src/encryption.rs)
+  — the current (v1-equivalent) server encryption implementation.
+- Issue **#434**.

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -216,6 +216,7 @@ How the Cimmeria emulator itself is structured. 25 documents.
 | [mercury-bundle.md](architecture/mercury-bundle.md) | `ChannelBundle` accumulator: cross-entity bundling rule, transaction-state hazard, AoI burst migration (#356), follow-up migration playbook | Complete |
 | [negative-logging-convention.md](architecture/negative-logging-convention.md) | Negative-logging convention (issue #304): three patterns, field-naming rules, level discipline, defensible silent sends, `LogCapture` regression-guard helper | Complete |
 | [instrumentation-discipline.md](architecture/instrumentation-discipline.md) | Instrumentation discipline (issue #482): success-side rules — dispatch-entrypoint info spans, debug-event discriminators, hot-loop span discipline, metric-label cardinality | Complete |
+| [encryption-modernization.md](architecture/encryption-modernization.md) | ADR (Proposed) for issue #434: auth TLS (rustls loopback proxy around libcurl), argon2id passwords, Mercury v2 wire crypto (HKDF/random-IV/HMAC-SHA256, version-gated). RE targets in [findings/auth-and-crypto-modernization-targets.md](reverse-engineering/findings/auth-and-crypto-modernization-targets.md) | Proposed |
 
 See also: [building.md](building.md), [connection-flow.md](connection-flow.md), [../TESTING.md](../TESTING.md)
 

--- a/docs/reverse-engineering/README.md
+++ b/docs/reverse-engineering/README.md
@@ -52,6 +52,12 @@ The end-to-end "from `git clone` to MCPs reachable" walkthrough lives one level 
 
 [`findings/`](findings/) holds the per-system findings docs that earlier phases produced. As of 2026-05-12, 19 docs cover combat, inventory, missions, organizations, crafting, gate travel, minigames, chat, mail, black market, contact list, group, trade, duel, pet, entity types, entity creation, position/movement, space/viewport, system protocol, and the CME EventSignal pipeline. All rated HIGH confidence at time of writing — but per [`evidence-standards.md`](evidence-standards.md) and the [`reverse-engineering-with-claude.md`](../guides/reverse-engineering-with-claude.md) "verify load-bearing claims" rule, pre-V5 docs are hypotheses; re-verify before pinning a claim into a bible chapter or production Rust.
 
+Beyond the V5 evidence pool, [`findings/`](findings/) also carries issue-scoped
+de-risking findings — e.g. [`auth-and-crypto-modernization-targets.md`](findings/auth-and-crypto-modernization-targets.md)
+(issue #434), which maps the client's login transport, SHA-1 password site,
+anti-debug posture, and Mercury crypto to exact `SGW.exe` addresses for the
+encryption-modernization patch work.
+
 See [`findings/README.md`](findings/README.md) for the full per-doc index.
 
 ## Bible relationship

--- a/docs/reverse-engineering/findings/README.md
+++ b/docs/reverse-engineering/findings/README.md
@@ -38,6 +38,7 @@ This directory contains per-system reverse engineering findings with evidence.
 | `mercury-nub-anatomy.md` | V5 | Mercury `Nub` / `BaseNub` / `ChannelInternal` / `Connection` class layouts (22 functions, 4 struct anatomies); two-channel-map design; network thread loop; `Nub::send` 4-phase pipeline; rdtsc inactivity vs our `MAX_RETRIES`; two latent wire gaps (REPLY piggyback XOR-inverted length, ACK batching per 10ms tick) | HIGH |
 | `dialog-portrait-lookup.md` | V5 | Dialog portrait + speaker-name lookup — wire EntityId path (not DatabaseId) through LookupEntityListenerEntry → slot 17 → UnitMappingChanged → createCharacterPortrait; CookedData SpeakerID PAK parse at piVar2[7]; empty-name fallback to player name; Prisoner 329 + Col Marsh root-cause diagnoses | HIGH |
 | `client-wire-emit-suppression.md` | V5 | Client-side gates suppressing wire emit — Heal Focus arg-validation drop at `0x00aa2910`; P90 bandolier-swap Lua `getActiveSlotForContainer` no-op gate; in-flight ability queue at `GameEntityManager+0x228`; proposed server-side mitigations (resend `onActiveSlotUpdate` post-`onClientReady`, ensure `AbilityCooldownUpdate` drains the in-flight queue) | HIGH (binary anatomy) / MEDIUM (proposed mitigations need playtest) |
+| `auth-and-crypto-modernization-targets.md` | #434 | Auth login transport (libcurl), client SHA-1 site, anti-debug status, Mercury crypto v2 targets | HIGH |
 
 ## Finding Format
 

--- a/docs/reverse-engineering/findings/auth-and-crypto-modernization-targets.md
+++ b/docs/reverse-engineering/findings/auth-and-crypto-modernization-targets.md
@@ -1,0 +1,242 @@
+# Auth & Crypto Modernization Targets — Client Binary Analysis
+
+> **Last updated**: 2026-06-19
+> **Source**: SGW.exe Ghidra decompilation (image base `0x00400000`, ASLR disabled)
+> **Confidence**: HIGH for binary anatomy
+
+---
+
+This finding de-risks issue **#434** (encryption modernization). It maps the four
+client-side surfaces the rewrite must touch — login transport, the client-side
+SHA-1 password site, the anti-debug/anti-tamper posture, and the Mercury packet
+crypto — to exact addresses in `SGW.exe`, and records where a patch hook should
+land for each. The design that consumes these targets is the ADR at
+[../../architecture/encryption-modernization.md](../../architecture/encryption-modernization.md).
+
+All addresses are static (`SGW.exe` loads at its preferred base `0x00400000`;
+ASLR is disabled), so they double as live breakpoint addresses in x64dbg.
+
+---
+
+## 1. Login transport — libcurl, not gSOAP
+
+The SOAP auth login uses statically-linked **libcurl 7.17.0** for HTTP transport.
+gSOAP 2.7 is present, but **only as an XML serialization layer** — it never owns
+the socket. The gSOAP `tcp_connect` / `fsend` / `frecv` symbols appear in the
+binary solely as dead diagnostic strings, not as called functions.
+
+> **This corrects the prior assumption** (and any earlier RE note implying gSOAP
+> owns the TCP login socket) that login could be intercepted at the gSOAP layer.
+> It cannot — gSOAP hands a serialized XML body to libcurl, and libcurl does all
+> socket I/O.
+
+### Call chain
+
+```text
+logOnBegin                          0x00DDF580
+  → LoginReplyHandler ctor          0x00DDED60
+      curl_easy_init      @ thunk   0x013A96A0
+      curl_multi_init     @ thunk   0x013A7970
+      curl_easy_setopt    @ thunk   0x013A96E0   (×9 calls)
+      curl_multi_add_handle @ thunk 0x013A9040
+  → BW_servconn pump                0x00DE10B0
+      curl_multi_perform  @ thunk   0x013A9210   (actual socket I/O, do/while loop)
+```
+
+`curl_multi_perform` at `0x013A9210` is where the socket actually drains, inside
+a `do { … } while` pump loop in `BW_servconn`. libcurl is **statically linked** —
+there is no DLL import (no curl IAT entries); the `0x013A9xxx` addresses are
+internal call thunks, not import stubs.
+
+### CURLOPT codes observed at the `curl_easy_setopt` site
+
+| CURLOPT | Code | Meaning |
+|---|---|---|
+| `CURLOPT_URL` | `0x2712` | request URL |
+| `CURLOPT_POSTFIELDS` | `0x271F` | POST body (the serialized SOAP XML) |
+| `CURLOPT_HTTPHEADER` | `0x2751` | header list |
+| `CURLOPT_POST` | `0x4E` | POST method flag |
+| `CURLOPT_WRITEFUNCTION` | `0x4E2B` | response-body callback |
+| `CURLOPT_TIMEOUT` | `0x0D` | request timeout |
+
+### Endpoint URL
+
+A hardcoded fallback URL string `"http://www.stargateworlds.com/xml/sgwlogin"`
+lives at `0x019CEB8C`. Note the scheme: **plain HTTP**. The live endpoint URL is
+*not* this constant in practice — it arrives at runtime via `logOnBegin`'s
+server-address parameter; the constant is the baked-in fallback.
+
+---
+
+## 2. TLS injection target (issue #434 Phase 1)
+
+**Recommended hook:** an inline detour at `curl_easy_setopt` (`0x013A96E0`).
+Intercept the `CURLOPT_URL` set (option code `0x2712`) and rewrite the URL's
+scheme/host before curl ever uses it.
+
+**The wrinkle that drives the whole Phase 1 design:** the client's bundled
+OpenSSL is **0.9.8g (2007)**. It predates TLS 1.2 and SNI and cannot complete a
+handshake against any modern HTTPS endpoint. Reusing curl's own SSL stack is
+therefore a dead end.
+
+So the recommended approach is **not** to make curl speak TLS. Instead:
+
+1. The injected shim rewrites the URL to a **localhost loopback** (curl talks
+   plain HTTP to `127.0.0.1`).
+2. A **modern rustls proxy inside the injected shim** terminates that plain HTTP
+   and re-originates the request as proper TLS 1.3 upstream.
+
+curl never sees TLS; its ancient OpenSSL is bypassed entirely.
+
+**Debugger confirmation:** `bp 0x013A96E0`, watch `arg2 == 0x2712` → confirm the
+URL argument is `http://…` (proving the scheme is rewritable here and the
+transport is unencrypted at this seam).
+
+---
+
+## 3. Client SHA-1 password site (Phase 2)
+
+The password is hashed **inline in `logOnBegin`** before it goes on the wire:
+
+- SHA-1 constructor `FUN_0040D270` @ `0x0040D270`.
+- CryptoPP `HexEncoder`, **uppercase**, `GroupSize = 0` → a 40-char hex string.
+- Result is stored at `ServerConnection + 0x130`.
+- **The plaintext password is stored at `ServerConnection + 0x3C`** (a
+  `std::string`) *before* hashing. Input is ASCII.
+
+**Cleanest Phase 2 patch:** hook the `LoginReplyHandler` ctor @ `0x00DDED60` and
+swap `c_str(this + 0x3C)` (the plaintext) in for the hashed-password argument, so
+the plaintext travels over the now-TLS-protected channel and the server does the
+modern hashing. (This is only safe *because* Phase 1 has wrapped the transport in
+TLS — never send plaintext over the legacy plain-HTTP path.)
+
+> **Loose end to verify in x64dbg:** a *second* `logOnBegin` variant references
+> the same debug string near `0x019CF248`. Confirm it has **no separate SHA-1
+> path** before declaring the swap complete — otherwise one login route would
+> still emit a hashed password.
+
+---
+
+## 4. Anti-debug / anti-tamper — CLEAN
+
+There is **no anti-debug and no anti-tamper** in this binary. Every API that
+*could* be used for detection is present in the IAT but has **zero code xrefs**
+(dead imports):
+
+| Import | IAT address | xrefs |
+|---|---|---|
+| `IsDebuggerPresent` | `0x01D6B052` | 0 |
+| `OutputDebugStringA` / `OutputDebugStringW` | — | 0 |
+| `GetTickCount` | — | 0 |
+| `QueryPerformanceCounter` | — | 0 |
+| `ContinueDebugEvent` | — | 0 |
+
+Additionally:
+
+- **No PEB `fs:[30h]` `BeingDebugged` probes** (0 hits).
+- **No `NtGlobalFlag` checks, no DR-register (hardware breakpoint) checks.**
+- **No INT3 / `0xCC` scanning loop.** The `0xCC` clusters in `.text` are MSVC
+  inter-function padding, not a self-scan.
+- **No TLS callbacks.** The `"TLS Directory"` string at `0x01B1C39C` belongs to
+  UE3's own PE inspector, not to a TLS callback table.
+- **No `.text` CRC / `MapFileAndCheckSum` self-integrity check.**
+- Binary is **not packed**; ASLR is disabled (loads at `0x00400000`).
+- The `Debugger.ini` / `UnDebuggerCore` strings are UnrealScript's *script*
+  debugger, not a native anti-debug.
+
+> **Verdict:** DLL injection (`CreateRemoteThread` or search-order hijack) plus
+> inline / IAT / vtable hooking are **all safe**. There is nothing to neutralize
+> before patching.
+
+---
+
+## 5. Mercury crypto internals (Phase 3) — v1 == our server, byte-exact
+
+The client's Mercury packet crypto is implemented by a CryptoPP `PacketEncrypter`:
+
+| Component | Address |
+|---|---|
+| `PacketEncrypter` ctor | `0x01603A70` |
+| `PacketEncrypter` vtable | `0x01B27374` |
+| `filterOut` / encrypt | `0x01603B80` |
+| `filterIn` / decrypt | `0x01603FA0` |
+
+### Confirmed v1 scheme
+
+- **Cipher:** AES-256-CBC (Rijndael Enc vtable `0x0040E030` / Dec vtable
+  `0x01604EA0`), CBC mode (`0x0040D000` / `0x0040D0B0`).
+- **Padding:** PKCS7 (`PKCS_PADDING = 4`).
+- **MAC:** HMAC-MD5 (`CryptoPP::HMAC<Weak1::MD5>` vtable `0x01604D00`), computed
+  **over ciphertext only** — encrypt-then-MAC (the `HashFilter` at `0x00414720`
+  sits downstream of the `StreamTransformationFilter`). Tag is **16 bytes**.
+- **Key reuse:** HMAC key **== AES key** (the same 32 bytes).
+- **IV:** a **16-byte zero IV**, stored once in the ctor at `this + 0x18` and
+  **reused** for every packet.
+- **No KDF:** the session key is copied **verbatim** into `this + 0x8`.
+- **Decrypt path:** `filterIn` uses a `HashVerificationFilter` (`0x00409440`),
+  **verify-then-decrypt**, and the comparison is **NOT constant-time**
+  (memcmp-style).
+
+### Wire layout (v1)
+
+```text
+[ AES-256-CBC ciphertext, PKCS7 padded ][ 16-byte HMAC-MD5 tag ]
+```
+
+No IV, no version byte, no length, no sequence number inside the encrypted unit —
+Mercury's outer layer frames all of that.
+
+> This is a **byte-exact match** with our Rust server at
+> [`crates/mercury/src/encryption.rs`](../../crates/mercury/src/encryption.rs).
+> The Rust side is in fact *more* secure: it verifies the tag in constant time
+> via the `subtle` crate, where the client uses a `memcmp`-style compare.
+
+### Why the v2 hook lands one layer up
+
+The CryptoPP filter objects are **stack-allocated and rebuilt per call** behind
+an **SEH frame**, so inline-patching `filterOut` / `filterIn` directly is
+fragile (the stack layout and SEH unwinding make a stable detour hard to place).
+
+**Recommended v2 hook:** `Mercury::Channel::send` @ `0x01576F90` — a vtable hook
+on the heap-allocated channel object, one layer above the per-call filter
+construction. This is the same `Channel::send` documented in
+[mercury-protocol-internals.md](mercury-protocol-internals.md).
+
+### Proposed v2 layout
+
+```text
+[ 0x02 version ][ 16-byte random IV ][ ciphertext ][ 16-byte truncated HMAC-SHA256 over IV||ciphertext ]
+```
+
+with **HKDF-SHA256** splitting separate encryption and MAC keys from the session
+key.
+
+---
+
+## 6. Suggested debugger confirmations (x64dbg)
+
+| Breakpoint | Address | What it proves |
+|---|---|---|
+| curl URL is `http://` | `0x013A96E0` | login transport is unencrypted and rewritable at `curl_easy_setopt` (watch `arg2 == 0x2712`) |
+| plaintext password present | `0x00DDED60` | dump `[ServerConnection + 0x3C]` → plaintext is available at the `LoginReplyHandler` ctor for the swap |
+| no 2nd SHA-1 path | 2nd `logOnBegin` (string near `0x019CF248`) | the second login variant does not separately hash |
+| right v2 layer | `0x01576F90` | `Channel::send` pre-encryption buffer is the correct hook point for the v2 framing |
+
+---
+
+## Implementation impact
+
+- **Phase 1 (auth TLS):** hook `curl_easy_setopt` (`0x013A96E0`), rewrite
+  `CURLOPT_URL` to loopback, run a rustls proxy in the shim. Do **not** reuse
+  curl's OpenSSL 0.9.8g.
+- **Phase 2 (password):** hook `LoginReplyHandler` ctor (`0x00DDED60`), swap the
+  plaintext at `ServerConnection + 0x3C` for the hashed argument — only valid
+  once Phase 1 TLS is in place. Verify the second `logOnBegin` variant.
+- **Phase 3 (Mercury v2):** vtable-hook `Mercury::Channel::send` (`0x01576F90`),
+  not the CryptoPP filters; emit the version-byte-gated `[version][IV][ciphertext][HMAC]`
+  layout with HKDF-split keys and a per-packet random IV.
+- **Anti-tamper:** none — no neutralization step required before any of the above.
+
+See the ADR at
+[../../architecture/encryption-modernization.md](../../architecture/encryption-modernization.md)
+for the full design rationale, alternatives considered, and the transition plan.


### PR DESCRIPTION
Documentation groundwork for #434, produced from a Ghidra RE pass that resolved every client-side unknown. No code — docs only. The issue itself has been rewritten to match.

## What's here
- **`docs/reverse-engineering/findings/auth-and-crypto-modernization-targets.md`** — binary-validated targets (SGW.exe @ `0x00400000`):
  - **Login transport is libcurl 7.17.0, not gSOAP** — corrects the prior assumption; the gSOAP `tcp_connect/fsend/frecv` hook plan would intercept nothing. Hook target: `curl_easy_setopt @ 0x013A96E0`.
  - **Client OpenSSL is 0.9.8g** (too old for modern TLS) → recommend a local rustls proxy in the shim rather than reusing curl's SSL.
  - **SHA-1 password site** + plaintext at `ServerConnection+0x3c` (Phase 2 patch point).
  - **Anti-debug: CLEAN** — all detection APIs are dead IAT imports; injection + hooking safe.
  - **Mercury v1 crypto == our `encryption.rs`, byte-exact**; v2 hook layer `Mercury::Channel::send 0x01576F90` (not the stack-allocated filter funcs).
- **`docs/architecture/encryption-modernization.md`** — ADR (**Proposed**): the four-phase design, rejected alternatives, transition/downgrade-gating consequences, split HIGH (RE) / MEDIUM (client-patch) confidence.
- Index sync: findings README, RE top-level README, `docs/readme.md`.

## Notes
- Confidence: RE targets **HIGH** (binary-validated); client-patch engineering **MEDIUM** until each hook is built + runtime-confirmed.
- Three open decisions are tracked in the rewritten #434 (hook crate vs extend client-telemetry; transition windows; schema-in-`db/sgw` vs `db/scripts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added architecture decision record outlining planned encryption and transport modernization across multiple phases.
  * Added reverse-engineering findings documentation detailing implementation targets and recommended patch strategies.
  * Updated documentation indices to reference new materials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->