### PR TITLE
feat(aoi): instrument entity-introduction emit path for invisible-NPC repro

### DIFF
--- a/crates/services/src/base/helpers/mod.rs
+++ b/crates/services/src/base/helpers/mod.rs
@@ -103,7 +103,9 @@ pub(crate) enum WitnessSendOutcome {
 }
 
 impl WitnessSendOutcome {
-    /// `true` only for [`WitnessSendOutcome::Sent`].
+    /// `true` only for [`WitnessSendOutcome::Sent`]. Test-only inspector
+    /// (the seams match the variant directly).
+    #[cfg(test)]
     pub(crate) fn is_sent(&self) -> bool {
         matches!(self, WitnessSendOutcome::Sent { .. })
     }
@@ -155,7 +157,9 @@ pub(crate) enum BundleSendOutcome {
 }
 
 impl BundleSendOutcome {
-    /// `true` only for [`BundleSendOutcome::Sent`].
+    /// `true` only for [`BundleSendOutcome::Sent`]. Test-only inspector
+    /// (the seams match the variant directly).
+    #[cfg(test)]
     pub(crate) fn is_sent(&self) -> bool {
         matches!(self, BundleSendOutcome::Sent { .. })
     }

--- a/crates/services/src/base/helpers/mod.rs
+++ b/crates/services/src/base/helpers/mod.rs
@@ -69,6 +69,114 @@ use crate::cell::messages::BaseToCellMsg;
 
 use super::ConnectedClientState;
 
+/// Outcome of a single-packet witness send ([`send_to_witness`] /
+/// [`send_to_witness_reliable`]).
+///
+/// Both helpers already emit their own structured `warn!`/`debug!` on the
+/// failure arms; this return value exists so a *caller* that wants
+/// success-side visibility (the AoI entity-introduction emit path —
+/// `aoi.create_emit` / `aoi.create_send_failed`) can log per-packet
+/// `seq`/`bytes`/`addr_resolved` without re-resolving the address itself.
+///
+/// Returning a value is purely additive: existing call sites use these
+/// helpers as `...await;` statements and ignore the result. The type is
+/// intentionally NOT `#[must_use]` so those sites compile unchanged.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum WitnessSendOutcome {
+    /// Packet hit the wire. `seq` is the reliable/unreliable sequence
+    /// number consumed; `bytes` is the encrypted datagram length.
+    Sent {
+        addr: SocketAddr,
+        seq: u32,
+        bytes: usize,
+    },
+    /// `witness_id` had no entry in `entity_to_addr` — packet dropped.
+    /// Mirrors the helper's `reason = "entity_to_addr_miss"` warn.
+    AddrUnresolved,
+    /// The session was gone from `connected` mid-send (logoff race) —
+    /// packet dropped. Mirrors the helper's `reason = "client_disconnected"`
+    /// debug.
+    ClientDisconnected,
+    /// Address resolved and session present, but `transport.send_to`
+    /// returned an I/O error. Mirrors the helper's send-failure warn.
+    SendError,
+}
+
+impl WitnessSendOutcome {
+    /// `true` only for [`WitnessSendOutcome::Sent`].
+    pub(crate) fn is_sent(&self) -> bool {
+        matches!(self, WitnessSendOutcome::Sent { .. })
+    }
+
+    /// `true` when the address was successfully resolved from
+    /// `entity_to_addr` — i.e. anything other than
+    /// [`WitnessSendOutcome::AddrUnresolved`]. Used as the `addr_resolved`
+    /// field on the AoI create-emit seam.
+    pub(crate) fn addr_resolved(&self) -> bool {
+        !matches!(self, WitnessSendOutcome::AddrUnresolved)
+    }
+
+    /// Stable `reason` token for the failure arms, or `None` on success.
+    /// Pinned by the negative-logging regression guards — treat as API.
+    pub(crate) fn failure_reason(&self) -> Option<&'static str> {
+        match self {
+            WitnessSendOutcome::Sent { .. } => None,
+            WitnessSendOutcome::AddrUnresolved => Some("entity_to_addr_miss"),
+            WitnessSendOutcome::ClientDisconnected => Some("client_disconnected"),
+            WitnessSendOutcome::SendError => Some("send_error"),
+        }
+    }
+}
+
+/// Outcome of a bundle witness send ([`send_bundle_to_witness_reliable`]).
+///
+/// Same rationale as [`WitnessSendOutcome`] but carries the multi-fragment
+/// shape: a bundle finalizes to `packets` fragments starting at `base_seq`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BundleSendOutcome {
+    /// All fragments hit the wire. `base_seq` is the first reserved seq;
+    /// `packets` is the fragment count; `bytes` is the total accumulated
+    /// body length.
+    Sent {
+        addr: SocketAddr,
+        base_seq: u32,
+        packets: usize,
+        bytes: usize,
+    },
+    /// `witness_id` had no entry in `entity_to_addr` — bundle dropped.
+    AddrUnresolved,
+    /// Session gone from `connected` mid-send — bundle dropped.
+    ClientDisconnected,
+    /// Empty bundle (no messages, no acks) — nothing reserved, no-op.
+    Empty,
+    /// A fragment failed to send mid-bundle; the reliable seq stream now
+    /// has a gap and the channel will be reaped on inactivity timeout.
+    SendError,
+}
+
+impl BundleSendOutcome {
+    /// `true` only for [`BundleSendOutcome::Sent`].
+    pub(crate) fn is_sent(&self) -> bool {
+        matches!(self, BundleSendOutcome::Sent { .. })
+    }
+
+    /// `true` when the address resolved from `entity_to_addr`.
+    pub(crate) fn addr_resolved(&self) -> bool {
+        !matches!(self, BundleSendOutcome::AddrUnresolved)
+    }
+
+    /// Stable `reason` token for the non-sent arms, or `None` on success.
+    pub(crate) fn failure_reason(&self) -> Option<&'static str> {
+        match self {
+            BundleSendOutcome::Sent { .. } => None,
+            BundleSendOutcome::AddrUnresolved => Some("entity_to_addr_miss"),
+            BundleSendOutcome::ClientDisconnected => Some("client_disconnected"),
+            BundleSendOutcome::Empty => Some("empty_bundle"),
+            BundleSendOutcome::SendError => Some("send_error"),
+        }
+    }
+}
+
 /// Format a byte slice as a hex string for trace logging.
 pub(crate) fn to_hex(data: &[u8]) -> String {
     data.iter()
@@ -367,7 +475,8 @@ pub(crate) async fn send_to_witness<F>(
     entity_to_addr: &Arc<Mutex<HashMap<u32, SocketAddr>>>,
     witness_id: u32,
     build_packet: F,
-) where
+) -> WitnessSendOutcome
+where
     F: FnOnce(&[u8; 32], EncryptionVersion, u32, &[u32]) -> Vec<u8>,
 {
     // Extract all data from locks in a sync block so no MutexGuard crosses an await.
@@ -399,7 +508,7 @@ pub(crate) async fn send_to_witness<F>(
                     entity_count_in_map = map_size,
                     "AoI: no client addr for witness -- packet dropped"
                 );
-                return;
+                return WitnessSendOutcome::AddrUnresolved;
             }
         };
 
@@ -434,12 +543,16 @@ pub(crate) async fn send_to_witness<F>(
         }
     };
 
-    if let Some((addr, key, version, seq, acks)) = send_data {
-        let packet = build_packet(&key, version, seq, &acks);
-        if let Err(e) = transport.send_to(&packet, addr).await {
-            tracing::warn!(witness_id, %addr, "AoI: failed to send packet: {e}");
-        }
+    let Some((addr, key, version, seq, acks)) = send_data else {
+        return WitnessSendOutcome::ClientDisconnected;
+    };
+    let packet = build_packet(&key, version, seq, &acks);
+    let bytes = packet.len();
+    if let Err(e) = transport.send_to(&packet, addr).await {
+        tracing::warn!(witness_id, %addr, "AoI: failed to send packet: {e}");
+        return WitnessSendOutcome::SendError;
     }
+    WitnessSendOutcome::Sent { addr, seq, bytes }
 }
 
 /// Send an AoI packet to a specific witness's client — **reliable**
@@ -466,7 +579,8 @@ pub(crate) async fn send_to_witness_reliable<F>(
     entity_to_addr: &Arc<Mutex<HashMap<u32, SocketAddr>>>,
     witness_id: u32,
     build_packet: F,
-) where
+) -> WitnessSendOutcome
+where
     F: FnOnce(&[u8; 32], EncryptionVersion, u32, &[u32]) -> Vec<u8>,
 {
     let send_data = {
@@ -490,7 +604,7 @@ pub(crate) async fn send_to_witness_reliable<F>(
                     entity_count_in_map = map_size,
                     "AoI reliable: no client addr for witness -- packet dropped"
                 );
-                return;
+                return WitnessSendOutcome::AddrUnresolved;
             }
         };
 
@@ -516,21 +630,24 @@ pub(crate) async fn send_to_witness_reliable<F>(
         }
     };
 
-    if let Some((addr, key, version, seq, acks)) = send_data {
-        let packet = build_packet(&key, version, seq, &acks);
-        if let Err(e) = transport.send_to(&packet, addr).await {
-            tracing::warn!(witness_id, %addr, "AoI reliable: failed to send packet: {e}");
-            return;
-        }
-        // Register the encrypted bytes with the per-session Channel so
-        // the retransmit driver in tick_sync re-sends on RTO expiry.
-        shadow_register_reliable_send(
-            connected,
-            addr,
-            seq,
-            cimmeria_mercury::packet::Bytes::copy_from_slice(&packet),
-        );
+    let Some((addr, key, version, seq, acks)) = send_data else {
+        return WitnessSendOutcome::ClientDisconnected;
+    };
+    let packet = build_packet(&key, version, seq, &acks);
+    let bytes = packet.len();
+    if let Err(e) = transport.send_to(&packet, addr).await {
+        tracing::warn!(witness_id, %addr, "AoI reliable: failed to send packet: {e}");
+        return WitnessSendOutcome::SendError;
     }
+    // Register the encrypted bytes with the per-session Channel so
+    // the retransmit driver in tick_sync re-sends on RTO expiry.
+    shadow_register_reliable_send(
+        connected,
+        addr,
+        seq,
+        cimmeria_mercury::packet::Bytes::copy_from_slice(&packet),
+    );
+    WitnessSendOutcome::Sent { addr, seq, bytes }
 }
 
 /// Send a [`ChannelBundle`] of N messages to a witness's client as a
@@ -572,7 +689,7 @@ pub(crate) async fn send_bundle_to_witness_reliable(
     entity_to_addr: &Arc<Mutex<HashMap<u32, SocketAddr>>>,
     witness_id: u32,
     mut bundle: cimmeria_mercury::channel_bundle::ChannelBundle,
-) {
+) -> BundleSendOutcome {
     use cimmeria_mercury::packet::{FLAG_ON_CHANNEL, FLAG_RELIABLE, SEQUENCE_MASK};
 
     let send_data = {
@@ -596,7 +713,7 @@ pub(crate) async fn send_bundle_to_witness_reliable(
                     entity_count_in_map = map_size,
                     "AoI bundle: no client addr for witness -- bundle dropped"
                 );
-                return;
+                return BundleSendOutcome::AddrUnresolved;
             }
         };
 
@@ -610,7 +727,7 @@ pub(crate) async fn send_bundle_to_witness_reliable(
                     reason = "client_disconnected",
                     "AoI bundle: client disconnected mid-send -- bundle dropped"
                 );
-                return;
+                return BundleSendOutcome::ClientDisconnected;
             }
         };
 
@@ -625,7 +742,7 @@ pub(crate) async fn send_bundle_to_witness_reliable(
         // otherwise ceil(body / FRAGMENT_BODY_SIZE)).
         let packet_count = bundle.estimated_packet_count();
         if packet_count == 0 {
-            return;
+            return BundleSendOutcome::Empty;
         }
 
         // Atomically reserve `packet_count` consecutive sequence numbers.
@@ -639,7 +756,9 @@ pub(crate) async fn send_bundle_to_witness_reliable(
     };
 
     let Some((addr, key, version, base_seq, packet_count)) = send_data else {
-        return;
+        // Unreachable: every None path inside the block above early-returns
+        // a specific outcome. Defensive fallback keeps the match exhaustive.
+        return BundleSendOutcome::Empty;
     };
 
     let num_messages = bundle.num_messages();
@@ -696,7 +815,7 @@ pub(crate) async fn send_bundle_to_witness_reliable(
                 frag_seq,
                 base_seq.wrapping_add(packet_count as u32) & SEQUENCE_MASK,
             );
-            return;
+            return BundleSendOutcome::SendError;
         }
         shadow_register_reliable_send(
             connected,
@@ -704,6 +823,13 @@ pub(crate) async fn send_bundle_to_witness_reliable(
             frag_seq,
             cimmeria_mercury::packet::Bytes::copy_from_slice(pkt),
         );
+    }
+
+    BundleSendOutcome::Sent {
+        addr,
+        base_seq,
+        packets: packets.len(),
+        bytes: body_len,
     }
 }
 

--- a/crates/services/src/base/helpers/tests.rs
+++ b/crates/services/src/base/helpers/tests.rs
@@ -727,8 +727,8 @@ async fn send_bundle_to_witness_reliable_returns_sent_outcome_on_success() {
     use std::net::SocketAddr;
     use std::sync::{Arc, Mutex};
 
-    let transport: Arc<dyn cimmeria_mercury::transport::Transport> =
-        Arc::new(TestTransport::default());
+    let tt = Arc::new(TestTransport::default());
+    let transport: Arc<dyn cimmeria_mercury::transport::Transport> = tt.clone();
     let addr: SocketAddr = "127.0.0.1:55801".parse().unwrap();
     let witness_id = 600u32;
     let connected = Arc::new(Mutex::new(HashMap::from([(
@@ -765,7 +765,7 @@ async fn send_bundle_to_witness_reliable_returns_sent_outcome_on_success() {
             assert_eq!(base_seq, 0, "fresh session reserves from seq 0");
             assert_eq!(packets, 1, "small body fits in one fragment");
             assert_eq!(
-                transport.send_count_to(addr),
+                tt.send_count_to(addr),
                 1,
                 "exactly one fragment hit the wire"
             );

--- a/crates/services/src/base/helpers/tests.rs
+++ b/crates/services/src/base/helpers/tests.rs
@@ -624,3 +624,152 @@ fn get_access_level_fails_closed_for_poisoned_lock() {
         "poisoned lock must fail closed to Player (0), never privileged"
     );
 }
+
+// ──────────────────────────────────────────────────────────────────
+// Witness-send OUTCOME plumbing guards. The AoI create-emit
+// observability seam (`aoi.create_emit` / `aoi.create_send_failed`)
+// relies on the witness-send helpers RETURNING their outcome instead
+// of swallowing it. These guards pin the return contract so a refactor
+// that drops the return value (back to `-> ()`) trips here.
+// ──────────────────────────────────────────────────────────────────
+
+/// A reliable send to a resolvable, connected witness returns
+/// `Sent { addr, seq, bytes }` with the consumed seq (0 on a fresh
+/// session) and the encrypted-packet length. This is the success-side
+/// data the `aoi.create_emit` DEBUG seam logs per packet.
+#[tokio::test]
+async fn send_to_witness_reliable_returns_sent_outcome_on_success() {
+    use std::collections::HashMap;
+    use std::net::SocketAddr;
+    use std::sync::{Arc, Mutex};
+
+    let transport: Arc<dyn cimmeria_mercury::transport::Transport> =
+        Arc::new(TestTransport::default());
+    let addr: SocketAddr = "127.0.0.1:55800".parse().unwrap();
+    let witness_id = 500u32;
+    let connected = Arc::new(Mutex::new(HashMap::from([(
+        addr,
+        crate::test_support::test_default_connected_client_state(),
+    )])));
+    let entity_to_addr = Arc::new(Mutex::new(HashMap::from([(witness_id, addr)])));
+
+    let outcome = send_to_witness_reliable(
+        &transport,
+        &connected,
+        &entity_to_addr,
+        witness_id,
+        |_key, _version, _seq, _acks| vec![0xAA; 12],
+    )
+    .await;
+
+    assert!(
+        outcome.is_sent(),
+        "resolvable witness must report Sent: {outcome:?}"
+    );
+    assert!(
+        outcome.addr_resolved(),
+        "Sent outcome must report addr_resolved=true"
+    );
+    assert_eq!(outcome.failure_reason(), None, "Sent has no failure reason");
+    match outcome {
+        WitnessSendOutcome::Sent {
+            addr: got_addr,
+            seq,
+            bytes,
+        } => {
+            assert_eq!(got_addr, addr, "Sent carries the resolved witness addr");
+            assert_eq!(seq, 0, "fresh session consumes reliable seq 0");
+            assert_eq!(bytes, 12, "Sent carries the on-wire packet length");
+        }
+        other => panic!("expected Sent, got {other:?}"),
+    }
+}
+
+/// A reliable send to a witness with no `entity_to_addr` entry returns
+/// `AddrUnresolved` — `addr_resolved()` is false and `failure_reason()`
+/// is the stable `entity_to_addr_miss` token the create-emit failure
+/// seam pivots on.
+#[tokio::test]
+async fn send_to_witness_reliable_returns_addr_unresolved_on_miss() {
+    use std::collections::HashMap;
+    use std::net::SocketAddr;
+    use std::sync::{Arc, Mutex};
+
+    let transport: Arc<dyn cimmeria_mercury::transport::Transport> =
+        Arc::new(TestTransport::default());
+    let connected = Arc::new(Mutex::new(
+        HashMap::<SocketAddr, ConnectedClientState>::new(),
+    ));
+    let entity_to_addr = Arc::new(Mutex::new(HashMap::<u32, SocketAddr>::new()));
+
+    let outcome = send_to_witness_reliable(
+        &transport,
+        &connected,
+        &entity_to_addr,
+        4242,
+        |_key, _version, _seq, _acks| vec![0u8; 4],
+    )
+    .await;
+
+    assert!(!outcome.is_sent(), "unresolvable witness must not be Sent");
+    assert_eq!(outcome, WitnessSendOutcome::AddrUnresolved);
+    assert!(!outcome.addr_resolved());
+    assert_eq!(outcome.failure_reason(), Some("entity_to_addr_miss"));
+}
+
+/// The bundle helper returns `BundleSendOutcome::Sent { base_seq,
+/// packets, bytes }` on a successful multi-message flush — the shape the
+/// bundled create-emit seam logs for the pre-onClientReady burst path.
+#[tokio::test]
+async fn send_bundle_to_witness_reliable_returns_sent_outcome_on_success() {
+    use cimmeria_mercury::channel_bundle::{ChannelBundle, IDBASE_SGW_PLAYER};
+    use std::collections::HashMap;
+    use std::net::SocketAddr;
+    use std::sync::{Arc, Mutex};
+
+    let transport: Arc<dyn cimmeria_mercury::transport::Transport> =
+        Arc::new(TestTransport::default());
+    let addr: SocketAddr = "127.0.0.1:55801".parse().unwrap();
+    let witness_id = 600u32;
+    let connected = Arc::new(Mutex::new(HashMap::from([(
+        addr,
+        crate::test_support::test_default_connected_client_state(),
+    )])));
+    let entity_to_addr = Arc::new(Mutex::new(HashMap::from([(witness_id, addr)])));
+
+    let mut bundle = ChannelBundle::new(true);
+    bundle.append_entity_method(5, IDBASE_SGW_PLAYER, witness_id, &[1, 2, 3]);
+    bundle.append_entity_method(6, IDBASE_SGW_PLAYER, witness_id, &[4, 5]);
+
+    let outcome = send_bundle_to_witness_reliable(
+        &transport,
+        &connected,
+        &entity_to_addr,
+        witness_id,
+        bundle,
+    )
+    .await;
+
+    assert!(
+        outcome.is_sent(),
+        "resolvable witness must report Sent: {outcome:?}"
+    );
+    match outcome {
+        BundleSendOutcome::Sent {
+            addr: got_addr,
+            base_seq,
+            packets,
+            ..
+        } => {
+            assert_eq!(got_addr, addr);
+            assert_eq!(base_seq, 0, "fresh session reserves from seq 0");
+            assert_eq!(packets, 1, "small body fits in one fragment");
+            assert_eq!(
+                transport.send_count_to(addr),
+                1,
+                "exactly one fragment hit the wire"
+            );
+        }
+        other => panic!("expected Sent, got {other:?}"),
+    }
+}

--- a/crates/services/src/base/world_entry/cell_dispatch/aoi.rs
+++ b/crates/services/src/base/world_entry/cell_dispatch/aoi.rs
@@ -18,9 +18,120 @@ use crate::mercury::{
 
 use super::super::super::deferred_aoi::{self, DeferredAoiMsg};
 use super::super::super::helpers::{
-    send_bundle_to_witness_reliable, send_to_witness, send_to_witness_reliable,
+    send_bundle_to_witness_reliable, send_to_witness, send_to_witness_reliable, BundleSendOutcome,
+    WitnessSendOutcome,
 };
 use super::super::super::ConnectedClientState;
+
+/// Emit the success-side (`aoi.create_emit`, DEBUG) or failure-side
+/// (`aoi.create_send_failed`, WARN) observability seam for one packet of
+/// the entity-introduction pair.
+///
+/// `phase` is `"create_base"` (CREATE_ENTITY + UPDATE_AVATAR) or
+/// `"cascade"` (createOnClient property cascade). This is the visibility
+/// the invisible-static-NPC (Castle_CellBlock GuardBody corpse) bug needs:
+/// the entity-create/cascade packets ride Mercury and were previously
+/// unlogged, and `entered_aoi`'s two reliable sends discarded their
+/// outcomes — so an addr-resolution miss or a swallowed enqueue failure on
+/// either packet was invisible. See
+/// `docs/architecture/negative-logging-convention.md` (failure side) and
+/// `docs/architecture/instrumentation-discipline.md` (success side).
+fn log_create_emit(
+    witness_id: u32,
+    entity_id: u32,
+    class_id: u8,
+    phase: &'static str,
+    outcome: WitnessSendOutcome,
+) {
+    match outcome {
+        WitnessSendOutcome::Sent { seq, bytes, .. } => {
+            tracing::debug!(
+                target: "aoi.create_emit",
+                event = "create_emit",
+                witness_id,
+                entity_id,
+                class_id,
+                phase,
+                addr_resolved = true,
+                bytes,
+                seq,
+                "AoI create emit: {phase} packet delivered to witness"
+            );
+        }
+        failed => {
+            // reason is one of: entity_to_addr_miss / client_disconnected /
+            // send_error. The helper already logged its own line; this seam
+            // is the AoI-create-specific WARN that names the phase + entity
+            // so the invisible-corpse repro can be pinned to CREATE vs CASCADE.
+            tracing::warn!(
+                target: "aoi.create_send_failed",
+                event = "create_send_failed",
+                witness_id,
+                entity_id,
+                class_id,
+                phase,
+                addr_resolved = failed.addr_resolved(),
+                reason = failed.failure_reason().unwrap_or("unknown"),
+                "AoI create emit: {phase} packet NOT delivered to witness -- \
+                 entity may be invisible until relog"
+            );
+        }
+    }
+}
+
+/// Bundle-path analogue of [`log_create_emit`] — emits the success
+/// (`aoi.create_emit`, DEBUG) or failure (`aoi.create_send_failed`, WARN)
+/// seam for the pre-onClientReady bundled introduction in
+/// [`flush_deferred_aoi`]. `entered` is the NPC count folded into the
+/// bundle; `phase` distinguishes the phase-1 (`"create_base"`) and
+/// phase-2 (`"cascade"`) bundles. Per-entity ids aren't available here —
+/// the bundle carries N entities — so the seam reports the aggregate
+/// count instead.
+fn log_bundle_emit(
+    witness_id: u32,
+    entered: usize,
+    phase: &'static str,
+    outcome: BundleSendOutcome,
+) {
+    match outcome {
+        BundleSendOutcome::Sent {
+            base_seq,
+            packets,
+            bytes,
+            ..
+        } => {
+            tracing::debug!(
+                target: "aoi.create_emit",
+                event = "create_emit",
+                witness_id,
+                entered,
+                phase,
+                addr_resolved = true,
+                bytes,
+                seq = base_seq,
+                packets,
+                "AoI create emit: {phase} bundle ({entered} NPC) delivered to witness"
+            );
+        }
+        // Empty bundle is a benign no-op (the caller already gates on
+        // `is_empty()`), so it never reaches here in practice; treat it as
+        // non-failure to avoid a spurious WARN if that gate ever changes.
+        BundleSendOutcome::Empty => {}
+        failed => {
+            tracing::warn!(
+                target: "aoi.create_send_failed",
+                event = "create_send_failed",
+                witness_id,
+                entered,
+                phase,
+                addr_resolved = failed.addr_resolved(),
+                reason = failed.failure_reason().unwrap_or("unknown"),
+                "AoI create emit: {phase} bundle ({entered} NPC) NOT delivered to witness -- \
+                 entities may be invisible until relog"
+            );
+        }
+    }
+}
 
 /// Drain a session's deferred-AoI buffer and dispatch each held message
 /// through the normal AoI handlers.
@@ -142,8 +253,15 @@ pub(crate) async fn flush_deferred_aoi(
             phase1_packets = phase1.estimated_packet_count(),
             "AoI flush: phase-1 bundle (CREATE_ENTITY + UPDATE_AVATAR per NPC)"
         );
-        send_bundle_to_witness_reliable(transport, connected, entity_to_addr, witness_id, phase1)
-            .await;
+        let outcome = send_bundle_to_witness_reliable(
+            transport,
+            connected,
+            entity_to_addr,
+            witness_id,
+            phase1,
+        )
+        .await;
+        log_bundle_emit(witness_id, entered_count, "create_base", outcome);
     }
     if !phase2.is_empty() {
         tracing::debug!(
@@ -153,8 +271,15 @@ pub(crate) async fn flush_deferred_aoi(
             phase2_packets = phase2.estimated_packet_count(),
             "AoI flush: phase-2 bundle (createOnClient() cascade per NPC)"
         );
-        send_bundle_to_witness_reliable(transport, connected, entity_to_addr, witness_id, phase2)
-            .await;
+        let outcome = send_bundle_to_witness_reliable(
+            transport,
+            connected,
+            entity_to_addr,
+            witness_id,
+            phase2,
+        )
+        .await;
+        log_bundle_emit(witness_id, entered_count, "cascade", outcome);
     }
 
     for msg in tail {
@@ -201,7 +326,7 @@ pub(super) async fn entered_aoi(
     );
     // Packet 1: CREATE_ENTITY + UPDATE_AVATAR (BaseApp immediate) — RELIABLE.
     // NPC spawn into player AoI; loss = NPC permanently invisible.
-    send_to_witness_reliable(
+    let base_outcome = send_to_witness_reliable(
         transport,
         connected,
         entity_to_addr,
@@ -213,8 +338,9 @@ pub(super) async fn entered_aoi(
         },
     )
     .await;
+    log_create_emit(witness_id, entity_id, class_id, "create_base", base_outcome);
     // Packet 2: createOnClient() property cascade (CellApp round-trip) — RELIABLE
-    send_to_witness_reliable(
+    let cascade_outcome = send_to_witness_reliable(
         transport,
         connected,
         entity_to_addr,
@@ -233,6 +359,7 @@ pub(super) async fn entered_aoi(
         },
     )
     .await;
+    log_create_emit(witness_id, entity_id, class_id, "cascade", cascade_outcome);
 }
 
 /// `CellToBaseMsg::LeftAoI` — entity left a witness's range.
@@ -441,7 +568,8 @@ pub(super) async fn entity_invisible(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_support::{test_default_connected_client_state, TestTransport};
+    use crate::test_support::{test_default_connected_client_state, LogCapture, TestTransport};
+    use tracing::Level;
 
     /// Domain A (fan-out byte test): one AoI event (entity 200 leaves) routed
     /// to two witnesses lands as exactly two packets — one per witness — each
@@ -518,5 +646,147 @@ mod tests {
         );
         assert_eq!(sent[0].1, expected, "witness A leave bytes (seq 0)");
         assert_eq!(sent[1].1, expected, "witness B leave bytes (seq 0)");
+    }
+
+    /// Build the single-witness IO triple used by the create-emit seam
+    /// tests: one witness wired into both maps with a fresh client state.
+    fn single_witness_io(
+        witness_id: u32,
+        addr: SocketAddr,
+    ) -> (
+        Arc<TestTransport>,
+        Arc<Mutex<HashMap<SocketAddr, ConnectedClientState>>>,
+        Arc<Mutex<HashMap<u32, SocketAddr>>>,
+    ) {
+        let transport = Arc::new(TestTransport::new());
+        let entity_to_addr = Arc::new(Mutex::new(HashMap::from([(witness_id, addr)])));
+        let connected = Arc::new(Mutex::new(HashMap::from([(
+            addr,
+            test_default_connected_client_state(),
+        )])));
+        (transport, connected, entity_to_addr)
+    }
+
+    /// Success-side seam: `entered_aoi` emits the `aoi.create_emit` DEBUG
+    /// event for BOTH the `create_base` and `cascade` phases when the
+    /// witness addr resolves. This is the success-path visibility the
+    /// invisible-static-NPC (Castle_CellBlock GuardBody corpse, class_id=0)
+    /// bug needs — the two reliable sends previously discarded their
+    /// outcomes, so a delivered CREATE/CASCADE was unobservable. Reverting
+    /// the `log_create_emit` calls (or downgrading them below DEBUG) trips
+    /// this guard.
+    #[tokio::test]
+    async fn entered_aoi_emits_create_and_cascade_success_seams() {
+        let capture = LogCapture::install();
+
+        let witness_id = 100u32;
+        let addr: SocketAddr = "127.0.0.1:50200".parse().unwrap();
+        let (transport, connected, entity_to_addr) = single_witness_io(witness_id, addr);
+        let dyn_transport: Arc<dyn Transport> = transport.clone();
+
+        // class_id = 0 is the GuardBody corpse class from the colo repro.
+        entered_aoi(
+            witness_id,
+            777, // entity_id
+            0,   // class_id (corpse)
+            [1.0, 2.0, 3.0],
+            [0.0, 0.0, 0.0],
+            1, // level
+            None,
+            &dyn_transport,
+            &connected,
+            &entity_to_addr,
+        )
+        .await;
+
+        // Both packets actually hit the wire (the bug is about delivery).
+        assert_eq!(
+            transport.send_count_to(addr),
+            2,
+            "create_base + cascade both sent to the witness"
+        );
+
+        let base = capture
+            .all()
+            .into_iter()
+            .find(|c| c.has_field("phase", "create_base") && c.level == Level::DEBUG)
+            .expect("create_base DEBUG seam must fire");
+        assert!(
+            base.has_field("phase", "create_base"),
+            "create_base seam carries phase=create_base: {base:#?}"
+        );
+        assert!(
+            base.has_field("addr_resolved", "true"),
+            "create_base seam carries addr_resolved=true: {base:#?}"
+        );
+        assert!(
+            base.has_field("class_id", "0"),
+            "create_base seam carries the corpse class_id: {base:#?}"
+        );
+
+        let cascade = capture
+            .all()
+            .into_iter()
+            .find(|c| c.has_field("phase", "cascade") && c.level == Level::DEBUG)
+            .expect("cascade DEBUG seam must fire");
+        assert!(
+            cascade.has_field("addr_resolved", "true"),
+            "cascade seam carries addr_resolved=true: {cascade:#?}"
+        );
+        assert!(
+            cascade.has_field("entity_id", "777"),
+            "cascade seam carries the entity_id: {cascade:#?}"
+        );
+    }
+
+    /// Failure-side seam: when the witness addr is missing from
+    /// `entity_to_addr`, `entered_aoi` emits the `aoi.create_send_failed`
+    /// WARN with `reason=entity_to_addr_miss` for the (failed) create_base
+    /// packet — the negative-logging seam that names the invisible-corpse
+    /// drop. Reverting the helper-return plumbing or the WARN seam trips
+    /// this guard.
+    #[tokio::test]
+    async fn entered_aoi_emits_failure_seam_on_missing_witness_addr() {
+        let capture = LogCapture::install();
+
+        // entity_to_addr is EMPTY — the witness has no resolvable address.
+        let transport = Arc::new(TestTransport::new());
+        let dyn_transport: Arc<dyn Transport> = transport.clone();
+        let connected: Arc<Mutex<HashMap<SocketAddr, ConnectedClientState>>> =
+            Arc::new(Mutex::new(HashMap::new()));
+        let entity_to_addr: Arc<Mutex<HashMap<u32, SocketAddr>>> =
+            Arc::new(Mutex::new(HashMap::new()));
+
+        entered_aoi(
+            999, // witness_id with no addr mapping
+            777, // entity_id
+            0,   // class_id (corpse)
+            [0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0],
+            1,
+            None,
+            &dyn_transport,
+            &connected,
+            &entity_to_addr,
+        )
+        .await;
+
+        assert_eq!(
+            transport.len(),
+            0,
+            "no packet leaves the transport when the witness addr is unresolved"
+        );
+
+        let failed = capture
+            .find_event(Level::WARN, "AoI create emit", "entity_to_addr_miss")
+            .expect("create_send_failed WARN seam must fire with reason=entity_to_addr_miss");
+        assert!(
+            failed.has_field("addr_resolved", "false"),
+            "failure seam reports addr_resolved=false: {failed:#?}"
+        );
+        assert!(
+            failed.has_field("phase", "create_base"),
+            "failure seam names the failing phase: {failed:#?}"
+        );
     }
 }

--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -180,6 +180,8 @@ to crate-rename churn) and **named for the question they answer**.
 | `mercury.backpressure` | WARN | `Channel::send_packet` when TX window ≥ 50% full | Send-window saturation — early warning for stalled clients |
 | `wire.in` / `wire.out` | INFO | `wire_log::{log_inbound, log_outbound_entity_method}` | Decoded entity-method calls |
 | `aoi.entity_enter` / `aoi.entity_leave` | DEBUG | AoI tick witness fanout | Per-entity AoI transitions |
+| `aoi.create_emit` | DEBUG | `base::world_entry::cell_dispatch::aoi::{entered_aoi, flush_deferred_aoi}` | Per-packet entity-introduction delivery (CREATE_ENTITY+UPDATE_AVATAR / createOnClient cascade) — fields `witness_id`, `entity_id`, `class_id`, `phase` (`create_base` \| `cascade`), `addr_resolved`, `bytes`, `seq`. Success-side visibility for the invisible-static-NPC drop |
+| `aoi.create_send_failed` | WARN | `base::world_entry::cell_dispatch::aoi::{entered_aoi, flush_deferred_aoi}` | Entity-introduction packet/bundle that could NOT be delivered — `reason` (`entity_to_addr_miss` \| `client_disconnected` \| `send_error`), `phase`, `addr_resolved`. Negative-logging seam for the invisible-corpse class |
 | `movement.player` | DEBUG (1-in-10 sampled) | `cell::service::base_messages` position-update path | Player avatar position updates |
 | `movement.npc` | DEBUG (1-in-10 sampled `step`, always `waypoint_reached`) | `cell::service::ticks::npc_movement` | NPC nav-path movement |
 | `npc_ai` | DEBUG / INFO | `cell::service::npc_ai_fight` | NPC AI tick outcomes — see `decision_outcome` |


### PR DESCRIPTION
## Why

The Castle_CellBlock `GuardBody` corpse (`class_id=0`) is intermittently
**invisible-until-relog**. This PR adds the observability seams needed to
pinpoint the drop on the next colo session — it does **not** change
delivery behavior.

### Investigation (2026-06-20 colo log analysis)

- **Spawn is fine.** All 28 NPCs spawn in every instanced space, no errors.
- **Server-side AoI introduction is uniform.** Every corpse logs exactly
  one `AoI: entity entered witness range` per login.
- **The two existing warns never fire.** `entered_no_witness_addr` and
  `cascade_appearance_missing` are silent → the witness-addr gate and the
  appearance cascade are **not** the drop.
- **So the drop is downstream, in create + appearance delivery — and our
  logs couldn't see it.** The entity-create/cascade packets ride the
  Mercury layer unlogged, and `entered_aoi`'s two `send_to_witness_reliable`
  calls **discarded their results**.
- **Leading suspect:** the per-entity `CREATE_ENTITY` + cascade hits the
  client's HOLD-FOR-TRANSACTION path (a same-entity message following
  `CREATE_ENTITY` in one client frame is silently dropped) when multiple
  entities enter range in the same world-entry tick — **or** a Mercury
  enqueue / addr-resolution failure that is currently swallowed.

## What each new seam reveals

| Seam | Level | Target | Fields | Reveals |
|---|---|---|---|---|
| Create-emit success | DEBUG | `aoi.create_emit` | `witness_id`, `entity_id`, `class_id`, `phase` (`create_base`\|`cascade`), `addr_resolved`, `bytes`, `seq` (+ `packets`/`entered` on the bundle path) | The previously-invisible success path: did the CREATE and the CASCADE actually reach the wire, with what seq/size, for the corpse entity? |
| Create-emit failure | WARN | `aoi.create_send_failed` | `reason` (`entity_to_addr_miss`\|`client_disconnected`\|`send_error`), `phase`, `addr_resolved` | A swallowed addr-resolution miss or enqueue/send failure on either packet — the negative-logging seam for the invisible-corpse class. |

Both fire from `entered_aoi` (per-entity path) **and** `flush_deferred_aoi`'s
phase-1/phase-2 bundles (pre-`onClientReady` burst path).

### Plumbing change (logging-only, behavior-preserving)

`send_to_witness` / `send_to_witness_reliable` now return a
`WitnessSendOutcome`, and `send_bundle_to_witness_reliable` returns a
`BundleSendOutcome`. The helpers already emitted their own failure
`warn!`/`debug!`; the return value just surfaces the **success-side** data
(`addr_resolved` / `seq` / `bytes`) so the AoI emit path can log it. The
outcome types are intentionally **not** `#[must_use]`, so the ~30 existing
statement call sites compile unchanged.

## Transaction-coalesce layer: deliberately NOT instrumented

The HOLD-FOR-TRANSACTION drop is a **client-side** silent drop — the server
cannot observe that the client discarded a same-entity-after-`CREATE_ENTITY`
message. `ChannelBundle` also carries no per-entity transaction state to key
detection on; adding it would mean parsing `CREATE_ENTITY` ids out of opaque
raw bodies and tracking an in-transaction set, with real false-positive risk
on legitimate cross-entity bundles. The current AoI paths already
**structurally avoid** the hazard: `entered_aoi` sends CREATE and CASCADE as
two separate datagrams (two client frames), and `flush_deferred_aoi` splits
phase-1 / phase-2 into separate bundles. So this layer is left alone by
design.

## Next-repro plan

1. Run a colo session at `RUST_LOG` including `aoi.create_emit=debug`.
2. Reproduce the invisible corpse, then relog.
3. Pivot SigNoz on `scope_name = 'aoi.create_emit'` filtered to the corpse
   `entity_id`:
   - **Both `create_base` and `cascade` present with `addr_resolved=true`**
     → the packets reached the wire; the drop is the client-side
     HOLD-FOR-TRANSACTION coalesce (or another client-side path). Shift the
     investigation client-side.
   - **A `aoi.create_send_failed` WARN appears** → read `reason`/`phase`;
     the drop is server-side (addr miss / enqueue / send error) and now
     named.
   - **The cascade is missing entirely with no failure seam** → the cell
     never emitted it; move upstream to the cascade composer.

## Tests

- `aoi.rs`: `entered_aoi` emits **both** the `create_base` and `cascade`
  success seams for a delivered corpse entity; the failure seam fires with
  `reason=entity_to_addr_miss` when the witness addr is missing. The
  existing `left_aoi_fans_out…` fan-out byte test is untouched.
- `helpers/tests.rs`: return-value guards pin the `Sent{addr,seq,bytes}` /
  `AddrUnresolved` outcome contract for the single-packet and bundle
  helpers, so a refactor back to `-> ()` trips here.

## Docs

New `aoi.create_emit` / `aoi.create_send_failed` rows in the
`docs/architecture/observability.md` stable target catalog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Claude-Session: https://claude.ai/code/session_0151DAFJemGM1jhv8sfPBVki
