### PR TITLE
fix(contact-list): EContactListEvent eventId is a bitfield (LoggedInStatus=1, not 0)

### DIFF
--- a/.claude/agent-memory/social-systems-engineer/reference_contact_list_system.md
+++ b/.claude/agent-memory/social-systems-engineer/reference_contact_list_system.md
@@ -40,8 +40,9 @@ Rust constants: `ON_CONTACT_LIST_UPDATE=85`, `ON_CONTACT_LIST_DELETE=86`,
 `ON_CONTACT_LIST_ADD_MEMBERS=87`, `ON_CONTACT_LIST_REMOVE_MEMBERS=88`,
 `ON_CONTACT_LIST_EVENT=89`.
 
-EContactListEvent values: 0=LoggedInStatus (data_value: 1=online, 0=offline),
-1=GainLevel, 2=Death, 3=GateTravel.
+EContactListEvent is a UINT32 bitfield (powers of two, per entities/defs/enumerations.xml):
+1=LoggedInStatus (data_value: 1=online, 0=offline), 2=GainLevel (data_value=new level),
+4=Death, 8=GateTravel. NOT a 0-based index — sending 0 for LoggedInStatus never matches.
 
 ### DB schema
 
@@ -98,7 +99,7 @@ deferred to Phase 5 (TODO #572).
 `fanout_login_status` in `handlers/presence_fanout.rs`:
 1. Calls `find_watchers(pool, player_name)` → Vec<i32> of watcher player_ids
 2. Finds each watcher's entity_id via `collect_watcher_entity_ids` (pure fn, unit-tested)
-3. Sends CM 89 (onContactListEvent, eventId=0, data_value=1/0) to each online watcher
+3. Sends CM 89 (onContactListEvent, eventId=1 [LoggedInStatus bitfield], data_value=1/0) to each online watcher
 
 ### db_pool threading
 
@@ -124,7 +125,7 @@ instead. Discovered when fixing persistence.rs during #572 impl.
 
 ### Deferred (Phase 5)
 
-- GainLevel/Death/GateTravel events (CM 89, eventId 1/2/3)
+- GainLevel/Death/GateTravel events (CM 89, eventId bitfield 2/4/8)
 - Abrupt-disconnect offline fanout via `destroy_client_entities`
 - Ignore-list check before queueing fanout events
 - Slash commands and modify-button routing

--- a/crates/services/src/base/contact_list/wire.rs
+++ b/crates/services/src/base/contact_list/wire.rs
@@ -57,9 +57,14 @@ pub(crate) fn build_on_contact_list_remove_members(list_id: i32, names: &[String
 
 /// Serialize `onContactListEvent` (CM 89) args.
 ///
-/// `event_id` values (EContactListEvent):
-///   0 = LoggedInStatus (data_value 1=online / 0=offline)
-///   1 = GainLevel, 2 = Death, 3 = GateTravel  [TODO: data values need x64dbg runtime capture]
+/// `event_id` is the `EContactListEvent` **bitfield** value (UINT32), per
+/// `entities/defs/enumerations.xml` (mirrored in `db/resources/Social/Types/
+/// EContactListEvent.sql` and the original `Atrea/enums.py`):
+///   1 = LoggedInStatus (data_value 1=online / 0=offline)
+///   2 = GainLevel (data_value = new level), 4 = Death, 8 = GateTravel
+/// NOTE: these are power-of-two bit flags, NOT a 0-based index — the client tests
+/// the flag value, so sending 0 for LoggedInStatus never matches. Death/GateTravel
+/// data_value semantics are still unconfirmed (UI-asset RE; not in the binary).
 pub(crate) fn build_on_contact_list_event(
     player_name: &str,
     event_id: u32,
@@ -81,10 +86,22 @@ pub(crate) fn build_on_contact_list_event(
 /// contact-list wire module — so both layers share a single definition.
 pub(crate) const MAX_MEMBERS_PER_REQUEST: usize = 100;
 
-// ── EContactListEvent integer codes ─────────────────────────────────────────
+// ── EContactListEvent bitfield values (UINT32) ───────────────────────────────
+// Power-of-two flags from entities/defs/enumerations.xml — NOT a 0-based index.
 
-/// `EContactListEvent::ECONTACT_LIST_EVENT_LoggedInStatus`
-pub(crate) const EVENT_LOGGED_IN_STATUS: u32 = 0;
+/// `EContactListEvent::ECONTACT_LIST_EVENT_LoggedInStatus` (bit 0).
+pub(crate) const EVENT_LOGGED_IN_STATUS: u32 = 1;
+// Defined now for protocol completeness; not yet emitted (the GainLevel/Death/
+// GateTravel presence events are deferred — see #572). allow(dead_code) until wired.
+/// `ECONTACT_LIST_EVENT_GainLevel` (bit 1). data_value = the player's new level.
+#[allow(dead_code)]
+pub(crate) const EVENT_GAIN_LEVEL: u32 = 2;
+/// `ECONTACT_LIST_EVENT_Death` (bit 2). data_value semantics unconfirmed.
+#[allow(dead_code)]
+pub(crate) const EVENT_DEATH: u32 = 4;
+/// `ECONTACT_LIST_EVENT_GateTravel` (bit 3). data_value semantics unconfirmed.
+#[allow(dead_code)]
+pub(crate) const EVENT_GATE_TRAVEL: u32 = 8;
 
 /// `dataValue` for LoggedInStatus: player came online.
 pub(crate) const DATA_ONLINE: i32 = 1;
@@ -199,6 +216,12 @@ mod tests {
 
         let event_id = u32::from_le_bytes(payload[consumed..consumed + 4].try_into().unwrap());
         assert_eq!(event_id, EVENT_LOGGED_IN_STATUS);
+        // Pin the literal wire value: LoggedInStatus is the bitfield flag 1, NOT 0.
+        // (A self-referential `== EVENT_LOGGED_IN_STATUS` check let the 0 bug ship.)
+        assert_eq!(
+            event_id, 1,
+            "LoggedInStatus must serialize as bitfield value 1"
+        );
 
         let data_value =
             i32::from_le_bytes(payload[consumed + 4..consumed + 8].try_into().unwrap());
@@ -216,5 +239,15 @@ mod tests {
         let data_value =
             i32::from_le_bytes(payload[consumed + 4..consumed + 8].try_into().unwrap());
         assert_eq!(data_value, DATA_OFFLINE);
+    }
+
+    /// Guard: EContactListEvent values are the power-of-two bit flags from
+    /// `entities/defs/enumerations.xml` (1/2/4/8), not a 0-based index.
+    #[test]
+    fn event_ids_match_canonical_bitfield() {
+        assert_eq!(EVENT_LOGGED_IN_STATUS, 1);
+        assert_eq!(EVENT_GAIN_LEVEL, 2);
+        assert_eq!(EVENT_DEATH, 4);
+        assert_eq!(EVENT_GATE_TRAVEL, 8);
     }
 }


### PR DESCRIPTION
## What

RE follow-up to #574. The `EContactListEvent` enum is a **UINT32 bitfield** — `LoggedInStatus=1, GainLevel=2, Death=4, GateTravel=8` (power-of-two flags, not a 0-based index). Source: [`entities/defs/enumerations.xml`](../blob/main/entities/defs/enumerations.xml), mirrored in `db/resources/Social/Types/EContactListEvent.sql` and the original `deprecated/python/Atrea/enums.py`.

## The bug

The merged contact-list code sent **`eventId = 0`** for `LoggedInStatus`. The client tests the flag value, so `0` never matches `LoggedInStatus (1)` — **the online/offline presence notification would silently never display in the client.** Because this is pre-playtest, the bug was latent; I caught it via static RE of the canonical enum (the C++ binary dispatches the event generically to the UI by name, so the enum/def is the authoritative source — there's no C++ switch to read).

## Fix

- `wire.rs`: `EVENT_LOGGED_IN_STATUS` `0 → 1`; added `EVENT_GAIN_LEVEL=2` / `EVENT_DEATH=4` / `EVENT_GATE_TRAVEL=8` for protocol completeness (`allow(dead_code)` until those events are wired); corrected the doc comment.
- **Tests:** the existing byte-layout test asserted `event_id == EVENT_LOGGED_IN_STATUS` — self-referential, which is exactly how the `0` shipped. Pinned the **literal** wire value (`event_id == 1`) and added `event_ids_match_canonical_bitfield` guarding all four values against the canonical enum.
- Corrected the eventId values in the social-systems-engineer memory doc.

## How RE'd / verified

Canonical enum cross-checked across def + SQL + Python (all agree: 1/2/4/8). `clippy -D warnings` clean; contact-list tests 36 → 37 (new guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed encoding of login status events in contact lists

* **Chores**
  * Refactored contact list event messaging protocol
  * Added validation tests for event handling consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->