### PR TITLE
docs(re): gameplay-system restoration findings + implementation-plan issues

### DIFF
--- a/docs/reverse-engineering/findings/README.md
+++ b/docs/reverse-engineering/findings/README.md
@@ -1,6 +1,6 @@
 # RE Findings
 
-This directory contains 56 per-system reverse engineering findings with evidence.
+This directory contains 62 per-system reverse engineering findings with evidence.
 
 ## Documents
 
@@ -62,6 +62,12 @@ This directory contains 56 per-system reverse engineering findings with evidence
 | `stat-scaling-formulas.md` | V5 | Stat scaling & XP progression — recovered stat-scaling and leveling formulas | MEDIUM |
 | `struct-field-layouts.md` | V5 | FIXED_DICT struct field layouts — client-binary anatomy of key FIXED_DICT structures | HIGH |
 | `weapon-ammo-pipeline.md` | V5 | Weapon / ammo pipeline — clip sizes, ammo consumption, and bandolier-slot wiring recovered from the binary | HIGH |
+| `crafting-restoration.md` | Restore | Crafting (craft/research/reverse-engineer/alloy/spendASP) — 3-layer completeness assessment + phased Rust restoration plan (supersedes #53, tracked by #567) | HIGH |
+| `organization-restoration.md` | Restore | Organization / squad / guild — completeness + phased plan; 9-rank + 26-bit permission model, OrgAuthority service (supersedes #68, tracked by #568) | HIGH |
+| `duel-restoration.md` | Restore | Duel system — challenge/arena/PvP-flag lifecycle, SGWDuelMarker entity; never server-implemented originally (supersedes #70, tracked by #569) | HIGH |
+| `pet-restoration.md` | Restore | Pet / companion — SGWPet entity, command dispatch, ownership/AoI; includes pet-wire-formats.md corrections (new, tracked by #570) | HIGH |
+| `black-market-restoration.md` | Restore | Black market / auction house — listings/bids/expiry/CoD; CEGUI UI; includes wire-format corrections (supersedes #67, tracked by #571) | HIGH |
+| `contact-list-restoration.md` | Restore | Contact list (friends/ignore/presence fanout) — generic named-list model; answers #275 (supersedes #71, tracked by #572) | HIGH |
 
 ## Finding Format
 

--- a/docs/reverse-engineering/findings/black-market-restoration.md
+++ b/docs/reverse-engineering/findings/black-market-restoration.md
@@ -1,0 +1,101 @@
+# Black Market / Auction House — Restoration Findings
+
+> **Date**: 2026-06-20
+> **Phase**: Post-V5 deep restoration assessment
+> **Confidence**: HIGH (wire format: RTTI + emitter decompile); MEDIUM (CoD/payout flow: architecture-inferred); LOW (error/watch-update enums)
+> **Sources**: `SGW.exe` Ghidra; `entities/defs/SGWBlackMarket.def`; `entities/defs/SGWEscrow.def`;
+>   `deprecated/python/{base,cell}/SGWBlackMarket.py`; `deprecated/python/base/SGWPlayer.py`;
+>   `crates/services/src/cell/{cell_methods,client_methods}/black_market.rs`; `db/sgw/` (no auction tables);
+>   `docs/reverse-engineering/findings/black-market-wire-formats.md`
+> **Tracking issue**: replaces #67
+
+## Completeness assessment
+
+Player-to-player auction house. Client class `BlackMarket` (RTTI). UI is **CEGUI** (`UIAuctionView`,
+`UIAuctionTime`), not Scaleform. The Python server is **empty stubs** (both `SGWBlackMarket.py` files
+`__init__`-only; `BMSearch`/`BMCreate`/`BMPlaceBid`/`BMCancel`/`BMStartWatch`/`BMStopWatch` all `pass`).
+`SGWEscrow` is **loot-transfer**, NOT auction settlement (it has no BaseMethods). CoD delivery reuses the
+existing `sgw_gate_mail` table.
+
+| Layer | % |
+|---|---|
+| Wire format docs | ~90% (`filterFlags` gap below) |
+| Entity model | ~85% (SGWEscrow misclassification clarified) |
+| Server logic | ~0% |
+| DB persistence (auction tables) | ~0% (none exist) |
+| **Overall** | **~0% functional** |
+
+## ⚠️ Corrections to existing artifacts
+
+1. **`BMCreateAuction` Rust decode is wrong**: `cell_methods/black_market.rs` reads `auctionLength` as
+   INT32; the binary emitter `FUN_00e59970` packs it as **UINT8**. Correct payload is **13 bytes** (4+4+4+1),
+   not 16. HIGH confidence.
+2. **`BMSearchOptions` has 11 fields, not 10**: emitter `FUN_00e59f70` shows an 11th field `filterFlags`
+   (INT32) at `puVar1+0x15`. The existing doc lists `monikerCRC` in that position — likely a wrong/aliased
+   name. HIGH confidence.
+
+## Entity model
+
+**SGWBlackMarket** (`<ServerOnly/>`, no parent): one property `watchedItems: PYTHON` (BASE) — itemDefId →
+subscriber mailbox registry. Six base methods (all pass the caller MAILBOX so the singleton replies to the
+player base): `searchBlackMarket(MAILBOX, INT32, BMSearchOptions, INT32 langId)`, `placeBid(INT32 seqId,
+INT32 bid)`, `createAuction(MAILBOX, INT32, INT32 itemInstance, INT32 buyout, UINT8 length, INT32 starting)`,
+`cancelAuction(MAILBOX, INT32, INT32 seqId)`, `registerWatchedItems(ARRAY<INT32>, MAILBOX)`,
+`unregisterWatchedItems(ARRAY<INT32>, MAILBOX)`.
+
+**SGWEscrow** (clarified): loot-roll/instanced-loot transfer, two CELL_PRIVATE props + two CellMethods
+(`lootItemTransfer`, `lootItemTransferCallback`), **zero BaseMethods** → not auction settlement.
+
+## Wire messages
+
+### Client → Server (NetOut)
+
+- `BMCreateAuction` (RTTI `0x01e660b8`, emitter `0x00e59970`): `INT32 itemInstanceId, INT32 startingPrice,
+  INT32 buyoutPrice, UINT8 auctionLength` — **13 bytes**.
+- `BMCancelAuction` (`0x01e66138`, `0x00e59c70`): `INT32 sequenceId` — 4B.
+- `BMSearch` (`0x01e6622c`, `0x00e59f70`) `BMSearchOptions` (11 fields, packing order): `UINT8 sortId,
+  INT32 clientKey, INT32 sequenceId, UINT8 bForward, STRING sellerName, STRING bidderName, STRING itemName,
+  INT32 minTC, INT32 maxTC, INT32 quality, INT32 filterFlags`.
+- `BMPlaceBid` (`0x01e661b8`, register `0x00e5c740`): `INT32 sequenceId, INT32 bidAmount` — 8B (emitter body
+  not decompiled; MEDIUM).
+
+### Server → Client (NetIn — `BlackMarket` subscribes to all five)
+
+`BMOpen` (`0x01e4d4b0`/reg `0x00d83ec0`), `BMAuctions` (`0x01e4d51c`/`0x00d84160`), `BMAuctionUpdate`
+(`0x01e4d590`/`0x00d84400`), `BMAuctionRemove` (`0x01e4d610`/`0x00d846a0`), `BMError` (`0x01e4d690`/`0x00d84940`).
+`onBMWatchedItemsUpdate` (Rust client idx 95, `ARRAY<INT32>`) — **no matching `Event_NetIn_BMWatched*` RTTI
+found** → delivery path unknown (open Q).
+
+## UI / CoD
+
+CEGUI Lua bindings confirmed: `createAuction` (`0x00aabf70`, 5 args), `refreshMyAuctions` (`0x00aac090`,
+seeds sellerName from `GamePlayer+0x10c`), `getAuctionItemInfo` (`0x00aac260`), `cancelAuction` (`0x00aac1e0`),
+`searchAuctions` (`0x00aca360`, 11 args).
+
+**CoD delivery** uses `sgw_gate_mail` (has `cash`, `item_id`, `flags`) via `payCODForMailMessage` +
+`sendMailMessage(bCOD)`. Inferred payout: winner pays bid; seller gets a cash mail; buyer gets an item mail
+(or a CoD mail). MEDIUM confidence (no Python impl).
+
+## Open questions
+
+1. `EBlackMarketError` enum values (no string defs found). → x64dbg D.1.
+2. `onBMWatchedItemsUpdate` delivery trigger (no RTTI). → x64dbg D.2.
+3. `BMPlaceBid` emitter field layout (decompile timed out). → x64dbg D.3.
+4. `filterFlags` semantics (category/faction/mode?). → x64dbg D.4.
+5. `auctionLength` UINT8 enum values (12h/24h/48h?). → x64dbg D.5.
+6. `nextMinBidPrice` formula. → x64dbg D.6.
+
+## Dynamic-analysis needs (x64dbg)
+
+- **D.1** BP `0x00d84940` (BMError register) — trace callers; capture INT32 errorId per dispatch.
+- **D.2** Trace client method-95 dispatch via the `BlackMarket` MemberCallback cluster (`0x01e65a10`–`0x01e65ee8`).
+- **D.3** Step `register_NetOut_BMPlaceBid` (`0x00e5c740`) emit path for field layout.
+- **D.4** BP `0x00e59f70` — capture `filterFlags` across search tabs (All / My listings / Watched).
+- **D.5** BP `0x00e59970` — capture the `auctionLength` byte per duration option.
+- **D.6** Capture `currentBid`→`nextMinBidPrice` pairs across several bids.
+
+## Ghidra annotations
+
+None applied. Recommended renames: `0x00e59970`→`BMCreateAuction_NetOut_emit`,
+`0x00e59c70`→`BMCancelAuction_NetOut_emit`, `0x00e59f70`→`BMSearch_NetOut_emit`, plus the CEGUI Lua-binding
+functions listed above.

--- a/docs/reverse-engineering/findings/contact-list-restoration.md
+++ b/docs/reverse-engineering/findings/contact-list-restoration.md
@@ -1,0 +1,107 @@
+# Contact List System — Restoration Findings
+
+> **Date**: 2026-06-20
+> **Phase**: Post-V5 deep restoration assessment
+> **Confidence**: HIGH (wire formats, client Lua bridge); MEDIUM (presence semantics); LOW (flags bitmap internals)
+> **Sources**: `SGW.exe` Ghidra; `ContactListManager.def`; `alias.xml`;
+>   `deprecated/python/base/SGWPlayer.py`; `crates/services/src/cell/{cell_methods,client_methods}/contact_list.rs`;
+>   `crates/services/src/wire_log/decoders/generated.rs`; `db/resources/Social/Types/E*.sql`;
+>   `db/resources/Texts/Seed/texts.sql`; `docs/reverse-engineering/findings/contact-list-wire-formats.md`
+> **Tracking issue**: replaces #71; resolves #275
+
+## #275 answer
+
+**The `contactListFlagsUpdate` handler EXISTS** — method index 58 in
+`crates/services/src/cell/cell_methods/contact_list.rs`. It correctly parses `list_id` (i32) + `flags`
+(u32) and dispatches to a `tracing::info!` **no-op stub**. So #275's "verify handler exists" is answered
+YES; the work is to implement it, folded into this issue.
+
+## Completeness assessment
+
+A **generic named-list system** (not a hardcoded friends/ignore pair). The Python server never implemented
+it (`chatIgnore`/`chatFriend` are trace-only stubs; no `ContactListManager` class). Rust has all 6 cell
+handlers as `UNIMPLEMENTED` stubs and 5 server→client decoders, but no persistence, no fanout, no login push.
+
+| Sub-system | % |
+|---|---|
+| Wire format C→S / S→C | ~90% / ~90% |
+| Handler dispatch routing | ~80% |
+| Handler logic | 0% |
+| Persistence (DB schema) | 0% (no table) |
+| Online-presence fanout | 0% |
+| **Overall** | **~15%** |
+
+## Architecture
+
+Each list: `(id INT32, name WSTRING, flags UINT32, members WSTRING[])`. Two system lists seeded via text
+monikers: **300 = "Friends"**, **301 = "Ignore"** (`texts.sql` lines 42541/42563). `ERelationshipType`:
+Friend/Foe/Neutral. `EMemberInfo`: 9-value presence descriptor (Position/Space/Level/Health/Focus/Energy/
+Name/Archetype/World) — hypothesised to be the per-list `flags` subscription mask.
+
+`/friend` and `/ignore` slash commands (`Event_SlashCmd_ChatFriend` vtable `0x018444d0`,
+`…ChatIgnore` `0x018444b4`) are a **separate NetOut path** (`SGWNetworkManager` handlers `0x00d58010` /
+`0x00d57ed0`) routing `chatFriend(name, nick, flag)` / `chatIgnore(name, flag)` — both Python stubs.
+
+Client Lua bridge (6 functions): `getAllContactLists` (`0x00aac8f0`), `getContactList` (`0x00aac870`),
+`requestCreateContactList`, `requestDeleteContactList`, `requestRenameContactList`,
+`requestModifyContactList` (`0x00aac9c0` → `FUN_00ada540` → `FUN_00e61b10` builds `{aListId, aFlags}`).
+
+## Wire messages
+
+### Client → Server (cell methods, RTTI-confirmed, post cyclic-shift correction)
+
+- 55 `contactListCreate` — `WSTRING name, UINT32 flags` (RTTI `0x00e5f950`)
+- 56 `contactListDelete` — `INT32 listId` (`0x00e5f970`)
+- 57 `contactListRename` — `INT32 listId, WSTRING name` (`0x00e5f990`)
+- 58 `contactListFlagsUpdate` — `INT32 listId, UINT32 flags` (`0x00e5f9b0`)
+- 59 `contactListAddMembers` — `INT32 listId, ARRAY<WSTRING> names` (`0x00e5f9d0`)
+- 60 `contactListRemoveMembers` — `INT32 listId, ARRAY<WSTRING> names` (`0x00e5f9f0`)
+
+### Server → Client (client methods, decoded in `wire_log/decoders`)
+
+- 85 `onContactListUpdate` — `INT32 listId, WSTRING name, UINT32 flags` (create + update)
+- 86 `onContactListDelete` — `INT32 listId`
+- 87 `onContactListAddMembers` — `INT32 listId, ARRAY<WSTRING> names`
+- 88 `onContactListRemoveMembers` — `INT32 listId, ARRAY<WSTRING> names`
+- 89 `onContactListEvent` — `WSTRING playerName, UINT32 eventId, INT32 dataValue`
+
+`EContactListEvent` (`EContactListEvent.sql`): 0 LoggedInStatus (dataValue 1/0), 1 GainLevel (new level),
+2 Death, 3 GateTravel. dataValue for 1–3 inferred from convention.
+
+## Flows
+
+- **Login push** (expected): after world entry, server pushes `onContactListUpdate` [85] per list, then
+  `onContactListAddMembers` [87] with rosters. Client is server-pushed, does not poll.
+- **Add/remove**: `requestModifyContactList(listId, name, add)` → `contactListAddMembers`/`RemoveMembers`
+  [59/60] → echo [87]/[88]. Ignore is just membership in the "Ignore" list; chat-filtering must live in the
+  chat dispatch layer.
+- **Presence fanout**: on A login/logout/level/death/gate, push `onContactListEvent` [89] to every online
+  player who has A in any list.
+
+## Open questions
+
+1. Does `requestModifyContactList` route to `contactListAddMembers/RemoveMembers` (59/60) or
+   `contactListFlagsUpdate` (58)? `FUN_00e61b10` builds `{listId, flags}` which matches CM 58, but the Lua
+   name implies member edit. → x64dbg D.1.
+2. `aFlags` semantics (EMemberInfo subscription mask?). → x64dbg D.2.
+3. `onContactListEvent` dataValue for GainLevel/Death/GateTravel. → x64dbg D.3.
+4. ChatFriend/ChatIgnore — base-layer vs cell-layer RPC. → x64dbg D.4.
+
+## Dynamic-analysis needs (x64dbg)
+
+- **D.1** BP `0x00ada540` then step into `FUN_00e61b10` / `0x00e62560` — which event is emitted on add-friend.
+- **D.2** BP `0x00e5f9b0` (`contactListFlagsUpdate` emit) — capture `flags` across list configs.
+- **D.3** BP `0x00d8fa20` (`onContactListEvent` emit) — capture playerName/eventId/dataValue for login,
+  level-up, death, gate travel (needs two clients).
+- **D.4** BP `0x00d57fa0` / `0x00d57e60` — capture ChatFriend/ChatIgnore payloads.
+- **D.5** BP `0x00aac8f0` (`getAllContactLists`) — confirm server pushes lists at login (poll vs push).
+
+## Persistence
+
+No `sgw_contact_list`/`sgw_friend`/`sgw_ignore` table exists anywhere — must be added.
+
+## Ghidra annotations
+
+None applied. Recommended renames: `FUN_00e61b10`→`ContactList_EmitFlagsUpdate`,
+`FUN_00adfcf0`→`Lua_getContactList_bridge`, `FUN_00ada540`→`ContactListManager_RequestModify_Dispatch`,
+plus a plate comment on `0x00e5f9b0` citing the cyclic-shift correction.

--- a/docs/reverse-engineering/findings/crafting-restoration.md
+++ b/docs/reverse-engineering/findings/crafting-restoration.md
@@ -1,0 +1,132 @@
+# Crafting System — Full Restoration Findings
+
+> **Date**: 2026-06-20
+> **Phase**: Post-V5 deep restoration assessment
+> **Confidence**: HIGH (binary RTTI + Python reference + Rust codebase cross-checked)
+> **Sources**: Ghidra `SGW.exe` decompilation; `deprecated/python/cell/Crafter.py`;
+>   `deprecated/python/cell/commands/Crafting.py`; `crates/entity/src/crafting.rs`;
+>   `crates/services/src/base/crafting/`; `docs/reverse-engineering/findings/crafting-state-machine.md`;
+>   `docs/reverse-engineering/findings/crafting-wire-formats.md`
+> **Tracking issue**: replaces #53
+
+## Completeness assessment
+
+Crafting is unusual among the "missing" systems: its **infrastructure is ~100% done**
+(state struct, DB persistence with 5 live-DB tests, world-entry blueprint sync, the
+`onUpdateDiscipline` emit, GM grants, blueprint/discipline/paradigm DB seed). What is
+missing is the **activity layer** — the six cell handlers that actually do work are
+parse-and-log stubs (~3% complete).
+
+| Subsystem | Client (SGW.exe) | Server (Python) | Rust server | Rust % |
+|---|---|---|---|---|
+| State struct + DB persistence | VCrafting client-side | `Crafter.__init__` | `crates/entity/src/crafting.rs` + `base::crafting::persistence` | 100% |
+| World-entry blueprint sync (`onUpdateKnownCrafts`, 139) | expects `ARRAY<INT32>` | `onClientReady` | `map_loaded.rs` step 23 | 100% |
+| `onUpdateDiscipline` emit (136) | INT32+INT32 | `gainExpertise` | byte-exact test in entity crate | 100% |
+| GM grant expertise / ASP | — | `commands/Crafting.py` | `base::crafting::handlers` | 100% |
+| `spendAppliedSciencePoints` (95) | INT32 disciplineId | full paradigm+prereq check | parse → `UNIMPLEMENTED` | 5% |
+| `craft` (96) | craftId + ARRAY + qty | full validate/consume/timer/grant | parse → `UNIMPLEMENTED` | 5% |
+| `research` (97) | itemId + kickers | researchable check + random +5 | `UNIMPLEMENTED` | 2% |
+| `reverseEngineer` (98) | itemId | blueprint lookup, bias, recover | `UNIMPLEMENTED` | 2% |
+| `alloying` (99) | craftId + tier item + elems | tier/quality validation | `UNIMPLEMENTED` | 2% |
+| 3s induction timer | TimerUpdate → `UEvent_UI_CraftInductionStart` | `Atrea.addTimer(3.0)` | absent | 0% |
+| `onUpdateCraftingOptions` (140) + entity gate | FIXED_DICT; `isCraftingAllowed` | `craftingEntityFlags` | absent | 0% |
+
+**Overall: ~28% restored** (infrastructure ~100%, activity layer ~3%).
+
+## Architecture
+
+Server-authoritative request/response. Client sends one of six cell methods; the server
+validates, runs a 3s induction timer, and pushes result events. Client is a pure display
+consumer — no client-side state machine.
+
+- **Client class**: `class_SGW::Crafting` (RTTI-confirmed), aka `VCrafting`. Drives the
+  crafting window via `SGWScriptedWindow` (Scaleform).
+- **Server class (Python)**: `Crafter`, held as `entity.crafting` on each `SGWPlayer`.
+- **Craft type enum** (confirmed from `Crafting_isCraftTypeAllowed` @ `0x00e465d0` +
+  `Crafting_getKnownBlueprints` @ `0x00e46830` switch statements; string literals at
+  `0x019559a4`/`0x019559c0`/`0x019559e0`/`0x01955a00`):
+
+  | Value | Name | Notes |
+  |---|---|---|
+  | 1 | CraftBlueprint | blueprint at `this+0x38` |
+  | 2 | CraftResearch | shares static empty placeholder (no blueprint) |
+  | 4 | CraftReverseEng | shares static empty placeholder (no blueprint) |
+  | 8 | CraftAlloy | blueprint at `this+0x10` |
+
+## Wire messages
+
+### Client → Server (cell methods)
+
+| Idx | Name | Payload | Confidence |
+|---|---|---|---|
+| 95 | `spendAppliedSciencePoints` | `INT32 disciplineSeqId` | HIGH (.def) |
+| 96 | `craft` | `INT32 craftId` + `ARRAY<INT32> items` + `INT32 quantity` | HIGH (.def) |
+| 97 | `research` | `INT32 itemId` + `ARRAY<INT32> kickers` | HIGH (.def) |
+| 98 | `reverseEngineer` | `INT32 itemId` | HIGH (.def) |
+| 99 | `alloying` | `INT32 craftId` + `INT32 currentTierItemId` + `ARRAY<INT32> lowerTierItems` | HIGH (.def) |
+| 100 | `respecCrafting` | (no args) | HIGH (RTTI `0x01de9e6c`, stub `0x00aea3d0`) |
+
+### Server → Client (client methods)
+
+| Idx | Name | Payload | Confidence |
+|---|---|---|---|
+| 112 | `onCraftingRespecPrompt` | `INT32 CostToRespec` | HIGH (.def) |
+| 136 | `onUpdateDiscipline` | `INT32 disciplineSeqId` + `INT32 expertise` | HIGH (byte-exact test) |
+| 137 | `onDisciplineRespec` | (no args) | HIGH (RTTI `0x019c20c4`) |
+| 138 | `onUpdateRacialParadigmLevel` | **UNKNOWN** (see open Q) | MEDIUM (RTTI `0x00e45a60`) |
+| 139 | `onUpdateKnownCrafts` | `ARRAY<INT32> craftList` | HIGH (emitted in `map_loaded.rs`) |
+| 140 | `onUpdateCraftingOptions` | `CraftingOptions` FIXED_DICT (4 × `CraftingInfo{items:ARRAY<INT32>, entities:ARRAY<INT32>}`) | HIGH (.def + Python `debugAllCraft`) |
+
+## Activity logic (from `Crafter.py`, confirmed against Ghidra strings)
+
+- **craft (96)**: guard busy → blueprint known → items in `INV_Main`/`INV_Crafting` → not an
+  alloy blueprint → match `componentSet` → sufficient qty → consume → 3s timer →
+  `pickedUpItem(product, qty)` + `gainExpertise(discipline, 1)`. Error strings `0x019da800`,
+  `0x019da890` confirm the server-side `isCraftingAllowed` entity gate.
+- **research (97)**: item `researchable`, kickers flagged `kicker` → consume → eligible
+  disciplines = known AND `expertise < techCompetency` → `chance = 100 - expertise + 5×kickerCount`
+  → roll → 3s timer → `gainExpertise(discipline, 5)` on success.
+- **reverseEngineer (98)**: item `reverseEngineerable` → find blueprints producing it → bias =
+  `techCompetency/expertise` (if tc>exp) else `1 + 0.4×(tc-exp)/exp` → recover
+  `floor(rand × min(bias,1) × component.qty)` per component.
+- **alloying (99)**: alloy blueprint known → `ALLOYING_ELEMENTARY_COUNTS[quality]` elementary
+  components, each `tier == component.tier - 1` → consume → 3s timer → product + expertise +1.
+- **spendAppliedSciencePoints (95)**: ASP≥1, paradigm level met, prereq disciplines at
+  expertise≥50 → `learnDiscipline(id, 1)` → consume ASP → `onUpdateDiscipline`.
+
+Server enforces a **crafting zone/entity gate** (`isCraftingAllowed` @ `0x00e465d0`,
+`craftingEntityFlags` CELL_PRIVATE INT32) — entirely absent in Rust; players can currently
+craft from anywhere once handlers exist.
+
+## Open questions
+
+1. **`onUpdateRacialParadigmLevel` (138) wire format** — RTTI `0x00e45a60`; the INT8-level
+   inference comes from the Python `level` cap (5), not a decompiled emitter. → x64dbg D.2.
+2. **Respec confirm flow** — does the client re-send `respecCrafting` after the cost prompt, or
+   a separate confirm? Only one `RespecCraft` EventHandler in the binary. → x64dbg D.1.
+3. **`ALLOYING_ELEMENTARY_COUNTS`** — quality-indexed count table in
+   `deprecated/python/common/Constants.py`; not yet ported to Rust.
+4. **`craftingEntityFlags` values** — flag meaning (which tool types) undocumented. → x64dbg D.3.
+5. **Busy state** — `beginBusy`/`endBusy` are commented out in all four Python paths; mirror that
+   (keep the guard, skip the set).
+
+## Dynamic-analysis needs (x64dbg — debugger not currently connected)
+
+- **D.1 Respec confirm**: BP `0x00d68450` (`Event_NetOut_RespecCraft` handler vfunc_0). Hit count
+  on respec confirm: fires once (prompt only) or twice (query + confirm)?
+- **D.2 `onUpdateRacialParadigmLevel` format**: BP `0x00e45a60` (VCrafting member callback). Dump
+  event object; compare against `onUpdateDiscipline` (8 bytes). Confirm INT8 vs INT32 level.
+- **D.3 `isCraftingAllowed` gate**: BP `0x01952048` (Scaleform `isCraftingAllowed`). Dump
+  `this->craftingEntityFlags` as the player approaches/leaves a crafting station.
+- **D.4 Craft timer delivery**: BP `0x00e45ce0` (VCrafting `TimerUpdate` callback). Confirm whether
+  the server sends an initial TimerUpdate on craft start or a dedicated "craft started" message.
+- **D.5 `onUpdateCraftingOptions` FIXED_DICT bytes**: BP at the universal wire-send for a
+  CraftingOptions event (emitter registered `0x019c207c`/`0x019c20a0`). Capture raw bytes to pin
+  the nested-array encoding.
+
+## Ghidra annotations made
+
+- `0x00e465d0` `Crafting_isCraftTypeAllowed` — PRE_COMMENT: craft-type enum (1/2/4/8) with the
+  string-literal evidence addresses.
+- `0x00e46830` `Crafting_getKnownBlueprints` — PRE_COMMENT: returns blueprint collection by craft
+  type; Research/ReverseEng share a static empty placeholder.

--- a/docs/reverse-engineering/findings/duel-restoration.md
+++ b/docs/reverse-engineering/findings/duel-restoration.md
@@ -1,0 +1,103 @@
+# Duel System — Restoration Findings
+
+> **Date**: 2026-06-20
+> **Phase**: Post-V5 deep restoration assessment
+> **Confidence**: HIGH (wire format: binary RTTI + register fns); MEDIUM (lifecycle: reconstructed from .def, no server impl); LOW (timers/range/abort)
+> **Sources**: `SGW.exe` Ghidra; `deprecated/python/{base,cell}/SGWDuelMarker.py`; `deprecated/python/{base,cell}/SGWPlayer.py`;
+>   `entities/defs/SGWPlayer.def`; `entities/defs/SGWDuelMarker.def`; `python/Atrea/enums.py`;
+>   `crates/services/src/cell/cell_methods/player/social.rs`; `docs/reverse-engineering/findings/duel-wire-formats.md`
+> **Tracking issue**: replaces #70
+
+## Completeness assessment
+
+The duel system was **never implemented server-side** in the original game either — both
+`SGWDuelMarker.py` files are skeletons (`__init__` + `super()`), and the SGWPlayer duel handlers are
+`pass`. The client side is fully shipped and confirms `duel-wire-formats.md` with **no corrections
+needed**. This is consistent with SGW's pre-launch cancellation.
+
+| Aspect | % |
+|---|---|
+| Wire format recovery | ~90% (all shapes confirmed by RTTI names) |
+| State machine / server logic | ~2% (two stub handlers) |
+| Client-send fanout (onDuelChallenge/EntitiesSet/Remove/Clear) | ~5% (constants only) |
+| `SGWDuelMarker` entity | 0% |
+| **Overall functional** | **~5%** |
+
+## Wire messages (all confirmed by binary RTTI)
+
+### Client → Server (NetOut)
+
+- `sendDuelChallenge` [base] — `WSTRING aPlayerName` + `INT8 aSquadDuel`. RTTI `0x01df5e18`, register
+  `0x00cbee10`, param name `aSquadDuel` @ `0x019afa18`.
+- `sendDuelResponse` [cell, CM 102] — `INT8 aResponse` (0=decline,1=accept). Emitter `FUN_00aeafb0`
+  (alloc 0xC, set bool→INT8 `aResponse`); Lua bridge `0x00aab030`.
+- `duelForfeit` [cell, CM 103] — no args. RTTI `0x01df5e94`, register `0x00cbefc0`.
+- `Event_SlashCmd_SetPVP` (`/pvp`) — `INT8 aPvPValue`. `FUN_00e5d450` emits 1-byte payload. Distinct from
+  the server-driven duel PvP flag.
+
+### Server → Client (client methods on SGWPlayer)
+
+- `onDuelChallenge` [143] — `INT32 aEntityId` + `ARRAY<INT32> aSquadList`. UI handler `0x00ce3a30` →
+  `FUN_00cc18b0` iterates squad list.
+- `onDuelEntitiesSet` [151] — `ARRAY<INT32> aEntityList`. register `0x00d89aa0`.
+- `onDuelEntitiesRemove` [152] — `INT32 aEntityId`. register `0x00d89d40`.
+- `onDuelEntitiesClear` [153] — no args. register `0x00d89fe0`.
+- `Event_UI_DuelTimerStart` — `float duration` (handler `0x00ce3a50` → `FUN_00cd65a0(float*)`). **Addition
+  not in duel-wire-formats.md.**
+
+## SGWDuelMarker entity
+
+Inherits `SGWSpawnableEntity`. Client entity-type index **2** (confirmed `FUN_00c67420` registration
+order: Account=0, SGWSpawnableEntity=1, SGWDuelMarker=2, …). entities.xml type id 6.
+Properties (CELL_PRIVATE): `duelDetectorID: CONTROLLER_ID = 0`, `duelEntities: ARRAY<MAILBOX>`.
+CellMethod: `onEntityDefeated(INT32 entity_id)`. 0/1 methods implemented anywhere.
+
+## State machine (`python/Atrea/enums.py`)
+
+`EDUEL_STATE_*`: None=0, ResponsePending=1, Challenged=2, StartPending=3, Engaged=4.
+`EDUEL_DEFEAT_*`: Health=1, LeftSquad=2, Connection=3, Range=4, Teleport=5, InDuel=6, Forfeit=7.
+DuelTimer type=14, PvPTimer type=15.
+
+SGWPlayer.def internal cell methods (none implemented): `duelChallenge`, `duelResponse`,
+`duelEntityDefeat`, `startSquadDuel`, `duelAbort`, `onDuelDefeat`, `registerDuelMarker`, `startDuel`.
+
+## Lifecycle (reconstructed; MEDIUM confidence)
+
+1. **Challenge**: `/duel <name>` → `sendDuelChallenge(name, squadFlag)` → base resolves name → cell
+   `duelChallenge(challengerMailbox, squadMailboxes)` → `onDuelChallenge` [143] + `Event_UI_DuelTimerStart`.
+2. **Response**: accept/decline → `sendDuelResponse` [102] → `duelResponse`.
+3. **Arena setup**: spawn `SGWDuelMarker`, `registerDuelMarker` + `startDuel` on participants, set
+   `GENERICPROPERTY_PvPFlag=4` to value 1 (fan out to AoI witnesses), `onDuelEntitiesSet` [151].
+4. **Combat**: PvP flag active; both can damage each other.
+5. **Resolution**: on death/forfeit/teleport/disconnect/range → `duelEntityDefeat(mailbox, reason)` →
+   marker `onEntityDefeated` → `onDuelEntitiesRemove` [152] → when empty: `onDuelEntitiesClear` [153] +
+   reset PvP flag + destroy marker.
+
+**PvP flag**: `GENERICPROPERTY_PvPFlag = 4` via `onEntityProperty(4, INT32)`. Current Rust sends `(4,0)`
+at world entry only (`world_data.rs`); no setter to 1 / no duel-time fanout exists.
+
+## Open questions
+
+1. DuelTimer (type 14) — server-started or pure client countdown? No server dispatch site found.
+2. `duelAbort` semantics on decline/timeout/disconnect — no impl anywhere.
+3. Squad-duel scope — can any member challenge, or leader only? (`aSquadDuel` flag client-controlled.)
+4. `duelDetectorID` CONTROLLER_ID — implies a trigger-region arena boundary (→ EDUEL_DEFEAT_Range), always
+   0 in practice; likely planned-not-wired.
+5. `sendDuelResponse` byte: confirm 1=accept (standard Lua truthy). → x64dbg.
+
+## Dynamic-analysis needs (x64dbg)
+
+- **D.1** BP `0x00cd65a0` — capture `Event_UI_DuelTimerStart` float (response-window duration).
+- **D.2** Range limit — trigger a duel, walk away; find the periodic check that sends `duelEntityDefeat`
+  with `EDUEL_DEFEAT_Range=4`.
+- **D.3** BP `0x00d694d0` (SGWNetworkManager DuelChallenge handler) — recover the `sendDuelChallenge` base
+  msg_id; also watch register at `0x00cbee10`.
+- **D.4** BP at `register_NetIn_onDuelChallenge` return (`0x00d89800`) — confirm empty `aSquadList` is
+  `00 00 00 00` (count=0) for 1v1.
+- **D.5** BP `0x00aeafb0` — confirm `sendDuelResponse` true=Accept via the Lua bridge `0x00aab030`.
+
+## Ghidra annotations
+
+None applied this session. Recommended renames: `FUN_00c67420`→`Entity_RegisterAllTypes`,
+`FUN_00aeafb0`→`sendDuelResponse_emit`, `FUN_00e5d450`→`SetPVP_emit`, `FUN_00cd65a0`→`DuelTimerStart_handler`,
+`FUN_00cc18b0`→`onDuelChallenge_ui_invoke`, `0x00aab030`→`Lua_duelResponse_bridge`.

--- a/docs/reverse-engineering/findings/organization-restoration.md
+++ b/docs/reverse-engineering/findings/organization-restoration.md
@@ -1,0 +1,129 @@
+# Organization / Squad / Guild System — Restoration Findings
+
+> **Date**: 2026-06-20
+> **Phase**: Post-V5 deep restoration assessment
+> **Confidence**: HIGH (wire format: .def + binary RTTI); MEDIUM (server logic: Python stubs only); LOW (persistence schema: no original DB recovered)
+> **Sources**: `entities/defs/interfaces/{OrganizationMember,GroupAuthority}.def`,
+>   `entities/defs/SGWPlayerGroupAuthority.def`, `python/Atrea/enums.py`,
+>   `deprecated/python/{base,cell}/SGWPlayer.py`, `deprecated/python/{base,cell}/SGWPlayerGroupAuthority.py`,
+>   `db/resources/Social/Types/*.sql`, `SGW.exe` Ghidra, `crates/services/src/cell/{cell_methods,client_methods}/organization.rs`,
+>   `crates/game/src/social/guilds.rs`, `docs/reverse-engineering/findings/organization-wire-formats.md`
+> **Tracking issue**: replaces #68
+
+## Completeness assessment
+
+Three org types: **Squad** (ephemeral/session-only), **Team** (persistent), **Command** (persistent
+guild). All three are confirmed concrete C++ classes in the client (vtable/ctor chain). The original
+Python server **never implemented org logic** — both `SGWPlayerGroupAuthority` Python files are empty
+stubs and the `SGWPlayer` org handlers are all `pass`. So this is greenfield against the .def + wire spec.
+
+| Dimension | Estimate |
+|---|---|
+| Wire format documentation | ~92% (existing doc accurate; additions below) |
+| Client binary confirmation | ~88% (all named events confirmed) |
+| Rust server implementation | ~8% (wire parsing stubs only) |
+| DB schema | ~10% (type ENUMs only; zero runtime tables) |
+| **Overall** | **~12%** |
+
+## Entity model
+
+**Client C++ hierarchy** (vtable-confirmed): `Squad → Organization ← Team ← Command`. Organization ctor
+`0x00e4c570` registers 16 CME event subscribers. Squad ctor delegates via `0x00e5cc40`; Team `0x00eb4140`;
+Command `0x00eb3000`.
+
+**`EOrganizationType`**: `Squad=0, Team=1, Command=2`. `EPersistentOrganizationType` lists only
+`POT_Team`, `POT_Command` — **Squad is not persisted**.
+
+**Server entities**: `SGWPlayerGroupAuthority` (`<ServerOnly/>`, implements `GroupAuthority`) is a
+singleton authority owning all groups in `authGroups: PYTHON`. Methods: `joinGroup`, `leaveGroup`,
+`leaveGroupByName`, `callMethodOnGroup`. In Cimmeria this maps to a **base-side singleton service**, not
+per-player state.
+
+**`OrganizationMember` interface** (on SGWPlayer): `records: PYTHON` (CELL_PRIVATE, org→data),
+`squad: INT32` (**CELL_PUBLIC** — replicated to AoI observers so they can see squad membership),
+`strikeTeamTimers`, `pendingPvPTimers`, `pendingGroups`, `pendingJoins`, `pendingInvitesByType`. **All org
+state lives in `records` and is pushed via explicit client methods — there are NO replicated org
+properties.**
+
+### Rank system (9 levels — DIVERGENCE ALERT)
+
+`EORG_RANK_*`: `0 None, 1 Initiate, 2 Member, 3 SeniorMember, 4 Veteran, 5 SeniorVeteran, 6 Officer,
+7 SeniorOfficer, 8 Leader`. **`crates/game/src/social/guilds.rs` defines only 3 ranks** (Member/Officer/
+Leader) — the wire sends `UINT8` 0–8; the 3-rank model corrupts the field. Must be replaced with a 9-value enum.
+
+### Permission system (26-bit bitmask)
+
+`EORG_PERM_*` bits 0–25: DoNotUse(0x1), Invite(0x2), Promote(0x4), Demote(0x8), Eject(0x10),
+RosterNotes(0x20), OfficerNotes(0x40), RankNames(0x80), OfficerChat(0x100), EmailLists(0x200), MOTD(0x400),
+HistoryLog(0x800), Calendar(0x1000), RecruitDesc(0x2000), Adjectives(0x4000), Insignia(0x8000),
+DepositBank(0x10000), WithdrawBank(0x20000), DepositCash(0x40000), WithdrawCash(0x80000), ViewBankLogs(0x100000),
+LeaderChat(0x200000), AllianceChat(0x400000), AlterPerms(0x800000), TransferLeader(0x1000000), AllianceCmds(0x2000000).
+
+## Wire message catalog
+
+Existing `organization-wire-formats.md` is substantially accurate. **Additions discovered**:
+`onOrganizationHeaderUpdate` (cell method — bulk header dump: orgId, name, UINT64 XP, MOTD, UINT64 cash, on
+join/login, before the roster dump); `receivedMinimapPing` (org-wide fanout of CM 10);
+`organizationInviteResults` (internal invite-handshake callback); `onOrganizationCreation` cell method.
+
+**Client methods (S→C, on OrganizationMember)**: 34 onOrganizationInvite, 35 onOrganizationJoined,
+36 onOrganizationLeft, 37 onMemberJoinedOrganization, 38 onOrganizationRosterInfo, 39 onMemberLeftOrganization,
+40 onMemberRankChangedOrganization, 41 onStrikeTeamUpdate, 42 onPvPOrganizationLeaveRequest,
+43 onOrganizationNameUpdate, 44 onOrganizationExperienceUpdate, 45 onOrganizationMOTDUpdate,
+46 onOrganizationNoteUpdate, 47 onOrganizationOfficerNoteUpdate, 48 onOrganizationCashUpdate,
+49 onOrganizationRankUpdate, 50 onOrganizationRankNameUpdate, 51 onSquadLootType. (SGWPlayer methods:
+134 onOrganizationCreationResult, 135 launchOrganizationCreation.)
+
+**Cell methods (C→S)**: 8 organizationInviteResponse, 9 organizationLeave, 10 BroadcastMinimapPing,
+11 strikeTeamResponse, 12 pvpOrganizationLeaveResponse, 13 organizationMOTD, 14 organizationNote,
+15 organizationOfficerNote, 16 organizationSetRankPermissions, 17 organizationSetRankName,
+18 squadSetLootMode, 19 organizationTransferCash. **Bug**: the Rust stub for CM 17 decodes only 8 bytes
+(orgId+rank) and drops the trailing WSTRING.
+
+**Base methods (C→S)**: organizationInvite (orgId, WSTRING name), organizationInviteByType (UINT8 type,
+WSTRING name), organizationKick, organizationRankChange (…, UINT8 rank), organizationCreation (UINT8 type, WSTRING name).
+
+**Slash commands** confirmed in binary (RTTI strings `0x0184212c`–`0x0184244c`): Squad/Team/Command
+Invite/Accept/Decline, SquadKick, SquadPromote, SquadLeave, ChooseOrgName, ReloadOrganizations (dev).
+`TargetSquadMember1..6` at `0x0184094c`–`0x018409ec`.
+
+## Flows (reconstructed)
+
+- **Creation**: `/chooseOrgName` → `organizationCreation(type,name)` base → `GroupAuthority.joinGroup` →
+  `onOrganizationJoined` cell → `onOrganizationCreationResult` [134]. The server sends
+  `launchOrganizationCreation` [135] to OPEN the dialog (server-gated), before the client names the org.
+- **Invite**: `organizationInvite`/`…ByType` base → resolve name → `organizationInvite` cell on target →
+  `onOrganizationInvite` [34] → `organizationInviteResponse` [CM 8] → on accept: `joinGroup`,
+  `onMemberJoinedOrganization` [37] to existing, `onOrganizationJoined` [35] + `onOrganizationRosterInfo`
+  [38] to new member.
+- **Leave/Kick**: `organizationLeave` [CM 9] / `organizationKick` base → `GroupAuthority.leaveGroup` →
+  `onMemberLeftOrganization` [39] to members + `onOrganizationLeft` [36] to departer. (EReasons enum values
+  not yet recovered — see open Q.)
+- **Strike-team PvP**: `onStrikeTeamUpdate` [41] / `onPvPOrganizationLeaveRequest` [42] →
+  `strikeTeamResponse` [11] / `pvpOrganizationLeaveResponse` [12]; timers auto-decline on expiry.
+
+## Current Rust gaps
+
+No `SGWPlayerGroupAuthority` handler; no org state on SGWPlayer; zero roster fanout; no persistence
+(`Guild::save`/`load` are `todo!()`, no `sgw.organizations*` tables); wrong rank model; no base-method
+handlers; chat channels CHAN_SQUAD/COMMAND/OFFICER defined but not org-routed; `squad` CELL_PUBLIC not synced.
+
+## Open questions
+
+1. EReasons enum values for `onOrganizationLeft` (left/kicked/disbanded). → x64dbg.
+2. `RosterInfo` element layout — does it carry an `isOnline` bool not in the .def? → x64dbg.
+3. `launchOrganizationCreation` trigger timing (first login? NPC interaction?). → x64dbg.
+4. Cash field width — .def says UINT64; confirm not UINT32 in practice. → x64dbg.
+
+## Dynamic-analysis needs (x64dbg)
+
+- BP `0x00d8a360` (onOrganizationInvite register caller) — confirm WSTRING/byte order.
+- BP `0x00d8ade0` (onOrganizationRosterInfo register) — capture `RosterInfo` ARRAY; check `isOnline`.
+- BP `0x00d8c9f0` (onLaunchOrganizationCreation) — 1-byte payload; trace callers for trigger timing.
+- BP `0x00e4c570` (Organization ctor) — map the 16 CME subscriptions to event names.
+- BP `0x00d8c290` (onOrganizationCashUpdate) — confirm UINT64 LE.
+
+## Ghidra annotations
+
+None applied this session. Recommended renames: `0x00e4c570`→`Organization_ctor_body`,
+`0x00e5cc40`→`Squad_ctor_body`; plate comments on Squad/Team/Command vfunc_0 ctors.

--- a/docs/reverse-engineering/findings/pet-restoration.md
+++ b/docs/reverse-engineering/findings/pet-restoration.md
@@ -1,0 +1,114 @@
+# Pet / Companion System — Restoration Findings
+
+> **Date**: 2026-06-20
+> **Phase**: Post-V5 deep restoration assessment
+> **Confidence**: HIGH (wire formats: .def + binary confirmed); MEDIUM (server lifecycle: minimal Python); LOW (per-instance persistence: no DB schema found)
+> **Sources**: `entities/defs/SGWPet.def`; `entities.xml`; `deprecated/python/{base,cell}/SGWPet.py`;
+>   `deprecated/python/common/defs/PetCommand.py`; `SGW.exe` Ghidra (`GamePet.cpp`);
+>   `crates/services/src/cell/cell_methods/player/social.rs`; `db/resources/AI/Types/EPetStance.sql`;
+>   `docs/reverse-engineering/findings/pet-wire-formats.md`
+> **Tracking issue**: new (no prior pets issue existed)
+
+## Completeness assessment
+
+`SGWPet` is fully specified (`SGWPet → SGWMob → SGWBeing → SGWEntity`, entity-type index **5**,
+`GamePet` struct 436 bytes / `malloc(0x1b4)` @ `0x00c69f90`). The Python server implemented almost
+nothing (`cell/SGWPet.py` only has `createOnClient`; `base/SGWPet.py` empty). The three client→server
+pet-command stubs in Rust parse correctly but do nothing.
+
+| Layer | Coverage |
+|---|---|
+| Entity def | 100% |
+| Original server (Python) | ~5% |
+| Client binary | fully recoverable (`GamePet` class confirmed) |
+| Rust server | ~12% (wire skeleton only) |
+| **Overall functional** | **~10%** |
+
+## ⚠️ Wire-format corrections to `pet-wire-formats.md`
+
+Two existing-doc errors that will desync the client if implemented as documented:
+
+1. **`onPetStanceList`**: doc says `ARRAY<INT32>` (4B/element). `.def` line 88 declares `ARRAY<INT8>`
+   (1B/element). HIGH confidence.
+2. **`onPetStanceUpdate`**: doc says `INT32` (5B total). `.def` line 92 declares `INT8` (2B total). HIGH.
+
+## Entity model
+
+`SGWPet` 12 properties (all CELL_PRIVATE/PUBLIC, none PERSISTENT — pet persistence is manual via
+`saveToDB`): `ownerID: INT32` (**CELL_PUBLIC**), `ownerBase: MAILBOX` (**CELL_PUBLIC**), `transferXP: FLOAT=1.0`,
+`petDespawnTimerId: CONTROLLER_ID`, `abilityToResolve: INT32`, `abilityInformation: PYTHON`,
+`toggledAbilities: ARRAY<INT32>` (abilities toggled OFF), `lastOwnerPositionCheck/lastTeleportTime: FLOAT`,
+`ownerLastPosition/petLastPosition: VECTOR3`, `petStance: INT8=1`.
+
+`EPetStance`: 0 Passive, 1 Defensive (default), 2 Aggressive.
+
+## Wire messages
+
+### Server → Client (SGWPet entity methods)
+
+- `onPetAbilityList` [client idx 1] — `ARRAY<INT32> abilityIds`. register `0x00d77720`.
+- `onPetStanceList` [idx 0] — `ARRAY<INT8>` (see correction). register `0x00d779c0`.
+- `onPetStanceUpdate` [idx 2] — `INT8` (see correction). register `0x00d77c60`.
+
+`GamePet` subscribes to all three (RTTI `0x01e261b0`/`0x01e26280`/`0x01e26350`).
+
+### Client → Server (player cell methods — pet commands ride on SGWPlayer, not SGWPet)
+
+- `petInvokeAbility` [88] — `INT32 entityId, INT32 abilityId, INT32 targetId` (12B). `NetOut` `0x019b42a4`.
+- `petAbilityToggle` [89] — `INT32 entityId, INT32 abilityId, INT8 toggle` (9B). `NetOut` `0x019b42d8`.
+- `petChangeStance` [90] — `INT32 entityId, INT8 stance` (5B). `NetOut` `0x019bc070`.
+
+Rust stub byte widths (12/9/5) **agree** with the .def. `entityId` is the pet's id — ownership must be
+verified server-side (spoofing surface).
+
+## Lifecycle
+
+- **Summon**: no `petSummon` method — pets are spawned by **ability resolution**. The ability handler
+  creates the SGWPet, sets `ownerID`/`ownerBase`/`abilityToResolve`/`abilityInformation`/`petStance`, spawns
+  into AoI, then `createOnClient` → `onPetAbilityList` + `onPetStanceList`. **`Event_NetOut_Summon`
+  (`0x019be290`) is the GM `/summon <player>` command — NOT pet summon** (RTTI routes via SGWTextCommandMgr).
+- **Despawn**: `petDespawnTimerId` (timer handle) → destroy; or `onOwnerDeath` / `onOwnerLeash`. No explicit
+  dismiss message.
+- **Follow AI**: poll loop via `lastOwnerPositionCheck`/`ownerLastPosition`/`petLastPosition`; teleport to
+  owner when `dist > leash`, rate-limited by `lastTeleportTime`. `onOwnerLeash` forces immediate teleport.
+  `onOwnerRespawn(INT8 aShouldDespawn)` decides survive-vs-despawn after owner death.
+- **Ability integration**: `toggledAbilities` opt-out list; `sendPetInfoToOwner(MAILBOX, ARRAY<INT32>)`
+  pushes stance+ability lists to a new owner.
+
+## Ownership / AoI
+
+`ownerID`/`ownerBase` CELL_PUBLIC → replicated to AoI observers (clients show "X's Pet"). Client supports
+**6 party-pet targeting slots** (`Event_Action_TargetPartyPet1..6` @ `0x01840a24`–`0x01840ac4`) — so
+`ownerID` must be reliably synced to all party members. `saveToDB(INT32 playerDbId)` persists pet state, but
+**no `pets` DB table exists anywhere** (open Q).
+
+## Client UI (confirmed)
+
+`UIPetStance`, `PetCommandAction`/`PetStanceAction`/`PetAbilityAction` action-bar classes; ScrFuncs
+`getPetAbilityList`/`getPetCommandList`/`getPetStanceList`/`changePetStance`/`usePetAbility`/`togglePetAbility`;
+UI events `UEvent_UI_PetChanged`/`PetStanceChange`/`PetUpdate`.
+
+## Open questions
+
+1. **Pets DB table** — `saveToDB(playerDbId)` exists but no schema; were pets persistent or blob-on-character?
+2. Leash teleport threshold distance. → x64dbg.
+3. Owner-position poll interval. → x64dbg.
+4. Stance change: user-only or also auto-sync? → x64dbg.
+5. `onOwnerRespawn` default (despawn vs teleport).
+6. `onPetStanceList` element meaning (stance indices vs ability ids). → x64dbg.
+
+## Dynamic-analysis needs (x64dbg)
+
+- Leash threshold / poll interval: watchpoint on `GamePet` `lastTeleportTime` / `lastOwnerPositionCheck`
+  fields; capture distance + timestamp deltas.
+- BP `0x00d39cb0` (`GamePet` ctor) — construction state (`[0x5b]=5` type index; stance bytes `[0x171..0x173]`
+  init `0/0/0xff`).
+- BP `register_NetIn_PetStances` (`0x00d779c0`) emit — capture `ARRAY<INT8>` payload (resolves stance-list meaning).
+- Inject MercuryLogger and use a summoning ability: capture `createEntity(class_id=5)` + property-sync to
+  resolve the wire representation and the `ownerID` sync bytes.
+
+## Ghidra annotations
+
+None applied this session. Recommended renames: `0x00d39cb0`→`GamePet__ctor`,
+`0x00c69f90`→`GameEntityFactory_GamePet__Register`, `0x00d66110`→`SGWNetworkManager_PetInvokeAbility_HandlerCtor`,
+`0x00d66320`→`…PetChangeStance…`, `0x00d661e0`→`…PetAbilityToggle…`.


### PR DESCRIPTION
## What

Deep reverse-engineering completeness assessment of the six unimplemented gameplay systems you flagged — **crafting, organizations/squads/guilds, duels, pets, black market, contact lists** — adding a restoration findings doc per system and filing a detailed phased implementation issue per system.

Each system was mined across **three evidence layers**: `SGW.exe` (Ghidra, live), the deprecated Python/C++ server reference, and the current Rust server (via RAG + grep). Six parallel `game-archaeology-specialist` agents did the analysis; findings were verified against the binary (RTTI names, function addresses) and the `.def` files.

## New docs (this PR)

`docs/reverse-engineering/findings/{crafting,organization,duel,pet,black-market,contact-list}-restoration.md` + RE findings index updated (56 → 62).

## New issues (filed)

| System | Issue | Supersedes | Rust % today |
|---|---|---|---|
| Crafting | #567 | #53 | ~28% (infra done, activity stubs) |
| Organization / Squad / Guild | #568 | #68 | ~12% |
| Duel | #569 | #70 | ~5% |
| Pet / Companion | #570 | *(new)* | ~10% |
| Black Market / Auction | #571 | #67 | ~0% |
| Contact List | #572 | #71 + resolves #275 | ~15% |

Old pre-V5 reference issues **#53/#67/#68/#70/#71/#275 closed** as superseded.

## Notable findings beyond the plans

- **The original Python server never implemented** org, duel, black-market, or contact-list logic — they were empty stubs. So these are **greenfield against the recovered spec**, not ports.
- **Bugs surfaced in existing artifacts** (fix before implementing):
  - `pet-wire-formats.md`: `onPetStanceList` is `ARRAY<INT8>` (not INT32); `onPetStanceUpdate` is `INT8` (not INT32).
  - `black-market`: `BMCreateAuction.auctionLength` is **UINT8** (payload 13B not 16); `BMSearchOptions` has **11 fields** incl. `filterFlags` (existing doc lists 10 w/ `monikerCRC`). Current Rust decode is wrong.
  - `crates/game/src/social/guilds.rs` has a **3-rank** model vs the wire's **9-value** `EORG_RANK_*` — would corrupt the rank field.
- **#275 answered**: `contactListFlagsUpdate` handler exists (CM 58) but is a no-op stub.

## Debugger dependency

x64dbg is not currently connected. Every findings doc + issue lists the **specific breakpoints** needed to close its remaining open questions. @Steve to drive the client to those breakpoints when we pick a system to implement — a consolidated list is in my session summary.

## Scope

Analysis + documentation + issue-tracking only — **no `crates/` code changes**. These systems remain low-priority; the issues capture the plan so they're not forgotten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive reverse-engineering findings for six game systems: Black Market/Auction House, Contact List, Crafting, Duel, Organization, and Pet systems.
  * Updated documentation index reflecting expanded reverse-engineering coverage from 56 to 62 system directories.
  * Each new findings document includes completeness assessments, reconstructed system architectures, and analysis notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->