### PR TITLE
test(discord): cover config parse + toggles error paths

### DIFF
--- a/crates/discord/src/config/parse.rs
+++ b/crates/discord/src/config/parse.rs
@@ -571,9 +571,37 @@ rate_limit_per_min = 0
     /// A `${VAR}` that resolves successfully through `from_toml_str`
     /// produces a usable webhook URL -- the happy interpolation path that
     /// passes the `validate()` webhook-prefix check end to end.
+    /// Restores (or removes) a process-global env var on drop so env-mutating
+    /// tests don't leak state to parallel siblings (cargo runs tests in a
+    /// binary in parallel by default).
+    struct EnvGuard {
+        key: &'static str,
+        prev: Option<String>,
+    }
+    impl EnvGuard {
+        fn set(key: &'static str, val: &str) -> Self {
+            let prev = std::env::var(key).ok();
+            std::env::set_var(key, val);
+            Self { key, prev }
+        }
+        fn unset(key: &'static str) -> Self {
+            let prev = std::env::var(key).ok();
+            std::env::remove_var(key);
+            Self { key, prev }
+        }
+    }
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.prev {
+                Some(v) => std::env::set_var(self.key, v),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+
     #[test]
     fn env_var_substitution_produces_valid_webhook_url() {
-        std::env::set_var(
+        let _guard = EnvGuard::set(
             "TEST_SUBST_OK_WEBHOOK",
             "https://discord.com/api/webhooks/42/substituted",
         );
@@ -603,7 +631,7 @@ url = "${TEST_SUBST_OK_WEBHOOK}"
     /// the variable name (the channel field was only spot-checked before).
     #[test]
     fn missing_env_var_error_carries_channel_name() {
-        std::env::remove_var("TEST_MISSING_NAMED_WEBHOOK");
+        let _guard = EnvGuard::unset("TEST_MISSING_NAMED_WEBHOOK");
         let toml_src = r#"
 [discord]
 enabled = true

--- a/crates/discord/src/config/parse.rs
+++ b/crates/discord/src/config/parse.rs
@@ -456,7 +456,7 @@ rate_limit_per_min = 9999
         assert!(matches!(err, ConfigError::UnclosedEnvVar { .. }));
     }
 
-    // -- NET-NEW coverage (#531): config-parse error paths --
+    // -- NET-NEW coverage: config-parse error paths --
 
     /// Malformed TOML must surface as [`ConfigError::Toml`], not panic.
     /// The deserialize step in `from_toml_str` is the only producer of

--- a/crates/discord/src/config/parse.rs
+++ b/crates/discord/src/config/parse.rs
@@ -455,4 +455,203 @@ rate_limit_per_min = 9999
         let err = interpolate_env_vars("${OOPS", "test").unwrap_err();
         assert!(matches!(err, ConfigError::UnclosedEnvVar { .. }));
     }
+
+    // -- NET-NEW coverage (#531): config-parse error paths --
+
+    /// Malformed TOML must surface as [`ConfigError::Toml`], not panic.
+    /// The deserialize step in `from_toml_str` is the only producer of
+    /// this variant and was previously unexercised.
+    #[test]
+    fn malformed_toml_returns_toml_error() {
+        // `enabled = ` with no value is a syntax error for the TOML parser.
+        let toml_src = r#"
+[discord]
+enabled =
+"#;
+        let err = Config::from_toml_str(toml_src).unwrap_err();
+        assert!(matches!(err, ConfigError::Toml(_)));
+    }
+
+    /// A type mismatch on a typed field (string where a bool is expected)
+    /// also routes through the `toml::from_str` deserialize error path.
+    #[test]
+    fn wrong_type_for_enabled_returns_toml_error() {
+        let toml_src = r#"
+[discord]
+enabled = "yes"
+"#;
+        let err = Config::from_toml_str(toml_src).unwrap_err();
+        assert!(matches!(err, ConfigError::Toml(_)));
+    }
+
+    /// A `[discord.channels.<name>]` block missing the required `url`
+    /// field fails at deserialize time (the field has no `#[serde(default)]`).
+    #[test]
+    fn channel_missing_url_field_returns_toml_error() {
+        let toml_src = r#"
+[discord]
+enabled = true
+
+[discord.channels.lifecycle]
+rate_limit_per_min = 30
+"#;
+        let err = Config::from_toml_str(toml_src).unwrap_err();
+        assert!(matches!(err, ConfigError::Toml(_)));
+    }
+
+    /// An unclosed `${...` reaching `from_toml_str` (not just the unit
+    /// helper) must produce [`ConfigError::UnclosedEnvVar`] carrying the
+    /// offending channel name.
+    #[test]
+    fn unclosed_env_var_via_from_toml_str_names_channel() {
+        let toml_src = r#"
+[discord]
+enabled = true
+
+[discord.channels.errors]
+url = "https://discord.com/api/webhooks/${OOPS"
+"#;
+        let err = Config::from_toml_str(toml_src).unwrap_err();
+        assert!(
+            matches!(err, ConfigError::UnclosedEnvVar { ref channel } if channel == "errors"),
+            "expected UnclosedEnvVar for `errors`, got {err:?}"
+        );
+    }
+
+    /// The `discordapp.com` host is the legacy-but-still-valid webhook
+    /// domain. The validate() OR-branch that accepts it was uncovered.
+    #[test]
+    fn legacy_discordapp_webhook_url_accepted() {
+        let toml_src = r#"
+[discord]
+enabled = true
+
+[discord.channels.lifecycle]
+url = "https://discordapp.com/api/webhooks/1/legacyABC"
+"#;
+        let cfg = Config::from_toml_str(toml_src).expect("discordapp.com host must be accepted");
+        let lc = cfg.channels.get(&ChannelKind::Lifecycle).unwrap();
+        assert_eq!(lc.url, "https://discordapp.com/api/webhooks/1/legacyABC");
+    }
+
+    /// When no `rate_limit_per_min` is given the `default_rate_limit`
+    /// serde default (60) applies, then survives the clamp unchanged.
+    #[test]
+    fn rate_limit_defaults_to_sixty_when_omitted() {
+        let toml_src = r#"
+[discord]
+enabled = true
+
+[discord.channels.lifecycle]
+url = "https://discord.com/api/webhooks/1/abc"
+"#;
+        let cfg = Config::from_toml_str(toml_src).unwrap();
+        let lc = cfg.channels.get(&ChannelKind::Lifecycle).unwrap();
+        assert_eq!(lc.rate_limit_per_min, 60, "serde default must be 60");
+    }
+
+    /// A `rate_limit_per_min` of 0 is below Discord's floor; the clamp
+    /// raises it to the minimum of 1 (the lower clamp bound, previously
+    /// untested -- only the upper bound was exercised).
+    #[test]
+    fn rate_limit_zero_clamped_up_to_one() {
+        let toml_src = r#"
+[discord]
+enabled = true
+
+[discord.channels.lifecycle]
+url = "https://discord.com/api/webhooks/1/abc"
+rate_limit_per_min = 0
+"#;
+        let cfg = Config::from_toml_str(toml_src).unwrap();
+        let lc = cfg.channels.get(&ChannelKind::Lifecycle).unwrap();
+        assert_eq!(lc.rate_limit_per_min, 1, "must clamp up to the floor of 1");
+    }
+
+    /// A `${VAR}` that resolves successfully through `from_toml_str`
+    /// produces a usable webhook URL -- the happy interpolation path that
+    /// passes the `validate()` webhook-prefix check end to end.
+    #[test]
+    fn env_var_substitution_produces_valid_webhook_url() {
+        std::env::set_var(
+            "TEST_SUBST_OK_WEBHOOK",
+            "https://discord.com/api/webhooks/42/substituted",
+        );
+        let toml_src = r#"
+[discord]
+enabled = true
+
+[discord.channels.lifecycle]
+url = "${TEST_SUBST_OK_WEBHOOK}"
+"#;
+        let cfg = Config::from_toml_str(toml_src).unwrap();
+        let lc = cfg.channels.get(&ChannelKind::Lifecycle).unwrap();
+        assert_eq!(lc.url, "https://discord.com/api/webhooks/42/substituted");
+    }
+
+    /// `interpolate_env_vars` passes a bare `$` (not followed by `{`)
+    /// through untouched and emits a string with no placeholders intact.
+    #[test]
+    fn interpolate_passes_through_bare_dollar_and_plain_text() {
+        let out = interpolate_env_vars("cost is $5 flat", "test").unwrap();
+        assert_eq!(out, "cost is $5 flat");
+        let plain = interpolate_env_vars("no placeholders here", "test").unwrap();
+        assert_eq!(plain, "no placeholders here");
+    }
+
+    /// The `MissingEnvVar` error must carry the channel name as well as
+    /// the variable name (the channel field was only spot-checked before).
+    #[test]
+    fn missing_env_var_error_carries_channel_name() {
+        std::env::remove_var("TEST_MISSING_NAMED_WEBHOOK");
+        let toml_src = r#"
+[discord]
+enabled = true
+
+[discord.channels.world]
+url = "${TEST_MISSING_NAMED_WEBHOOK}"
+"#;
+        let err = Config::from_toml_str(toml_src).unwrap_err();
+        match err {
+            ConfigError::MissingEnvVar { channel, var } => {
+                assert_eq!(channel, "world");
+                assert_eq!(var, "TEST_MISSING_NAMED_WEBHOOK");
+            }
+            other => panic!("expected MissingEnvVar, got {other:?}"),
+        }
+    }
+
+    /// Spot-check the human-facing `Display` text for the validation
+    /// errors. The `#[error("...")]` formats are part of the operator UX
+    /// (they appear in startup logs) and were entirely uncovered.
+    #[test]
+    fn config_error_display_messages() {
+        let unknown_chan = ConfigError::UnknownChannel("audit".to_string());
+        assert!(unknown_chan.to_string().contains("audit"));
+        assert!(unknown_chan.to_string().contains("unknown channel"));
+
+        let unknown_evt = ConfigError::UnknownEvent("playr_login".to_string());
+        assert!(unknown_evt.to_string().contains("playr_login"));
+
+        let bad_url = ConfigError::BadWebhookUrl {
+            channel: "errors".to_string(),
+            url: "https://example.com/hook".to_string(),
+        };
+        let bad_url_str = bad_url.to_string();
+        assert!(bad_url_str.contains("errors"));
+        assert!(bad_url_str.contains("https://example.com/hook"));
+
+        let missing = ConfigError::MissingEnvVar {
+            channel: "world".to_string(),
+            var: "DISCORD_WORLD_WEBHOOK".to_string(),
+        };
+        let missing_str = missing.to_string();
+        assert!(missing_str.contains("world"));
+        assert!(missing_str.contains("DISCORD_WORLD_WEBHOOK"));
+
+        let unclosed = ConfigError::UnclosedEnvVar {
+            channel: "chat".to_string(),
+        };
+        assert!(unclosed.to_string().contains("chat"));
+    }
 }

--- a/crates/discord/src/config/toggles.rs
+++ b/crates/discord/src/config/toggles.rs
@@ -202,7 +202,7 @@ mod tests {
         assert!(!t.loot_generated);
     }
 
-    // -- NET-NEW coverage (#531): is_enabled mapping + default branches --
+    // -- NET-NEW coverage: is_enabled mapping + default branches --
 
     /// `is_enabled` must round-trip every `EventKind` against the matching
     /// struct field. We mutate one field at a time from a known baseline

--- a/crates/discord/src/config/toggles.rs
+++ b/crates/discord/src/config/toggles.rs
@@ -201,4 +201,135 @@ mod tests {
         assert!(!t.player_death);
         assert!(!t.loot_generated);
     }
+
+    // -- NET-NEW coverage (#531): is_enabled mapping + default branches --
+
+    /// `is_enabled` must round-trip every `EventKind` against the matching
+    /// struct field. We mutate one field at a time from a known baseline
+    /// and assert `is_enabled(kind)` tracks it -- this walks every arm of
+    /// the big `match` (previously only a handful were touched indirectly).
+    #[test]
+    fn is_enabled_tracks_every_field() {
+        // Start from a default and flip each field both ways, asserting
+        // `is_enabled(kind)` follows the field. The on-then-off pair makes
+        // the result independent of each field's default value and proves
+        // every `match` arm is bound to the field it names.
+        let mut t = EventToggles::default();
+        macro_rules! check {
+            ($field:ident, $kind:expr) => {{
+                t.$field = true;
+                assert!(
+                    t.is_enabled($kind),
+                    concat!("is_enabled must read ", stringify!($field), " when true")
+                );
+                t.$field = false;
+                assert!(
+                    !t.is_enabled($kind),
+                    concat!("is_enabled must read ", stringify!($field), " when false")
+                );
+            }};
+        }
+
+        check!(server_startup, EventKind::ServerStartup);
+        check!(server_shutdown, EventKind::ServerShutdown);
+        check!(server_panic, EventKind::ServerPanic);
+        check!(player_login, EventKind::PlayerLogin);
+        check!(player_logout, EventKind::PlayerLogout);
+        check!(player_disconnect, EventKind::PlayerDisconnect);
+        check!(player_auth_failed, EventKind::PlayerAuthFailed);
+        check!(player_world_entry, EventKind::PlayerWorldEntry);
+        check!(player_world_exit, EventKind::PlayerWorldExit);
+        check!(chat_global, EventKind::ChatGlobal);
+        check!(chat_say, EventKind::ChatSay);
+        check!(chat_whisper, EventKind::ChatWhisper);
+        check!(chat_guild, EventKind::ChatGuild);
+        check!(chat_team, EventKind::ChatTeam);
+        check!(chat_command, EventKind::ChatCommand);
+        check!(player_level_up, EventKind::PlayerLevelUp);
+        check!(player_death, EventKind::PlayerDeath);
+        check!(player_respawn, EventKind::PlayerRespawn);
+        check!(mission_accepted, EventKind::MissionAccepted);
+        check!(mission_completed, EventKind::MissionCompleted);
+        check!(mission_failed, EventKind::MissionFailed);
+        check!(mission_reward_granted, EventKind::MissionRewardGranted);
+        check!(loot_generated, EventKind::LootGenerated);
+        check!(item_used, EventKind::ItemUsed);
+        check!(character_created, EventKind::CharacterCreated);
+        check!(npc_death, EventKind::NpcDeath);
+        check!(minigame_result, EventKind::MinigameResult);
+        check!(dialog, EventKind::Dialog);
+        check!(gm_command, EventKind::GmCommand);
+        check!(gm_teleport, EventKind::GmTeleport);
+        check!(gm_spawn, EventKind::GmSpawn);
+        check!(gm_item_grant, EventKind::GmItemGrant);
+        check!(warning, EventKind::Warning);
+        check!(error, EventKind::Error);
+        check!(wire_format_error, EventKind::WireFormatError);
+        check!(db_error, EventKind::DbError);
+        check!(assertion_failure, EventKind::AssertionFailure);
+        check!(mercury_timeout, EventKind::MercuryTimeout);
+        check!(high_latency, EventKind::HighLatency);
+        check!(packet_loss_spike, EventKind::PacketLossSpike);
+        check!(memory_warning, EventKind::MemoryWarning);
+        check!(tick_stall, EventKind::TickStall);
+        check!(aoi_burst_warning, EventKind::AoiBurstWarning);
+        check!(outbox_lag, EventKind::OutboxLag);
+    }
+
+    /// Pin the documented default-OFF gameplay/chat events that the doc
+    /// comment in `Default` calls out explicitly. These complement the
+    /// existing `default_toggles_match_documented_defaults` test without
+    /// duplicating its assertions.
+    #[test]
+    fn additional_default_off_events_pinned() {
+        let t = EventToggles::default();
+        assert!(!t.player_respawn, "respawn is noise -> off");
+        assert!(!t.mission_failed, "mission_failed off by default");
+        assert!(!t.mission_reward_granted, "reward_granted off by default");
+        assert!(!t.item_used, "item_used off by default");
+        assert!(!t.npc_death, "npc_death high-volume -> off");
+        assert!(!t.dialog, "dialog high-volume -> off");
+        assert!(!t.chat_guild);
+        assert!(!t.chat_team);
+        assert!(!t.chat_command);
+    }
+
+    /// Pin the documented default-ON events not already asserted by the
+    /// existing default test: the new gameplay events, GM events, and the
+    /// ops/error alerts that ship enabled.
+    #[test]
+    fn additional_default_on_events_pinned() {
+        let t = EventToggles::default();
+        // New gameplay events.
+        assert!(t.character_created, "character_created on by default");
+        assert!(t.minigame_result, "minigame_result on by default");
+        // World.
+        assert!(t.player_world_entry);
+        assert!(t.player_world_exit);
+        // GM (all on -- privileged visibility).
+        assert!(t.gm_teleport);
+        assert!(t.gm_spawn);
+        assert!(t.gm_item_grant);
+        // Error/diagnostic alerts.
+        assert!(t.wire_format_error);
+        assert!(t.db_error);
+        assert!(t.assertion_failure);
+        assert!(t.mercury_timeout);
+        // Ops alerts.
+        assert!(t.high_latency);
+        assert!(t.packet_loss_spike);
+        assert!(t.memory_warning);
+        assert!(t.tick_stall);
+        assert!(t.aoi_burst_warning);
+        assert!(t.outbox_lag);
+        // Lifecycle / auth.
+        assert!(t.server_shutdown);
+        assert!(t.server_panic);
+        assert!(t.player_logout);
+        assert!(t.player_disconnect);
+        assert!(t.player_auth_failed);
+        assert!(t.mission_accepted);
+        assert!(t.mission_completed);
+        assert!(t.player_level_up);
+    }
 }


### PR DESCRIPTION
Net-new unit tests closing coverage gaps from the #529 split effort. **Pure-TOML config parsing only** — no production code changed, no network/filesystem (the `notify` watcher is untouched).

Part of #531

## What's covered

### `crates/discord/src/config/parse.rs` (error paths, was ~86%)
- **`ConfigError::Toml`** — malformed TOML (`enabled =` with no value), wrong-type field (`enabled = "yes"`), and a `[discord.channels.*]` block missing the required `url` field all route through the deserialize error path.
- **`UnclosedEnvVar` via `from_toml_str`** — previously only the bare `interpolate_env_vars` helper was exercised; now verified end-to-end with the offending channel name carried in the error.
- **Legacy `discordapp.com` webhook host** — the second arm of the validate() URL-prefix OR was uncovered.
- **Rate-limit serde default (60)** when `rate_limit_per_min` is omitted, and the **lower clamp bound (`0 -> 1`)** — only the upper bound (`9999 -> 150`) was tested before.
- **Successful `${VAR}` substitution** producing a valid webhook URL end-to-end.
- **Bare `$` / plain-text passthrough** in `interpolate_env_vars`.
- **`MissingEnvVar`** carries both channel and var name.
- **`ConfigError` `Display` strings** — operator-facing `#[error("…")]` formats were entirely uncovered.

### `crates/discord/src/config/toggles.rs` (toggle map, was ~85%)
- **`is_enabled` exhaustively walks all 44 `EventKind` match arms** — flips each field on then off and asserts `is_enabled(kind)` tracks it, proving every arm is bound to the field it names (copy-paste guard for a 44-arm match).
- **Additional default-ON / default-OFF pins** for the events the existing default test didn't assert (new gameplay events, GM events, ops/error alerts).

## Notes
- Existing tests untouched; all additions are net-new and appended to the in-file `#[cfg(test)] mod tests`.
- New tests use distinctive env-var names (`TEST_SUBST_OK_WEBHOOK`, `TEST_MISSING_NAMED_WEBHOOK`) to avoid cross-test process-env clashes.
- `cargo fmt -p cimmeria-discord -- --check` is clean. Per-PR CI gates build/clippy/test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151DAFJemGM1jhv8sfPBVki