### PR TITLE
fix(inventory): reject requestAmmoChange when weapon def is not cached

### DIFF
--- a/crates/services/src/cell/cell_methods/inventory/bandolier/ammo_change.rs
+++ b/crates/services/src/cell/cell_methods/inventory/bandolier/ammo_change.rs
@@ -29,7 +29,11 @@ use super::super::constants::{build_entity_property_args, GENERICPROPERTY_AMMO_T
 /// - Validates `ammo_type` is in the weapon's `allowed_ammo_types`
 ///   whitelist (`crates/entity/src/inventory.rs:81`) so a forged
 ///   request can't persist an arbitrary subtype the client UI can't
-///   render.
+///   render. Fail-closed: a weapon with no `item_defs` cache entry is
+///   rejected — every ammo-bearing weapon is in the cache
+///   (`load_item_defs` selects `WHERE clip_size > 0`), so a miss means
+///   either a forged request for a non-weapon or a broken cache load,
+///   never a legit swap.
 /// - Rejects ambiguous matches when the player has the same item_id in
 ///   multiple bandolier slots — the wire request doesn't carry a slot
 ///   id, so guessing would mis-attribute the swap.
@@ -56,15 +60,10 @@ pub(crate) async fn handle_request_ammo_change(
     let ammo_type = i32::from_le_bytes([args[4], args[5], args[6], args[7]]);
     tracing::debug!(entity_id, item_id, ammo_type, "requestAmmoChange");
 
-    // Loose validation — the legacy is literally `pass`. Reject
-    // anything non-positive: 0 is the "no choice" sentinel, and
+    // Reject anything non-positive: 0 is the "no choice" sentinel, and
     // the DB column has CHECK (cur_ammo_type >= 0), so a negative
     // value would mutate cell + client state then fail the DB
-    // write later, leaving them ahead of persistence. The proper
-    // whitelist lives on the item template's `ammo_types`
-    // (crates/entity/src/inventory.rs:81).
-    // TODO: validate against item.ammo_types whitelist
-    //       (see crates/entity/src/inventory.rs:81 — `Item.ammo_types`).
+    // write later, leaving them ahead of persistence.
     if ammo_type <= 0 {
         tracing::warn!(
             entity_id,
@@ -77,10 +76,11 @@ pub(crate) async fn handle_request_ammo_change(
 
     // Snapshot the weapon's allowed-ammo whitelist BEFORE taking
     // the mutable entity borrow — both read from `space_mgr` and
-    // can't coexist. `None` means the cache had no entry (custom
-    // item the loader skipped), in which case we accept any
-    // positive ammo_type to match the legacy `pass` semantics
-    // for unknown weapons.
+    // can't coexist. `None` is rejected in phase 1 after slot
+    // resolution (fail closed), not here: resolving the slot first
+    // routes forged design-ids to the "item not in bandolier" warn,
+    // so the cache-miss warn only fires for weapons the player
+    // actually holds — a real ops signal, not attacker noise.
     let weapon_def = space_mgr.item_defs.get(&item_id).cloned();
 
     // Phase 1: locate the slot, mutate, capture the BandolierAmmoUpdate
@@ -124,20 +124,35 @@ pub(crate) async fn handle_request_ammo_change(
         // subtypes whitelist (snapshotted into `weapon_def`
         // above). Without this an attacker could persist an
         // arbitrary ammo subtype that the client UI can't
-        // render. Falls through when the cache entry is
-        // missing — see comment at the snapshot site.
-        if let Some(def) = weapon_def.as_ref() {
-            let allowed =
-                ammo_type == def.default_ammo_type || def.allowed_ammo_types.contains(&ammo_type);
-            if !allowed {
-                tracing::warn!(
-                    entity_id, item_id, ammo_type,
-                    allowed = ?def.allowed_ammo_types,
-                    default_ammo = def.default_ammo_type,
-                    "requestAmmoChange: ammo_type not in weapon's allowed list, rejecting"
-                );
-                return;
-            }
+        // render. Fail closed on a cache miss: the player holds
+        // this weapon in a bandolier slot but `load_item_defs`
+        // (WHERE clip_size > 0) produced no entry, so either the
+        // item is not an ammo-bearing weapon (nothing to swap) or
+        // the def cache failed to load — worth an operator look
+        // either way.
+        let Some(def) = weapon_def.as_ref() else {
+            tracing::warn!(
+                entity_id,
+                item_id,
+                ammo_type,
+                reason = "weapon_def_cache_miss",
+                "requestAmmoChange: expected a WeaponDef cache entry for a \
+                 bandolier-held item but found none — rejecting; player's ammo \
+                 swap is dropped (investigate item-def cache load if the item \
+                 should be an ammo-bearing weapon)"
+            );
+            return;
+        };
+        let allowed =
+            ammo_type == def.default_ammo_type || def.allowed_ammo_types.contains(&ammo_type);
+        if !allowed {
+            tracing::warn!(
+                entity_id, item_id, ammo_type,
+                allowed = ?def.allowed_ammo_types,
+                default_ammo = def.default_ammo_type,
+                "requestAmmoChange: ammo_type not in weapon's allowed list, rejecting"
+            );
+            return;
         }
         // Mutate the slot and mark it dirty. The dirty marker stays set
         // until phase 2 confirms BandolierAmmoUpdate was accepted by the

--- a/crates/services/src/cell/cell_methods/inventory/tests/ammo_change.rs
+++ b/crates/services/src/cell/cell_methods/inventory/tests/ammo_change.rs
@@ -14,9 +14,22 @@ use super::make_test_space_mgr;
 /// `onEntityProperty(AmmoTypeId)` to the client.
 #[tokio::test]
 async fn request_ammo_change_updates_slot_and_sends_property() {
+    use crate::cell::spawner::WeaponDef;
+
     let mut mgr = make_test_space_mgr();
     mgr.create_entity(1, "Castle_CellBlock", [0.0; 3], [0.0; 3])
         .unwrap();
+    // The handler fails closed on a missing WeaponDef cache entry, so the
+    // happy path must seed one whose whitelist allows the requested type.
+    mgr.item_defs.insert(
+        42,
+        WeaponDef {
+            clip_size: 30,
+            default_ammo_type: 1,
+            allowed_ammo_types: vec![1, 3, 5],
+            holster_animation_duration: std::time::Duration::from_millis(600),
+        },
+    );
 
     if let Some(e) = mgr.get_entity_mut(1) {
         e.is_player = true;
@@ -163,9 +176,8 @@ async fn request_ammo_change_rejects_non_positive() {
 
 /// CodeRabbit #15: requestAmmoChange must reject ammo subtypes that aren't
 /// in the weapon's `allowed_ammo_types` whitelist (mirrors
-/// `resources.items.ammo_types`). Items with no cache entry fall through
-/// (matching legacy `pass` for unknown weapons) — already covered by
-/// the existing happy-path test.
+/// `resources.items.ammo_types`). Items with no cache entry are rejected
+/// outright — see `request_ammo_change_rejects_missing_weapon_def`.
 #[tokio::test]
 async fn request_ammo_change_rejects_unlisted_subtype() {
     use crate::cell::spawner::WeaponDef;
@@ -223,4 +235,63 @@ async fn request_ammo_change_rejects_unlisted_subtype() {
         "cur_ammo_type unchanged"
     );
     assert!(!entity.bandolier_ammo_dirty.contains(&0));
+}
+
+/// CAT-D fall-open guard: a bandolier item with **no WeaponDef cache
+/// entry** must be rejected, not waved through. The old behavior skipped
+/// the whitelist entirely when `item_defs` had no entry (legacy Python
+/// `pass` semantics), letting a forged request persist any positive
+/// `cur_ammo_type` — e.g. 0x7FFFFFFE — for any weapon the loader didn't
+/// cache. Reverting the fail-closed check makes this test fail: the slot
+/// would mutate and BandolierAmmoUpdate + onEntityProperty would fire.
+#[tokio::test]
+async fn request_ammo_change_rejects_missing_weapon_def() {
+    let mut mgr = make_test_space_mgr();
+    mgr.create_entity(1, "Castle_CellBlock", [0.0; 3], [0.0; 3])
+        .unwrap();
+    // Deliberately NO mgr.item_defs entry for item 42.
+
+    if let Some(e) = mgr.get_entity_mut(1) {
+        e.is_player = true;
+        e.player_id = Some(100);
+        e.bandolier_items.insert(
+            0,
+            BandolierItem {
+                instance_id: 4242,
+                item_id: 42,
+                clip_size: 30,
+                default_ammo_type: 1,
+                current_ammo: 20,
+                cur_ammo_type: 1,
+            },
+        );
+        // Active slot so a fall-open would also emit onEntityProperty —
+        // the assertion below proves neither message escapes.
+        e.active_bandolier_slot = 0;
+    }
+
+    let (tx, mut rx) = mpsc::channel(8);
+
+    // The repro from the finding: a huge but positive ammo_type.
+    let mut args = Vec::with_capacity(8);
+    args.extend_from_slice(&42i32.to_le_bytes());
+    args.extend_from_slice(&0x7FFF_FFFEi32.to_le_bytes());
+
+    let engine = cimmeria_content_engine::chain::ChainEngine::new();
+    let handled = dispatch(1, REQUEST_AMMO_CHANGE, &args, &tx, &mut mgr, &engine).await;
+
+    assert!(handled, "REQUEST_AMMO_CHANGE should be claimed");
+    assert!(
+        rx.try_recv().is_err(),
+        "no BandolierAmmoUpdate and no onEntityProperty for a weapon with no cached def"
+    );
+    let entity = mgr.get_entity(1).unwrap();
+    assert_eq!(
+        entity.bandolier_items[&0].cur_ammo_type, 1,
+        "cur_ammo_type must be unchanged when the weapon def is not cached"
+    );
+    assert!(
+        !entity.bandolier_ammo_dirty.contains(&0),
+        "no dirty flag — nothing may be queued for persistence"
+    );
 }

--- a/docs/gameplay/weapon-ammo-reload.md
+++ b/docs/gameplay/weapon-ammo-reload.md
@@ -141,6 +141,8 @@ Client (player clicks an ammo subtype icon)
   │
   │ requestAmmoChange(item_id, ammo_type) ──▶ Cell
   │                                              │ scan bandolier_items for matching item_id
+  │                                              │ validate ammo_type against the WeaponDef
+  │                                              │   whitelist (fail closed on cache miss)
   │                                              │ item.cur_ammo_type = ammo_type
   │                                              │ (mark + immediately drain dirty for this slot)
   │                                              │
@@ -150,9 +152,9 @@ Client (player clicks an ammo subtype icon)
   │ ◀── onEntityProperty(AmmoTypeId, ammo_type) ─│   refreshes the ammo-type indicator
 ```
 
-The persistence emit is **immediate**, not batched, because subtype is a deliberate user action and we want it durable before the next packet. The legacy validator was literally `pass`; we reject `ammo_type == 0` as obvious junk, with a TODO to whitelist against `Item.ammo_types` ([`crates/entity/src/inventory.rs:81`](../../crates/entity/src/inventory.rs#L81)).
+The persistence emit is **immediate**, not batched, because subtype is a deliberate user action and we want it durable before the next packet. The legacy validator was literally `pass`; the Rust handler rejects non-positive `ammo_type`, requires the design id to resolve to exactly one bandolier slot, and validates the subtype against the weapon's `allowed_ammo_types` whitelist from the `item_defs` cache. The whitelist check **fails closed**: a bandolier-held weapon with no cache entry is rejected with a `warn!` (every ammo-bearing weapon is cached — `load_item_defs` selects `WHERE clip_size > 0` — so a miss means a forged request for a non-weapon or a broken cache load).
 
-Def: [`entities/defs/interfaces/SGWInventoryManager.def:190-194`](../../entities/defs/interfaces/SGWInventoryManager.def#L190). Implementation: [`crates/services/src/cell/cell_methods/inventory.rs:250-329`](../../crates/services/src/cell/cell_methods/inventory.rs#L250).
+Def: [`entities/defs/interfaces/SGWInventoryManager.def:190-194`](../../entities/defs/interfaces/SGWInventoryManager.def#L190). Implementation: [`crates/services/src/cell/cell_methods/inventory/bandolier/ammo_change.rs`](../../crates/services/src/cell/cell_methods/inventory/bandolier/ammo_change.rs).
 
 ## Active slot swap
 

--- a/docs/security-audit/2026-05-31-server-authority/findings/CAT-D-inventory.md
+++ b/docs/security-audit/2026-05-31-server-authority/findings/CAT-D-inventory.md
@@ -327,6 +327,16 @@ No — static.
 
 ### CAT-D-06 — `requestAmmoChange` falls through to "any positive ammo_type" when the weapon's `item_defs` cache row is missing
 
+**Status**: ✅ RESOLVED (#448) — `handle_request_ammo_change`
+(`cell/cell_methods/inventory/bandolier/ammo_change.rs`) now fails closed
+on an `item_defs` cache miss: the request is rejected with a
+`reason = "weapon_def_cache_miss"` warn instead of skipping the
+whitelist. Every ammo-bearing weapon is in the cache (`load_item_defs`
+selects `WHERE clip_size > 0`), so a miss means either a forged request
+for a non-weapon or a broken cache load — never a legitimate swap.
+Regression guard: `request_ammo_change_rejects_missing_weapon_def`
+(fails when the fall-open is reinstated).
+
 **Severity**: Medium
 **Class**: Missing whitelist on edge case
 **Wire surface**: `Event_NetOut_RequestAmmoChange` (cell method 42)

--- a/docs/technical/network-messages.md
+++ b/docs/technical/network-messages.md
@@ -626,7 +626,7 @@ The catalog above lists messages by client-side `Event_NetOut_*` / `Event_NetIn_
 | Wire opcode | Cell method | Interface | Args | Notes |
 |-------------|-------------|-----------|------|-------|
 | 41 (`0x29`) | `requestActiveSlotChange` | SGWInventoryManager | INT32 BagId, INT32 SlotId | Only `BagId == 3` (INV_Bandolier) carries an active slot |
-| 42 (`0x2A`) | `requestAmmoChange` | SGWInventoryManager | INT32 ItemId, INT32 AmmoType | Server validates `ammo_type != 0` |
+| 42 (`0x2A`) | `requestAmmoChange` | SGWInventoryManager | INT32 ItemId, INT32 AmmoType | Server rejects `ammo_type <= 0`, requires a unique bandolier-slot match, and enforces the weapon's `allowed_ammo_types` whitelist (fail-closed when no cached `WeaponDef`) |
 | 86 (`0x56`) | `requestReload` | SGWPlayer | UINT8 EReloadType | Starts warmup deadline; refill is server-driven. Source: [`REQUEST_RELOAD` in cell/cell_methods/player/constants.rs](../../crates/services/src/cell/cell_methods/player/constants.rs). The decompiled client-side binding at [`14_standalone_named.c:298900-298909`](../reverse-engineering/decompiled/14_standalone_named.c#L298900) shows `0x14` — that is a **registration index** in the `BW__unknown_00438c40` setup call, not the wire opcode. |
 
 Server → client ammo updates flow through **`onStatUpdate`** (client method index 20) carrying one or more `AmmoSlot{N}` stat entries (stat IDs 49–53). Active-slot subtype refresh uses **`onEntityProperty`** with `GENERICPROPERTY_AmmoTypeId = 3`. `ActiveSlotUpdate` and `BandolierAmmoUpdate` are internal cell→base messages for persistence and are not sent over the wire to the client.


### PR DESCRIPTION
## Summary

`requestAmmoChange` validated the requested ammo subtype against the weapon's `allowed_ammo_types` whitelist **only when** the weapon had an entry in the cell's `item_defs` cache. On a cache miss the handler fell open (preserving the legacy Python `pass` semantics), leaving `ammo_type > 0` as the only gate — so a forged request could mutate the slot, fire `BandolierAmmoUpdate`, and persist an arbitrary positive `cur_ammo_type` (e.g. `0x7FFFFFFE`) to `sgw_inventory`.

This PR makes the cache miss a **fail-closed reject**:

- A bandolier-held weapon with no `WeaponDef` cache entry is rejected before any mutation, with a `warn!` carrying `reason = "weapon_def_cache_miss"` per the negative-logging convention. `load_item_defs` selects `WHERE clip_size > 0`, so every ammo-bearing weapon is in the cache — a miss means either a forged request for a non-weapon or a broken cache load, never a legitimate swap.
- The reject fires **after** slot resolution, so forged design-ids that aren't in the player's bandolier still hit the existing "item not in bandolier" warn. The new cache-miss warn only fires for weapons the player actually holds, keeping it a high-signal operator alert (investigate item-def cache load) rather than attacker-spammable noise.
- Removed the stale TODO — the whitelist validation it asked for already exists; the fall-open edge was the remaining gap.

## Testing

- New regression guard `request_ammo_change_rejects_missing_weapon_def`: item in the bandolier, no `item_defs` entry, `ammo_type = 0x7FFFFFFE` → no slot mutation, no `BandolierAmmoUpdate`, no `onEntityProperty`, no dirty flag. **Temporary-revert check done**: reinstating the fall-open makes this test fail (`no BandolierAmmoUpdate and no onEntityProperty` assertion trips).
- Happy-path test now seeds the `WeaponDef` cache (it previously relied on the fall-open to skip validation — itself evidence of the hole).
- Existing whitelist-reject and non-positive-reject guards unchanged and green.

## Docs

- `docs/security-audit/2026-05-31-server-authority/findings/CAT-D-inventory.md` — CAT-D-06 marked ✅ RESOLVED.
- `docs/gameplay/weapon-ammo-reload.md` — flow diagram + validator paragraph updated (also fixes the stale pre-split `inventory.rs` implementation link).
- `docs/technical/network-messages.md` — opcode 42 validation note updated.

Closes #448

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ammo type changes now reject invalid requests more reliably, including cases where weapon data is unavailable.
  * Unlisted ammo types are no longer accepted when the allowed list can’t be verified.
  * Added coverage to ensure rejected changes do not update ammo state or queue persistence.

* **Documentation**
  * Updated gameplay, network, and security notes to match the stricter ammo-change behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->