### PR TITLE
feat(contact-list): GainLevel / Death / GateTravel presence events

### DIFF
--- a/crates/services/src/base/contact_list/handlers/mod.rs
+++ b/crates/services/src/base/contact_list/handlers/mod.rs
@@ -32,7 +32,7 @@ pub(crate) mod presence_fanout;
 // can import from `handlers::*` without knowing the split.
 pub(crate) use header_ops::{handle_create, handle_delete, handle_flags_update, handle_rename};
 pub(crate) use member_ops::{handle_add_members, handle_remove_members};
-pub(crate) use presence_fanout::fanout_login_status;
+pub(crate) use presence_fanout::{fanout_contact_event, fanout_login_status};
 
 /// Push all contact lists + members to the player's client on world entry.
 ///

--- a/crates/services/src/base/contact_list/handlers/presence_fanout.rs
+++ b/crates/services/src/base/contact_list/handlers/presence_fanout.rs
@@ -1,5 +1,10 @@
-//! `fanout_login_status` — broadcast CM 89 (onContactListEvent / LoggedInStatus)
-//! to all online players who have `player_name` in any of their contact lists.
+//! Presence fan-out helpers — broadcast CM 89 (`onContactListEvent`) to all
+//! online players who have a given player in any of their contact lists.
+//!
+//! `fanout_login_status` is a thin wrapper around the generic
+//! `fanout_contact_event` for the `LoggedInStatus` case. All three new
+//! presence events (GainLevel / Death / GateTravel) use `fanout_contact_event`
+//! directly with the appropriate `event_id` + `data_value` pair.
 
 use std::collections::{HashMap, HashSet};
 use std::net::SocketAddr;
@@ -33,25 +38,25 @@ fn collect_watcher_entity_ids(
         .collect()
 }
 
-/// Fan out `onContactListEvent` (CM 89, eventId=LoggedInStatus) to all online
-/// players who have `player_name` in any of their contact lists.
+/// Fan out `onContactListEvent` (CM 89) to all online players who have
+/// `player_name` in any of their contact lists.
 ///
-/// Called on player login (`data_value = DATA_ONLINE`) and logout
-/// (`data_value = DATA_OFFLINE`).
+/// Generic core used by `fanout_login_status` and the three new presence
+/// events (GainLevel, Death, GateTravel). `event_id` is one of the
+/// `EVENT_*` bitfield constants from `wire.rs`; `data_value` is the
+/// event-specific payload (new level, 0, or world_id).
+///
+/// Fire-and-forget — spawn this via `tokio::spawn` at call sites that must
+/// not block a critical path (gate travel, XP grant, death burst).
 ///
 /// # Invariant #5 (ignore-list leak)
-/// This function is for the *caller's* presence fanout only — it does NOT
-/// check the recipient's ignore list because the spec does not filter
-/// LoggedInStatus events on the notifier's side. If that becomes a
-/// requirement (e.g., muted players), add a join against the recipient's
-/// Ignore list in `find_watchers` or filter here before the send.
-///
-/// # TODO: presence dataValues for level/death/gate events (needs runtime capture)
-/// GainLevel / Death / GateTravel events (eventId 1/2/3) are deferred —
-/// their data values need x64dbg confirmation.
-pub(crate) async fn fanout_login_status(
+/// Does NOT filter on the recipient's ignore list — `find_watchers` returns
+/// all contact-list watchers regardless. Ignore-list filtering before fanout
+/// is deferred to Phase 5.
+pub(crate) async fn fanout_contact_event(
     player_name: &str,
-    is_online: bool,
+    event_id: u32,
+    data_value: i32,
     db_pool: &Option<Arc<PgPool>>,
     transport: &Arc<dyn Transport>,
     connected: &Arc<Mutex<HashMap<SocketAddr, ConnectedClientState>>>,
@@ -62,7 +67,8 @@ pub(crate) async fn fanout_login_status(
         None => {
             tracing::warn!(
                 player_name,
-                "ContactList LoginStatus fanout: no DB pool, skipping"
+                event_id,
+                "ContactList presence fanout: no DB pool, skipping"
             );
             return;
         }
@@ -73,7 +79,8 @@ pub(crate) async fn fanout_login_status(
         Err(e) => {
             tracing::error!(
                 player_name,
-                "ContactList LoginStatus fanout: find_watchers failed: {e}"
+                event_id,
+                "ContactList presence fanout: find_watchers failed: {e}"
             );
             return;
         }
@@ -86,8 +93,7 @@ pub(crate) async fn fanout_login_status(
     // Build a HashSet for O(1) membership tests during the connected scan below.
     let watcher_set: HashSet<i32> = watcher_ids.iter().copied().collect();
 
-    let data_value = if is_online { DATA_ONLINE } else { DATA_OFFLINE };
-    let args = build_on_contact_list_event(player_name, EVENT_LOGGED_IN_STATUS, data_value);
+    let args = build_on_contact_list_event(player_name, event_id, data_value);
 
     // Map player_id → entity_id for online players only.
     // Locks `connected` to iterate active sessions; does NOT take entity_to_addr.
@@ -97,7 +103,8 @@ pub(crate) async fn fanout_login_status(
             Err(_) => {
                 tracing::error!(
                     player_name,
-                    "ContactList LoginStatus fanout: connected lock poisoned"
+                    event_id,
+                    "ContactList presence fanout: connected lock poisoned"
                 );
                 return;
             }
@@ -129,15 +136,45 @@ pub(crate) async fn fanout_login_status(
 
     tracing::debug!(
         player_name,
-        is_online,
+        event_id,
+        data_value,
         watcher_count = watcher_ids.len(),
-        "ContactList: LoginStatus fanout complete"
+        "ContactList: presence fanout complete"
     );
+}
+
+/// Fan out `onContactListEvent` (CM 89, eventId=LoggedInStatus) to all online
+/// players who have `player_name` in any of their contact lists.
+///
+/// Called on player login (`data_value = DATA_ONLINE`) and logout
+/// (`data_value = DATA_OFFLINE`). Thin wrapper around `fanout_contact_event`.
+pub(crate) async fn fanout_login_status(
+    player_name: &str,
+    is_online: bool,
+    db_pool: &Option<Arc<PgPool>>,
+    transport: &Arc<dyn Transport>,
+    connected: &Arc<Mutex<HashMap<SocketAddr, ConnectedClientState>>>,
+    entity_to_addr: &Arc<Mutex<HashMap<u32, SocketAddr>>>,
+) {
+    let data_value = if is_online { DATA_ONLINE } else { DATA_OFFLINE };
+    fanout_contact_event(
+        player_name,
+        EVENT_LOGGED_IN_STATUS,
+        data_value,
+        db_pool,
+        transport,
+        connected,
+        entity_to_addr,
+    )
+    .await;
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::base::contact_list::wire::{
+        EVENT_DEATH, EVENT_GAIN_LEVEL, EVENT_GATE_TRAVEL, EVENT_LOGGED_IN_STATUS,
+    };
     use crate::test_support::test_default_connected_client_state;
     use std::net::{IpAddr, Ipv4Addr};
 
@@ -249,5 +286,88 @@ mod tests {
 
         let entity_ids = collect_watcher_entity_ids(&clients, &watcher_set);
         assert!(entity_ids.is_empty());
+    }
+
+    // ── fanout_contact_event wire-arg correctness ────────────────────────────
+    // These tests drive `build_on_contact_list_event` through the same path the
+    // fanout takes so a refactor that passes the wrong (event_id, data_value)
+    // pair fails here before the wire desync reaches the client.
+
+    /// Helper: decode WSTRING and return (decoded_string, bytes_consumed).
+    fn read_wstring(buf: &[u8]) -> (String, usize) {
+        let count = u32::from_le_bytes(buf[0..4].try_into().unwrap()) as usize;
+        let mut chars = Vec::with_capacity(count);
+        for i in 0..count {
+            let off = 4 + i * 2;
+            chars.push(u16::from_le_bytes(buf[off..off + 2].try_into().unwrap()));
+        }
+        (String::from_utf16(&chars).unwrap(), 4 + count * 2)
+    }
+
+    /// Helper: build a CM 89 payload and decode (event_id, data_value).
+    fn decode_event(player_name: &str, event_id: u32, data_value: i32) -> (u32, i32) {
+        let buf = build_on_contact_list_event(player_name, event_id, data_value);
+        let (_, consumed) = read_wstring(&buf);
+        let eid = u32::from_le_bytes(buf[consumed..consumed + 4].try_into().unwrap());
+        let dv = i32::from_le_bytes(buf[consumed + 4..consumed + 8].try_into().unwrap());
+        (eid, dv)
+    }
+
+    /// GainLevel: event_id must be EVENT_GAIN_LEVEL (2); data_value is the new
+    /// level. Regression guard: a refactor using EVENT_LOGGED_IN_STATUS here
+    /// would produce (1, level) and the client's `if flags == 2` branch never
+    /// fires, silently dropping the notification.
+    #[test]
+    fn gain_level_arg_correctness() {
+        let new_level = 7i32;
+        let (eid, dv) = decode_event("Teal'c", EVENT_GAIN_LEVEL, new_level);
+        assert_eq!(
+            eid, EVENT_GAIN_LEVEL,
+            "GainLevel must use event_id 2 (EVENT_GAIN_LEVEL), not {eid}"
+        );
+        assert_eq!(
+            dv, new_level,
+            "GainLevel data_value must be the new level ({new_level}), got {dv}"
+        );
+    }
+
+    /// Death: event_id must be EVENT_DEATH (4); data_value is always 0
+    /// (client ignores the value but shows "{Name} has died").
+    #[test]
+    fn death_arg_correctness() {
+        let (eid, dv) = decode_event("O'Neill", EVENT_DEATH, 0);
+        assert_eq!(
+            eid, EVENT_DEATH,
+            "Death must use event_id 4 (EVENT_DEATH), not {eid}"
+        );
+        assert_eq!(
+            dv, 0,
+            "Death data_value must be 0 (client ignores it), got {dv}"
+        );
+    }
+
+    /// GateTravel: event_id must be EVENT_GATE_TRAVEL (8); data_value is the
+    /// destination world_id that the client passes to getWorldInfo(value).Name.
+    #[test]
+    fn gate_travel_arg_correctness() {
+        let world_id = 19i32; // Tollana from resources.worlds seed
+        let (eid, dv) = decode_event("Carter", EVENT_GATE_TRAVEL, world_id);
+        assert_eq!(
+            eid, EVENT_GATE_TRAVEL,
+            "GateTravel must use event_id 8 (EVENT_GATE_TRAVEL), not {eid}"
+        );
+        assert_eq!(
+            dv, world_id,
+            "GateTravel data_value must be the destination world_id ({world_id}), got {dv}"
+        );
+    }
+
+    /// LoggedInStatus (via fanout_login_status path) still uses event_id 1.
+    /// Regression guard for the wrapper that calls fanout_contact_event.
+    #[test]
+    fn logged_in_status_event_id_unchanged() {
+        let (eid, dv) = decode_event("Jackson", EVENT_LOGGED_IN_STATUS, 1);
+        assert_eq!(eid, EVENT_LOGGED_IN_STATUS);
+        assert_eq!(dv, 1);
     }
 }

--- a/crates/services/src/base/contact_list/wire.rs
+++ b/crates/services/src/base/contact_list/wire.rs
@@ -61,10 +61,11 @@ pub(crate) fn build_on_contact_list_remove_members(list_id: i32, names: &[String
 /// `entities/defs/enumerations.xml` (mirrored in `db/resources/Social/Types/
 /// EContactListEvent.sql` and the original `Atrea/enums.py`):
 ///   1 = LoggedInStatus (data_value 1=online / 0=offline)
-///   2 = GainLevel (data_value = new level), 4 = Death, 8 = GateTravel
+///   2 = GainLevel     (data_value = new level)
+///   4 = Death         (data_value = 0 — client ignores it)
+///   8 = GateTravel    (data_value = destination world_id from resources.worlds)
 /// NOTE: these are power-of-two bit flags, NOT a 0-based index — the client tests
-/// the flag value, so sending 0 for LoggedInStatus never matches. Death/GateTravel
-/// data_value semantics are still unconfirmed (UI-asset RE; not in the binary).
+/// the flag value, so sending 0 for LoggedInStatus never matches.
 pub(crate) fn build_on_contact_list_event(
     player_name: &str,
     event_id: u32,
@@ -91,16 +92,13 @@ pub(crate) const MAX_MEMBERS_PER_REQUEST: usize = 100;
 
 /// `EContactListEvent::ECONTACT_LIST_EVENT_LoggedInStatus` (bit 0).
 pub(crate) const EVENT_LOGGED_IN_STATUS: u32 = 1;
-// Defined now for protocol completeness; not yet emitted (the GainLevel/Death/
-// GateTravel presence events are deferred — see #572). allow(dead_code) until wired.
 /// `ECONTACT_LIST_EVENT_GainLevel` (bit 1). data_value = the player's new level.
-#[allow(dead_code)]
 pub(crate) const EVENT_GAIN_LEVEL: u32 = 2;
-/// `ECONTACT_LIST_EVENT_Death` (bit 2). data_value semantics unconfirmed.
-#[allow(dead_code)]
+/// `ECONTACT_LIST_EVENT_Death` (bit 2). data_value = 0 (client ignores it).
 pub(crate) const EVENT_DEATH: u32 = 4;
-/// `ECONTACT_LIST_EVENT_GateTravel` (bit 3). data_value semantics unconfirmed.
-#[allow(dead_code)]
+/// `ECONTACT_LIST_EVENT_GateTravel` (bit 3). data_value = destination world_id
+/// from `resources.worlds` — client passes it to `getWorldInfo(value).Name`.
+/// Confirm the exact id-space via send-and-observe in playtest if needed.
 pub(crate) const EVENT_GATE_TRAVEL: u32 = 8;
 
 /// `dataValue` for LoggedInStatus: player came online.

--- a/crates/services/src/base/world_entry/cell_dispatch/contact_list_dispatch.rs
+++ b/crates/services/src/base/world_entry/cell_dispatch/contact_list_dispatch.rs
@@ -6,8 +6,8 @@
 //! the appropriate handler.
 
 use crate::base::contact_list::handlers::{
-    handle_add_members, handle_create, handle_delete, handle_flags_update, handle_remove_members,
-    handle_rename,
+    fanout_contact_event, handle_add_members, handle_create, handle_delete, handle_flags_update,
+    handle_remove_members, handle_rename,
 };
 use crate::cell::messages::CellToBaseMsg;
 
@@ -129,6 +129,31 @@ pub(super) async fn route(msg: CellToBaseMsg, ctx: &DispatchCtx<'_>) {
                 ctx.entity_to_addr,
             )
             .await
+        }
+
+        CellToBaseMsg::ContactListPresenceEvent {
+            player_name,
+            event_id,
+            data_value,
+        } => {
+            // Fire-and-forget: spawn so the cell channel drains immediately
+            // rather than blocking on the DB lookup + network fan-out.
+            let db_pool = ctx.db_pool.clone();
+            let transport = std::sync::Arc::clone(ctx.transport);
+            let connected = std::sync::Arc::clone(ctx.connected);
+            let entity_to_addr = std::sync::Arc::clone(ctx.entity_to_addr);
+            tokio::spawn(async move {
+                fanout_contact_event(
+                    &player_name,
+                    event_id,
+                    data_value,
+                    &db_pool,
+                    &transport,
+                    &connected,
+                    &entity_to_addr,
+                )
+                .await;
+            });
         }
 
         // Unreachable by construction — the outer match only routes

--- a/crates/services/src/base/world_entry/cell_dispatch/mod.rs
+++ b/crates/services/src/base/world_entry/cell_dispatch/mod.rs
@@ -132,7 +132,8 @@ pub(crate) async fn handle_cell_message(
         | CellToBaseMsg::ContactListRename { .. }
         | CellToBaseMsg::ContactListFlagsUpdate { .. }
         | CellToBaseMsg::ContactListAddMembers { .. }
-        | CellToBaseMsg::ContactListRemoveMembers { .. } => {
+        | CellToBaseMsg::ContactListRemoveMembers { .. }
+        | CellToBaseMsg::ContactListPresenceEvent { .. } => {
             contact_list_dispatch::route(msg, &ctx).await
         }
 

--- a/crates/services/src/base/world_entry/cell_dispatch/tests_dispatch_arms/passthrough.rs
+++ b/crates/services/src/base/world_entry/cell_dispatch/tests_dispatch_arms/passthrough.rs
@@ -251,6 +251,68 @@ async fn execute_trade_routes_to_handler_and_warns_when_no_db_pool() {
     );
 }
 
+/// `ContactListPresenceEvent` is a cell→base hop for contact-list presence
+/// events that originate cell-side (currently: Death). The dispatcher routes
+/// it to `contact_list_dispatch::route`, which spawns a fire-and-forget
+/// `fanout_contact_event`. With `db_pool: None`, `fanout_contact_event`
+/// short-circuits with `warn!("ContactList presence fanout: no DB pool")`.
+///
+/// Revert-verifier: removing or mis-routing the
+/// `ContactListPresenceEvent` arm in `handle_cell_message` causes this
+/// test to fail because the no-pool warning is never emitted from
+/// `fanout_contact_event`.
+#[tokio::test]
+async fn contact_list_presence_event_routes_to_fanout_and_warns_when_no_pool() {
+    use crate::base::contact_list::wire::EVENT_DEATH;
+    let capture = LogCapture::install();
+    let typed_transport = Arc::new(TestTransport::new());
+    let transport: Arc<dyn Transport> = typed_transport.clone();
+    let (connected, entity_to_addr) = empty_maps();
+
+    handle_cell_message(
+        CellToBaseMsg::ContactListPresenceEvent {
+            player_name: "O'Neill".to_string(),
+            event_id: EVENT_DEATH,
+            data_value: 0,
+        },
+        &transport,
+        &connected,
+        &entity_to_addr,
+        &None,
+        &None, // db_pool: None — fanout short-circuits with warn
+        &None,
+        "127.0.0.1",
+        7777,
+    )
+    .await;
+
+    // The spawn is fire-and-forget; yield to let the spawned task run.
+    tokio::task::yield_now().await;
+
+    assert!(
+        typed_transport.is_empty(),
+        "ContactListPresenceEvent is DB-only fan-out — no wire emit expected"
+    );
+    let event = capture
+        .find_message(
+            tracing::Level::WARN,
+            "ContactList presence fanout: no DB pool",
+        )
+        .expect(
+            "dispatch must reach fanout_contact_event's no-pool branch. \
+             If this assertion fails, either (a) the ContactListPresenceEvent arm \
+             was removed or mis-routed, or (b) the no-pool warn was renamed.",
+        );
+    assert!(
+        event.has_field("player_name", "O'Neill"),
+        "fanout warn must record player_name: {event:#?}"
+    );
+    assert!(
+        event.has_field("event_id", &EVENT_DEATH.to_string()),
+        "fanout warn must record event_id: {event:#?}"
+    );
+}
+
 /// `TeleportPlayer` is delegated to `handle_teleport_player`. With no
 /// entity_to_addr mapping, the handler logs
 /// `warn!("TeleportPlayer: no client addr for entity")` and returns

--- a/crates/services/src/base/world_entry/gate_travel/mod.rs
+++ b/crates/services/src/base/world_entry/gate_travel/mod.rs
@@ -14,6 +14,8 @@ use cimmeria_mercury::transport::Transport;
 use sqlx::PgPool;
 use tokio::sync::mpsc;
 
+use crate::base::contact_list::handlers::fanout_contact_event;
+use crate::base::contact_list::wire::EVENT_GATE_TRAVEL;
 use crate::cell::messages::BaseToCellMsg;
 use crate::mercury::{build_reset_entities, WorldEntryInfo, SGWPLAYER_CLASS_ID};
 
@@ -237,10 +239,61 @@ pub(crate) async fn handle_gate_travel(
     cimmeria_discord::emit_player_world_exit(
         account_id,
         account_name,
-        exit_name.unwrap_or_else(|| "<unknown>".to_string()),
+        exit_name.clone().unwrap_or_else(|| "<unknown>".to_string()),
         exit_from_world.unwrap_or_else(|| "<unknown>".to_string()),
         Some(target_world_name.to_string()),
     );
+
+    // Contact-list GateTravel fanout (CM 89, eventId=GateTravel).
+    //
+    // data_value = the destination world_id from `resources.worlds`. The client
+    // passes this value to `getWorldInfo(value).Name` to display the world name.
+    // We use the same table the gate_travel persistence UPDATE already uses for
+    // COALESCE world_id lookup — this is the canonical source. If the client's
+    // getWorldInfo index space differs from resources.worlds.world_id, confirm
+    // via send-and-observe in playtest and adjust the lookup accordingly.
+    //
+    // Fire-and-forget: spawned so the pending_world_entry store below (which
+    // drives the client's create-player step) is not delayed by the DB lookup.
+    if let Some(traveler_name) = exit_name {
+        let db_pool_clone = db_pool.clone();
+        let transport_clone = Arc::clone(transport);
+        let connected_clone = Arc::clone(connected);
+        let entity_to_addr_clone = Arc::clone(entity_to_addr);
+        let dest_world = target_world_name.to_string();
+        tokio::spawn(async move {
+            // Resolve the numeric world_id the client expects.
+            let world_id: i32 = if let Some(pool) = &db_pool_clone {
+                sqlx::query_scalar::<_, i32>(
+                    "SELECT world_id FROM resources.worlds WHERE world = $1",
+                )
+                .bind(&dest_world)
+                .fetch_optional(pool.as_ref())
+                .await
+                .unwrap_or_else(|e| {
+                    tracing::warn!(
+                        world = %dest_world,
+                        "GateTravel fanout: world_id lookup failed: {e}"
+                    );
+                    None
+                })
+                .unwrap_or(0)
+            } else {
+                0
+            };
+
+            fanout_contact_event(
+                &traveler_name,
+                EVENT_GATE_TRAVEL,
+                world_id,
+                &db_pool_clone,
+                &transport_clone,
+                &connected_clone,
+                &entity_to_addr_clone,
+            )
+            .await;
+        });
+    }
 
     // Store pending world entry for the create-player step (ENABLE_ENTITIES handler)
     {

--- a/crates/services/src/base/world_entry/methods/progression/mod.rs
+++ b/crates/services/src/base/world_entry/methods/progression/mod.rs
@@ -8,6 +8,8 @@ use sqlx::PgPool;
 
 use cimmeria_game::player::{MAX_LEVEL, TRAINING_POINTS_PER_LEVEL};
 
+use super::super::super::contact_list::handlers::fanout_contact_event;
+use super::super::super::contact_list::wire::EVENT_GAIN_LEVEL;
 use super::super::super::gm_feedback::send_gm_feedback_to_client;
 use super::super::super::helpers::{send_bundle_to_witness_reliable, send_to_witness_reliable};
 use super::super::super::ConnectedClientState;
@@ -187,9 +189,33 @@ pub async fn handle_grant_xp(
     // Discord gameplay-channel: only on an actual level boundary crossing,
     // and only once per grant (reporting the final level even on a multi-level
     // catch-up grant). Skipped when the name isn't cached yet (pre-character).
+    //
+    // Also fans out `onContactListEvent` (CM 89, eventId=GainLevel) to all
+    // online players who have this player in any contact list. Fire-and-forget:
+    // the tokio::spawn ensures the fanout doesn't block the XP grant bundle
+    // emit below. Only fires on an actual level-boundary crossing and only
+    // when the player name is cached (same gate as the Discord emit).
     if !levels_gained.is_empty() {
         if let Some(name) = &player_name {
             cimmeria_discord::emit_level_up(name.clone(), new_level);
+
+            let name_owned = name.clone();
+            let db_pool_clone = db_pool.clone();
+            let transport_clone = Arc::clone(transport);
+            let connected_clone = Arc::clone(connected);
+            let entity_to_addr_clone = Arc::clone(entity_to_addr);
+            tokio::spawn(async move {
+                fanout_contact_event(
+                    &name_owned,
+                    EVENT_GAIN_LEVEL,
+                    new_level as i32,
+                    &db_pool_clone,
+                    &transport_clone,
+                    &connected_clone,
+                    &entity_to_addr_clone,
+                )
+                .await;
+            });
         }
     }
 

--- a/crates/services/src/cell/abilities/death.rs
+++ b/crates/services/src/cell/abilities/death.rs
@@ -21,6 +21,8 @@
 
 use tokio::sync::mpsc;
 
+use crate::base::contact_list::wire::EVENT_DEATH;
+
 use super::super::messages::CellToBaseMsg;
 use super::super::space_manager::SpaceManager;
 use super::loot_drop::generate_loot_on_death;
@@ -55,6 +57,12 @@ pub(super) async fn apply_death_transition(
     // Discord gameplay-channel (off by default — content/debug signal). Only
     // player deaths post. Killer name + pvp/pve cause are best-effort from the
     // attacker entity; read before the mutation bursts below.
+    //
+    // Also sends `CellToBaseMsg::ContactListPresenceEvent` for PLAYER deaths so
+    // base can fan out CM 89 (eventId=Death, data_value=0) to the deceased
+    // player's contact-list watchers. NPC/mob deaths do NOT trigger a fanout —
+    // the event makes no sense for mobs and would flood the channel during
+    // combat.
     {
         let killer = space_mgr.get_entity(attacker_id).and_then(|e| {
             if attacker_is_player {
@@ -69,7 +77,18 @@ pub(super) async fn apply_death_transition(
                 .and_then(|e| e.character_name.clone())
                 .unwrap_or_else(|| format!("entity:{target_eid}"));
             let cause = if attacker_is_player { "pvp" } else { "pve" };
-            cimmeria_discord::emit_player_death(character_name, killer, cause);
+            cimmeria_discord::emit_player_death(character_name.clone(), killer, cause);
+
+            // Contact-list Death fanout — cell→base hop. The base handler calls
+            // `fanout_contact_event` with the player's name and EVENT_DEATH.
+            // data_value=0 per spec (client ignores it; shows "{Name} has died").
+            let _ = tx
+                .send(CellToBaseMsg::ContactListPresenceEvent {
+                    player_name: character_name,
+                    event_id: EVENT_DEATH,
+                    data_value: 0,
+                })
+                .await;
         } else {
             // NPC / mob death (off by default — high volume during combat).
             let npc_name = space_mgr
@@ -622,6 +641,80 @@ mod tests {
         assert!(
             auto_cycle_broadcast,
             "dying player must receive an onStateFieldUpdate clearing BSF_AUTO_CYCLING",
+        );
+    }
+
+    /// When a PLAYER dies, `apply_death_transition` must route a
+    /// `ContactListPresenceEvent` (event_id=EVENT_DEATH, data_value=0) through
+    /// the `tx` channel so the base-side contact-list fanout fires.
+    ///
+    /// Regression guard: removing the `tx.send(ContactListPresenceEvent {...})`
+    /// block from the `if target_is_player` branch causes this test to fail
+    /// because no `ContactListPresenceEvent` appears in the drained messages.
+    #[tokio::test]
+    async fn player_death_emits_contact_list_presence_event() {
+        use crate::base::contact_list::wire::EVENT_DEATH;
+
+        let mut mgr = make_mgr_with_player_and_npc();
+        // Promote entity 2 (the target) to a player with a known character name.
+        if let Some(t) = mgr.get_entity_mut(2) {
+            t.is_player = true;
+            t.player_id = Some(200);
+            t.character_name = Some("Teal'c".to_string());
+        }
+        let (tx, mut rx) = mpsc::channel(64);
+
+        apply_death_transition(2, 1, DEAD_STATE, true, true, &tx, &mut mgr).await;
+
+        let msgs = drain(&mut rx);
+        let presence_event = msgs.iter().find(|m| {
+            matches!(
+                m,
+                CellToBaseMsg::ContactListPresenceEvent {
+                    event_id,
+                    data_value: 0,
+                    ..
+                } if *event_id == EVENT_DEATH
+            )
+        });
+        assert!(
+            presence_event.is_some(),
+            "player death must emit ContactListPresenceEvent(EVENT_DEATH, 0); \
+             got: {msgs:?}"
+        );
+
+        // Pin the player_name carried in the event — it must be the entity's
+        // character_name, not a fallback like "entity:2".
+        if let Some(CellToBaseMsg::ContactListPresenceEvent { player_name, .. }) = presence_event {
+            assert_eq!(
+                player_name, "Teal'c",
+                "ContactListPresenceEvent must carry the entity's character_name"
+            );
+        }
+    }
+
+    /// NPC death must NOT emit a `ContactListPresenceEvent` — the event is
+    /// player-only. High-volume NPC kills during combat must not flood the
+    /// contact-list fanout channel.
+    ///
+    /// Regression guard: moving the `tx.send(ContactListPresenceEvent {...})`
+    /// block outside the `if target_is_player` guard would cause this test to
+    /// fail by finding an unexpected presence event for an NPC target.
+    #[tokio::test]
+    async fn npc_death_does_not_emit_contact_list_presence_event() {
+        let mut mgr = make_mgr_with_player_and_npc();
+        // entity 2 stays as NPC (is_player = false by default from the fixture).
+        let (tx, mut rx) = mpsc::channel(64);
+
+        apply_death_transition(2, 1, DEAD_STATE, true, false, &tx, &mut mgr).await;
+
+        let msgs = drain(&mut rx);
+        let has_presence = msgs
+            .iter()
+            .any(|m| matches!(m, CellToBaseMsg::ContactListPresenceEvent { .. }));
+        assert!(
+            !has_presence,
+            "NPC death must NOT emit ContactListPresenceEvent; got: {msgs:?}"
         );
     }
 

--- a/crates/services/src/cell/messages/cell_to_base.rs
+++ b/crates/services/src/cell/messages/cell_to_base.rs
@@ -629,6 +629,22 @@ pub enum CellToBaseMsg {
         names: Vec<String>,
     },
 
+    /// Fan out a contact-list presence event to all online players who have
+    /// `player_name` in any of their contact lists (CM 89, eventId = event_id).
+    ///
+    /// Generic cell→base hop for events that originate cell-side (e.g., Death)
+    /// but need base context to reach the DB and the transport layer.
+    ///
+    /// `event_id` is one of the `EVENT_*` bitfield constants in
+    /// `base::contact_list::wire` (1=LoggedInStatus, 2=GainLevel, 4=Death,
+    /// 8=GateTravel). `data_value` is the event-specific payload (new level,
+    /// 0 for death, destination world_id for gate travel).
+    ContactListPresenceEvent {
+        player_name: String,
+        event_id: u32,
+        data_value: i32,
+    },
+
     /// Both players in a trade reached `LockedAndConfirmed` — base must
     /// now perform the atomic swap (items + cash) inside a single sqlx
     /// transaction, then send `onTradeResults` to both clients.


### PR DESCRIPTION
## What

Implements the three remaining `EContactListEvent` notifications on top of #574/#578, using the `dataValue` semantics RE'd from the client's `Social.lua` (documented on #572):

| Event | eventId | dataValue | Hook |
|---|---|---|---|
| GainLevel | 2 | new level | `handle_grant_xp` (base) — on a level-boundary crossing |
| Death | 4 | 0 (client ignores) | `apply_death_transition` (cell→base) — **player deaths only** |
| GateTravel | 8 | destination world id | `handle_gate_travel` (base) — after RESET_ENTITIES |

## How

- **Generalized the fanout:** `fanout_contact_event(name, event_id, data_value, …)` is now the core; `fanout_login_status` is a thin wrapper. All sends stay fire-and-forget (`tokio::spawn`) — none block the XP-bundle, RESET_ENTITIES, or death-burst critical paths.
- **Death** routes cell→base via a new generalized `CellToBaseMsg::ContactListPresenceEvent { player_name, event_id, data_value }` (reusable for any future cell-originated presence event), gated to player deaths (NPC/mob deaths excluded).
- The client matches `eventId` with **exact equality**, so each event sends exactly one flag value (never OR'd) — the bitfield is only for per-list notification toggles.

## Tests

- Arg-correctness per event (`event_id` + `data_value`): GainLevel→level, Death→0, GateTravel→world_id; plus a regression guard that the `fanout_login_status` wrapper still sends eventId 1.
- `player_death_emits_contact_list_presence_event` (fails if the send is removed) + `npc_death_does_not_emit...` (fails if the player guard is removed).
- Dispatch-arm routing test for `ContactListPresenceEvent`.
- contact-list 36→44; progression/death/gate_travel suites still green.

## One thing to confirm in playtest

GateTravel's `dataValue` is the destination `world_id` from the canonical `resources.worlds` lookup (the same COALESCE the gate-travel UPDATE uses). The client renders it via `getWorldInfo(value).Name`. If `getWorldInfo`'s index space differs from `resources.worlds.world_id`, it's a one-line lookup adjustment — flagged with a code comment and confirmable via send-and-observe once the client's up. (LoggedInStatus/GainLevel/Death are unambiguous.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)