### PR TITLE
feat(434): auto-reload auth TLS cert on file change (mtime watcher)

### DIFF
--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -133,7 +133,7 @@ impl Default for ServerConfig {
             auth_tls_key_path: None,
             // Poll the cert/key mtimes every 30s by default. Cheap (two stats)
             // and picks up a rotated cert within half a minute. Operators who
-            // rotate via SIGHUP or never rotate can set this to 0 to disable.
+            // never rotate certs at runtime can set this to 0 to disable polling.
             auth_tls_reload_interval_secs: 30,
             base_host: "0.0.0.0".to_string(),
             base_external_host: "127.0.0.1".to_string(),

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -38,6 +38,15 @@ pub struct ServerConfig {
     /// for the auth HTTPS listener. `None` disables TLS.
     pub auth_tls_key_path: Option<PathBuf>,
 
+    /// How often (in seconds) the background watcher polls the auth TLS
+    /// cert/key file mtimes and hot-reloads the live `rustls::ServerConfig`
+    /// when either file changes on disk. This lets an operator's cert rotation
+    /// (e.g. a Let's Encrypt renewal) take effect without restarting the
+    /// server. `0` disables the watcher entirely. The watcher is only spawned
+    /// when the TLS listener itself is configured (both cert and key paths set).
+    /// Default: 30.
+    pub auth_tls_reload_interval_secs: u64,
+
     /// BaseApp bind address (the interface the UDP socket is bound to).
     /// Use `0.0.0.0` to listen on all interfaces.
     /// Default: `0.0.0.0`
@@ -122,6 +131,10 @@ impl Default for ServerConfig {
             auth_tls_port: 13443,
             auth_tls_cert_path: None,
             auth_tls_key_path: None,
+            // Poll the cert/key mtimes every 30s by default. Cheap (two stats)
+            // and picks up a rotated cert within half a minute. Operators who
+            // rotate via SIGHUP or never rotate can set this to 0 to disable.
+            auth_tls_reload_interval_secs: 30,
             base_host: "0.0.0.0".to_string(),
             base_external_host: "127.0.0.1".to_string(),
             base_port: 32832,
@@ -229,6 +242,15 @@ mod tests {
         // documented hour so flipping to v2 gives the intended cadence.
         let config = ServerConfig::default();
         assert_eq!(config.mercury_key_rotation_secs, 3600);
+    }
+
+    #[test]
+    fn default_config_cert_reload_interval_is_30s() {
+        // The watcher defaults to a 30-second poll. `0` would disable it; this
+        // guard pins the on-by-default behaviour so a cert rotation is picked
+        // up without a server restart out of the box.
+        let config = ServerConfig::default();
+        assert_eq!(config.auth_tls_reload_interval_secs, 30);
     }
 
     #[test]

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -12,6 +12,7 @@
 //! | `AUTH_HOST` | `0.0.0.0` | Auth service bind address |
 //! | `AUTH_PORT` | `13001` | Auth service port (BaseApp connections) |
 //! | `LOGON_PORT` | `8081` | Auth HTTP port (SOAP client login) |
+//! | `AUTH_TLS_RELOAD_INTERVAL_SECS` | `30` | How often the background watcher polls the auth TLS cert/key file mtimes and hot-reloads the live config when either changes (e.g. a Let's Encrypt renewal), without restarting the server. `0` disables the watcher. Only active when the TLS listener is configured (cert + key paths set). |
 //! | `BASE_HOST` | `0.0.0.0` | BaseApp UDP bind address |
 //! | `BASE_EXTERNAL` | `127.0.0.1` | BaseApp address advertised to game clients |
 //! | `BASE_PORT` | `32832` | BaseApp UDP port |
@@ -329,6 +330,16 @@ fn config_from_env() -> ServerConfig {
     if let Ok(v) = std::env::var("LOGON_PORT") {
         if let Ok(p) = v.parse() {
             cfg.logon_port = p;
+        }
+    }
+    if let Ok(v) = std::env::var("AUTH_TLS_RELOAD_INTERVAL_SECS") {
+        if let Ok(secs) = v.parse() {
+            cfg.auth_tls_reload_interval_secs = secs;
+        } else {
+            tracing::warn!(
+                value = %v,
+                "AUTH_TLS_RELOAD_INTERVAL_SECS is not a number; keeping default"
+            );
         }
     }
     if let Ok(v) = std::env::var("BASE_HOST") {

--- a/crates/services/src/auth/cert_watcher.rs
+++ b/crates/services/src/auth/cert_watcher.rs
@@ -1,0 +1,323 @@
+//! Background watcher that hot-reloads the auth TLS certificate when the
+//! cert/key files change on disk.
+//!
+//! Why mtime polling, not `notify`/inotify: a two-`stat`-per-tick poll is
+//! dependency-free, behaves identically on every platform (Linux inotify vs.
+//! Windows `ReadDirectoryChangesW` have meaningfully different edge cases around
+//! atomic renames and editor write patterns), and is trivially testable — the
+//! "check + maybe reload" step is a pure-ish function we can drive directly
+//! without a running task or a real clock. Cert rotation is rare and not
+//! latency-sensitive (a renewed Let's Encrypt cert being picked up within one
+//! poll interval is fine), so the simplicity wins.
+//!
+//! Resilience contract: an operator mid-write of a PEM file (truncated cert,
+//! key not yet rewritten) must never crash the watcher or swap a broken config
+//! in. [`TlsCertStore::reload`] only swaps after a *successful* rebuild, so a
+//! failed read/parse leaves the previous config live; the watcher logs the
+//! failure (negative-logging convention) and retries on the next tick. Because
+//! the watcher only advances its "last seen" mtime snapshot when a reload
+//! *succeeds*, a transient failure is automatically retried until the operator
+//! finishes writing both files.
+
+use std::path::Path;
+use std::time::{Duration, SystemTime};
+
+use tokio::time::{interval, MissedTickBehavior};
+
+use super::tls::TlsCertStore;
+
+/// The last-observed modification times of the cert and key files.
+///
+/// `None` means the file could not be stat'd at the last check (missing, or a
+/// transient I/O error) — treated as "no known mtime yet" so the next
+/// successful stat that differs triggers a reload.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(super) struct FileMtimes {
+    cert: Option<SystemTime>,
+    key: Option<SystemTime>,
+}
+
+impl FileMtimes {
+    /// Stat both files and capture their mtimes. A file that cannot be stat'd
+    /// contributes `None` (logged at debug); this is not an error here — the
+    /// reload attempt downstream surfaces a genuine read failure.
+    pub(super) fn read(cert_path: &Path, key_path: &Path) -> Self {
+        Self {
+            cert: mtime_of(cert_path),
+            key: mtime_of(key_path),
+        }
+    }
+
+    /// True when either file's mtime differs from `other` (advanced, regressed,
+    /// or appeared/disappeared). We deliberately treat *any* difference as a
+    /// reload trigger rather than only forward movement: a restore-from-backup
+    /// or a clock adjustment can move an mtime backward, and the operator still
+    /// means "use what's on disk now".
+    fn differs_from(&self, other: &FileMtimes) -> bool {
+        self.cert != other.cert || self.key != other.key
+    }
+}
+
+/// Read a single file's modification time, returning `None` (and logging at
+/// debug) if it can't be stat'd. Never an error — a missing file mid-rotation
+/// is expected and handled by the retry-next-tick loop.
+fn mtime_of(path: &Path) -> Option<SystemTime> {
+    match std::fs::metadata(path).and_then(|m| m.modified()) {
+        Ok(t) => Some(t),
+        Err(e) => {
+            tracing::debug!(
+                path = %path.display(),
+                error = %e,
+                "auth TLS cert watcher could not stat file; treating mtime as unknown"
+            );
+            None
+        }
+    }
+}
+
+/// The single "check + maybe reload" step, factored out of the task loop so it
+/// is directly testable without a running interval or real wall-clock waits.
+///
+/// Compares the current on-disk mtimes against `last`. If nothing changed, logs
+/// at debug and returns `last` unchanged. If either file changed, attempts a
+/// [`TlsCertStore::reload`]:
+///
+/// - On success: logs `info` with the new cert mtime and returns the *new*
+///   mtime snapshot, so subsequent ticks compare against the just-loaded state.
+/// - On failure (mid-write PEM, transient I/O): logs a negative `warn` and
+///   returns `last` **unchanged**, so the change is retried on the next tick
+///   until the read succeeds. The live config is untouched (`reload` only swaps
+///   after a successful rebuild).
+pub(super) fn check_and_reload(store: &TlsCertStore, last: FileMtimes) -> FileMtimes {
+    let current = FileMtimes::read(store.cert_path(), store.key_path());
+
+    if !current.differs_from(&last) {
+        tracing::debug!(
+            cert = %store.cert_path().display(),
+            "auth TLS cert unchanged; no reload"
+        );
+        return last;
+    }
+
+    match store.reload() {
+        Ok(()) => {
+            tracing::info!(
+                cert = %store.cert_path().display(),
+                new_cert_mtime = ?current.cert,
+                new_key_mtime = ?current.key,
+                "auth TLS cert changed on disk; hot-swapped live config"
+            );
+            current
+        }
+        Err(e) => {
+            // Negative-logging convention: a change was detected but the reload
+            // did not take effect. Keep the old mtime snapshot so we retry.
+            tracing::warn!(
+                cert = %store.cert_path().display(),
+                error = %e,
+                "auth TLS cert changed but reload failed (mid-write?); keeping previous config, will retry"
+            );
+            last
+        }
+    }
+}
+
+/// Spawn the background mtime-watcher task.
+///
+/// Polls the cert/key mtimes every `interval_secs` seconds and calls
+/// [`check_and_reload`]. The task runs until the process exits. Only call this
+/// when the TLS listener is actually configured; an `interval_secs` of `0`
+/// disables the watcher (the caller should not spawn it at all in that case,
+/// but this is defended here too).
+pub(super) fn spawn_cert_watcher(store: TlsCertStore, interval_secs: u64) {
+    if interval_secs == 0 {
+        tracing::debug!("auth TLS cert watcher disabled (interval = 0)");
+        return;
+    }
+
+    tracing::info!(
+        cert = %store.cert_path().display(),
+        key = %store.key_path().display(),
+        interval_secs,
+        "Starting auth TLS cert watcher"
+    );
+
+    tokio::spawn(async move {
+        // Seed the snapshot with the mtimes at start so we only react to changes
+        // that happen *after* the listener came up with its initial cert.
+        let mut last = FileMtimes::read(store.cert_path(), store.key_path());
+
+        let mut ticker = interval(Duration::from_secs(interval_secs));
+        // If the runtime stalls and we miss ticks, collapse them — we only ever
+        // need one check, not a backlog of catch-up reloads.
+        ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
+        // The first tick fires immediately; consume it so the first *real* check
+        // happens one interval after start, not instantly.
+        ticker.tick().await;
+
+        loop {
+            ticker.tick().await;
+            last = check_and_reload(&store, last);
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    /// RAII temp dir under the OS temp root. Deletes its tree on drop. Mirrors
+    /// the helper in `tls.rs`/`tls_smoke.rs` to avoid a `tempfile` dep.
+    struct TempDir(PathBuf);
+
+    impl TempDir {
+        fn new(tag: &str) -> Self {
+            use std::sync::atomic::{AtomicU64, Ordering};
+            static SEQ: AtomicU64 = AtomicU64::new(0);
+            let n = SEQ.fetch_add(1, Ordering::Relaxed);
+            let mut p = std::env::temp_dir();
+            p.push(format!(
+                "cimmeria-certwatch-{tag}-{}-{n}",
+                std::process::id()
+            ));
+            std::fs::create_dir_all(&p).expect("create temp dir");
+            TempDir(p)
+        }
+        fn path(&self) -> &Path {
+            &self.0
+        }
+    }
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    /// Write a fresh self-signed cert/key pair to the given paths.
+    fn write_self_signed(cert_path: &Path, key_path: &Path) {
+        let certified = rcgen::generate_simple_self_signed(vec!["localhost".to_string()])
+            .expect("self-signed cert");
+        std::fs::write(cert_path, certified.cert.pem()).expect("write cert");
+        std::fs::write(key_path, certified.key_pair.serialize_pem()).expect("write key");
+    }
+
+    /// Bump a file's mtime forward unconditionally so the change is detectable
+    /// even on filesystems with coarse mtime granularity, where rewriting
+    /// within the same tick could otherwise leave mtime unchanged.
+    fn bump_mtime(path: &Path) {
+        let future = SystemTime::now() + Duration::from_secs(10);
+        // `set_modified` is stable since Rust 1.75; the workspace MSRV is newer.
+        let f = std::fs::OpenOptions::new()
+            .write(true)
+            .open(path)
+            .expect("open for mtime bump");
+        f.set_modified(future).expect("set mtime");
+    }
+
+    #[test]
+    fn check_and_reload_swaps_in_new_cert_when_files_change() {
+        let dir = TempDir::new("reload");
+        let cert_path = dir.path().join("cert.pem");
+        let key_path = dir.path().join("key.pem");
+        write_self_signed(&cert_path, &key_path);
+
+        let store = TlsCertStore::load(&cert_path, &key_path).expect("store loads");
+        let before_der = store.current_leaf_cert_der();
+        let last = FileMtimes::read(&cert_path, &key_path);
+
+        // Operator rotates the cert: a *different* valid self-signed pair lands
+        // at the same paths, with a forward mtime so the poll detects it.
+        write_self_signed(&cert_path, &key_path);
+        bump_mtime(&cert_path);
+        bump_mtime(&key_path);
+
+        let new_snapshot = check_and_reload(&store, last);
+
+        // The watcher must have advanced its mtime snapshot...
+        assert_ne!(
+            new_snapshot, last,
+            "mtime snapshot must advance after a detected change"
+        );
+        // ...and, crucially, the *served* leaf cert must now be the new one.
+        // This is what fails if the reload is removed: with no reload the store
+        // keeps serving `before_der`.
+        let after_der = store.current_leaf_cert_der();
+        assert_ne!(
+            before_der, after_der,
+            "live config must serve the rotated cert after check_and_reload"
+        );
+    }
+
+    #[test]
+    fn check_and_reload_is_noop_when_files_unchanged() {
+        let dir = TempDir::new("noop");
+        let cert_path = dir.path().join("cert.pem");
+        let key_path = dir.path().join("key.pem");
+        write_self_signed(&cert_path, &key_path);
+
+        let store = TlsCertStore::load(&cert_path, &key_path).expect("store loads");
+        let before_der = store.current_leaf_cert_der();
+        let last = FileMtimes::read(&cert_path, &key_path);
+
+        // No file change between snapshot and check.
+        let after_snapshot = check_and_reload(&store, last);
+
+        assert_eq!(after_snapshot, last, "snapshot must not change on a no-op");
+        assert_eq!(
+            before_der,
+            store.current_leaf_cert_der(),
+            "served cert must be untouched when nothing changed"
+        );
+    }
+
+    #[test]
+    fn corrupt_pem_on_tick_is_ignored_and_old_config_retained() {
+        let dir = TempDir::new("corrupt");
+        let cert_path = dir.path().join("cert.pem");
+        let key_path = dir.path().join("key.pem");
+        write_self_signed(&cert_path, &key_path);
+
+        let store = TlsCertStore::load(&cert_path, &key_path).expect("store loads");
+        let good_der = store.current_leaf_cert_der();
+        let last = FileMtimes::read(&cert_path, &key_path);
+
+        // Operator is mid-write: the cert file is now a truncated/garbage PEM
+        // while the key may already have been rewritten. mtime advances so the
+        // poll sees a change and *attempts* a reload — which must fail safely.
+        std::fs::write(&cert_path, b"-----BEGIN CERTIFICATE-----\ngarbage\n")
+            .expect("write corrupt");
+        bump_mtime(&cert_path);
+
+        let new_snapshot = check_and_reload(&store, last);
+
+        // The reload failed, so the snapshot must NOT advance — guaranteeing the
+        // change is retried on the next tick once the write completes.
+        assert_eq!(
+            new_snapshot, last,
+            "snapshot must stay put when reload fails so the change is retried"
+        );
+        // And the live config must still serve the original, valid cert.
+        assert_eq!(
+            good_der,
+            store.current_leaf_cert_der(),
+            "a broken PEM must never replace the live config"
+        );
+    }
+
+    #[test]
+    fn spawn_with_zero_interval_is_disabled() {
+        // A zero interval must not spawn a polling task. We can't easily observe
+        // "no task spawned" directly, but the function must return without panic
+        // and the call is a documented no-op.
+        let dir = TempDir::new("disabled");
+        let cert_path = dir.path().join("cert.pem");
+        let key_path = dir.path().join("key.pem");
+        write_self_signed(&cert_path, &key_path);
+        let store = TlsCertStore::load(&cert_path, &key_path).expect("store loads");
+
+        // Must not panic; nothing to await.
+        spawn_cert_watcher(store, 0);
+    }
+}

--- a/crates/services/src/auth/cert_watcher.rs
+++ b/crates/services/src/auth/cert_watcher.rs
@@ -307,6 +307,43 @@ mod tests {
     }
 
     #[test]
+    fn mismatched_cert_and_key_is_rejected_and_old_config_retained() {
+        let dir = TempDir::new("mismatch");
+        let cert_path = dir.path().join("cert.pem");
+        let key_path = dir.path().join("key.pem");
+        write_self_signed(&cert_path, &key_path);
+
+        let store = TlsCertStore::load(&cert_path, &key_path).expect("store loads");
+        let good_der = store.current_leaf_cert_der();
+        let last = FileMtimes::read(&cert_path, &key_path);
+
+        // Non-atomic rotation: a NEW cert lands but the key file is still the
+        // OLD key (operator hasn't rewritten it yet), so the pair no longer
+        // matches. mtime advances, so the poll attempts a reload.
+        let other = rcgen::generate_simple_self_signed(vec!["localhost".to_string()])
+            .expect("other self-signed cert");
+        std::fs::write(&cert_path, other.cert.pem()).expect("write mismatched cert");
+        bump_mtime(&cert_path);
+
+        let new_snapshot = check_and_reload(&store, last);
+
+        // The mismatched pair must be rejected (keys_match guard): the snapshot
+        // must NOT advance (so it retries once the key is rewritten too) and the
+        // live config must still serve the original, self-consistent cert. If
+        // the keys_match check is removed, with_single_cert accepts the bad pair
+        // and both assertions fail.
+        assert_eq!(
+            new_snapshot, last,
+            "snapshot must stay put when the cert/key pair is mismatched"
+        );
+        assert_eq!(
+            good_der,
+            store.current_leaf_cert_der(),
+            "a cert that does not match the live key must never be swapped in"
+        );
+    }
+
+    #[test]
     fn spawn_with_zero_interval_is_disabled() {
         // A zero interval must not spawn a polling task. We can't easily observe
         // "no task spawned" directly, but the function must return without panic

--- a/crates/services/src/auth/mod.rs
+++ b/crates/services/src/auth/mod.rs
@@ -9,6 +9,7 @@
 //!
 //! See `docs/protocol/login-handshake.md` for the full protocol spec.
 
+mod cert_watcher;
 mod credentials;
 mod handlers;
 mod service;

--- a/crates/services/src/auth/service.rs
+++ b/crates/services/src/auth/service.rs
@@ -215,11 +215,10 @@ impl AuthService {
             })?;
             // Stash the store so reload_certs() can hot-swap the cert later.
             self.cert_store = Some(store.clone());
-
-            // Spawn the background mtime watcher so an operator's cert rotation
-            // (e.g. a Let's Encrypt renewal) is hot-reloaded without restarting
-            // the server. `0` disables it; the watcher no-ops in that case.
-            spawn_cert_watcher(store.clone(), self.tls_reload_interval_secs);
+            // Hold a handle for the mtime watcher, which we start only *after* a
+            // successful bind — a bind failure (e.g. port in use) returns below
+            // and must not leave a watcher task running orphaned.
+            let watcher_store = store.clone();
 
             let tls_listener = TlsListener::bind(self.tls_addr, store).await.map_err(|e| {
                 tracing::error!(addr = %self.tls_addr, error = %e, "Failed to bind auth TLS listener");
@@ -256,6 +255,12 @@ impl AuthService {
                 }
                 tracing::trace!("Auth TLS server task exited");
             });
+
+            // Listener is bound and serving — now start the background mtime
+            // watcher so an operator's cert rotation (e.g. a Let's Encrypt
+            // renewal) is hot-reloaded without a restart. `0` disables it; the
+            // watcher no-ops in that case.
+            spawn_cert_watcher(watcher_store, self.tls_reload_interval_secs);
         } else {
             tracing::debug!("Auth TLS listener not configured (cert/key paths unset); HTTP-only");
         }

--- a/crates/services/src/auth/service.rs
+++ b/crates/services/src/auth/service.rs
@@ -15,6 +15,7 @@ use cimmeria_common::ServerConfig;
 
 use crate::audit::{LoginEvent, LoginEventBuffer};
 
+use super::cert_watcher::spawn_cert_watcher;
 use super::handlers::{handle_server_selection, handle_user_auth};
 use super::tls::{hsts_layer, tls_marker_layer, TlsCertStore, TlsListener};
 use super::{
@@ -37,6 +38,9 @@ pub struct AuthService {
     tls_cert_path: Option<PathBuf>,
     /// PEM private key path; `None` disables the TLS listener.
     tls_key_path: Option<PathBuf>,
+    /// How often (seconds) the background watcher polls the cert/key mtimes and
+    /// hot-reloads on change. `0` disables the watcher.
+    tls_reload_interval_secs: u64,
     /// Live cert store (set once `start` loads the cert). Held so `reload_certs`
     /// can hot-swap the cert without restarting the listener.
     cert_store: Option<TlsCertStore>,
@@ -71,6 +75,7 @@ impl AuthService {
             tls_addr,
             tls_cert_path: config.auth_tls_cert_path.clone(),
             tls_key_path: config.auth_tls_key_path.clone(),
+            tls_reload_interval_secs: config.auth_tls_reload_interval_secs,
             cert_store: None,
             is_running: false,
             shards: Vec::new(),
@@ -210,6 +215,11 @@ impl AuthService {
             })?;
             // Stash the store so reload_certs() can hot-swap the cert later.
             self.cert_store = Some(store.clone());
+
+            // Spawn the background mtime watcher so an operator's cert rotation
+            // (e.g. a Let's Encrypt renewal) is hot-reloaded without restarting
+            // the server. `0` disables it; the watcher no-ops in that case.
+            spawn_cert_watcher(store.clone(), self.tls_reload_interval_secs);
 
             let tls_listener = TlsListener::bind(self.tls_addr, store).await.map_err(|e| {
                 tracing::error!(addr = %self.tls_addr, error = %e, "Failed to bind auth TLS listener");

--- a/crates/services/src/auth/tls.rs
+++ b/crates/services/src/auth/tls.rs
@@ -183,6 +183,18 @@ fn build_live_tls(cert_path: &Path, key_path: &Path) -> Result<LiveTls, TlsError
     let leaf_cert_der = certs[0].as_ref().to_vec();
 
     let provider = Arc::new(tokio_rustls::rustls::crypto::aws_lc_rs::default_provider());
+
+    // Verify the private key actually matches the leaf certificate BEFORE
+    // building the live config. `with_single_cert` does NOT cross-check this,
+    // so without the guard a non-atomic rotation (new cert written, old key
+    // still on disk for a tick) could install a mismatched pair that fails
+    // every TLS handshake until the next reload. On mismatch we error here;
+    // `reload` then retains the previous good config and the watcher retries on
+    // the next tick once both files are consistent.
+    let signing_key = provider.key_provider.load_private_key(key.clone_key())?;
+    let certified = tokio_rustls::rustls::sign::CertifiedKey::new(certs.clone(), signing_key);
+    certified.keys_match()?;
+
     let config = ServerConfig::builder_with_provider(provider)
         .with_safe_default_protocol_versions()?
         .with_no_client_auth()

--- a/crates/services/src/auth/tls.rs
+++ b/crates/services/src/auth/tls.rs
@@ -19,8 +19,9 @@
 //!   [`TlsCertStore::reload`] re-reads the cert/key files and atomically swaps
 //!   the config in. In-flight connections keep the config they handshook with;
 //!   new connections pick up the rotated cert — no listener restart, no dropped
-//!   socket. The mtime/SIGHUP watcher that *calls* `reload` is a documented
-//!   follow-up; this module exposes the reload seam now.
+//!   socket. The background mtime watcher in [`super::cert_watcher`] calls
+//!   `reload` on a poll interval so an operator's cert rotation is picked up
+//!   without restarting the server.
 //!
 //! - **Handshake failures never kill the listener.** Per the `Listener` trait
 //!   contract, `accept()` must log-and-retry on error. A client speaking plain
@@ -58,6 +59,23 @@ pub enum TlsError {
     Rustls(#[from] tokio_rustls::rustls::Error),
 }
 
+/// The live, served TLS material: the assembled `rustls::ServerConfig` plus the
+/// DER of the leaf certificate it serves.
+///
+/// Bundling the leaf DER with the config (rather than digging it back out of
+/// rustls, which hides its cert chain behind a private `ClientHello`) lets the
+/// reload path and tests observe *which* cert is currently live with a cheap
+/// byte comparison — proving a hot-swap installed *different* material, not just
+/// a fresh-but-identical config.
+struct LiveTls {
+    config: Arc<ServerConfig>,
+    // Only read by the test-only `current_leaf_cert_der` observability hook; in
+    // a release build nothing reads it back out, but it is still captured on
+    // every (re)build so the hook is always accurate when tests run.
+    #[cfg_attr(not(test), allow(dead_code))]
+    leaf_cert_der: Vec<u8>,
+}
+
 /// Holds the live `rustls::ServerConfig` behind an `ArcSwap` so the cert can be
 /// hot-reloaded without restarting the listener.
 ///
@@ -66,7 +84,7 @@ pub enum TlsError {
 pub struct TlsCertStore {
     cert_path: PathBuf,
     key_path: PathBuf,
-    config: Arc<ArcSwap<ServerConfig>>,
+    live: Arc<ArcSwap<LiveTls>>,
 }
 
 impl std::fmt::Debug for TlsCertStore {
@@ -86,24 +104,25 @@ impl TlsCertStore {
     pub fn load(cert_path: impl AsRef<Path>, key_path: impl AsRef<Path>) -> Result<Self, TlsError> {
         let cert_path = cert_path.as_ref().to_path_buf();
         let key_path = key_path.as_ref().to_path_buf();
-        let config = build_server_config(&cert_path, &key_path)?;
+        let live = build_live_tls(&cert_path, &key_path)?;
         Ok(Self {
             cert_path,
             key_path,
-            config: Arc::new(ArcSwap::from_pointee(config)),
+            live: Arc::new(ArcSwap::from_pointee(live)),
         })
     }
 
     /// Re-read the cert/key files from their original paths and atomically swap
     /// the active `ServerConfig`.
     ///
-    /// This is the reload **seam** — an mtime/SIGHUP watcher that calls this on
-    /// a schedule is a documented follow-up. On error the previous config is
-    /// left in place (the swap only happens after a successful rebuild), so a
-    /// botched cert rotation can't take the listener down.
+    /// This is the reload **seam** — the background mtime watcher in
+    /// [`super::cert_watcher`] calls this on a poll interval. On error the
+    /// previous config is left in place (the swap only happens after a
+    /// successful rebuild), so a botched cert rotation can't take the listener
+    /// down.
     pub fn reload(&self) -> Result<(), TlsError> {
-        let new_config = build_server_config(&self.cert_path, &self.key_path)?;
-        self.config.store(Arc::new(new_config));
+        let new_live = build_live_tls(&self.cert_path, &self.key_path)?;
+        self.live.store(Arc::new(new_live));
         tracing::info!(
             cert = %self.cert_path.display(),
             "Reloaded auth TLS certificate"
@@ -113,12 +132,42 @@ impl TlsCertStore {
 
     /// Snapshot the current config (read per-connection in the accept loop).
     fn current(&self) -> Arc<ServerConfig> {
-        self.config.load_full()
+        Arc::clone(&self.live.load().config)
+    }
+
+    /// The configured cert chain path. Used by the mtime watcher to stat the
+    /// file it must reload from.
+    pub(super) fn cert_path(&self) -> &Path {
+        &self.cert_path
+    }
+
+    /// The configured private key path. Used by the mtime watcher to stat the
+    /// file it must reload from.
+    pub(super) fn key_path(&self) -> &Path {
+        &self.key_path
+    }
+
+    /// Return the DER bytes of the leaf certificate the store is *currently*
+    /// serving.
+    ///
+    /// The leaf DER carries the SPKI + serial, so a reload test can prove a
+    /// hot-swap installed *different* cert material — not merely that a swap
+    /// occurred — by comparing this value across a reload. Captured at build
+    /// time and carried alongside the live config (see [`LiveTls`]) so it always
+    /// reflects exactly what the listener serves.
+    #[cfg(test)]
+    pub(super) fn current_leaf_cert_der(&self) -> Vec<u8> {
+        self.live.load().leaf_cert_der.clone()
     }
 }
 
-/// Read a PEM cert chain + private key and assemble a `rustls::ServerConfig`
-/// with no client-cert verification (standard server-auth-only TLS).
+/// Read a PEM cert chain + private key, assemble a `rustls::ServerConfig` with
+/// no client-cert verification (standard server-auth-only TLS), and capture the
+/// leaf certificate's DER for the live-cert observability hook.
+///
+/// Both the initial [`TlsCertStore::load`] and every [`TlsCertStore::reload`]
+/// go through here, so the leaf DER carried in [`LiveTls`] always matches the
+/// config actually built — there is no second read that could drift.
 ///
 /// The provider is pinned to **aws-lc-rs** explicitly rather than relying on
 /// `ServerConfig::builder()`'s process-default: this crate's dependency graph
@@ -126,16 +175,22 @@ impl TlsCertStore {
 /// other deps each pull one), and with two providers present rustls 0.23
 /// refuses to auto-select and panics. Pinning the provider here makes the auth
 /// listener deterministic regardless of what the rest of the binary links.
-fn build_server_config(cert_path: &Path, key_path: &Path) -> Result<ServerConfig, TlsError> {
+fn build_live_tls(cert_path: &Path, key_path: &Path) -> Result<LiveTls, TlsError> {
     let certs = load_certs(cert_path)?;
     let key = load_private_key(key_path)?;
+
+    // `load_certs` guarantees a non-empty, leaf-first chain.
+    let leaf_cert_der = certs[0].as_ref().to_vec();
 
     let provider = Arc::new(tokio_rustls::rustls::crypto::aws_lc_rs::default_provider());
     let config = ServerConfig::builder_with_provider(provider)
         .with_safe_default_protocol_versions()?
         .with_no_client_auth()
         .with_single_cert(certs, key)?;
-    Ok(config)
+    Ok(LiveTls {
+        config: Arc::new(config),
+        leaf_cert_der,
+    })
 }
 
 /// Parse the leaf-first PEM certificate chain.

--- a/docs/architecture/encryption-modernization.md
+++ b/docs/architecture/encryption-modernization.md
@@ -67,7 +67,16 @@ client-telemetry" open decision in favour of **extending client-telemetry**.
 ### Phase 1 — auth TLS
 
 - **Server side:** terminate TLS with **tokio-rustls**, with **arc-swap**-based
-  hot certificate reload (rotate the cert without dropping the listener).
+  hot certificate reload (rotate the cert without dropping the listener). **Cert
+  hot-reload is implemented:** a background mtime watcher
+  (`crates/services/src/auth/cert_watcher.rs`) polls the cert/key files and
+  atomically swaps the live `rustls::ServerConfig` via `TlsCertStore::reload`
+  when either file changes, so an operator's cert rotation (e.g. a Let's Encrypt
+  renewal) is picked up without a server restart. The poll interval is
+  `auth_tls_reload_interval_secs` (env `AUTH_TLS_RELOAD_INTERVAL_SECS`, default
+  30s; `0` disables the watcher). A mid-write/corrupt PEM on a tick is logged and
+  retried on the next tick — the swap only happens after a successful rebuild, so
+  a botched rotation never takes the listener down.
 - **Client side:** hook `curl_easy_setopt` (`0x013A96E0`), intercept
   `CURLOPT_URL` (`0x2712`), and rewrite the URL to a **localhost loopback**. A
   **local rustls proxy inside the injected shim** then re-originates the request


### PR DESCRIPTION
Follow-up to #566 (auth TLS): the cert store had a `reload_certs()` seam but nothing triggered it. This adds the watcher so an operator's cert rotation (e.g. Let's Encrypt renewal) is picked up **without restarting the server**.

## What's here
- **mtime-polling watcher** (`crates/services/src/auth/cert_watcher.rs`) — dependency-free (no `notify`/inotify), cross-platform, testable. Only spawned when both cert+key paths are set.
- Config knob `auth_tls_reload_interval_secs` (default `30`, `0` disables) + env `AUTH_TLS_RELOAD_INTERVAL_SECS`.
- **Resilient:** `TlsCertStore::reload` only swaps after a successful rebuild, so a broken/half-written PEM never goes live; the watcher's "last seen" snapshot only advances on a successful reload, so a mid-write change is retried next tick. `info!` on hot-swap, `warn!` (negative-logging) on failed reload.
- The check step is factored as a standalone `check_and_reload(store, last)` for testing; the loop is a thin wrapper.

## Tests
- `check_and_reload_swaps_in_new_cert_when_files_change` — writes a *different* valid self-signed pair (rcgen) to the same paths, bumps mtime, asserts the **served leaf-cert DER changed** (rustls hides the chain, so the leaf DER is bundled alongside the `ServerConfig` in the ArcSwap). Removing the `reload()` call makes this fail — a real regression guard.
- `corrupt_pem_on_tick_is_ignored_and_old_config_retained`, `check_and_reload_is_noop_when_files_unchanged`, `spawn_with_zero_interval_is_disabled`, default-config guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)