### PR TITLE
docs(inventory): cite the declared sgw_inventory PK in bandolier TOCTOU comments

### DIFF
--- a/crates/entity/src/cell_entity/mod.rs
+++ b/crates/entity/src/cell_entity/mod.rs
@@ -98,9 +98,12 @@ pub struct LootItem {
 pub struct BandolierItem {
     /// The `sgw_inventory.item_id` value — the per-row *instance* id of the
     /// physical item row backing this slot. It's a server-allocated surrogate
-    /// (sequence default, never reused), unique per slot via the
-    /// `sgw_inventory_unique_slot` index — unique by construction rather than
-    /// by a declared PK/UNIQUE constraint. This is the TOCTOU guard for
+    /// (sequence default, never reused) and the table's declared primary key
+    /// (`sgw_inventory_pkey PRIMARY KEY (item_id)`, `db/sgw/_primary_keys.sql`;
+    /// the child table carries its own PK because a parent PK doesn't span
+    /// `INHERITS` children). The `local_id_check` CHECK pins real rows to
+    /// `item_id >= 10000`, so the optimistic-grant `instance_id: 0` sentinel
+    /// can never collide with a live row. This is the TOCTOU guard for
     /// ammo persistence: it flows into `BandolierAmmoUpdate.expected_instance_id`
     /// and the WHERE clause of `update_bandolier_ammo`. Two physical items of
     /// the same weapon *design* share `item_id` (the design id below) but have

--- a/crates/services/src/base/world_entry/methods/inventory/ammo.rs
+++ b/crates/services/src/base/world_entry/methods/inventory/ammo.rs
@@ -11,8 +11,10 @@ use sqlx::PgPool;
 /// `expected_instance_id` is added to the WHERE clause as a TOCTOU guard.
 /// Between the cell sending `BandolierAmmoUpdate` and this UPDATE running, the
 /// player could have swapped the slot's weapon. The predicate keys on the
-/// `sgw_inventory.item_id` per-row instance id (a server-allocated surrogate,
-/// unique per slot via `sgw_inventory_unique_slot`), so it fires even
+/// `sgw_inventory.item_id` per-row instance id — a server-allocated surrogate
+/// and the table's declared primary key (`sgw_inventory_pkey PRIMARY KEY
+/// (item_id)`, `db/sgw/_primary_keys.sql`), so at most one row can ever
+/// match — and it fires even
 /// when the swapped-in weapon shares the same *design* (`type_id`) as the one
 /// the ammo writeback was computed for. Keying on `type_id` instead — as an
 /// earlier version did — left a same-type-swap window: two physical instances


### PR DESCRIPTION
## Summary

Corrects two doc comments that understated the uniqueness guarantee behind the bandolier-ammo TOCTOU guard. Both claimed `sgw_inventory.item_id` is unique only *incidentally* (sequence allocation + the `sgw_inventory_unique_slot` index) with "no declared PK/UNIQUE constraint." That's wrong — `db/sgw/_primary_keys.sql` declares:

- L31 `sgw_inventory_base_pkey PRIMARY KEY (item_id)`
- L39 `sgw_inventory_pkey PRIMARY KEY (item_id)`

The child table carries its own PK because a parent PK doesn't span `INHERITS` children, and `update_bandolier_ammo` targets `sgw_inventory` directly — so the child PK applies and the `WHERE … item_id = $5` guard added in #520 matches at most one row **by declared constraint**, not just by construction.

## Changes

- `crates/entity/src/cell_entity/mod.rs` — `BandolierItem.instance_id` doc now cites `sgw_inventory_pkey`, notes the `INHERITS` PK subtlety, and mentions the `local_id_check` CHECK (`item_id >= 10000`) that keeps the optimistic-grant `instance_id: 0` sentinel collision-free.
- `crates/services/src/base/world_entry/methods/inventory/ammo.rs` — `update_bandolier_ammo` doc keys the at-most-one-row claim on the declared PK instead of the slot-uniqueness index.

Also settles #520's "defense-in-depth `UNIQUE INDEX` on `item_id`" follow-up note as moot — the PK already provides it; no migration needed.

No runtime change — comment accuracy only. `cargo fmt` + `cargo clippy --all-targets` green on both touched crates.

Closes #533

🤖 Generated with [Claude Code](https://claude.com/claude-code)
