### PR TITLE
fix(vendor,gm-gate): emit store methods on 109/110, gate the minigame debug quartet

### DIFF
--- a/.claude/agent-memory/rust-gameserver-dev/MEMORY.md
+++ b/.claude/agent-memory/rust-gameserver-dev/MEMORY.md
@@ -26,6 +26,7 @@
 
 ## Wire-format gotchas
 
+- [method-idx-duplicate-table-drift.md](method-idx-duplicate-table-drift.md) — TWO client-method index tables; `cell/client_methods/` is authoritative, `mercury::method_idx` is a drifted partial copy (shipped vendor payload to mission handlers).
 - [read-wstring-offset-semantic.md](read-wstring-offset-semantic.md) — `read_wstring` returns BYTES CONSUMED, not the new absolute offset; chain with `offset += n`, never `offset = n`.
 - [ue3-staticmesh-extraction.md](ue3-staticmesh-extraction.md) — UE3 StaticMeshActor→Component→Mesh resolution in SGW cooked .umap: tagged-prop offset varies by class kind (Actor=32, StaticMesh=4, Component=8); ~20% of actors use prefab archetypes; kDOP tri indices reference LOD0 vertices; master .umap files exist alongside chunks.
 
@@ -43,4 +44,5 @@
 
 ## Testing patterns
 
+- [cargo-test-vs-nextest-flakiness.md](cargo-test-vs-nextest-flakiness.md) — full-suite `cargo test -p cimmeria-services` has PRE-EXISTING order-dependent failures (LogCapture thread bleed); validate with `cargo nextest`, don't assume you broke it.
 - [db-test-revert-verification.md](db-test-revert-verification.md) — split async DB-touching function into pure sync helper + DB shell; unit-test the helper so local revert-verification works when live-DB is the canonical guard.

--- a/.claude/agent-memory/rust-gameserver-dev/cargo-test-vs-nextest-flakiness.md
+++ b/.claude/agent-memory/rust-gameserver-dev/cargo-test-vs-nextest-flakiness.md
@@ -1,0 +1,38 @@
+---
+name: cargo-test-vs-nextest-flakiness
+description: Full-suite `cargo test -p cimmeria-services` has pre-existing order-dependent failures; nextest is the source of truth — don't assume you broke it
+metadata:
+  type: project
+---
+
+A full-suite `cargo test -p cimmeria-services --lib` run fails 1-2 tests
+that pass in isolation. `cargo nextest run --profile=ci -p cimmeria-services`
+passes all of them. This is **pre-existing**, not something your change
+caused.
+
+Observed failing test (there may be others): `cell::service::tests::npc_ai::
+state_machine::stationary_no_los_or_range_emits_structured_decision_log`.
+The failure count varies run to run (saw 1, 1, 2 across three consecutive
+clean-tree runs), which is the tell that it's scheduling-dependent.
+
+**Why:** `cargo test` runs all tests as threads in one process. Tests using
+`crate::test_support::LogCapture` install a *thread-local* subscriber via
+`set_default`, so events bleed across tests sharing a thread — the capture
+comes back populated with events from unrelated modules and the expected
+event is missing. nextest runs each test in its own process, so no bleed.
+CI runs nextest, which is why this never shows up in the pipeline.
+
+**How to apply:** Two things follow.
+
+1. **Don't diagnose a full-`cargo test` failure as yours without checking
+   the clean tree the same way.** The trap: `git stash` then run the
+   *filtered* single test — it passes, and you wrongly conclude your change
+   broke it. Adding any tests shifts the thread partition, so the flake
+   moves. Compare like with like: stash and run the **full suite**, several
+   times.
+2. **Validate with nextest before reporting done.** `cargo nextest run
+   --profile=ci -p cimmeria-services` is what CI gates on. Use `cargo test`
+   only for fast filtered iteration on your own tests.
+
+Related: [[db-test-revert-verification]] for the other case where the local
+runner can't prove what CI proves.

--- a/.claude/agent-memory/rust-gameserver-dev/concurrent-claude-sessions.md
+++ b/.claude/agent-memory/rust-gameserver-dev/concurrent-claude-sessions.md
@@ -19,4 +19,6 @@ New-Item -ItemType Junction -Path "<worktree>/external" -Target "C:/Users/Steve/
 
 Then `cd` into the worktree for all bash/cargo commands. The worktree has independent HEAD + index + working tree, immune to checkouts in the main checkout.
 
+**Symptom of a forgotten `external/` junction:** the build dies in `cc-rs` while building `cimmeria-entity`, with nothing in the error mentioning `external/` — `fatal error C1083: Cannot open include file: 'DetourNavMesh.h'`, repeated once per Detour source file. If you see Detour/Recast compile errors in a fresh worktree, you're missing the junction, not the toolchain.
+
 Cleanup when the PR merges: `git worktree remove <path>`. The worktree pattern is already used heavily in this repo (see `git worktree list` — 30+ active worktrees for parallel feature branches).

--- a/.claude/agent-memory/rust-gameserver-dev/method-idx-duplicate-table-drift.md
+++ b/.claude/agent-memory/rust-gameserver-dev/method-idx-duplicate-table-drift.md
@@ -1,0 +1,44 @@
+---
+name: method-idx-duplicate-table-drift
+description: Two client-method index tables exist; cell/client_methods is authoritative, mercury::method_idx is a partial drifted copy — prefer the former for new emit paths
+metadata:
+  type: project
+---
+
+The repo has **two** server→client method-index tables, and they have
+drifted:
+
+- `crates/services/src/cell/client_methods/` — one file per interface
+  (`player.rs`, `missionary.rs`, `combatant.rs`, ...), complete, matches
+  `entities/defs/*.def` and `docs/protocol/client-method-dispatch-table.md`.
+  **Treat as authoritative.**
+- `crates/services/src/mercury/mod.rs::method_idx` — a partial flat copy
+  covering only the indices some emit path happened to need. This is the
+  one that drifts.
+
+**Why it matters:** the drift is not inert. `method_idx` carried
+`ON_STORE_OPEN = 80` / `ON_STORE_UPDATE = 81` under a fabricated
+"SGWVendorStore interface (80-81)" heading — no such interface exists in
+`entities/defs/interfaces/`. 80/81 are Missionary's `onMissionUpdate` /
+`onStepUpdate`, so the vendor emit path shipped the store payload to the
+client's mission handlers. The correct `client_methods::player` constants
+were defined and referenced nowhere. Fixed 2026-07, but the structural
+hazard remains: nothing stops the two tables diverging again.
+
+Second-order damage worth knowing about: `method_idx` gets used to *label*
+sub-slot bytes when interpreting pcaps, so a wrong constant silently
+mislabels wire evidence. `docs/audits/entity-property-sync-section2-audit-2026-05-16.md`
+and `docs/audits/mercury-rust-conformance-2026-05-15.md` both label
+sub_idx 19/20 as `ON_STORE_OPEN`/`ON_STORE_UPDATE` in their evidence
+tables; those rows are actually mission traffic. The audits' *conclusions*
+(idbase = 61, not 62) stand on other rows and are unaffected.
+
+**How to apply:** For a new server→client emit, import from
+`crate::cell::client_methods::<interface>`. Before trusting any
+`method_idx` constant, cross-check it against the matching
+`client_methods/` file and the dispatch table. If a `method_idx` comment
+names an interface, verify that `entities/defs/interfaces/<Name>.def`
+actually exists — that check is what exposed this bug.
+
+Related: [[witness-entity-method-dual-fn]] — the same "two places, both
+need changing" shape on the fan-out side.

--- a/crates/services/src/base/world_entry/methods/vendor/store.rs
+++ b/crates/services/src/base/world_entry/methods/vendor/store.rs
@@ -14,7 +14,8 @@ use super::data::{
 use super::serializers::{
     serialize_empty_store_open, serialize_store_open, serialize_store_update, StoreItemCostUpdate,
 };
-use crate::mercury::{build_player_entity_method_packet, method_idx};
+use crate::cell::client_methods::player::{ON_STORE_OPEN, ON_STORE_UPDATE};
+use crate::mercury::build_player_entity_method_packet;
 
 #[derive(sqlx::FromRow)]
 pub struct VendorTemplateLists {
@@ -148,6 +149,10 @@ pub async fn handle_open_vendor_store(
 }
 
 /// Send vendor store open to client.
+///
+/// `onStoreOpen` is SGWPlayer flat index 109 (`SGWPlayer.def`), which is
+/// above `IDBASE_SGW_PLAYER` (61) and therefore rides the extended
+/// encoding: `[0xBD][word_len: u16][entity_id: u32][109 - 61 = 48][args]`.
 pub async fn send_store_open_to_client(
     entity_id: u32,
     vendor_entity_id: i32,
@@ -167,7 +172,7 @@ pub async fn send_store_open_to_client(
                 seq,
                 acks,
                 entity_id,
-                method_idx::ON_STORE_OPEN,
+                ON_STORE_OPEN,
                 &args,
                 version,
             )
@@ -178,6 +183,9 @@ pub async fn send_store_open_to_client(
 }
 
 /// Send vendor store price updates to client.
+///
+/// `onStoreUpdate` is SGWPlayer flat index 110 — extended encoding, sub-slot
+/// byte `110 - 61 = 49`.
 pub async fn send_store_update_to_client(
     entity_id: u32,
     updates: &[StoreItemCostUpdate],
@@ -201,11 +209,183 @@ pub async fn send_store_update_to_client(
                 seq,
                 acks,
                 entity_id,
-                method_idx::ON_STORE_UPDATE,
+                ON_STORE_UPDATE,
                 &args,
                 version,
             )
         },
     )
     .await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::{test_default_connected_client_state, TestTransport};
+    use cimmeria_mercury::encryption::MercuryEncryption;
+
+    /// `test_default_connected_client_state` builds its cipher from this key,
+    /// so the test can decrypt what the handler put on the wire.
+    const SESSION_KEY: [u8; 32] = [0u8; 32];
+
+    /// Extended-encoding marker byte emitted for any method index at or above
+    /// `IDBASE_SGW_PLAYER`.
+    const EXTENDED_MARKER: u8 = 0xBD;
+
+    fn make_client(
+        entity_id: u32,
+        addr: SocketAddr,
+    ) -> (
+        Arc<Mutex<HashMap<SocketAddr, ConnectedClientState>>>,
+        Arc<Mutex<HashMap<u32, SocketAddr>>>,
+    ) {
+        let connected = Arc::new(Mutex::new(HashMap::from([(
+            addr,
+            test_default_connected_client_state(),
+        )])));
+        let entity_to_addr = Arc::new(Mutex::new(HashMap::from([(entity_id, addr)])));
+        (connected, entity_to_addr)
+    }
+
+    /// Decrypt one recorded packet and return its Mercury body (flags byte
+    /// stripped from the front, 4-byte seq footer stripped from the back —
+    /// `pending_acks` is empty in the test client state, so `FLAG_HAS_ACKS`
+    /// is clear and the seq is the only footer).
+    fn decrypt_body(packet: &[u8]) -> Vec<u8> {
+        let enc = MercuryEncryption::from_session_key(SESSION_KEY);
+        let pt = enc.decrypt(packet).expect("decrypt vendor packet");
+        pt[1..pt.len() - 4].to_vec()
+    }
+
+    /// Wire-format regression guard: the vendor store-open payload must be
+    /// addressed to SGWPlayer flat method **109** (`onStoreOpen`).
+    ///
+    /// Bug shape: the emit path used a `method_idx` constant that claimed a
+    /// nonexistent "SGWVendorStore interface" at 80/81. Index 80 is
+    /// `onMissionUpdate` (Missionary interface), so the entire store payload
+    /// was delivered to the client's mission handler — a silent
+    /// wrong-recipient dispatch that no length or DB assertion can see.
+    ///
+    /// The sub-slot byte is asserted as a **literal** `0x30`, not computed
+    /// from the constant, so this fails if the emit path is pointed back at
+    /// 80 (whose sub-slot byte is `80 - 61 = 19 = 0x13`). Computing it from
+    /// `ON_STORE_OPEN` would make the assertion tautological.
+    #[tokio::test]
+    async fn store_open_is_emitted_on_method_109_not_a_mission_index() {
+        let transport = Arc::new(TestTransport::new());
+        let dyn_transport: Arc<dyn Transport> = transport.clone();
+
+        let entity_id = 0x0000_1234u32;
+        let vendor_entity_id = 777i32;
+        let addr: SocketAddr = "127.0.0.1:41090".parse().unwrap();
+        let (connected, entity_to_addr) = make_client(entity_id, addr);
+
+        // A short, recognisable arg blob: the byte layout of the store
+        // payload is pinned by the serializer's own tests; this test is
+        // about which method index carries it.
+        let args = vec![0xAAu8, 0xBB, 0xCC, 0xDD];
+
+        send_store_open_to_client(
+            entity_id,
+            vendor_entity_id,
+            args.clone(),
+            &dyn_transport,
+            &connected,
+            &entity_to_addr,
+        )
+        .await;
+
+        let sent = transport.drain();
+        assert_eq!(sent.len(), 1, "store open is one packet to the owner");
+        assert_eq!(sent[0].0, addr, "store open goes to the vendor user's addr");
+
+        let body = decrypt_body(&sent[0].1);
+
+        // Extended encoding: [0xBD][word_len: u16 LE][entity_id: u32 LE][sub_index: u8][args]
+        let expected_len = u16::try_from(4 + 1 + args.len()).unwrap();
+        let mut expected = vec![EXTENDED_MARKER];
+        expected.extend_from_slice(&expected_len.to_le_bytes());
+        expected.extend_from_slice(&entity_id.to_le_bytes());
+        expected.push(0x30); // 109 - IDBASE_SGW_PLAYER(61) = 48 = 0x30
+        expected.extend_from_slice(&args);
+
+        assert_eq!(
+            body, expected,
+            "onStoreOpen must ride method 109 (sub-slot byte 0x30). A sub-slot \
+             byte of 0x13 means the emit path regressed to index 80, which is \
+             onMissionUpdate — the client would route the store payload into \
+             its mission handler"
+        );
+    }
+
+    /// Same guard for the price-update emit: `onStoreUpdate` is flat method
+    /// **110**, sub-slot byte `110 - 61 = 49 = 0x31`. The regression value to
+    /// trip on is `0x14` (index 81 = `onStepUpdate`).
+    #[tokio::test]
+    async fn store_update_is_emitted_on_method_110_not_a_mission_index() {
+        let transport = Arc::new(TestTransport::new());
+        let dyn_transport: Arc<dyn Transport> = transport.clone();
+
+        let entity_id = 0x0000_5678u32;
+        let addr: SocketAddr = "127.0.0.1:41091".parse().unwrap();
+        let (connected, entity_to_addr) = make_client(entity_id, addr);
+
+        let updates = vec![StoreItemCostUpdate {
+            item_id: 4242,
+            sell_price: 10,
+            repair_price: 20,
+            recharge_price: 30,
+        }];
+
+        send_store_update_to_client(
+            entity_id,
+            &updates,
+            &dyn_transport,
+            &connected,
+            &entity_to_addr,
+        )
+        .await;
+
+        let sent = transport.drain();
+        assert_eq!(sent.len(), 1, "store update is one packet to the owner");
+        assert_eq!(sent[0].0, addr);
+
+        let body = decrypt_body(&sent[0].1);
+        let args = serialize_store_update(&updates);
+
+        let expected_len = u16::try_from(4 + 1 + args.len()).unwrap();
+        let mut expected = vec![EXTENDED_MARKER];
+        expected.extend_from_slice(&expected_len.to_le_bytes());
+        expected.extend_from_slice(&entity_id.to_le_bytes());
+        expected.push(0x31); // 110 - IDBASE_SGW_PLAYER(61) = 49 = 0x31
+        expected.extend_from_slice(&args);
+
+        assert_eq!(
+            body, expected,
+            "onStoreUpdate must ride method 110 (sub-slot byte 0x31). A \
+             sub-slot byte of 0x14 means the emit path regressed to index 81, \
+             which is onStepUpdate"
+        );
+    }
+
+    /// An empty update list must not put anything on the wire — the early
+    /// return exists so the client isn't handed a zero-length array to
+    /// re-render the store from.
+    #[tokio::test]
+    async fn store_update_with_no_rows_sends_nothing() {
+        let transport = Arc::new(TestTransport::new());
+        let dyn_transport: Arc<dyn Transport> = transport.clone();
+
+        let entity_id = 0x0000_9ABCu32;
+        let addr: SocketAddr = "127.0.0.1:41092".parse().unwrap();
+        let (connected, entity_to_addr) = make_client(entity_id, addr);
+
+        send_store_update_to_client(entity_id, &[], &dyn_transport, &connected, &entity_to_addr)
+            .await;
+
+        assert!(
+            transport.is_empty(),
+            "empty update list must short-circuit before the send"
+        );
+    }
 }

--- a/crates/services/src/cell/dispatch/gm_gate.rs
+++ b/crates/services/src/cell/dispatch/gm_gate.rs
@@ -24,6 +24,11 @@ use cimmeria_commands::permissions::AccessLevel;
 
 use super::super::messages::CellToBaseMsg;
 use super::super::space_manager::SpaceManager;
+use super::constants::{
+    CM_MG_DEBUG_INSTANCE, CM_MG_DEBUG_JOIN, CM_MG_DEBUG_SPECTATE, CM_MG_DEBUG_START,
+    CM_TOGGLE_COMBAT_DEBUG, CM_TOGGLE_COMBAT_VERBOSE_DEBUG, CM_TOGGLE_HEAL_DEBUG,
+    CM_WORLD_INSTANCE_RESET,
+};
 
 /// `onErrorCode` client method index (SGWPlayer flat index 121). The
 /// server→client feedback channel already used by the ability path for
@@ -65,21 +70,72 @@ pub const SGWGMPLAYER_CELL_METHOD_BASE: u16 = 109;
 /// here is an ordinary player method and passes the gate untouched.
 ///
 /// Two classes of restricted index:
-/// - The handful of GM/debug methods that live INSIDE the inherited
-///   SGWPlayer range (0-108) because they share an interface with player
-///   methods. These must be named explicitly:
+/// - The GM/debug methods that live INSIDE the inherited SGWPlayer range
+///   (0-108). The `>= SGWGMPLAYER_CELL_METHOD_BASE` range rule below cannot
+///   reach them: they are interleaved with ordinary player methods because
+///   they were declared on interfaces (`MinigamePlayer`, combat, ability
+///   management) that SGWPlayer implements, so they got flattened positions
+///   *below* the SGWGmPlayer base. There is no structural marker on the wire
+///   that distinguishes them from a legitimate player call — the only thing
+///   that gates them is being named here. Naming one is what makes it
+///   GM-only; forgetting one leaves a debug surface reachable by any
+///   modified client the moment somebody replaces its stub with a real
+///   implementation.
 ///   - `2` `toggleCombatDebug`, `3` `toggleCombatVerboseDebug`,
 ///     `6` `toggleHealDebug` — combat/heal debug toggles.
+///   - `20`-`23` `debugStartMinigame`, `debugSpectateMinigame`,
+///     `debugJoinMinigame`, `debugMinigameInstance` — MinigamePlayer debug
+///     entry points that force minigame state transitions. All four are
+///     no-op `pass` bodies in the reference cell script, i.e. developer
+///     hooks that were never meant to be player-reachable.
 ///   - `92` `onWorldInstanceReset` — tears down + recreates the current
 ///     space instance, kicking every co-located player (high impact).
 /// - The ENTIRE SGWGmPlayer tail (`>= SGWGMPLAYER_CELL_METHOD_BASE`, i.e.
 ///   109+). Every method there is a gm*/debug command by construction, so
 ///   one range rule gates all of them at once — no per-method bookkeeping.
 ///
+/// # What qualifies an index for this list
+///
+/// A sub-109 index belongs here only if it is *itself* a GM/debug surface.
+/// "It has a GM-shaped sibling" is **not** the test — the SGWGmPlayer tail
+/// deliberately mirrors several player-facing methods with uncosted GM
+/// twins, and the twin being GM-only says nothing about the player-facing
+/// original. Check what the method does, not what its name rhymes with.
+///
+/// # Deliberately NOT gated here
+///
+/// `resetMyAbilities` (CM 72) is the standing example, and gets proposed
+/// for this list periodically on name shape alone. It is a **player-facing**
+/// trainer respec: the reference cell script requires an active
+/// `trainerEntity` within `MAX_INTERACT_DISTANCE` and then delegates to
+/// `trainerEntity.onRespec`. Its gate is interaction *context*, not caller
+/// *privilege*. The hardening it actually needs belongs in the handler —
+/// charge the respec from `sgw_player.cash` and enforce a per-character
+/// cooldown before refunding training points — and is explicitly not a
+/// wire-shape match to the uncosted GM `gmRespec`.
+///
+/// `gmRespec` is the GM twin, and it lives on SGWGmPlayer above the base,
+/// so the range rule already covers it. The two are different methods on
+/// different index spaces; conflating them is what puts CM 72 on this list
+/// by mistake. Gating CM 72 here would make respec unreachable for ordinary
+/// players the moment the stub handler is implemented, and the symptom
+/// would be a misleading privilege-escalation `warn!` rather than anything
+/// pointing at this function.
+///
 /// Flattened cell-method positions are documented in
 /// `docs/protocol/cell-method-dispatch-table.md`.
 pub fn requires_gm(index: u16) -> bool {
-    matches!(index, 2 | 3 | 6 | 92) || index >= SGWGMPLAYER_CELL_METHOD_BASE
+    matches!(
+        index,
+        CM_TOGGLE_COMBAT_DEBUG
+            | CM_TOGGLE_COMBAT_VERBOSE_DEBUG
+            | CM_TOGGLE_HEAL_DEBUG
+            | CM_MG_DEBUG_START
+            | CM_MG_DEBUG_SPECTATE
+            | CM_MG_DEBUG_JOIN
+            | CM_MG_DEBUG_INSTANCE
+            | CM_WORLD_INSTANCE_RESET
+    ) || index >= SGWGMPLAYER_CELL_METHOD_BASE
 }
 
 /// Enforce the GM gate for `method_index` against the caller entity's
@@ -167,7 +223,7 @@ mod tests {
 
     #[test]
     fn restricted_indices_are_classified() {
-        for idx in [2u16, 3, 6, 92] {
+        for idx in [2u16, 3, 6, 20, 21, 22, 23, 92] {
             assert!(requires_gm(idx), "index {idx} must be GM-gated");
         }
     }
@@ -180,6 +236,96 @@ mod tests {
         for idx in [0u16, 1, 25, 36, 52, 67, 72, 108] {
             assert!(!requires_gm(idx), "index {idx} must NOT be GM-gated");
         }
+    }
+
+    /// The debug methods that live BELOW the SGWGmPlayer base are gated
+    /// *only* because they are named in `requires_gm` — the `>= 109` range
+    /// rule cannot reach them, and nothing on the wire distinguishes them
+    /// from a legitimate player call. Drop any one from the `matches!` arm
+    /// and a non-GM client reaches a debug surface directly.
+    ///
+    /// The MinigamePlayer debug quartet (20-23) is the set the range rule
+    /// silently missed: `debugStartMinigame`, `debugSpectateMinigame`,
+    /// `debugJoinMinigame`, `debugMinigameInstance` force minigame state
+    /// transitions and are no-ops in the reference cell script.
+    ///
+    /// Neighbours are pinned as *ungated* on purpose, so a "fix" that
+    /// widens the arm into a range (`20..=24`) fails too — `minigameStart`
+    /// (24) is an ordinary player call and gating it would break non-GM
+    /// clients. This test trips on both the under-gate and the over-gate.
+    #[test]
+    fn debug_methods_below_the_gm_base_are_individually_gated() {
+        // Pin the constants the dispatcher matches on — if a renumber moves
+        // a debug method, the gate has to move with it.
+        assert_eq!(CM_MG_DEBUG_START, 20);
+        assert_eq!(CM_MG_DEBUG_SPECTATE, 21);
+        assert_eq!(CM_MG_DEBUG_JOIN, 22);
+        assert_eq!(CM_MG_DEBUG_INSTANCE, 23);
+
+        for (idx, name) in [
+            (CM_TOGGLE_COMBAT_DEBUG, "toggleCombatDebug"),
+            (CM_TOGGLE_COMBAT_VERBOSE_DEBUG, "toggleCombatVerboseDebug"),
+            (CM_TOGGLE_HEAL_DEBUG, "toggleHealDebug"),
+            (CM_MG_DEBUG_START, "debugStartMinigame"),
+            (CM_MG_DEBUG_SPECTATE, "debugSpectateMinigame"),
+            (CM_MG_DEBUG_JOIN, "debugJoinMinigame"),
+            (CM_MG_DEBUG_INSTANCE, "debugMinigameInstance"),
+            (CM_WORLD_INSTANCE_RESET, "onWorldInstanceReset"),
+        ] {
+            assert!(
+                idx < SGWGMPLAYER_CELL_METHOD_BASE,
+                "{name} ({idx}) is supposed to be below the SGWGmPlayer base — \
+                 if it moved above it, this test is guarding the wrong thing"
+            );
+            assert!(
+                requires_gm(idx),
+                "{name} ({idx}) is a debug surface below the SGWGmPlayer base, \
+                 so the `>= {SGWGMPLAYER_CELL_METHOD_BASE}` range rule does not \
+                 cover it — it must be named explicitly in requires_gm"
+            );
+        }
+
+        // Immediate neighbours of the debug quartet must stay reachable by
+        // ordinary players — this is what fails if the arm is widened to a
+        // range instead of naming each index.
+        for (idx, name) in [
+            (19u16, "transferCash"),
+            (24, "minigameStart"),
+            (25, "endCurrentMinigame"),
+        ] {
+            assert!(
+                !requires_gm(idx),
+                "{name} ({idx}) is an ordinary player method — gating it would \
+                 break non-GM clients"
+            );
+        }
+    }
+
+    /// `resetMyAbilities` (CM 72) is the player-facing trainer respec, not a
+    /// GM command: the reference cell script gates it on an active
+    /// `trainerEntity` within interact distance, then delegates to
+    /// `trainerEntity.onRespec`. Its uncosted GM twin is `gmRespec`, which
+    /// sits on SGWGmPlayer above the base and is already covered by the
+    /// range rule.
+    ///
+    /// This is pinned as a test because CM 72 gets proposed for the
+    /// restricted list on name-shape alone. Adding it would make respec
+    /// unreachable for ordinary players the moment the handler stops being
+    /// a stub — a regression that would otherwise only surface as a player
+    /// bug report months later. The real hardening CM 72 needs (cash cost +
+    /// per-character cooldown) belongs in the handler, not in this gate.
+    #[test]
+    fn trainer_respec_is_not_treated_as_a_gm_command() {
+        assert_eq!(
+            crate::cell::cell_methods::player::RESET_MY_ABILITIES,
+            72,
+            "the constant this test is about must still be 72"
+        );
+        assert!(
+            !requires_gm(crate::cell::cell_methods::player::RESET_MY_ABILITIES),
+            "resetMyAbilities is the player-facing trainer respec — gating it \
+             on access_level breaks respec for every non-GM player"
+        );
     }
 
     /// The entire SGWGmPlayer cell-method tail (>= 109) is

--- a/crates/services/src/mercury/mod.rs
+++ b/crates/services/src/mercury/mod.rs
@@ -189,12 +189,16 @@ pub mod method_idx {
     pub const ON_BEING_NAME_UPDATE: u16 = 17;
     pub const ON_STATE_FIELD_UPDATE: u16 = 19;
 
-    // SGWCombatant interface (20–26)
+    // SGWCombatant interface (20–25)
     pub const ON_STAT_UPDATE: u16 = 20;
     pub const ON_STAT_BASE_UPDATE: u16 = 21;
     pub const ON_ARCHETYPE_UPDATE: u16 = 23;
     pub const ON_ALIGNMENT_UPDATE: u16 = 24;
     pub const ON_FACTION_UPDATE: u16 = 25;
+
+    // SGWBeing own (26) — not part of the SGWCombatant interface above.
+    // SGWBeing's Implements interfaces flatten first (12–25), then its own
+    // methods begin at 26.
     pub const BEING_APPEARANCE: u16 = 26;
 
     // Communicator interface (27–33)
@@ -218,9 +222,12 @@ pub mod method_idx {
     pub const ON_MAIL_READ: u16 = 78;
     pub const SEND_MAIL_RESULT: u16 = 79;
 
-    // SGWVendorStore interface (80–81)
-    pub const ON_STORE_OPEN: u16 = 80;
-    pub const ON_STORE_UPDATE: u16 = 81;
+    // Missionary interface (80–84) — see
+    // `crate::cell::client_methods::missionary`. 80/81 previously carried
+    // `ON_STORE_OPEN`/`ON_STORE_UPDATE` under a "SGWVendorStore interface"
+    // heading; no such interface exists in `entities/defs/interfaces/`, and
+    // the vendor methods are SGWPlayer's own at 109/110. Anything emitted on
+    // 80/81 lands in the client's mission handlers.
 
     // SGWContactListManager interface (85–89)
     pub const ON_CONTACT_LIST_UPDATE: u16 = 85;


### PR DESCRIPTION
Two server-side defects surfaced by the documentation audit in #608. Both were found by reading docs against code, and both are on `main` today.

## 1. Vendor store is emitted on the wrong wire index

`crates/services/src/mercury/mod.rs` defined:

```rust
// SGWVendorStore interface (80–81)
pub const ON_STORE_OPEN: u16 = 80;
pub const ON_STORE_UPDATE: u16 = 81;
```

**There is no `SGWVendorStore` interface.** No such file exists under `entities/defs/interfaces/`. `onStoreOpen` and `onStoreUpdate` are SGWPlayer *own* methods (`SGWPlayer.def:1173,1183`) and flatten to **109/110** — which is exactly what `cell/client_methods/player.rs:26,28` already said.

Indices 80 and 81 belong to Missionary: `onMissionUpdate` and `onStepUpdate` (`cell/client_methods/missionary.rs:4,6`).

The vendor emit path used the wrong pair (`vendor/store.rs:170,204`), while the correct constants were defined and **referenced nowhere**. So the server has been sending the vendor store payload to the client's **mission** handler.

`onMissionUpdate` expects `INT32 MissionID, INT8 Status, INT32 MissionGiverName` and was receiving a large `onStoreOpen` blob. Two consequences worth knowing:

- The vendor UI could never have worked, so there is no prior behaviour to regress — but any earlier manual testing that concluded "the vendor store opens fine" was observing something else and is void.
- If anyone has seen unexplained mission-log corruption or phantom mission entries near vendors, this is a plausible cause and should now stop. **Worth a targeted retest of the mission log after visiting a vendor.**

This is issue #171 ("two parallel method-index constant tables") made concrete. The fix points the emit path at 109/110 and deletes the two bogus constants along with the fabricated interface comment — `store.rs:170,204` were their only references. Also corrects an adjacent comment: `SGWCombatant` is 20–25, not 20–26; `BEING_APPEARANCE = 26` is SGWBeing's own method.

## 2. The #475 GM gate allow-list is incomplete

`cell/dispatch/gm_gate.rs` gated `matches!(index, 2 | 3 | 6 | 92) || index >= SGWGMPLAYER_CELL_METHOD_BASE` (109). The range rule covers the whole SGWGmPlayer tail, and the function's own doc comment correctly notes that methods inside the inherited SGWPlayer range "must be named explicitly."

The four MinigamePlayer debug methods sit below 109 and were not named: `DEBUG_START` (20), `DEBUG_SPECTATE` (21), `DEBUG_JOIN` (22), `DEBUG_INSTANCE` (23) — `cell_methods/minigame.rs:7-10`. That is security finding CAT-K-02.

All four are stubs today, so nothing is live-exploitable. But the systemic guarantee #475 advertises — "every future gm*/debug handler is gated by default" — does not hold for them, and whoever implements one would get no gate. This is an inconsistency in #475's own remediation rather than a scoping decision: CM 2/3/6/92 were allow-listed while in exactly this same latent state.

The allow-list is also converted from magic numbers to the `CM_*` constants already re-exported by the sibling `constants.rs`, so a renumber moves the gate with the method.

### CM 72 is deliberately **not** gated

The audit initially flagged `RESET_MY_ABILITIES` (CM 72, finding CAT-N-02) as a fifth gap. That was wrong, and gating it would have been a bug.

`resetMyAbilities` is the **player-facing trainer respec**. The reference implementation gates it on *context*, not privilege — `deprecated/python/cell/SGWPlayer.py:1282` requires an active trainer interaction within `MAX_INTERACT_DISTANCE`. It is declared on `SGWPlayer.def:602`, not `SGWGmPlayer.def`. The GM twin is a *different method*, `gmRespec` at `SGWGmPlayer.def:299`, which sits above 109 and is already covered by the range rule.

Gating 72 would have killed respec for every player the moment it was implemented, with a misleading "attempted privilege escalation" warning as the only symptom. CAT-N-02's own remediation says the same thing — it calls for a cash cost and a per-character cooldown, and explicitly warns that a wire-shape match to the uncosted `gmRespec` "is not the right model."

The exclusion is now recorded in the doc comment with the general rule attached: a method below `SGWGMPLAYER_CELL_METHOD_BASE` needs explicit naming only if it is genuinely a GM/debug surface — **"has a GM-shaped sibling" is not the test.**

## Tests

Four new tests, all revert-verified by actually reverting the fix and running, not by inspection.

- `debug_methods_below_the_gm_base_are_individually_gated` — pins all eight sub-base indices as gated **and** their immediate neighbours (19 `transferCash`, 24 `minigameStart`, 25 `endCurrentMinigame`) as **ungated**. That second half matters: it trips on the under-gate *and* on a lazy widening to `20..=24`, which would gate `minigameStart` and break non-GM clients.
- `trainer_respec_is_not_treated_as_a_gm_command` — pins the CM 72 exclusion so it does not get re-filed as a hole.
- Two wire-format guards in `store.rs` decrypt the emitted packet and assert the full extended-encoding header byte-for-byte. The sub-slot byte is a **literal** (`0x30` for 109, `0x31` for 110), not computed from the constant, so the assertion is not tautological.

Revert results: dropping the four constants fails 2 gm_gate tests; pointing the emit path back at 80/81 fails both wire guards with sub-slot `0x13` and `0x14` — exactly the predicted `onMissionUpdate` / `onStepUpdate` bytes.

`cargo fmt --all --check`, `cargo clippy -p cimmeria-services --all-targets -D warnings`, and `cargo nextest run --profile=ci -p cimmeria-services` (**1,690 passed**) are green.

## Not fixed here

**The structural hazard remains.** `mercury::method_idx` is still a hand-maintained partial duplicate of `cell/client_methods/`, and nothing prevents it drifting again. The real fix is to delete it and re-export from `client_methods` — larger than this change, and the substance of #171.

**Two dated audit records are contaminated by the drifted table.** `docs/audits/entity-property-sync-section2-audit-2026-05-16.md:961-962` and `docs/audits/mercury-rust-conformance-2026-05-15.md:434` label pcap sub-slot bytes 19/20 as `ON_STORE_OPEN`/`ON_STORE_UPDATE`; those rows are actually mission traffic. Both audits' *conclusions* (idbase = 61) rest on other rows and are unaffected — only the labels are wrong. Left alone deliberately, per the convention that dated audit records are not retroactively rewritten.

**Minigame debug stubs mis-parse their arguments.** `cell_methods/minigame.rs` reads 4 bytes as `game_id` for `DEBUG_SPECTATE` and `DEBUG_JOIN`, but `MinigamePlayer.def:356-361` declares both zero-arg; `DEBUG_INSTANCE` declares three INT32s and the stub reads one. Harmless today (log-only stubs, now GM-gated), but whoever implements them inherits the wrong layout.

**A pre-existing test-flakiness trap, unrelated to this change.** A full `cargo test -p cimmeria-services --lib` fails 1–2 tests on the **clean tree** as well — `LogCapture`'s thread-local subscriber bleeds across tests sharing a thread. nextest (process-per-test, what CI runs) is green. The trap is sharp: running the *filtered* test alone passes, which invites the wrong conclusion that your change caused it.

No DB or content changes, so nothing to seed or migrate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GhH7BcbHyhFZHdWxKKc6gu


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected vendor store notifications so open and update actions use the proper wire-format method indices.
  * Prevented empty store updates from sending unnecessary packets.
  * Strengthened access controls for minigame debugging and world-reset operations.
  * Corrected method-index documentation to accurately identify mission-related calls.

* **Tests**
  * Added regression coverage for vendor store packet encoding and restricted administrative methods.
  * Documented reliable test validation guidance for intermittent full-suite test failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->