### PR TITLE
docs(gameplay): enrich crafting + pet system pages with player-facing overview

### DIFF
--- a/docs/gameplay/crafting-system.md
+++ b/docs/gameplay/crafting-system.md
@@ -7,8 +7,8 @@ last_updated: 2026-05-27
 
 # Crafting System
 
-> **Last updated**: 2026-03-01
-> **Status**: ~30% implemented
+> **Last updated**: 2026-06-20
+> **Status**: ~28% — state/persistence/skills/GM-grants done; the six activity handlers are stubs (tracked in #567). Findings: [`reverse-engineering/findings/crafting-restoration.md`](../reverse-engineering/findings/crafting-restoration.md).
 
 ## Overview
 
@@ -133,6 +133,65 @@ Crafter.alloy(blueprintId, currentTierItemId, lowerTierItems)
 3. **Tech competency** - How `techCompetency` affects crafting beyond research chance
 4. **Quality system** - Item quality tiers and their effect on alloying
 5. **Crafting busy state** - Why `beginBusy`/`endBusy` are commented out
+
+## Concrete recipe examples
+
+The catalog is a multi-stage production chain: raw materials → intermediate parts
+("subcombines") → alloys → finished gear. All examples below are pulled directly from the
+seed data (`db/resources/Entities/Seed/blueprints.sql` + `blueprints_components.sql`,
+resolved against `Items/Seed/items.sql`).
+
+**One product, several recipes.** A blueprint can have multiple *component sets*, so you
+build with whatever you have. "IC-K-layer" (skill: *Electronic Engineering*) can be made
+four ways:
+
+- 13× Integrated Circuit, **or**
+- 5× Integrated Pseudocore, **or**
+- 6× Integrated Circuit + 1× Signal Damp, **or**
+- 1× Particle Dynamo + 1× Wave Guide
+
+**Materials refining.** "Steel Plating" (*Materials Engineering*) ← 13× Steel Core (or 5×
+Titanium Core). "Optical Fiber" (*Power Systems Engineering*) ← Wave Guides + Particle parts.
+
+**Alloying / tier-up.** 1× tier-1 "Cell" or "Drug" → **2× "Blend" (Bio-Medical Alloy)**,
+which jumps from quality *Normal* to *Great* and tier 1 → tier 2. (40 of the 498 recipes
+are alloy recipes.)
+
+**Finished consumables.** The chain ends in usable gear — e.g. the **"Mark III Stimpack"**
+line (Coordination / Engagement / Fortitude / Intellect — stat-boost consumables). The
+Intellect stim (skill: *Robotics*) = 1× IC-K-layer + 2× Signal Damp + 1× Integrated Pseudocore.
+
+Skills (disciplines) form faction-gated tech trees with prerequisites — e.g. *Biomedical
+Engineering → Retroviral Engineering*, *Electronic Engineering → Robotics → Drone Robotics*,
+*Power Systems Engineering → Naquadah Energy Systems → Energy Shielding*, plus faction-locked
+branches like *Goa'uld Synesthesia*.
+
+## Where materials come from
+
+- **Loot** — mobs and containers drop crafting components (see [loot-system.md](loot-system.md)).
+- **Salvage** — reverse-engineer gear you don't want back into parts.
+- **Vendors** — buy some base materials.
+- **Research is a sink, not a source** — it consumes items to train skills; it doesn't yield materials.
+
+(No evidence of gathering/mining nodes — SGW used loot + salvage + vendors.)
+
+## Balancing
+
+The balance is the authentic 2009 game's, recovered from the client data: every recipe's
+exact ingredient counts and outputs, item quality/tier, skill-training costs, and the
+research success formula (`chance = 100 − yourExpertise + 5×kickers`, so mastering a skill
+gets progressively harder). We restore these numbers rather than design them — but they're
+fully editable in the seed if we ever want to tune the economy.
+
+## Querying the data today
+
+The full crafting catalog is queryable now, even before the activity handlers land:
+
+- Recipes: `db/resources/Entities/Seed/blueprints.sql` + `blueprints_components.sql`
+- Skills: `db/resources/Archetypes/Seed/disciplines.sql`
+- Items/materials: `db/resources/Items/Seed/items.sql`
+
+Totals: **498 blueprints** (40 alloy), **78 disciplines**, ~**5,958 items**.
 
 ## Related Docs
 

--- a/docs/gameplay/pet-system.md
+++ b/docs/gameplay/pet-system.md
@@ -7,8 +7,8 @@ last_updated: 2026-05-27
 
 # Pet System
 
-> **Last updated**: 2026-03-01
-> **Status**: ~0% implemented
+> **Last updated**: 2026-06-20
+> **Status**: ~10% — engine support, content, and client are complete; the server-side summon/command/despawn lifecycle is unimplemented (tracked in #570). Findings: [`reverse-engineering/findings/pet-restoration.md`](../reverse-engineering/findings/pet-restoration.md).
 
 ## Overview
 
@@ -82,11 +82,13 @@ The `SGWPet` entity is defined in `entities/defs/SGWPet.def` (parent: `SGWMob`).
 ## Pet Stance System
 
 Stances control pet AI behavior mode. The `petStance` property defaults to 1.
+Confirmed values (from `db/resources/AI/Types/EPetStance.sql`):
 
-```
-TODO: Decompile stance enum values from client
-Likely values: Passive, Defensive, Aggressive, Follow
-```
+| Value | Stance | Notes |
+|-------|--------|-------|
+| 0 | Passive | Won't engage |
+| 1 | Defensive | Default — fights when owner/itself is attacked |
+| 2 | Aggressive | Engages on sight |
 
 ## Pet Ability Toggling
 
@@ -105,6 +107,75 @@ The `toggledAbilities` array tracks abilities that the player has turned OFF. Wh
 3. **Pet persistence** - `saveToDB` schema and what is saved
 4. **Leash distance** - How `lastOwnerPositionCheck` triggers `onOwnerLeash`
 5. **Spawn ability** - How `abilityToResolve` is used when pet spawns
+
+## What pets are (overview)
+
+Pets are summoned combat companions you command. The roster is Goa'uld-themed, and
+each pet type has its own authored ability kit:
+
+- **Jaffa** — *Double Blast*
+- **Lo'taur** — *Heal Health* (a healer pet)
+- **Prime** (a First Prime) — *Focus Degeneration*
+- **Ashrak** (Goa'uld assassin) — a full dagger move-set: *Back Slash, Onslaught,
+  Paralyze, Crippling Slash, Dervish, Decimation Wound, Double Slash, Inevitable
+  End, Prolong Agony, Assassin*
+- **Straegis** (enemy line) — *Disengage, Dissonance, Explode*
+- **Turret** (deployable) — *Burst, Cone Attack, AOE Attack, Enhance (Shield /
+  Contamination Damage), Repair (Full / Restoration)*, plus *Dual Turrets* and
+  *Prototype* summon variants
+- **System Lord** summon
+
+Player abilities also buff pets: *Lord's Concentration* (interrupt resist to **all**
+pets), *Defend Your God*, *Holy Warrior*, *To The Death*, *Heed Our Calling*. About
+**65** summon/command/buff abilities are authored in `db/resources/Abilities/Seed/abilities.sql`.
+
+The client supports three stances and targeting up to **6 party members' pets** at once.
+
+## Built vs. concept
+
+Pets are a real, built-out system at every layer except the original server's lifecycle:
+
+- **Engine — first-class.** The entity flag set (`db/resources/Entities/Types/EEntityFlags.sql`)
+  includes `ENTITYFLAG_Pet`, `ENTITYFLAG_DetectionPet`, `ENTITYFLAG_PetUseOwnFaction`,
+  `ENTITYFLAG_PetWaitToDespawn`, `ENTITYFLAG_NoPetLeveling`, `ENTITYFLAG_NoPetTargeting`.
+  Ownership is a `GENERICPROPERTY_PetOwnerId` entity property, and there's a
+  `RESOURCE_PetCommand` resource type. A mob *becomes* a pet by setting the Pet flag + owner id.
+- **Content — authored.** Summon abilities and per-pet ability kits are present.
+- **Client — complete.** The 2009 binary has a full `GamePet` class, the stance/command/
+  ability UI, and party-pet targeting (Ghidra-confirmed).
+- **Original server — stubbed.** Python `SGWPet` only sent the ability/stance lists on
+  spawn; summon/despawn/command/follow logic was never finished. Our restoration (#570)
+  is therefore greenfield on the server.
+
+## Models
+
+We have a large model library, in two styles:
+
+- **Dedicated creature meshes** — e.g. the Straegis line (`MOB_StraegisBeacon`,
+  `MOB_StraegisTitan`, `MOB_StraegisFighter`) and `MOB_AncientDrone`.
+- **Jaffa "kit" models** — every Jaffa shares one base body (`BS_JaffaMale`) and gets
+  its look from swappable **armor component sets**, so a few base meshes yield dozens of
+  variants: Standard (`AR_J_Standard.*`), Eagle (`AR_J_Eagle.*`), Praxis (`AR_J_Praxis.*`),
+  plus Bull/Cat/Cobra/Croc/Demon/Dragon/Falcon/Horse/Hyena/Jackal/Mayan/Morrigan/Naga/Ra/
+  Svarog/Tiki/Viking — full **Female** sets — and the **Unas 1–6** beasts.
+
+Model *references* live in `db/resources/Entities/Seed/entity_templates.sql` (133 mob
+templates); the model *binaries* ship in the cooked client art (available via the game
+cache; not in git).
+
+## How summoning works — and the one real gap
+
+Using a summon ability spawns a mob, flags it as a Pet, and stamps the caster's
+`PetOwnerId`; the player then commands it via the stance/ability UI.
+
+**The unresolved binding:** summoning runs through a generic **"Spawn Mob" effect** that
+carries **no template id** in the data — *which* creature it spawns was decided by that
+effect's *script*. Tellingly, the seed has **no dedicated `Lo'taur` / `Prime` / `Ashrak` /
+`Turret` entity templates** by name, even though their summon + command abilities are fully
+authored. (The **Straegis** line is the one fully-wired example: abilities **and** templates
+**and** models all present.) So the *summon → specific creature/model* mapping for the
+player-pet types still needs recovering from the effect scripts / a debugger capture — see
+the dynamic-analysis list in [`pet-restoration.md`](../reverse-engineering/findings/pet-restoration.md).
 
 ## Related Docs
 


### PR DESCRIPTION
Promotes the plain-language explainers posted on #567 (crafting) and #570 (pets) into the permanent `docs/gameplay/` pages, grounded in the seed data and the RE findings docs.

**`crafting-system.md`** — adds concrete recipe examples (the four-way "IC-K-layer" alternate component sets, materials refining, the Bio-Medical alloy tier-up, the finished Mark III Stimpack chain), where materials come from (loot / salvage / vendors; research is a sink), a balancing note (authentic 2009 numbers, editable), and queryable-data pointers + totals (498 blueprints / 78 disciplines / ~5,958 items). Status refreshed 30% → ~28% with a link to `crafting-restoration.md`.

**`pet-system.md`** — fills the previously-TODO stance enum with the confirmed `EPetStance` values (0 Passive / 1 Defensive / 2 Aggressive); adds the pet roster + ability kits (Jaffa / Lo'taur / Prime / Ashrak / Straegis / Turret / System Lord), the engine pet support (`ENTITYFLAG_Pet`, `PetOwnerId`, `RESOURCE_PetCommand`), the model library (dedicated Straegis/Drone meshes + the Jaffa armor-"kit" system), and the unresolved summon→model binding. Status refreshed 0% → ~10% with a link to `pet-restoration.md`.

Both docs already existed and are indexed in the gameplay dashboard, so no index/count changes are needed. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)