### PR TITLE
feat(content): server-authoritative effect-application entry point (launch_ability, apply_effect)

### DIFF
--- a/.claude/agent-memory/rust-gameserver-dev/MEMORY.md
+++ b/.claude/agent-memory/rust-gameserver-dev/MEMORY.md
@@ -18,7 +18,7 @@
 
 ## Build Environment
 
-- See [build-environment.md](build-environment.md) — repo `.cargo/config.toml` hardcodes another user's rust-lld path; need `CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_RUSTFLAGS` override.
+- See [build-environment.md](build-environment.md) — the rust-lld linker override is **obsolete** (config fixed upstream 2026-07-26); plain cargo commands work, don't re-apply it.
 
 ## Working Environment
 
@@ -50,3 +50,4 @@
 - [bincode-persisted-cache-format.md](bincode-persisted-cache-format.md) — bincode 2 needs `config::legacy()` for 1.x-written files; wrong config decodes SILENTLY, so assert bytes-consumed == len and use an old-version byte fixture (round-trip alone can't catch it).
 - [live-db-scratch-cluster.md](live-db-scratch-cluster.md) — `db.bat init` does NOT create the db/role or load the schema; recipe for an isolated scratchpad Postgres on :5544 so live-DB guards can actually be revert-verified.
 - [chain-replay-executor-guards.md](chain-replay-executor-guards.md) — chain-replay must run `execute_actions` (not just `resolve_event`) when the change is an executor arm; sentinel-chain pattern for verbs with zero seed rows; `0x7000_5000` reserved.
+- [local-postgres-port.md](local-postgres-port.md) — dev Postgres is on **5544**, not the documented 5433; on the wrong port `require_db_or_skip!` self-skips and still reports PASS, so green means nothing until you check the skip count.

--- a/.claude/agent-memory/rust-gameserver-dev/build-environment.md
+++ b/.claude/agent-memory/rust-gameserver-dev/build-environment.md
@@ -1,19 +1,15 @@
 ---
 name: Build environment quirks
-description: Cimmeria repo's .cargo/config.toml hardcodes another user's rust-lld path; need an env override to build.
+description: The old rust-lld linker override is OBSOLETE — .cargo/config.toml was fixed upstream; plain cargo commands work on this host.
 type: project
 ---
 
-The repo `.cargo/config.toml` hardcodes a `rust-lld` linker path under another user's home directory. To build on this host, prepend:
+**The linker override is no longer needed.** Verified 2026-07-26 on `main` @ 70ec45ef: `.cargo/config.toml`'s `[target.x86_64-pc-windows-msvc]` block now uses the portable bare name `linker = "rust-lld"` plus `linker-flavor=lld-link`, which rustc resolves through the toolchain's own bin directory. There is no hardcoded user-profile path anymore.
 
-```
-CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_RUSTFLAGS='-C linker=C:\Users\Steve\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib\rustlib\x86_64-pc-windows-msvc\bin\rust-lld.exe'
-```
+Plain `cargo check`, `cargo clippy --all-targets`, and `cargo nextest run -p cimmeria-services` all succeed with no env prefix.
 
-to every `cargo check`/`cargo test`/`cargo build` invocation.
+**Historical (do not re-apply):** an earlier config hardcoded a `rust-lld` path under another user's home, and every cargo invocation needed a `CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_RUSTFLAGS='-C linker=...'` prefix. If you see that advice repeated anywhere, it is stale.
 
-The original memory note had the path under `C:\Users\steven.cady\...` — that is the value in the tracked `.cargo/config.toml`, NOT the right path on this host. Confirmed 2026-05-27: rust-lld actually lives at the `C:\Users\Steve\...` path above.
+**How to apply:** just run cargo normally. If a link failure ever reappears, re-read `.cargo/config.toml` before reaching for an override — that file is the authority, not this note.
 
-**Why:** this avoids editing tracked config (which would conflict for the original author).
-
-**How to apply:** wrap every cargo command. Tests that don't need a linker (`cargo check`) sometimes work without it but `cargo test` always needs it.
+See [[local-postgres-port]] for the matching test-DB gotcha.

--- a/.claude/agent-memory/rust-gameserver-dev/local-postgres-port.md
+++ b/.claude/agent-memory/rust-gameserver-dev/local-postgres-port.md
@@ -1,0 +1,23 @@
+---
+name: local-postgres-port
+description: This host's dev Postgres listens on 5544, not the 5433 that CLAUDE.md and TESTING.md document — live-DB tests silently self-skip on the wrong port.
+type: project
+---
+
+The bundled Postgres on this host listens on **port 5544**, not the 5433 documented in CLAUDE.md / TESTING.md. Working `DATABASE_URL`:
+
+```
+postgres://w-testing:w-testing@localhost:5544/sgw
+```
+
+Binary lives at `external/postgresql_server/bin/` (`psql.exe`, `postgres.exe`). Role `w-testing` (password same as the name) exists; role `sgw` does not.
+
+**Why this matters:** `require_db_or_skip!` turns an unreachable DB into a **self-skip that still reports PASS**. On the wrong port every live-DB test "passes" without executing a line of its body — nextest shows green and the guard is worthless. The only tell is the line `skipping live-DB test (DATABASE_URL set but connect failed: pool timed out ...)`, which is invisible unless you pass `--no-capture`, and the `Summary` line's skip count.
+
+**How to apply:** before trusting a live-DB run, confirm the tests actually executed — either check `Summary` shows `0 skipped` for the filtered set, or run once with `--no-capture` and confirm no "skipping live-DB test" line. To find the port on a host where it differs again:
+
+```powershell
+Get-NetTCPConnection -State Listen | Where-Object { $_.OwningProcess -in (Get-Process -Name postgres).Id } | Select LocalPort -Unique
+```
+
+See [[build-environment]] and [[db-test-revert-verification]].

--- a/crates/services/src/cell/content/chain_replay_tests/castle_cellblock_wakeup.rs
+++ b/crates/services/src/cell/content/chain_replay_tests/castle_cellblock_wakeup.rs
@@ -1,0 +1,172 @@
+//! Castle Cellblock wake-up debuff — chains 5000 / 5001, `player_loaded`.
+//!
+//! Both chains carry `launch_ability 1372` ("Stasis Sickness - Stage 1"),
+//! the debuff the player wakes up with in the stasis room. These guards pin
+//! the seed → `Action::LaunchAbility` conversion, and pin two seed defects
+//! that make the action unreachable in play today so that neither gets
+//! mistaken for an executor bug:
+//!
+//! 1. **Both chains carry mutually-exclusive conditions.** Each has two
+//!    `mission_status 622` rows — `eq not_active` *and* `eq completed` —
+//!    and `ChainEngine` AND-s conditions. No context satisfies both, so
+//!    neither chain ever resolves its actions. This is not specific to
+//!    5001: chain 5000 has the identical pair.
+//! 2. **Chain 5001 is a duplicate export.** It repeats 5000's action set
+//!    with several actions fired twice, including `launch_ability 1372` at
+//!    sort 9 and again at sort 10.
+//!
+//! The conditions are pinned as *currently unsatisfiable* rather than
+//! asserted away. When the seed is corrected the pin trips, which is the
+//! intended prompt to revisit these guards alongside the fix.
+
+use cimmeria_content_engine::actions::Action;
+use cimmeria_content_engine::chain::ChainEngine;
+use cimmeria_content_engine::context::ExecutionContext;
+use cimmeria_content_engine::triggers::{TriggerEvent, TriggerType};
+
+use super::super::engine_loader::load_single_chain_for_test;
+use crate::test_support::require_db_or_skip;
+
+/// Chain 5000 must convert its `launch_ability` row into
+/// `Action::LaunchAbility { ability_id: 1372, entity_tag: None }` — exactly
+/// once, and with no tag so the debuff self-targets the waking player.
+///
+/// A non-`None` `entity_tag` would route the executor through
+/// `find_entity_by_tag` and (on a miss) skip the launch entirely, so the
+/// tag is pinned, not just the id.
+#[tokio::test]
+async fn chain_5000_launches_stasis_sickness_on_the_player_itself() {
+    let pool = require_db_or_skip!();
+    let chain = load_single_chain_for_test(&pool, 5000)
+        .await
+        .expect("DB query for chain 5000 must succeed")
+        .expect("chain 5000 must exist in seeded content_chains and convert successfully");
+
+    let launches: Vec<_> = chain
+        .actions
+        .iter()
+        .filter_map(|a| match a {
+            Action::LaunchAbility {
+                ability_id,
+                entity_tag,
+            } => Some((*ability_id, entity_tag.clone())),
+            _ => None,
+        })
+        .collect();
+
+    assert_eq!(
+        launches.len(),
+        1,
+        "chain 5000 must launch exactly one ability (the wake-up debuff); \
+         actions: {:?}",
+        chain.actions,
+    );
+    assert_eq!(
+        launches[0].0, 1372,
+        "chain 5000's launch must be ability 1372 (Stasis Sickness - Stage 1)",
+    );
+    assert_eq!(
+        launches[0].1, None,
+        "the wake-up debuff must be untagged so it self-targets the waking \
+         player -- a tag would send it through NPC lookup instead",
+    );
+}
+
+/// Chain 5001 is the auto-export duplicate: it fires `launch_ability 1372`
+/// twice. Pinned so the duplication is a recorded fact rather than a
+/// surprise, and so a de-duplication pass has to come past this test.
+#[tokio::test]
+async fn chain_5001_duplicates_the_stasis_sickness_launch() {
+    let pool = require_db_or_skip!();
+    let chain = load_single_chain_for_test(&pool, 5001)
+        .await
+        .expect("DB query for chain 5001 must succeed")
+        .expect("chain 5001 must exist in seeded content_chains and convert successfully");
+
+    let launch_count = chain
+        .actions
+        .iter()
+        .filter(|a| {
+            matches!(
+                a,
+                Action::LaunchAbility {
+                    ability_id: 1372,
+                    entity_tag: None
+                }
+            )
+        })
+        .count();
+
+    assert_eq!(
+        launch_count, 2,
+        "chain 5001 is a duplicate export of 5000 and repeats the \
+         launch_ability 1372 action; if this is now 1 the seed was \
+         de-duplicated -- revisit this module. Actions: {:?}",
+        chain.actions,
+    );
+}
+
+/// Both wake-up chains are gated on `mission_status 622 = not_active` AND
+/// `= completed`. Conditions are AND-ed, so no player state satisfies them
+/// and the `launch_ability` action can never resolve in play.
+///
+/// Fires `player_loaded` under each of the three reachable mission states
+/// and asserts nothing resolves. When the seed's condition pair is fixed,
+/// this test fails — that is the signal, not a regression.
+///
+/// First pins that both triggers are `OnPlayerLoaded { world_name: None }`,
+/// which `Trigger::matches` accepts unconditionally. Without that, an empty
+/// resolve would be ambiguous between "conditions rejected it" and "the
+/// trigger never matched in the first place" — two very different fixes.
+#[tokio::test]
+async fn wakeup_chains_never_resolve_under_any_mission_622_state() {
+    let pool = require_db_or_skip!();
+
+    let mut engine = ChainEngine::new();
+    for chain_id in [5000, 5001] {
+        let chain = load_single_chain_for_test(&pool, chain_id)
+            .await
+            .unwrap_or_else(|e| panic!("DB query for chain {chain_id} must succeed: {e}"))
+            .unwrap_or_else(|| {
+                panic!("chain {chain_id} must exist in seeded content_chains and convert")
+            });
+        assert!(
+            matches!(
+                chain.trigger,
+                cimmeria_content_engine::triggers::Trigger::OnPlayerLoaded { world_name: None }
+            ),
+            "chain {chain_id}'s trigger must be an unqualified player_loaded \
+             (event_key NULL) so the empty resolve below is attributable to \
+             the conditions, not to a trigger mismatch. Got: {:?}",
+            chain.trigger,
+        );
+        engine.register_chain(chain);
+    }
+
+    for status in ["not_active", "active", "completed"] {
+        let mut ctx = ExecutionContext::new();
+        ctx.set_param(
+            "world_name".to_string(),
+            serde_json::json!("Castle_CellBlock"),
+        );
+        ctx.set_param("mission_622_status".to_string(), serde_json::json!(status));
+
+        let event = TriggerEvent {
+            trigger_type: TriggerType::PlayerLoaded,
+            source_entity: None,
+            target_entity: None,
+            params: ctx.params.clone(),
+        };
+
+        let resolved = engine.resolve_event(&event, &ctx);
+        assert!(
+            resolved.actions.is_empty(),
+            "chains 5000/5001 carry mutually-exclusive mission_status 622 \
+             conditions (not_active AND completed) and must resolve nothing \
+             at mission status '{status}'. If this now resolves, the seed's \
+             condition pair was corrected -- update these guards to assert \
+             the launch actually fires. Got: {:?}",
+            resolved.actions,
+        );
+    }
+}

--- a/crates/services/src/cell/content/chain_replay_tests/mod.rs
+++ b/crates/services/src/cell/content/chain_replay_tests/mod.rs
@@ -23,6 +23,7 @@
 //! `CellToBaseMsg` traffic — a resolve-only test cannot tell a wired
 //! executor arm from the `other =>` catch-all.
 
+mod castle_cellblock_wakeup;
 mod cover_demo;
 mod grant_xp;
 mod mission_1562;

--- a/crates/services/src/cell/content/effect_apply.rs
+++ b/crates/services/src/cell/content/effect_apply.rs
@@ -1,0 +1,204 @@
+//! Server-initiated effect application.
+//!
+//! The combat pipeline (`cell::abilities::use_ability::handle_use_ability`)
+//! is the *client* entry point for firing an ability, and it is gated
+//! accordingly: the caster must know the ability, the target must be a
+//! hostile NPC, and the resolution path is unconditionally QR damage.
+//! Those gates are correct for client input and wrong for content — a
+//! scripted debuff like the Castle Cellblock wake-up sickness is applied
+//! to a player who has never trained the ability, targets *itself*, and
+//! is not damage at all.
+//!
+//! This module is the server-authoritative counterpart: it skips the
+//! caster/target/hostility gates and goes straight to the effect layer.
+//!
+//! # Reachability is the security boundary
+//!
+//! Bypassing the combat gates is only safe because nothing client-driven
+//! can reach this code. Three properties enforce that, and all three are
+//! load-bearing:
+//!
+//! 1. **The module is private.** `cell/content/mod.rs` declares
+//!    `mod effect_apply;` without `pub`, so the path
+//!    `crate::cell::content::effect_apply` does not exist outside
+//!    `cell::content`. A `use` from a cell method or a Mercury handler is
+//!    a hard compile error, not a lint.
+//! 2. **The functions are `pub(super)`.** Even within the crate the only
+//!    modules that can name them are `cell::content` and its descendants
+//!    — in practice `cell::content::executor`.
+//! 3. **The ability/effect id is never client-supplied.** Both entry
+//!    points take their id from a `content_actions` seed row that was
+//!    loaded from the database at startup. No wire field reaches these
+//!    parameters.
+//!
+//! Do not widen any of the three. Re-exporting these functions from
+//! `cell::content`, or threading a client-supplied id into `ability_id` /
+//! `effect_id`, turns this into an "apply arbitrary effect to arbitrary
+//! entity" primitive that any forged packet can drive.
+
+use std::time::Instant;
+
+use tokio::sync::mpsc;
+
+use crate::cell::abilities::send_entity_method;
+use crate::cell::effects::{self, EffectContext};
+use crate::cell::messages::CellToBaseMsg;
+use crate::cell::space_manager::SpaceManager;
+
+/// Apply every effect owned by `ability_id` to `target_id`, sourced from
+/// `invoker_id`. Backs `Action::LaunchAbility`.
+///
+/// Returns the number of effects that produced a lasting active-effect
+/// instance on the target. A return of `0` is normal, not an error: an
+/// ability whose effects are all single-shot (`pulse_count == 1`) and
+/// script-less resolves to a no-op, which is what the effect definition
+/// asked for.
+///
+/// `invoker_id` becomes the effect instance's source, which matters for
+/// stacking — `register_active_effect` refreshes same-invoker instances
+/// and stacks different-invoker ones. Self-applied content debuffs pass
+/// the same id for both, so re-firing the chain refreshes rather than
+/// stacking.
+pub(super) async fn apply_ability_effects(
+    ability_id: i32,
+    target_id: u32,
+    invoker_id: u32,
+    chain_id: i64,
+    tx: &mpsc::Sender<CellToBaseMsg>,
+    space_mgr: &mut SpaceManager,
+) -> usize {
+    // Clone the id list up front — the per-effect work needs `&mut
+    // space_mgr` and would otherwise hold an immutable borrow of
+    // `ability_defs` across the loop.
+    let Some(effect_ids) = space_mgr
+        .ability_defs
+        .get(&ability_id)
+        .map(|d| d.effect_ids.clone())
+    else {
+        // Seed drift: a `launch_ability` row names an ability that
+        // `load_ability_defs` didn't produce. Operator-actionable, and
+        // unreachable from client input, so warn is the right level.
+        tracing::warn!(
+            target: "abilities",
+            event = "content_launch_ability_unknown",
+            ability_id,
+            target_id,
+            invoker_id,
+            chain_id,
+            "Content launch_ability names an ability with no server def -- \
+             nothing applied; check the content_actions seed against \
+             resources.abilities"
+        );
+        return 0;
+    };
+
+    let mut registered = 0usize;
+    for effect_id in effect_ids {
+        if apply_effect(effect_id, target_id, invoker_id, chain_id, tx, space_mgr).await {
+            registered += 1;
+        }
+    }
+
+    tracing::info!(
+        target: "abilities",
+        event = "content_launch_ability",
+        ability_id,
+        target_id,
+        invoker_id,
+        chain_id,
+        registered,
+        "Content: launched ability (server-initiated, combat gates bypassed)"
+    );
+
+    registered
+}
+
+/// Apply a single effect to `target_id`. Backs `Action::ApplyEffect`, and
+/// is the per-effect body of [`apply_ability_effects`].
+///
+/// Returns `true` when the effect registered a lasting active-effect
+/// instance. Single-shot effects return `false` after running their
+/// script (if any) — they have no duration to track.
+///
+/// Note that `ability_id` is *not* a parameter: `register_active_effect`
+/// self-sources it from `EffectDef.ability_id` and owns the
+/// `onTimerUpdate` buff-icon send, so neither is duplicated here.
+pub(super) async fn apply_effect(
+    effect_id: i32,
+    target_id: u32,
+    invoker_id: u32,
+    chain_id: i64,
+    tx: &mpsc::Sender<CellToBaseMsg>,
+    space_mgr: &mut SpaceManager,
+) -> bool {
+    let Some(effect) = space_mgr.effect_defs.get(&effect_id).cloned() else {
+        tracing::warn!(
+            target: "abilities",
+            event = "content_apply_effect_unknown",
+            effect_id,
+            target_id,
+            invoker_id,
+            chain_id,
+            "Content effect application names an effect with no server def -- \
+             skipped; check the seed against resources.effects"
+        );
+        return false;
+    };
+
+    if space_mgr.get_entity(target_id).is_none() {
+        tracing::warn!(
+            target: "abilities",
+            event = "content_apply_effect_no_target",
+            effect_id,
+            target_id,
+            chain_id,
+            "Content effect application target entity is gone -- skipped"
+        );
+        return false;
+    }
+
+    // Script dispatch. `script_name` is NULL on most seeded effects; those
+    // carry their behaviour entirely in the pulse registration below, so a
+    // `None` here is the common case and not worth a log line.
+    if let Some(script_name) = effect.script_name.clone() {
+        let mut ctx = EffectContext {
+            source_id: invoker_id,
+            target_id,
+            effect: &effect,
+            space_mgr,
+        };
+        effects::dispatch_by_name(&script_name, &mut ctx);
+
+        // Flush whatever the script mutated. Scripts write stats through
+        // the dirty-tracking setters but never send; the combat path
+        // flushes for them in `damage_apply`, and this path has to do the
+        // same or a content-applied heal/debuff mutates server state the
+        // client never learns about.
+        if let Some(target) = space_mgr.get_entity_mut(target_id) {
+            let dirty = target.stats.serialize_dirty();
+            target.stats.clear_dirty();
+            if !dirty.is_empty() {
+                send_entity_method(
+                    target_id,
+                    crate::mercury::method_idx::ON_STAT_UPDATE,
+                    dirty,
+                    tx,
+                    space_mgr,
+                )
+                .await;
+            }
+        }
+    }
+
+    // Register the pulsing instance. No-ops and returns false for
+    // single-shot effects; also emits the `onTimerUpdate` buff icon.
+    effects::register_active_effect(
+        space_mgr,
+        target_id,
+        invoker_id,
+        &effect,
+        Instant::now(),
+        tx,
+    )
+    .await
+}

--- a/crates/services/src/cell/content/executor/mod.rs
+++ b/crates/services/src/cell/content/executor/mod.rs
@@ -440,6 +440,60 @@ pub(super) async fn execute_actions(
                     );
                 }
             }
+            Action::LaunchAbility {
+                ability_id,
+                entity_tag,
+            } => {
+                // `entity_tag: None` means "the entity that fired the
+                // chain" — for a `player_loaded` trigger that is the
+                // player themselves, which is exactly the self-target the
+                // combat pipeline's friendly-fire gate would reject.
+                let target_id = match entity_tag.as_deref() {
+                    None => Some(entity_id),
+                    Some(tag) => space_mgr.find_entity_by_tag(entity_id, tag),
+                };
+                match target_id {
+                    Some(target_id) => {
+                        super::effect_apply::apply_ability_effects(
+                            ability_id, target_id, entity_id, chain_id, tx, space_mgr,
+                        )
+                        .await;
+                    }
+                    None => {
+                        // Tagged NPC isn't spawned (or is in another
+                        // space). Same shape as the other tag-resolving
+                        // world actions: skip, don't fall back to self —
+                        // a debuff meant for an NPC must never land on
+                        // the player.
+                        tracing::warn!(
+                            entity_id,
+                            ability_id,
+                            entity_tag = ?entity_tag,
+                            chain_id,
+                            "LaunchAbility: no entity matched the tag -- ability not launched"
+                        );
+                    }
+                }
+            }
+            Action::ApplyEffect {
+                effect_id,
+                duration_secs: _,
+            } => {
+                // `duration_secs` is hardcoded `None` by the action
+                // loader and the effect's own `pulse_count` /
+                // `pulse_duration` already carry the duration, so there
+                // is nothing to honour here yet.
+                //
+                // This arm is correct but currently unreachable: the only
+                // seeded `apply_effect` row is on an `effect`-scoped
+                // chain, and no `effect_*` trigger is dispatched anywhere
+                // in the cell service. It fires as soon as that
+                // dispatch lands.
+                super::effect_apply::apply_effect(
+                    effect_id, entity_id, entity_id, chain_id, tx, space_mgr,
+                )
+                .await;
+            }
             Action::TriggerChain {
                 chain_id: target_chain_id,
             } => {

--- a/crates/services/src/cell/content/executor/tests/effects.rs
+++ b/crates/services/src/cell/content/executor/tests/effects.rs
@@ -1,0 +1,371 @@
+//! `Action::LaunchAbility` / `Action::ApplyEffect` executor coverage.
+//!
+//! These pin the server-initiated effect entry point (`content::effect_apply`)
+//! that content chains use instead of `handle_use_ability`. The combat entry
+//! point rejects a scripted self-debuff three ways — the caster doesn't know
+//! the ability, self-target trips the friendly-fire gate, and the path
+//! resolves as damage — so the arms below must reach the effect layer
+//! directly. Reverting either arm to the `other =>` fallback drops the
+//! effect on the floor, which is the shape every guard here reproduces.
+
+use super::*;
+
+use cimmeria_entity::abilities::{AbilityDef, EffectDef};
+
+/// Sentinel ids for the synthetic ability/effect defs. Chosen well clear of
+/// the seeded resource ranges so a fixture can never be confused for real
+/// content.
+const TEST_ABILITY: i32 = 90_001;
+const TEST_EFFECT: i32 = 90_002;
+const TEST_EFFECT_SINGLE_SHOT: i32 = 90_003;
+
+fn make_ability(ability_id: i32, effect_ids: Vec<i32>) -> AbilityDef {
+    AbilityDef {
+        ability_id,
+        name: format!("TestAbility{ability_id}"),
+        cooldown: 0.0,
+        warmup: 0.0,
+        flags: 0,
+        is_ranged: false,
+        min_range: 0,
+        max_range: 0,
+        target_type_id: 1,
+        effect_ids,
+        moniker_ids: Vec::new(),
+        required_ammo: 0,
+        event_set_id: None,
+        velocity: 0.0,
+    }
+}
+
+/// A pulsing (DoT-shaped) effect. `pulse_count > 1` is what makes
+/// `register_active_effect` store a lasting `ActiveEffectInstance` — a
+/// `pulse_count == 1` effect is single-shot and registers nothing.
+fn make_pulsing_effect(effect_id: i32, ability_id: i32) -> EffectDef {
+    EffectDef {
+        effect_id,
+        ability_id,
+        pulse_count: 4,
+        pulse_duration: 2.0,
+        ..Default::default()
+    }
+}
+
+/// Space with a player (entity 1, player 42) and a tagged NPC (entity 101),
+/// plus the synthetic ability/effect defs registered on the manager.
+fn make_mgr_with_defs() -> SpaceManager {
+    let mut mgr = make_space_mgr();
+    mgr.create_entity(1, "Agnos", [0.0; 3], [0.0; 3]).unwrap();
+    if let Some(p) = mgr.get_entity_mut(1) {
+        p.is_player = true;
+        p.player_id = Some(42);
+    }
+    mgr.spawn_npc(101, "Agnos", [10.0, 0.0, 10.0], [0.0; 3])
+        .unwrap();
+    if let Some(npc) = mgr.get_entity_mut(101) {
+        npc.tag = Some("Drone".to_string());
+    }
+
+    mgr.ability_defs
+        .insert(TEST_ABILITY, make_ability(TEST_ABILITY, vec![TEST_EFFECT]));
+    mgr.effect_defs
+        .insert(TEST_EFFECT, make_pulsing_effect(TEST_EFFECT, TEST_ABILITY));
+    mgr.effect_defs.insert(
+        TEST_EFFECT_SINGLE_SHOT,
+        EffectDef {
+            effect_id: TEST_EFFECT_SINGLE_SHOT,
+            ability_id: TEST_ABILITY,
+            pulse_count: 1,
+            ..Default::default()
+        },
+    );
+    mgr
+}
+
+fn resolved(action: Action) -> ResolvedActions {
+    ResolvedActions {
+        params: std::collections::HashMap::new(),
+        actions: vec![(5000, action)],
+    }
+}
+
+/// The core guard for `Action::LaunchAbility`. A chain firing an ability with
+/// `entity_tag: None` must apply that ability's effects to the *triggering
+/// player themselves* — the exact self-target the combat pipeline's
+/// friendly-fire gate rejects.
+///
+/// Assert on the registered instance's identity, not just "the list is
+/// non-empty": the effect id, the owning ability id, and the invoker must all
+/// be right, or a future refactor that registers the wrong def still passes.
+#[tokio::test]
+async fn launch_ability_registers_effects_on_the_triggering_player() {
+    let mut mgr = make_mgr_with_defs();
+    let (tx, _rx) = mpsc::channel(64);
+    let engine = ChainEngine::new();
+
+    assert!(
+        mgr.get_entity(1).unwrap().active_effects.is_empty(),
+        "fixture drift: player must start with no active effects",
+    );
+
+    execute_actions(
+        resolved(Action::LaunchAbility {
+            ability_id: TEST_ABILITY,
+            entity_tag: None,
+        }),
+        1,
+        42,
+        &tx,
+        &mut mgr,
+        &engine,
+    )
+    .await;
+
+    let active = &mgr.get_entity(1).unwrap().active_effects;
+    assert_eq!(
+        active.len(),
+        1,
+        "LaunchAbility must register exactly one active effect on the \
+         triggering player -- got {active:?}",
+    );
+    assert_eq!(
+        active[0].effect_id, TEST_EFFECT,
+        "registered instance must be the ability's own effect",
+    );
+    assert_eq!(
+        active[0].ability_id, TEST_ABILITY,
+        "instance must carry the owning ability id (self-sourced from the \
+         effect def, not the action)",
+    );
+    assert_eq!(
+        active[0].invoker_id, 1,
+        "the triggering player is the invoker for a self-applied content \
+         debuff -- a different invoker would stack instead of refresh on \
+         re-fire",
+    );
+}
+
+/// The NPC is never a party to a self-targeted launch. Pins that the effect
+/// lands on the player and *only* the player — a target-resolution bug that
+/// sprayed the whole space would still satisfy a player-only assertion.
+#[tokio::test]
+async fn launch_ability_without_tag_does_not_touch_other_entities() {
+    let mut mgr = make_mgr_with_defs();
+    let (tx, _rx) = mpsc::channel(64);
+    let engine = ChainEngine::new();
+
+    execute_actions(
+        resolved(Action::LaunchAbility {
+            ability_id: TEST_ABILITY,
+            entity_tag: None,
+        }),
+        1,
+        42,
+        &tx,
+        &mut mgr,
+        &engine,
+    )
+    .await;
+
+    assert!(
+        mgr.get_entity(101).unwrap().active_effects.is_empty(),
+        "an untagged LaunchAbility targets the trigger source only -- the \
+         co-located NPC must be untouched",
+    );
+}
+
+/// `entity_tag: Some(..)` resolves through `find_entity_by_tag`, so a chain
+/// can debuff a named NPC. Asserts both halves: the NPC gets it, the player
+/// does not.
+#[tokio::test]
+async fn launch_ability_with_tag_targets_the_tagged_npc_not_the_player() {
+    let mut mgr = make_mgr_with_defs();
+    let (tx, _rx) = mpsc::channel(64);
+    let engine = ChainEngine::new();
+
+    execute_actions(
+        resolved(Action::LaunchAbility {
+            ability_id: TEST_ABILITY,
+            entity_tag: Some("Drone".to_string()),
+        }),
+        1,
+        42,
+        &tx,
+        &mut mgr,
+        &engine,
+    )
+    .await;
+
+    let npc_active = &mgr.get_entity(101).unwrap().active_effects;
+    assert_eq!(
+        npc_active.len(),
+        1,
+        "a tagged LaunchAbility must apply to the tagged NPC -- got {npc_active:?}",
+    );
+    assert_eq!(npc_active[0].effect_id, TEST_EFFECT);
+    assert_eq!(
+        npc_active[0].invoker_id, 1,
+        "the triggering player is the invoker even when the target is an NPC",
+    );
+    assert!(
+        mgr.get_entity(1).unwrap().active_effects.is_empty(),
+        "a tagged LaunchAbility must NOT also land on the triggering player",
+    );
+}
+
+/// Unresolvable tag must be a no-op, never a silent fall-back to self. An
+/// NPC debuff landing on the player because the NPC wasn't spawned is the
+/// bug shape here.
+#[tokio::test]
+async fn launch_ability_with_unresolvable_tag_does_not_fall_back_to_self() {
+    let mut mgr = make_mgr_with_defs();
+    let (tx, _rx) = mpsc::channel(64);
+    let engine = ChainEngine::new();
+
+    execute_actions(
+        resolved(Action::LaunchAbility {
+            ability_id: TEST_ABILITY,
+            entity_tag: Some("NotSpawned".to_string()),
+        }),
+        1,
+        42,
+        &tx,
+        &mut mgr,
+        &engine,
+    )
+    .await;
+
+    assert!(
+        mgr.get_entity(1).unwrap().active_effects.is_empty(),
+        "an unresolvable entity_tag must skip the launch, not apply the \
+         ability to the triggering player",
+    );
+    assert!(mgr.get_entity(101).unwrap().active_effects.is_empty());
+}
+
+/// Seed drift: a `launch_ability` row naming an ability the server has no
+/// def for must no-op rather than panic or apply something arbitrary.
+#[tokio::test]
+async fn launch_ability_with_unknown_ability_id_is_a_noop() {
+    let mut mgr = make_mgr_with_defs();
+    let (tx, _rx) = mpsc::channel(64);
+    let engine = ChainEngine::new();
+
+    execute_actions(
+        resolved(Action::LaunchAbility {
+            ability_id: 90_999,
+            entity_tag: None,
+        }),
+        1,
+        42,
+        &tx,
+        &mut mgr,
+        &engine,
+    )
+    .await;
+
+    assert!(
+        mgr.get_entity(1).unwrap().active_effects.is_empty(),
+        "an unknown ability id must apply nothing",
+    );
+}
+
+/// `Action::ApplyEffect` is the single-effect degenerate case of the same
+/// helper — no ability lookup, the effect id comes straight off the action.
+///
+/// This arm cannot fire from seeded content today (the only `apply_effect`
+/// row sits on an `effect`-scoped chain and no `effect_*` trigger is
+/// dispatched), so this test is the only thing exercising it. It is
+/// deliberately a direct `execute_actions` call rather than a chain replay.
+#[tokio::test]
+async fn apply_effect_registers_the_named_effect_on_the_source_entity() {
+    let mut mgr = make_mgr_with_defs();
+    let (tx, _rx) = mpsc::channel(64);
+    let engine = ChainEngine::new();
+
+    execute_actions(
+        resolved(Action::ApplyEffect {
+            effect_id: TEST_EFFECT,
+            duration_secs: None,
+        }),
+        1,
+        42,
+        &tx,
+        &mut mgr,
+        &engine,
+    )
+    .await;
+
+    let active = &mgr.get_entity(1).unwrap().active_effects;
+    assert_eq!(
+        active.len(),
+        1,
+        "ApplyEffect must register the named effect on the source entity -- \
+         got {active:?}",
+    );
+    assert_eq!(active[0].effect_id, TEST_EFFECT);
+    assert_eq!(
+        active[0].invoker_id, 1,
+        "ApplyEffect self-sources the invoker from the trigger entity",
+    );
+}
+
+#[tokio::test]
+async fn apply_effect_with_unknown_effect_id_is_a_noop() {
+    let mut mgr = make_mgr_with_defs();
+    let (tx, _rx) = mpsc::channel(64);
+    let engine = ChainEngine::new();
+
+    execute_actions(
+        resolved(Action::ApplyEffect {
+            effect_id: 90_998,
+            duration_secs: None,
+        }),
+        1,
+        42,
+        &tx,
+        &mut mgr,
+        &engine,
+    )
+    .await;
+
+    assert!(mgr.get_entity(1).unwrap().active_effects.is_empty());
+}
+
+/// A `pulse_count == 1` effect with no `script_name` registers nothing and
+/// runs nothing — the arm reached the effect layer, the effect definition
+/// simply asked for no lasting state.
+///
+/// This is not a hypothetical: it is the shape of effect 1634, the only
+/// effect on the seeded Castle Cellblock wake-up ability. Pinning it here
+/// stops a future reader from diagnosing "no active effect appeared" as a
+/// bug in the executor arm when it is the seed's own definition.
+#[tokio::test]
+async fn single_shot_scriptless_effect_registers_no_active_instance() {
+    let mut mgr = make_mgr_with_defs();
+    mgr.ability_defs.insert(
+        TEST_ABILITY,
+        make_ability(TEST_ABILITY, vec![TEST_EFFECT_SINGLE_SHOT]),
+    );
+    let (tx, _rx) = mpsc::channel(64);
+    let engine = ChainEngine::new();
+
+    execute_actions(
+        resolved(Action::LaunchAbility {
+            ability_id: TEST_ABILITY,
+            entity_tag: None,
+        }),
+        1,
+        42,
+        &tx,
+        &mut mgr,
+        &engine,
+    )
+    .await;
+
+    assert!(
+        mgr.get_entity(1).unwrap().active_effects.is_empty(),
+        "a single-shot script-less effect has no duration to track -- \
+         register_active_effect must decline it",
+    );
+}

--- a/crates/services/src/cell/content/executor/tests/mod.rs
+++ b/crates/services/src/cell/content/executor/tests/mod.rs
@@ -4,6 +4,8 @@
 //! Split into per-theme submodules when the original `tests.rs` crossed
 //! the 700-line hard cap from `CLAUDE.md`:
 //!
+//! - [`effects`]          — `Action::LaunchAbility` / `Action::ApplyEffect`
+//!   (server-initiated effect application, target resolution).
 //! - [`stats`]            — `Action::ChangeStat` (heal / clamp / damage /
 //!   set-to-max / ammo-stat skip).
 //! - [`inventory_counter`] — `Action::RemoveItem`, increment / reset counter.
@@ -24,6 +26,7 @@ pub(super) use cimmeria_content_engine::actions::Action;
 pub(super) use cimmeria_content_engine::chain::{ChainEngine, ResolvedActions};
 pub(super) use tokio::sync::mpsc;
 
+mod effects;
 mod inventory_counter;
 mod mission;
 mod negative_logging;

--- a/crates/services/src/cell/content/mod.rs
+++ b/crates/services/src/cell/content/mod.rs
@@ -5,6 +5,10 @@
 //! ([`event_dispatch`]), and executes resolved actions against the game state
 //! ([`executor`]).
 
+// NOT `pub` — `effect_apply` bypasses the combat pipeline's caster/target
+// gates, and module privacy is what keeps it unreachable from any
+// client-dispatched path. See the module doc before widening this.
+mod effect_apply;
 mod engine_loader;
 mod event_dispatch;
 mod executor;

--- a/docs/architecture/abilities-and-effects-system.md
+++ b/docs/architecture/abilities-and-effects-system.md
@@ -216,6 +216,56 @@ The 0.5m number is a guess pending playtest feedback — if it's too aggressive,
 
 **Code:** [`crates/services/src/cell/service/message_loop.rs`](../../crates/services/src/cell/service/message_loop.rs).
 
+### 16. Content-initiated effects use a separate entry point, not `handle_use_ability`
+
+**Decision:** Content chains that apply an ability or an effect
+(`Action::LaunchAbility`, `Action::ApplyEffect`) call
+[`cell/content/effect_apply.rs`](../../crates/services/src/cell/content/effect_apply.rs),
+which resolves the effect defs and calls `dispatch_by_name` +
+`register_active_effect` directly. They do **not** route through
+`cell::abilities::use_ability::handle_use_ability`.
+
+**Why:** `handle_use_ability` is the *client* combat entry point, and its gates
+are correct for client input and wrong for content. A scripted debuff — the
+Castle Cellblock wake-up "Stasis Sickness" (ability 1372) is the motivating
+case — is rejected by it three independent ways:
+
+1. `has_ability` fails. The player never trained the ability and it is not
+   weapon-granted, so the check returns false with a WARN.
+2. Self-target trips the friendly-fire gate — a player entity may only
+   single-target a hostile NPC.
+3. The path resolves unconditionally as QR damage. There is no
+   offensive-vs-supportive branch, so "apply a debuff" has nowhere to land.
+
+Loosening any of those to admit content would loosen them for forged client
+packets too. A second entry point keeps the client gates intact.
+
+**The security constraint — this is the load-bearing part.** The helper
+bypasses the combat gates by design, so it is only safe while nothing
+client-driven can reach it. Three properties enforce that and none may be
+widened without re-deciding this ADR:
+
+- `mod effect_apply;` is declared **without `pub`**, so the path does not
+  exist outside `cell::content`. A `use` from a cell method or a Mercury
+  handler is a compile error, not a lint.
+- Both entry points are `pub(super)` — nameable only from `cell::content`
+  and its descendants (in practice `cell::content::executor`).
+- Neither takes a client-supplied id. `ability_id` / `effect_id` come from a
+  `content_actions` seed row loaded at startup; no wire field reaches them.
+
+Do not re-export these from `cell::content`, and do not add a cell method
+that forwards to them. That would turn this into an "apply arbitrary effect
+to arbitrary entity" primitive drivable by any forged packet.
+
+**Reversibility:** High. If an ability ever needs both client and content
+entry with shared warmup/cooldown/animation semantics, the right move is to
+factor the *effect-application tail* of `handle_use_ability` into a shared
+function that both call — not to route content back through the gated front
+door.
+
+**Code:** [`crates/services/src/cell/content/effect_apply.rs`](../../crates/services/src/cell/content/effect_apply.rs),
+dispatched from [`executor/mod.rs`](../../crates/services/src/cell/content/executor/mod.rs).
+
 ## Cross-cutting follow-ups
 
 These were considered and deliberately deferred:

--- a/docs/content/content-engine.md
+++ b/docs/content/content-engine.md
@@ -193,21 +193,44 @@ An action has to clear **two** hurdles to do anything. It needs a match arm in [
 | `start_minigame` | `StartMinigame` | 4 |
 | `trigger_transporter` | `TriggerTransporter` | 2 |
 | `cross_world_teleport` | `CrossWorldTeleport` | 1 |
+| `launch_ability` | `LaunchAbility` | 3 |
+| `apply_effect` | `ApplyEffect` | 1 |
 
 > An `open_black_market` / `OpenBlackMarket` action exists on the unmerged
 > `feat/571-black-market-phase1` branch (PR #586) and is **not** on `main`. It is
 > documented in [../architecture/black-market.md](../architecture/black-market.md);
 > do not author against it until that branch lands.
 
+`launch_ability` and `apply_effect` do **not** route through the combat
+pipeline. They call a separate server-authoritative entry point,
+[`cell/content/effect_apply.rs`](../../crates/services/src/cell/content/effect_apply.rs),
+which goes straight to the effect layer. `handle_use_ability` is the *client*
+entry point and rejects a scripted debuff three ways — the caster has not
+trained the ability, a self-target trips the friendly-fire gate, and the path
+resolves unconditionally as damage. The helper deliberately bypasses all
+three, so it is private to `cell::content` and takes no client-supplied id;
+see [../architecture/abilities-and-effects-system.md](../architecture/abilities-and-effects-system.md)
+for the full rationale and the constraints that must not be widened.
+
+Two caveats for authors:
+
+- **`apply_effect` cannot fire today.** Its only seeded row is on an
+  `effect`-scoped chain, and no `effect_*` trigger is dispatched anywhere in
+  the cell service. The arm is correct and will work as soon as that
+  dispatch lands.
+- **A single-shot, script-less effect is a legitimate no-op.** An effect with
+  `pulse_count = 1` and `script_name = NULL` registers no active instance and
+  runs nothing — that is the effect definition's own doing, not a failure of
+  the action. Effect 1634, the sole effect on the Castle Cellblock wake-up
+  ability 1372, is exactly this shape.
+
 #### Authorable but NOT executed — seeded rows that silently no-op
 
-These have a loader arm, so the seed accepts them and the engine resolves them, but **[executor/mod.rs](../../crates/services/src/cell/content/executor/mod.rs) has no match arm** — every one falls through to the `debug!` catch-all and does nothing. This is a live correctness gap, not a roadmap item: 8 seeded rows are currently dead.
+These have a loader arm, so the seed accepts them and the engine resolves them, but **[executor/mod.rs](../../crates/services/src/cell/content/executor/mod.rs) has no match arm** — every one falls through to the `debug!` catch-all and does nothing. This is a live correctness gap, not a roadmap item: 4 seeded rows are currently dead.
 
 | Seed verb | `Action` variant | Seed rows | Consequence |
 |---|---|---|---|
-| `launch_ability` | `LaunchAbility` | 3 | Scripted ability fires never happen |
 | `qr_combat_damage` | `QrCombatDamage` | 2 | Scripted damage is never applied |
-| `apply_effect` | `ApplyEffect` | 1 | No chain can apply a buff/debuff |
 | `remove_effect` | `RemoveEffect` | 1 | No chain can strip an effect |
 | `fail_objective` | `FailObjective` | 1 | Objective-fail branches never fire |
 
@@ -416,15 +439,17 @@ The fire-time logs (`info!` on match, `debug!` on no-match) at every `fire_*` si
 
 ### Defined-but-unhandled actions
 
-Fifteen `Action` variants have **no match arm in [executor/mod.rs](../../crates/services/src/cell/content/executor/mod.rs)** and fall through to the `debug!` catch-all at [mod.rs:453-455](../../crates/services/src/cell/content/executor/mod.rs#L453-L455):
+Thirteen `Action` variants have **no match arm in [executor/mod.rs](../../crates/services/src/cell/content/executor/mod.rs)** and fall through to the `debug!` catch-all at [mod.rs:453-455](../../crates/services/src/cell/content/executor/mod.rs#L453-L455):
 
-`ApplyEffect`, `RemoveEffect`, `SpawnEntity`, `DespawnEntity`, `PlayAnimation`, `PlaySound`, `ModifyProperty`, `RollLootTable`, `SpawnLootBag`, `StartTimer`, `CancelTimer`, `ExecuteCustom`, `QrCombatDamage`, `FailObjective`, `LaunchAbility`.
+`RemoveEffect`, `SpawnEntity`, `DespawnEntity`, `PlayAnimation`, `PlaySound`, `ModifyProperty`, `RollLootTable`, `SpawnLootBag`, `StartTimer`, `CancelTimer`, `ExecuteCustom`, `QrCombatDamage`, `FailObjective`.
 
-Five of those **are authorable from seed data and are used today** — `launch_ability` (3 rows), `qr_combat_damage` (2), `apply_effect` (1), `remove_effect` (1), `fail_objective` (1). Those 8 `content_actions` rows resolve, log a `debug!`, and do nothing. See the catalog in §3 for the full breakdown.
+Three of those **are authorable from seed data and are used today** — `qr_combat_damage` (2 rows), `remove_effect` (1), `fail_objective` (1). Those 4 `content_actions` rows resolve, log a `debug!`, and do nothing. See the catalog in §3 for the full breakdown.
+
+`launch_ability` and `apply_effect` were in this list until they were wired to [`effect_apply.rs`](../../crates/services/src/cell/content/effect_apply.rs); `grant_xp` and `move_entity` came off it in issues #611 and #613. Note that wiring the ability arm did not by itself make the Castle Cellblock wake-up debuff visible in play — both chains carrying it (5000 and 5001) also have mutually-exclusive `mission_status` conditions, and its effect is single-shot and script-less. See §3.
 
 Two more arms exist but are log-only: `SystemMessage` (11 seeded rows — wire format unknown, see below) and `SendMessage` (no seed verb).
 
-Biggest functional impacts: **no chain can apply a buff, schedule a timer, deal scripted damage, or fire a scripted ability today.** (XP grants and entity moves came off this list in issues #611 and #613.) See [proposed-extensions.md](proposed-extensions.md) for the wiring plan.
+Biggest functional impacts: **no chain can strip an effect, schedule a timer, or deal scripted damage today.** See [proposed-extensions.md](proposed-extensions.md) for the wiring plan.
 
 **`SystemMessage` wire format is still unresolved** (issue #268). The arm at [executor/mod.rs:275-287](../../crates/services/src/cell/content/executor/mod.rs#L275-L287) carries the reasoning: an earlier implementation routed the message id through `onPlayerCommunication` (method 28), which produced garbled `"[] says"` chat spam and client freezes, so it was reduced to an `info!`. Finding the correct client method for localized string-id display (possibly `onErrorCode` or a UI-specific method) still needs RE.
 


### PR DESCRIPTION
> **Stacked on #618.** Base is `feat/content-move-entity-grant-xp`, so the diff shows only this change. Merge #618 first and this retargets to `main` cleanly.

Introduces a server-authoritative effect-application entry point and wires two content-engine executor arms onto it: `Action::LaunchAbility` and `Action::ApplyEffect`.

## Why a new entry point rather than reusing the combat path

`handle_use_ability` is the **client** combat entry point and rejects a server-initiated debuff three independent ways. All three were verified against the code, not assumed:

1. `has_ability(1372)` fails (`use_ability/handle.rs:135`) — the player never trains Stasis Sickness, and it is not weapon-granted (`event_set_id` NULL, no `items_event_sets` binding), so it falls through to the weapon-granted fallback and returns `false` with a WARN at `:162`/`:174`.
2. Self-target trips the #444 friendly-fire gate at `handle.rs:223` — `entity.is_player && (target.is_player || target.faction != HOSTILE_FACTION)`.
3. The path resolves unconditionally as QR damage (`handle.rs:618` calls `apply_damage_to_target` with no offensive/supportive branch — the code's own TODO at `:215-222` confirms no such flag exists on `AbilityDef`).

So routing content-driven effects through the combat pipeline is not a matter of loosening a check; it is the wrong door.

## The helper

`crates/services/src/cell/content/effect_apply.rs`:

```rust
pub(super) async fn apply_ability_effects(
    ability_id: i32, target_id: u32, invoker_id: u32, chain_id: i64,
    tx: &mpsc::Sender<CellToBaseMsg>, space_mgr: &mut SpaceManager,
) -> usize                                  // effects that registered a lasting instance

pub(super) async fn apply_effect(
    effect_id: i32, target_id: u32, invoker_id: u32, chain_id: i64,
    tx: &mpsc::Sender<CellToBaseMsg>, space_mgr: &mut SpaceManager,
) -> bool
```

`ApplyEffect` is literally the per-effect body of `LaunchAbility`, not a parallel path. Argument order follows the executor's sibling handlers (`world::`, `stats::`) — payload args, `chain_id`, then `tx`, `space_mgr`.

One addition beyond the original spec: when an effect carries a `script_name`, the helper flushes the target's dirty stats via `ON_STAT_UPDATE`, mirroring `damage_apply`. Without it a content-applied script would mutate server state the client never learns about.

## Reachability — the part that matters

This bypasses the combat pipeline's gates by design, so it must be reachable **only** from server-initiated content execution. Three properties, all compile-enforced:

1. `mod effect_apply;` is declared **without `pub`** in `cell/content/mod.rs`. The path `crate::cell::content::effect_apply` does not exist outside `cell::content` — a `use` from a cell method or Mercury handler is **E0603**, not a lint.
2. Both functions are `pub(super)`, nameable only from `cell::content` and its descendants (in practice, `executor`).
3. Neither takes a client-supplied id. `ability_id` / `effect_id` come from `content_actions` rows loaded at startup; no wire field reaches them.

**On the requested "not reachable from client input" runtime test:** the constraint is a compile-time property, so a runtime test would add no signal — the compiler already rejects the violation. None was written rather than shipping something that looks like coverage but isn't. The invariant is protected instead by the module doc and ADR decision 16, both of which state explicitly not to re-export or thread a client id in.

## Two corrections to the brief this was built from

**1. Chain 5000 is broken the same way 5001 is.** The brief singled out 5001 as duplicate junk and presented 5000 as the working target. Both carry `mission_status 622 eq not_active` **AND** `eq completed` (`space_castle_cellblock_chains.sql:14,17` and `:40,43`), and conditions are AND-ed (`chain.rs:161`). Unsatisfiable. Verified empirically against a live DB — `resolve_event` on `player_loaded` returns zero actions for both under all three mission-622 states, and the alternative explanation was ruled out (both triggers are `OnPlayerLoaded { world_name: None }`, which `Trigger::matches` accepts unconditionally, so the empty resolve is attributable to conditions rather than a trigger miss).

**2. The originally-requested guard could never pass.** Effect 1634 (`effects.sql:2899`) has `pulse_count = 1`, and `EffectDef::is_pulsing()` is `pulse_count == 0 || pulse_count > 1` — so `register_active_effect` returns `false` on its first line and registers nothing, sending no `onTimerUpdate`. Combined with `script_name` NULL, **applying ability 1372 today is a complete no-op even with the arm wired.**

Covered instead by `single_shot_scriptless_effect_registers_no_active_instance`, which pins that shape explicitly so a future reader does not misdiagnose "no effect appeared" as an executor bug.

**Net: wiring the arm was necessary but not sufficient for the Castle Cellblock wake-up debuff.** Both remaining blockers are in the seed, which was left untouched as instructed. Worth knowing before anyone verifies against a live client and reports it as a regression.

## Tests

8 executor guards plus 3 chain-replay guards. Revert-verified by actually reverting and running:

| Revert | Result |
|---|---|
| `LaunchAbility` arm disabled | 2 FAIL |
| `ApplyEffect` arm disabled | 1 FAIL (the right one; the LaunchAbility guards stayed green) |

The 3 chain-replay guards pin the **seed**, not the arms — reverting the arms does not fail them, and no claim to the contrary is made. Their value is pinning the seed→Action conversion and the two defects above. The revert-guards use a synthetic pulsing def, which is the only way to observe the arm reaching the effect layer given effect 1634's shape.

## Verification

`cargo fmt --all --check` clean, `clippy -p cimmeria-services --all-targets -D warnings` clean, `nextest --profile=ci` 1,847 passed across services + content-engine. Live-DB run: 1,694 passed with **0 skipped** — the skip count was checked deliberately, because `require_db_or_skip!` early-returns and nextest scores that as PASS (see #615), so a green live-DB summary is not by itself evidence the tests ran.

Docs: `docs/content/content-engine.md` action catalogue updated (combined with #618, the dead-row count falls 13 → 4 and the unwired-variant list 17 → 13), and `docs/architecture/abilities-and-effects-system.md` gains decision 16 describing the entry point and why it exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GhH7BcbHyhFZHdWxKKc6gu
