### PR TITLE
test(services): cover console parsers + missions resend edge

### DIFF
--- a/crates/services/src/cell/console/parse.rs
+++ b/crates/services/src/cell/console/parse.rs
@@ -80,7 +80,15 @@ mod tests {
 
     /// `true` iff at least one GM-facing feedback message landed on the channel.
     fn fed_back(rx: &mut mpsc::Receiver<CellToBaseMsg>) -> bool {
-        rx.try_recv().is_ok()
+        // Exactly-one semantics: a parser emits a single feedback message per
+        // failure, so a double-feedback regression panics here instead of
+        // passing silently.
+        let first = rx.try_recv().is_ok();
+        assert!(
+            rx.try_recv().is_err(),
+            "expected at most one GM-feedback message"
+        );
+        first
     }
 
     // ---- parse_i32 ---------------------------------------------------------

--- a/crates/services/src/cell/console/parse.rs
+++ b/crates/services/src/cell/console/parse.rs
@@ -69,3 +69,135 @@ pub(crate) async fn parse_bool(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn channel() -> (mpsc::Sender<CellToBaseMsg>, mpsc::Receiver<CellToBaseMsg>) {
+        mpsc::channel(8)
+    }
+
+    /// `true` iff at least one GM-facing feedback message landed on the channel.
+    fn fed_back(rx: &mut mpsc::Receiver<CellToBaseMsg>) -> bool {
+        rx.try_recv().is_ok()
+    }
+
+    // ---- parse_i32 ---------------------------------------------------------
+
+    #[tokio::test]
+    async fn parse_i32_valid_returns_value_no_feedback() {
+        let (tx, mut rx) = channel();
+        let got = parse_i32(7, &["-42", "x"], 0, "count", &tx).await;
+        assert_eq!(got, Some(-42));
+        assert!(!fed_back(&mut rx), "valid input must not feed back");
+    }
+
+    #[tokio::test]
+    async fn parse_i32_non_numeric_returns_none_and_feeds_back() {
+        let (tx, mut rx) = channel();
+        let got = parse_i32(7, &["abc"], 0, "count", &tx).await;
+        assert_eq!(got, None);
+        assert!(fed_back(&mut rx), "malformed input must feed back");
+    }
+
+    #[tokio::test]
+    async fn parse_i32_missing_arg_returns_none_and_feeds_back() {
+        let (tx, mut rx) = channel();
+        // idx past the end of the slice exercises the `args.get` -> None arm.
+        let got = parse_i32(7, &["1"], 5, "count", &tx).await;
+        assert_eq!(got, None);
+        assert!(fed_back(&mut rx));
+    }
+
+    #[tokio::test]
+    async fn parse_i32_float_string_is_rejected() {
+        let (tx, mut rx) = channel();
+        // "1.5" is not a valid i32 literal.
+        let got = parse_i32(7, &["1.5"], 0, "count", &tx).await;
+        assert_eq!(got, None);
+        assert!(fed_back(&mut rx));
+    }
+
+    // ---- parse_f32 ---------------------------------------------------------
+
+    #[tokio::test]
+    async fn parse_f32_valid_returns_value_no_feedback() {
+        let (tx, mut rx) = channel();
+        let got = parse_f32(7, &["3.5"], 0, "x", &tx).await;
+        assert_eq!(got, Some(3.5));
+        assert!(!fed_back(&mut rx));
+    }
+
+    #[tokio::test]
+    async fn parse_f32_non_numeric_returns_none_and_feeds_back() {
+        let (tx, mut rx) = channel();
+        let got = parse_f32(7, &["nope"], 0, "x", &tx).await;
+        assert_eq!(got, None);
+        assert!(fed_back(&mut rx));
+    }
+
+    #[tokio::test]
+    async fn parse_f32_missing_arg_returns_none_and_feeds_back() {
+        let (tx, mut rx) = channel();
+        let got = parse_f32(7, &[], 0, "x", &tx).await;
+        assert_eq!(got, None);
+        assert!(fed_back(&mut rx));
+    }
+
+    #[tokio::test]
+    async fn parse_f32_nan_is_rejected_by_finite_filter() {
+        let (tx, mut rx) = channel();
+        // "NaN" parses to f32 but fails the `is_finite` filter -> None branch.
+        let got = parse_f32(7, &["NaN"], 0, "x", &tx).await;
+        assert_eq!(got, None);
+        assert!(fed_back(&mut rx));
+    }
+
+    #[tokio::test]
+    async fn parse_f32_inf_is_rejected_by_finite_filter() {
+        let (tx, mut rx) = channel();
+        let got = parse_f32(7, &["inf"], 0, "x", &tx).await;
+        assert_eq!(got, None);
+        assert!(fed_back(&mut rx));
+    }
+
+    // ---- parse_bool --------------------------------------------------------
+
+    #[tokio::test]
+    async fn parse_bool_truthy_values() {
+        for s in ["1", "true", "TRUE", "True"] {
+            let (tx, mut rx) = channel();
+            let got = parse_bool(7, &[s], 0, "flag", &tx).await;
+            assert_eq!(got, Some(true), "{s} should parse true");
+            assert!(!fed_back(&mut rx), "{s} should not feed back");
+        }
+    }
+
+    #[tokio::test]
+    async fn parse_bool_falsy_values() {
+        for s in ["0", "false", "FALSE", "False"] {
+            let (tx, mut rx) = channel();
+            let got = parse_bool(7, &[s], 0, "flag", &tx).await;
+            assert_eq!(got, Some(false), "{s} should parse false");
+            assert!(!fed_back(&mut rx), "{s} should not feed back");
+        }
+    }
+
+    #[tokio::test]
+    async fn parse_bool_invalid_returns_none_and_feeds_back() {
+        let (tx, mut rx) = channel();
+        let got = parse_bool(7, &["maybe"], 0, "flag", &tx).await;
+        assert_eq!(got, None);
+        assert!(fed_back(&mut rx));
+    }
+
+    #[tokio::test]
+    async fn parse_bool_missing_arg_returns_none_and_feeds_back() {
+        let (tx, mut rx) = channel();
+        // `args.get(idx)` -> None falls into the catch-all `_` arm.
+        let got = parse_bool(7, &[], 0, "flag", &tx).await;
+        assert_eq!(got, None);
+        assert!(fed_back(&mut rx));
+    }
+}

--- a/crates/services/src/cell/missions/resend.rs
+++ b/crates/services/src/cell/missions/resend.rs
@@ -80,8 +80,8 @@ mod tests {
         resend_missions(999, &tx, &mgr).await;
 
         assert!(
-            rx.try_recv().is_err(),
-            "unknown entity must produce no messages"
+            matches!(rx.try_recv(), Err(mpsc::error::TryRecvError::Empty)),
+            "unknown entity must produce no messages (channel empty, not disconnected)"
         );
     }
 }

--- a/crates/services/src/cell/missions/resend.rs
+++ b/crates/services/src/cell/missions/resend.rs
@@ -67,4 +67,21 @@ mod tests {
         // 1 mission × (1 update + 1 step + 1 objective) = 3
         assert_eq!(msgs.len(), 3);
     }
+
+    /// When the requested entity isn't in the space manager, `resend_missions`
+    /// takes the `None => return` early-out and sends nothing — guards the
+    /// uncovered missing-entity branch. No entity is created, so the lookup
+    /// misses purely in-memory (no DB / fixtures).
+    #[tokio::test]
+    async fn resend_missing_entity_sends_nothing() {
+        let mgr = SpaceManager::new(1);
+        let (tx, mut rx) = mpsc::channel(16);
+
+        resend_missions(999, &tx, &mgr).await;
+
+        assert!(
+            rx.try_recv().is_err(),
+            "unknown entity must produce no messages"
+        );
+    }
 }


### PR DESCRIPTION
## What

Net-new, pure-function unit tests closing coverage gaps surfaced by the #529 split effort. No DB, no fixtures — all tests run in-memory.

### `cell/console/parse.rs`
Inline `#[cfg(test)]` tests for the three arg parsers (previously the error/edge branches were uncovered):

- `parse_i32` — valid value (no feedback), non-numeric, missing arg (`args.get` → None), float-string rejected.
- `parse_f32` — valid, non-numeric, missing arg, and the `is_finite` filter rejecting `NaN` and `inf`.
- `parse_bool` — case-insensitive truthy (`1/true/TRUE/True`) and falsy (`0/false/FALSE/False`) values, plus invalid and missing-arg → catch-all arm.

Each error case asserts exactly one GM-facing feedback message is emitted on the channel; each success case asserts the channel stays silent (guards against feedback-on-success regression).

### `cell/missions/resend.rs`
Added a focused test for the previously-uncovered `None => return` missing-entity early-out: a fresh `SpaceManager` with no entity created, asserting `resend_missions` sends nothing. Pure in-memory lookup miss — no `SpaceManager` DB fixture needed.

## Notes
- Co-located inline in the same source files (both stay well under the line cap). No existing tests modified; no integration test files touched.
- Coverage reasoned from the code per task policy; `cargo build/check/test/clippy` not run locally (concurrent cargo OOMs the box). CI gates per-PR.

Part of #531

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151DAFJemGM1jhv8sfPBVki