### PR TITLE
fix(seed): add items_event_sets bridge for Radio (item 5168) — unblocks SGC_W1 mission 1561

### DIFF
--- a/crates/services/src/cell/spawner/tests/live_db_loaders.rs
+++ b/crates/services/src/cell/spawner/tests/live_db_loaders.rs
@@ -86,6 +86,36 @@ mod live_db {
         }
     }
 
+    /// Radio (item 5168) must have an `items_event_sets` binding for
+    /// `EVENT_ItemUse` (event_id 5) → quest-item-use ability 597. The
+    /// SGW client treats `items_event_sets` as the authoritative
+    /// "can this item be used?" gate, so without this row the Radio
+    /// shows no "Use" option and the `OnItemUse::5168` chains (SGC_W1
+    /// 3021/3025) never fire — mission 1561 softlocks. This exercises
+    /// the real loader against the seed, so dropping the INSERT from
+    /// `db/resources/Items/Seed/items_event_sets.sql` makes it fail.
+    #[tokio::test]
+    async fn load_item_event_set_abilities_binds_radio_use() {
+        // event_id 5 = EVENT_ItemUse (resources `EItemEvents`); shared by
+        // every quest-item-use row in the seed (vial 19, GDO 1893, ...).
+        const RADIO_ITEM_ID: i32 = 5168;
+        const EVENT_ITEM_USE: i32 = 5;
+        const QUEST_ITEM_USE_ABILITY: i32 = 597;
+
+        let pool = require_db_or_skip!();
+        let map = load_item_event_set_abilities(&pool)
+            .await
+            .expect("load_item_event_set_abilities must succeed against seeded DB");
+
+        assert_eq!(
+            map.get(&(RADIO_ITEM_ID, EVENT_ITEM_USE)),
+            Some(&QUEST_ITEM_USE_ABILITY),
+            "Radio (item 5168) must bind EVENT_ItemUse (5) to ability 597 so the \
+             client offers a Use option and OnItemUse::5168 fires (mission 1561). \
+             Missing row → the items_event_sets seed INSERT was dropped.",
+        );
+    }
+
     /// The slappack (type 2893, `clip_size = 0` in the seed) MUST NOT be
     /// in the WeaponDef cache. Companion to the `clip_size > 0` filter
     /// assertion above — that test catches "any zero-clip leak"; this

--- a/db/resources/Items/Seed/items_event_sets.sql
+++ b/db/resources/Items/Seed/items_event_sets.sql
@@ -5538,11 +5538,17 @@ INSERT INTO items_event_sets (item_event_id, item_id, ability_id, event_id) VALU
 
 INSERT INTO items_event_sets (item_event_id, item_id, ability_id, event_id) VALUES (2767, 8946, 711, 6);
 
+-- Radio (item 5168) — EVENT_ItemUse (event 5) → quest-item use ability 597.
+-- Without this bridge the client offers no "Use" option on the Radio, so the
+-- OnItemUse::5168 chains (SGC_W1 3021/3025) never fire and mission 1561
+-- softlocks. Mirrors the shape of the other quest-item rows above.
+INSERT INTO items_event_sets (item_event_id, item_id, ability_id, event_id) VALUES (2768, 5168, 597, 5);
+
 --
 -- TOC entry 3321 (class 0 OID 0)
 -- Dependencies: 307
 -- Name: items_event_sets_2_item_event_id_seq; Type: SEQUENCE SET; Schema: resources; Owner: -
 --
 
-SELECT pg_catalog.setval('items_event_sets_2_item_event_id_seq', 2767, true);
+SELECT pg_catalog.setval('items_event_sets_2_item_event_id_seq', 2768, true);
 


### PR DESCRIPTION
## Summary

Radio (item 5168) had no row in `resources.items_event_sets`. The SGW client treats that table as the authoritative "can this item be used?" gate, so with no row the Radio shows no **Use** option and the cell-side `OnItemUse::5168` trigger never fires — softlocking SGC_W1 mission 1561 (chains 3021 "use radio → advance to bomb defusal" and 3025 "use radio → complete mission" can never run).

Fix is a single seed `INSERT` mirroring the other quest-item-use rows (item 19 Ambernol vial → 1374, item 1893 GDO → 597, both on `event_id = 5` / `EVENT_ItemUse`):

```sql
INSERT INTO items_event_sets (item_event_id, item_id, ability_id, event_id)
  VALUES (2768, 5168, 597, 5);
```

`2768` is the next free `item_event_id` (prior max + `setval` were both 2767); the `setval` at the end of the file is bumped to 2768 in the same edit so a future sequence-driven insert doesn't collide.

Verified against the seed before editing:
- item 5168 exists in `items.sql` with `container_sets = '{2}'` (mission tab) — only the events bridge was missing.
- ability 597 ("quest-item use") exists in `abilities.sql` — the same ability the vial/GDO rows use.
- chains 3021 and 3025 in `sgc_w1_chains.sql` both trigger on `item_use '5168'` and already exist.
- no pre-existing `items_event_sets` row for 5168.

## Testing

Live-DB regression `load_item_event_set_abilities_binds_radio_use` (in `spawner/tests/live_db_loaders.rs`) runs the real loader against the seeded DB and asserts `(5168, 5) → 597`. It self-skips locally via `require_db_or_skip!` and runs in CI against the fresh `db/database.sql`-loaded Postgres; dropping the seed `INSERT` makes it fail there.

I chose a loader-backed seed guard over a chain-replay test on 3021/3025 because those chains exist independently of this row — a replay test would pass with or without the fix, so it wouldn't guard the change. The server's `UseInventoryItem` path fires `ItemUsed` without consulting `items_event_sets` (the chain decides consumption), so this row is specifically the client-side usability gate; the loader guard is the tightest revertable check for it.

No doc update: `docs/content/mission-chains.md` and `association-map.md` already document the two-step radio-use flow as the intended (canonical) behavior — none claimed it was broken, so there's no known-gap note to flip.

Closes #334

🤖 Generated with [Claude Code](https://claude.com/claude-code)
