### PR TITLE
test(entity): cover xrc/manager/appearance edges

### DIFF
--- a/crates/entity/src/abilities/manager.rs
+++ b/crates/entity/src/abilities/manager.rs
@@ -638,4 +638,125 @@ mod tests {
         mgr.add_ability(597);
         assert_eq!(mgr.first_known_ability(), Some(597));
     }
+
+    // ── cooldown edge branches ───────────────────────────────────────────
+
+    /// `is_on_cooldown` must return `false` for an entry that is *present*
+    /// but already expired (now >= expires_at), not just for a missing
+    /// entry. Covers the `Some(entry)` arm's false-comparison branch that
+    /// the happy-path `cooldown_tracking` test never reaches.
+    #[test]
+    fn is_on_cooldown_false_for_expired_present_entry() {
+        let mut mgr = AbilityManager::with_abilities(&[597]);
+        mgr.ability_cooldowns.insert(
+            597,
+            CooldownEntry {
+                expires_at: Instant::now() - Duration::from_secs(1),
+                total_duration: Duration::from_secs(5),
+            },
+        );
+        assert!(
+            !mgr.is_on_cooldown(597),
+            "an expired-but-present entry must read as not-on-cooldown"
+        );
+    }
+
+    /// Companion to the above for the moniker map's `Some(entry)`
+    /// expired branch.
+    #[test]
+    fn is_moniker_on_cooldown_false_for_expired_present_entry() {
+        let mut mgr = AbilityManager::new();
+        mgr.moniker_cooldowns.insert(
+            42,
+            CooldownEntry {
+                expires_at: Instant::now() - Duration::from_secs(1),
+                total_duration: Duration::from_secs(5),
+            },
+        );
+        assert!(!mgr.is_moniker_on_cooldown(42));
+    }
+
+    /// `start_cooldowns` with a sub-0.002s cooldown takes the `else`
+    /// branch: moniker_duration == the full ability duration (no
+    /// 0.001s shave). The happy-path test only exercises the
+    /// `> 0.002` arm.
+    #[test]
+    fn start_cooldowns_tiny_cooldown_uses_full_moniker_duration() {
+        let mut mgr = AbilityManager::with_abilities(&[597]);
+        let ability = test_ability(); // moniker_ids = [42]
+        mgr.start_cooldowns(&ability, 0.001);
+        let entry = mgr
+            .moniker_cooldowns
+            .get(&42)
+            .expect("moniker cooldown must be set");
+        // else branch: total_duration is the full (un-shaved) duration.
+        assert_eq!(entry.total_duration, Duration::from_secs_f32(0.001));
+    }
+
+    /// `can_use_ability` must reject when a moniker group is on cooldown
+    /// even though the ability itself is known and off cooldown. Covers
+    /// the moniker-on-cooldown error arm.
+    #[test]
+    fn can_use_ability_rejects_on_moniker_cooldown() {
+        let mut mgr = AbilityManager::with_abilities(&[597]);
+        let ability = test_ability(); // moniker_ids = [42]
+                                      // Put only the moniker on cooldown, not the ability.
+        mgr.moniker_cooldowns.insert(
+            42,
+            CooldownEntry {
+                expires_at: Instant::now() + Duration::from_secs(5),
+                total_duration: Duration::from_secs(5),
+            },
+        );
+        assert!(!mgr.is_on_cooldown(597), "ability itself is off cooldown");
+        assert_eq!(
+            mgr.can_use_ability(&ability).unwrap_err(),
+            "moniker on cooldown"
+        );
+    }
+
+    /// `clear_all_cooldowns` empties both the ability and moniker maps.
+    #[test]
+    fn clear_all_cooldowns_empties_both_maps() {
+        let mut mgr = AbilityManager::with_abilities(&[597]);
+        let ability = test_ability();
+        mgr.start_cooldowns(&ability, 5.0);
+        assert!(!mgr.ability_cooldowns.is_empty());
+        assert!(!mgr.moniker_cooldowns.is_empty());
+        mgr.clear_all_cooldowns();
+        assert!(mgr.ability_cooldowns.is_empty());
+        assert!(mgr.moniker_cooldowns.is_empty());
+    }
+
+    /// `cleanup_expired` must also prune the moniker map (not just the
+    /// ability map) and must keep entries that are still live.
+    #[test]
+    fn cleanup_expired_prunes_monikers_keeps_live() {
+        let mut mgr = AbilityManager::new();
+        // Expired moniker.
+        mgr.moniker_cooldowns.insert(
+            42,
+            CooldownEntry {
+                expires_at: Instant::now() - Duration::from_secs(1),
+                total_duration: Duration::from_secs(5),
+            },
+        );
+        // Still-live moniker.
+        mgr.moniker_cooldowns.insert(
+            43,
+            CooldownEntry {
+                expires_at: Instant::now() + Duration::from_secs(60),
+                total_duration: Duration::from_secs(60),
+            },
+        );
+        mgr.cleanup_expired();
+        assert!(
+            !mgr.moniker_cooldowns.contains_key(&42),
+            "expired moniker pruned"
+        );
+        assert!(
+            mgr.moniker_cooldowns.contains_key(&43),
+            "live moniker retained"
+        );
+    }
 }

--- a/crates/entity/src/cell_entity/appearance.rs
+++ b/crates/entity/src/cell_entity/appearance.rs
@@ -119,3 +119,55 @@ impl CellEntity {
         self.set_weapon_holstered(!in_combat)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn comps(items: &[&str]) -> Vec<String> {
+        items.iter().map(|s| s.to_string()).collect()
+    }
+
+    /// Holstered with a weapon visual present in the list → the weapon
+    /// entry is dropped and every other component survives.
+    #[test]
+    fn holstered_filters_matching_weapon_entry() {
+        let components = comps(&["body", "head", "WEAP_P90"]);
+        let out = filter_holstered_weapon(&components, Some("WEAP_P90"), true);
+        assert_eq!(out, comps(&["body", "head"]));
+    }
+
+    /// Not holstered → list returned unchanged even when a weapon_visual
+    /// is set (drawn pose keeps the weapon entry). Pins the early-return
+    /// `else` arm of the `.filter(|_| holstered)` guard.
+    #[test]
+    fn not_holstered_returns_components_unchanged() {
+        let components = comps(&["body", "WEAP_P90"]);
+        let out = filter_holstered_weapon(&components, Some("WEAP_P90"), false);
+        assert_eq!(out, components);
+    }
+
+    /// Holstered but no weapon_visual (e.g. unarmed / NPC) → unchanged.
+    /// Pins the `None` arm of the `let Some(weapon) = ... else` guard.
+    #[test]
+    fn holstered_without_weapon_visual_returns_unchanged() {
+        let components = comps(&["body", "head"]);
+        let out = filter_holstered_weapon(&components, None, true);
+        assert_eq!(out, components);
+    }
+
+    /// Invariant-violation edge: holstered with a weapon_visual that is
+    /// NOT present in the list. The filter is a no-op (post-filter length
+    /// equals input length), which fires the `warn` and — in debug/test
+    /// builds — the `debug_assert!(false, ...)`. This `should_panic`
+    /// guard covers the previously-uncovered warn + debug_assert branch.
+    /// Reverting the `debug_assert!` would make this test fail (no panic).
+    #[test]
+    #[should_panic(expected = "invariant violated")]
+    fn holstered_with_missing_weapon_visual_trips_invariant() {
+        let components = comps(&["body", "head"]);
+        // "WEAP_P90" is not in `components` — drift between weapon_visual
+        // and the components query. Filter can't remove what isn't there.
+        let _ = filter_holstered_weapon(&components, Some("WEAP_P90"), true);
+    }
+}

--- a/crates/entity/src/navigation/xrc.rs
+++ b/crates/entity/src/navigation/xrc.rs
@@ -142,6 +142,66 @@ pub(super) fn checked_alloc_size(
 mod tests {
     use super::*;
 
+    // ── scalar reader helpers ────────────────────────────────────────────
+
+    /// Each reader decodes its little-endian scalar from an exact-length
+    /// slice. Pins the success path of all four readers, which the
+    /// header-cap tests never exercise directly.
+    #[test]
+    fn readers_decode_little_endian_scalars() {
+        let mut r = &[0x78u8, 0x56, 0x34, 0x12][..];
+        assert_eq!(read_u32(&mut r).unwrap(), 0x1234_5678);
+
+        let mut r = &1.5f32.to_le_bytes()[..];
+        assert_eq!(read_f32(&mut r).unwrap(), 1.5);
+
+        let mut r = &[0xCDu8, 0xAB][..];
+        assert_eq!(read_u16(&mut r).unwrap(), 0xABCD);
+
+        let mut r = &[0x2Au8][..];
+        assert_eq!(read_u8(&mut r).unwrap(), 0x2A);
+    }
+
+    /// A reader whose source ends before the field is fully read must
+    /// surface the `read_exact` short-read error rather than returning a
+    /// truncated/zero value. Covers the hostile-input `?`-propagation
+    /// branch in each reader (the `Err(_)` arm of `read_exact`). A
+    /// truncated `.nav` file is exactly this shape.
+    #[test]
+    fn readers_propagate_short_read_error() {
+        // f32/u32 need 4 bytes — give 3.
+        let mut r = &[0x00u8, 0x01, 0x02][..];
+        assert!(read_u32(&mut r).is_err());
+        let mut r = &[0x00u8, 0x01, 0x02][..];
+        assert!(read_f32(&mut r).is_err());
+
+        // u16 needs 2 bytes — give 1.
+        let mut r = &[0x00u8][..];
+        assert!(read_u16(&mut r).is_err());
+
+        // u8 needs 1 byte — give 0 (empty).
+        let mut r = &[][..];
+        assert!(read_u8(&mut r).is_err());
+    }
+
+    /// `check_count` returns the value unchanged when it is within the
+    /// cap (including the boundary `value == max`). The existing
+    /// `check_count_emits_error_log_on_reject` test only covers the
+    /// over-cap reject path; this pins the `Ok(value)` accept path.
+    #[test]
+    fn check_count_accepts_value_at_or_below_cap() {
+        assert_eq!(check_count(0, MAX_NVERTS, "nverts").unwrap(), 0);
+        assert_eq!(
+            check_count(MAX_NVERTS, MAX_NVERTS, "nverts").unwrap(),
+            MAX_NVERTS,
+            "boundary value == max must be accepted"
+        );
+        assert_eq!(
+            check_count(MAX_NPOLYS - 1, MAX_NPOLYS, "npolys").unwrap(),
+            MAX_NPOLYS - 1
+        );
+    }
+
     /// Pin the u32→u64 widening contract of `checked_alloc_size`.
     ///
     /// Reviewer flagged that the existing hostile-input guards exercise


### PR DESCRIPTION
Net-new unit tests closing coverage gaps from the #529 split effort. **Part of #531.** Package `cimmeria-entity` (88% bar). No production code changed — tests only.

## What's covered

### `crates/entity/src/navigation/xrc.rs`
- `readers_decode_little_endian_scalars` — happy-path decode of all four scalar readers (`read_u32/f32/u16/u8`), which the existing header-cap tests never exercised directly.
- `readers_propagate_short_read_error` — hostile/truncated-input branch: each reader surfaces the `read_exact` short-read `Err` instead of a truncated value (the `?`-propagation arm).
- `check_count_accepts_value_at_or_below_cap` — the `Ok(value)` accept path (including the `value == max` boundary); the existing test only covered the over-cap reject path.

### `crates/entity/src/abilities/manager.rs`
- `is_on_cooldown_false_for_expired_present_entry` / `is_moniker_on_cooldown_false_for_expired_present_entry` — the `Some(entry)` expired-comparison branch (present-but-expired reads as off-cooldown).
- `start_cooldowns_tiny_cooldown_uses_full_moniker_duration` — the `else` arm of the `cooldown_secs > 0.002` moniker-shave guard.
- `can_use_ability_rejects_on_moniker_cooldown` — the moniker-on-cooldown error arm.
- `clear_all_cooldowns_empties_both_maps` — clears both maps.
- `cleanup_expired_prunes_monikers_keeps_live` — the moniker-map retain branch (prunes expired, keeps live).

### `crates/entity/src/cell_entity/appearance.rs` (no prior co-located tests)
- `holstered_filters_matching_weapon_entry` — happy filter.
- `not_holstered_returns_components_unchanged` / `holstered_without_weapon_visual_returns_unchanged` — both early-return guard arms.
- `holstered_with_missing_weapon_visual_trips_invariant` (`#[should_panic]`) — the previously-uncovered warn + `debug_assert!` invariant-violation no-op edge.

All tests are pure (inputs constructed directly, no DB, no fixtures) and co-located in the source files. Existing tests were not modified.

> [!NOTE]
> Per task policy, `cargo build/check/test/clippy/llvm-cov` were not run locally (concurrent cargo OOMs the box); only `cargo fmt` was run. CI gates the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151DAFJemGM1jhv8sfPBVki